### PR TITLE
Add an Advanced Operation History

### DIFF
--- a/src/UniGetUI.Core.Settings/SettingsEngine_Lists.cs
+++ b/src/UniGetUI.Core.Settings/SettingsEngine_Lists.cs
@@ -102,7 +102,7 @@ namespace UniGetUI.Core.SettingsEngine
         public static void AddToList<T>(string setting, T value)
         {
             List<T>? list = _getList<T>(setting);
-            if (list == null) return;
+            list ??= [];
 
             list.Add(value);
             SetList(setting, list);

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -98,21 +98,26 @@ namespace UniGetUI.PackageEngine.PackageClasses
 
             ignoredId = IgnoredUpdatesDatabase.GetIgnoredIdForPackage(this);
 
-            _iconId = Manager.Name switch
+            _iconId = GetPackageIconId(id, Manager.Name, Source.Name);
+        }
+
+        public static string GetPackageIconId(string PackageId, string ManagerName, string SourceName)
+        {
+            return ManagerName switch
             {
-                "Winget" => Source.Name switch
+                "Winget" => SourceName switch
                 {
-                    "Steam" => id.ToLower().Split("\\")[^1].Replace("steam app ", "steam-").Trim(),
-                    "Local PC" => id.ToLower().Split("\\")[^1],
-                    "Microsoft Store" => id.IndexOf('_') < id.IndexOf('.') ? // If the first underscore is before the period, this ID has no publisher
-                        string.Join('_', id.ToLower().Split("\\")[1].Split("_")[0..^4]) : // no publisher: remove `MSIX\`, then the standard ending _version_arch__{random id}
-                        string.Join('_', string.Join('.', id.ToLower().Split(".")[1..]).Split("_")[0..^4]), // remove the publisher (before the first .), then the standard _version_arch__{random id}
-                    _ => string.Join('.', id.ToLower().Split(".")[1..]),
+                    "Steam" => PackageId.ToLower().Split("\\")[^1].Replace("steam app ", "steam-").Trim(),
+                    "Local PC" => PackageId.ToLower().Split("\\")[^1],
+                    "Microsoft Store" => PackageId.IndexOf('_') < PackageId.IndexOf('.') ? // If the first underscore is before the period, this ID has no publisher
+                        string.Join('_', PackageId.ToLower().Split("\\")[1].Split("_")[0..^4]) : // no publisher: remove `MSIX\`, then the standard ending _version_arch__{random id}
+                        string.Join('_', string.Join('.', PackageId.ToLower().Split(".")[1..]).Split("_")[0..^4]), // remove the publisher (before the first .), then the standard _version_arch__{random id}
+                    _ => string.Join('.', PackageId.ToLower().Split(".")[1..]),
                 },
-                "Scoop" => id.ToLower().Replace(".app", ""),
-                "Chocolatey" => id.ToLower().Replace(".install", "").Replace(".portable", ""),
-                "vcpkg" => id.ToLower().Split(":")[0].Split("[")[0],
-                _ => id.ToLower()
+                "Scoop" => PackageId.ToLower().Replace(".app", ""),
+                "Chocolatey" => PackageId.ToLower().Replace(".install", "").Replace(".portable", ""),
+                "vcpkg" => PackageId.ToLower().Split(":")[0].Split("[")[0],
+                _ => PackageId.ToLower()
             };
         }
 

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
@@ -1,4 +1,5 @@
 using UniGetUI.Interface.Enums;
+using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 
 namespace UniGetUI.PackageEngine.PackageClasses
@@ -38,4 +39,16 @@ namespace UniGetUI.PackageEngine.PackageClasses
             SourceIconId = Source.Source.IconId;
         }
     }
+
+    public class AdvancedOperationHistoryEntry(
+        IPackage Source,
+        OperationType Type,
+        OperationStatus Status,
+        string Logs
+    ) : SimplePackage(Source)
+    {
+        public OperationType Type { get; } = Type;
+        public OperationStatus Status { get; } = Status;
+        public string Logs { get; } = Logs;
+    };
 }

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
@@ -15,6 +15,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
         public string IconId { get; }
         public string ManagerName { get; }
         public string ManagerDisplayName { get; }
+        public IconType ManagerIconId { get; }
         public string SourceName { get; }
         public Uri SourceUrl { get; }
         public IconType SourceIconId { get; }
@@ -34,6 +35,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
             IconId = Package.GetPackageIconId(Source.Id, Source.Manager.Name, Source.Source.Name);
             ManagerName = Source.Manager.Name;
             ManagerDisplayName = Source.Manager.DisplayName;
+            ManagerIconId = Source.Manager.Properties.IconId;
             SourceName = Source.Source.Name;
             SourceUrl = Source.Source.Url;
             SourceIconId = Source.Source.IconId;

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
@@ -1,35 +1,92 @@
+using System.Text.Json.Serialization;
 using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 
 namespace UniGetUI.PackageEngine.PackageClasses
 {
-    public class SimplePackage(IPackage Source)
+    public class SimplePackage
     {
-        public string Description { get; } = "Not loaded";
-        public string[] Tags { get; } = [];
-        public string Name { get; } = Source.Name;
-        public string Id { get; } = Source.Id;
-        public string VersionString { get; } = Source.VersionString;
-        public string NewVersionString { get; } = Source.NewVersionString;
-        public string IconId { get; } = Package.GetPackageIconId(Source.Id, Source.Manager.Name, Source.Source.Name);
-        public string ManagerName { get; } = Source.Manager.Name;
-        public string ManagerDisplayName { get; } = Source.Manager.DisplayName;
-        public IconType ManagerIconId { get; } = Source.Manager.Properties.IconId;
-        public string SourceName { get; } = Source.Source.Name;
-        public Uri SourceUrl { get; } = Source.Source.Url;
-        public IconType SourceIconId { get; } = Source.Source.IconId;
+        public SimplePackage(IPackage source)
+        {
+            Description = "Not loaded";
+            Tags = [];
+            Name = source.Name;
+            Id = source.Id;
+            VersionString = source.VersionString;
+            NewVersionString = source.NewVersionString;
+            IconId = Package.GetPackageIconId(source.Id, source.Manager.Name, source.Source.Name);
+            ManagerName = source.Manager.Name;
+            ManagerDisplayName = source.Manager.DisplayName;
+            ManagerIconId = source.Manager.Properties.IconId;
+            SourceName = source.Source.Name;
+            SourceUrl = source.Source.Url;
+            SourceIconId = source.Source.IconId;
+        }
+
+        [JsonConstructor]
+        public SimplePackage(
+            string description, string[] tags, string name, string id,
+            string versionString, string newVersionString, string iconId,
+            string managerName, string managerDisplayName, IconType managerIconId,
+            string sourceName, Uri sourceUrl, IconType sourceIconId)
+        {
+            Description = description;
+            Tags = tags;
+            Name = name;
+            Id = id;
+            VersionString = versionString;
+            NewVersionString = newVersionString;
+            IconId = iconId;
+            ManagerName = managerName;
+            ManagerDisplayName = managerDisplayName;
+            ManagerIconId = managerIconId;
+            SourceName = sourceName;
+            SourceUrl = sourceUrl;
+            SourceIconId = sourceIconId;
+        }
+
+        public string Description { get; }
+        public string[] Tags { get; }
+        public string Name { get; }
+        public string Id { get; }
+        public string VersionString { get; }
+        public string NewVersionString { get; }
+        public string IconId { get; }
+        public string ManagerName { get; }
+        public string ManagerDisplayName { get; }
+        public IconType ManagerIconId { get; }
+        public string SourceName { get; }
+        public Uri SourceUrl { get; }
+        public IconType SourceIconId { get; }
     }
 
-    public class AdvancedOperationHistoryEntry(
-        IPackage Source,
-        OperationType Type,
-        OperationStatus Status,
-        string Logs
-    ) : SimplePackage(Source)
+    public class AdvancedOperationHistoryEntry : SimplePackage
     {
-        public OperationType Type { get; } = Type;
-        public OperationStatus Status { get; } = Status;
-        public string Logs { get; } = Logs;
+        public AdvancedOperationHistoryEntry(IPackage source, OperationType type, OperationStatus status, string logs) : base(source)
+        {
+            Type = type;
+            Status = status;
+            Logs = logs;
+        }
+
+        [JsonConstructor]
+        public AdvancedOperationHistoryEntry(
+            OperationType type, OperationStatus status, string logs,
+            string description, string[] tags, string name, string id,
+            string versionString, string newVersionString, string iconId,
+            string managerName, string managerDisplayName, IconType managerIconId,
+            string sourceName, Uri sourceUrl, IconType sourceIconId)
+                : base(description, tags, name, id, versionString, newVersionString, iconId,
+                managerName, managerDisplayName, managerIconId, sourceName, sourceUrl, sourceIconId)
+        {
+            Type = type;
+            Status = status;
+            Logs = logs;
+        }
+
+        public OperationType Type { get; }
+        public OperationStatus Status { get; }
+        public string Logs { get; }
     };
 }

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
@@ -1,0 +1,41 @@
+using UniGetUI.Interface.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.PackageEngine.PackageClasses
+{
+    public class SimplePackage
+    {
+        public string Description { get; }
+        public string[] Tags { get; }
+        public string Name { get; }
+        public string Id { get; }
+        public string VersionString { get; }
+        public string NewVersionString { get; }
+        public string IconId { get; }
+        public string ManagerName { get; }
+        public string ManagerDisplayName { get; }
+        public string SourceName { get; }
+        public Uri SourceUrl { get; }
+        public IconType SourceIconId { get; }
+
+        public SimplePackage(IPackage Source)
+        {
+            // Load the details first
+            Source.Details.Load();
+
+            // Now assign the values
+            Description = Source.Details.Description ?? "No description";
+            Tags = Source.Details.Tags;
+            Name = Source.Name;
+            Id = Source.Id;
+            VersionString = Source.VersionString;
+            NewVersionString = Source.NewVersionString;
+            IconId = Package.GetPackageIconId(Source.Id, Source.Manager.Name, Source.Source.Name);
+            ManagerName = Source.Manager.Name;
+            ManagerDisplayName = Source.Manager.DisplayName;
+            SourceName = Source.Source.Name;
+            SourceUrl = Source.Source.Url;
+            SourceIconId = Source.Source.IconId;
+        }
+    }
+}

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/SimplePackage.cs
@@ -4,42 +4,21 @@ using UniGetUI.PackageEngine.Interfaces;
 
 namespace UniGetUI.PackageEngine.PackageClasses
 {
-    public class SimplePackage
+    public class SimplePackage(IPackage Source)
     {
-        public string Description { get; }
-        public string[] Tags { get; }
-        public string Name { get; }
-        public string Id { get; }
-        public string VersionString { get; }
-        public string NewVersionString { get; }
-        public string IconId { get; }
-        public string ManagerName { get; }
-        public string ManagerDisplayName { get; }
-        public IconType ManagerIconId { get; }
-        public string SourceName { get; }
-        public Uri SourceUrl { get; }
-        public IconType SourceIconId { get; }
-
-        public SimplePackage(IPackage Source)
-        {
-            // Load the details first
-            Source.Details.Load();
-
-            // Now assign the values
-            Description = Source.Details.Description ?? "No description";
-            Tags = Source.Details.Tags;
-            Name = Source.Name;
-            Id = Source.Id;
-            VersionString = Source.VersionString;
-            NewVersionString = Source.NewVersionString;
-            IconId = Package.GetPackageIconId(Source.Id, Source.Manager.Name, Source.Source.Name);
-            ManagerName = Source.Manager.Name;
-            ManagerDisplayName = Source.Manager.DisplayName;
-            ManagerIconId = Source.Manager.Properties.IconId;
-            SourceName = Source.Source.Name;
-            SourceUrl = Source.Source.Url;
-            SourceIconId = Source.Source.IconId;
-        }
+        public string Description { get; } = "Not loaded";
+        public string[] Tags { get; } = [];
+        public string Name { get; } = Source.Name;
+        public string Id { get; } = Source.Id;
+        public string VersionString { get; } = Source.VersionString;
+        public string NewVersionString { get; } = Source.NewVersionString;
+        public string IconId { get; } = Package.GetPackageIconId(Source.Id, Source.Manager.Name, Source.Source.Name);
+        public string ManagerName { get; } = Source.Manager.Name;
+        public string ManagerDisplayName { get; } = Source.Manager.DisplayName;
+        public IconType ManagerIconId { get; } = Source.Manager.Properties.IconId;
+        public string SourceName { get; } = Source.Source.Name;
+        public Uri SourceUrl { get; } = Source.Source.Url;
+        public IconType SourceIconId { get; } = Source.Source.IconId;
     }
 
     public class AdvancedOperationHistoryEntry(

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -4,7 +4,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UniGetUI.Interface.Pages"
-    xmlns:packages="using:UniGetUI.PackageEngine.PackageClasses"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animations="using:CommunityToolkit.WinUI.Animations"
@@ -40,7 +39,7 @@
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="packages:SimplePackage">
+                    <DataTemplate x:DataType="local:AdvancedOperationHistoryEntry">
                         <widgets:SettingsEntry
                             Text="{x:Bind Name}"
                             UnderText="[updated] on [March 10, 2025] at [11:27 AM]"

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UniGetUI.Interface.Pages"
+    xmlns:packages="using:UniGetUI.PackageEngine.PackageClasses"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animations="using:CommunityToolkit.WinUI.Animations"
@@ -39,15 +40,15 @@
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="local:AdvancedOperationHistoryEntry">
+                    <DataTemplate x:DataType="packages:SimplePackage">
                         <widgets:SettingsEntry
-                            Text="{x:Bind Title}"
+                            Text="{x:Bind Name}"
                             UnderText="[updated] on [March 10, 2025] at [11:27 AM]"
                             x:Name="InterfaceSettingsExpander"
                             Icon="interactive"
                             Margin="8">
                             <Toolkit:SettingsExpander.Items>
-                                <widgets:TranslatedTextBlock Text="{x:Bind Content}" Margin="8" />
+                                <widgets:TranslatedTextBlock Text="{x:Bind Description}" Margin="8" />
                             </Toolkit:SettingsExpander.Items>
                         </widgets:SettingsEntry>
                         <!--<Expander Header="{x:Bind Title}" HorizontalAlignment="Stretch" MaxWidth="600" BorderThickness="0">

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -4,7 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UniGetUI.Interface.Pages"
-    xmlns:packages="using:UniGetUI.PackageEngine.PackageClasses";
+    xmlns:packages="using:UniGetUI.PackageEngine.PackageClasses"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animations="using:CommunityToolkit.WinUI.Animations"

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -5,7 +5,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UniGetUI.Interface.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:animations="using:CommunityToolkit.WinUI.Animations" xmlns:widgets="using:UniGetUI.Interface.Widgets"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
+    xmlns:Toolkit="using:CommunityToolkit.WinUI.Controls"
+    xmlns:widgets="using:UniGetUI.Interface.Widgets"
     mc:Ignorable="d">
 
     <animations:Implicit.ShowAnimations>
@@ -13,37 +16,41 @@
         <animations:OpacityAnimation Duration="0:0:0.25" From="0" To="1"/>
     </animations:Implicit.ShowAnimations>
 
-    <Grid RowSpacing="4">
-        <!-- <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-        <Grid Grid.Row="0" ColumnSpacing="0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <Button Grid.Column="0" Name="CopyButton" Click="CopyButton_Click" CornerRadius="6,0,0,6">
-                <widgets:TranslatedTextBlock Text="Copy to clipboard"/>
-            </Button>
-            <Button Grid.Column="1" Name="ExportButton" Click="ExportButton_Click" CornerRadius="0,6,6,0">
-                <widgets:TranslatedTextBlock Text="Export to a file"/>
-            </Button>
-            <StackPanel Name="LogLevelPane" Grid.Column="3" Orientation="Horizontal" Spacing="10">
-                <widgets:TranslatedTextBlock Text="Log level:" VerticalAlignment="Center"/>
-                <ComboBox Name="LogLevelCombo" x:FieldModifier="protected" SelectionChanged="LogLevelCombo_SelectionChanged" PlaceholderText="Pick a color" Width="250" CornerRadius="6"/>
-            </StackPanel>
-            <Button Grid.Column="5" Name="ReloadButton" Click="ReloadButton_Click">
-                <widgets:TranslatedTextBlock Text="Reload log"/>
-            </Button>
-        </Grid>
-        <ScrollViewer  x:FieldModifier="protected" Name="MainScroller" Grid.Row="1" HorizontalScrollMode="Disabled" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" CornerRadius="8">
-            <RichTextBlock  x:FieldModifier="protected" LineHeight="18"  Name="LogTextBox" FontFamily="Consolas" TextWrapping="WrapWholeWords" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="8"/>
-        </ScrollViewer> -->
-		<widgets:TranslatedTextBlock Text="Hello" />
+    <Grid>
+        <StackPanel x:Name="MainLayout" HorizontalAlignment="Stretch" Grid.Column="1" Grid.Row="0" Orientation="Vertical" Spacing="8" Margin="0,0,0,20">
+            <widgets:TranslatedTextBlock FontSize="40" FontWeight="Bold" WrappingMode="NoWrap" Text="Advanced Operation History" HorizontalAlignment="Center"/>
+            <ListView x:Name="AdvancedOperationHistoryList" VerticalAlignment="Stretch" HorizontalAlignment="Center" Width="800">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ListViewItem">
+                                    <Grid>
+                                        <ContentPresenter />
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup x:Name="CommonStates">
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                    </Grid>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ListView.ItemContainerStyle>
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="local:OperationHistoryEntry">
+                        <widgets:SettingsEntry Text="{x:Bind Title}" Margin="8">
+                            <Toolkit:SettingsExpander.Items>
+                                <widgets:TranslatedTextBlock Text="{x:Bind Content}" Margin="8" />
+                            </Toolkit:SettingsExpander.Items>
+                        </widgets:SettingsEntry>
+                        <!--<Expander Header="{x:Bind Title}" HorizontalAlignment="Stretch" MaxWidth="600" BorderThickness="0">
+                            <widgets:TranslatedTextBlock Text="{x:Bind Content}" Margin="10" />
+                        </Expander>-->
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
     </Grid>
 </Page>

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -42,7 +42,7 @@
                     <DataTemplate x:DataType="local:AdvancedOperationHistoryEntry">
                         <widgets:SettingsEntry
                             Text="{x:Bind Title}"
-                            UnderText="{updated} on {March 10, 2025} at {11:27 AM}"
+                            UnderText="[updated] on [March 10, 2025] at [11:27 AM]"
                             x:Name="InterfaceSettingsExpander"
                             Icon="interactive"
                             Margin="8">

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -41,19 +41,28 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="packages:AdvancedOperationHistoryEntry">
-                        <widgets:SettingsEntry
-                            Text="{x:Bind Name}"
-                            UnderText="[updated] on [March 10, 2025] at [11:27 AM]"
-                            x:Name="InterfaceSettingsExpander"
-                            Icon="interactive"
-                            Margin="8">
-                            <Toolkit:SettingsExpander.Items>
-                                <widgets:TranslatedTextBlock Text="{x:Bind Description}" Margin="8" />
-                            </Toolkit:SettingsExpander.Items>
-                        </widgets:SettingsEntry>
-                        <!--<Expander Header="{x:Bind Title}" HorizontalAlignment="Stretch" MaxWidth="600" BorderThickness="0">
-                            <widgets:TranslatedTextBlock Text="{x:Bind Content}" Margin="10" />
-                        </Expander>-->
+                        <Expander HorizontalAlignment="Stretch" MaxWidth="800" BorderThickness="0" Margin="0,0,0,10">
+                            <Expander.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <widgets:LocalIcon Icon="Android" />
+                                    <TextBlock Text="{x:Bind Name}" Margin="20,0,0,0" />
+                                </StackPanel>
+                            </Expander.Header>
+                            <Expander.Content>
+                                <ScrollViewer Height="100">
+                                    <TextBlock TextWrapping="Wrap">
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, 
+                                        sed do eiusmod tempor incididunt ut labore et dolore magna 
+                                        aliqua. Ut enim ad minim veniam, quis nostrud exercitation 
+                                        ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+                                        Duis aute irure dolor in reprehenderit in voluptate velit 
+                                        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint 
+                                        occaecat cupidatat non proident, sunt in culpa qui officia 
+                                        deserunt mollit anim id est laborum.
+                                    </TextBlock>
+                                </ScrollViewer>
+                            </Expander.Content>
+                        </Expander>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UniGetUI.Interface.Pages"
+    xmlns:packages="using:UniGetUI.PackageEngine.PackageClasses";
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animations="using:CommunityToolkit.WinUI.Animations"
@@ -39,7 +40,7 @@
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="local:AdvancedOperationHistoryEntry">
+                    <DataTemplate x:DataType="packages:AdvancedOperationHistoryEntry">
                         <widgets:SettingsEntry
                             Text="{x:Bind Name}"
                             UnderText="[updated] on [March 10, 2025] at [11:27 AM]"

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="UniGetUI.Interface.Pages.AdvancedOperationHistoryPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UniGetUI.Interface.Pages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:animations="using:CommunityToolkit.WinUI.Animations" xmlns:widgets="using:UniGetUI.Interface.Widgets"
+    mc:Ignorable="d">
+
+    <animations:Implicit.ShowAnimations>
+        <animations:TranslationAnimation Duration="0:0:0.25" From="0,100,0" To="0"/>
+        <animations:OpacityAnimation Duration="0:0:0.25" From="0" To="1"/>
+    </animations:Implicit.ShowAnimations>
+
+    <Grid RowSpacing="4">
+        <!-- <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid Grid.Row="0" ColumnSpacing="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="0" Name="CopyButton" Click="CopyButton_Click" CornerRadius="6,0,0,6">
+                <widgets:TranslatedTextBlock Text="Copy to clipboard"/>
+            </Button>
+            <Button Grid.Column="1" Name="ExportButton" Click="ExportButton_Click" CornerRadius="0,6,6,0">
+                <widgets:TranslatedTextBlock Text="Export to a file"/>
+            </Button>
+            <StackPanel Name="LogLevelPane" Grid.Column="3" Orientation="Horizontal" Spacing="10">
+                <widgets:TranslatedTextBlock Text="Log level:" VerticalAlignment="Center"/>
+                <ComboBox Name="LogLevelCombo" x:FieldModifier="protected" SelectionChanged="LogLevelCombo_SelectionChanged" PlaceholderText="Pick a color" Width="250" CornerRadius="6"/>
+            </StackPanel>
+            <Button Grid.Column="5" Name="ReloadButton" Click="ReloadButton_Click">
+                <widgets:TranslatedTextBlock Text="Reload log"/>
+            </Button>
+        </Grid>
+        <ScrollViewer  x:FieldModifier="protected" Name="MainScroller" Grid.Row="1" HorizontalScrollMode="Disabled" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" CornerRadius="8">
+            <RichTextBlock  x:FieldModifier="protected" LineHeight="18"  Name="LogTextBox" FontFamily="Consolas" TextWrapping="WrapWholeWords" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="8"/>
+        </ScrollViewer> -->
+		<widgets:TranslatedTextBlock Text="Hello" />
+    </Grid>
+</Page>

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml
@@ -39,8 +39,13 @@
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="local:OperationHistoryEntry">
-                        <widgets:SettingsEntry Text="{x:Bind Title}" Margin="8">
+                    <DataTemplate x:DataType="local:AdvancedOperationHistoryEntry">
+                        <widgets:SettingsEntry
+                            Text="{x:Bind Title}"
+                            UnderText="{updated} on {March 10, 2025} at {11:27 AM}"
+                            x:Name="InterfaceSettingsExpander"
+                            Icon="interactive"
+                            Margin="8">
                             <Toolkit:SettingsExpander.Items>
                                 <widgets:TranslatedTextBlock Text="{x:Bind Content}" Margin="8" />
                             </Toolkit:SettingsExpander.Items>

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -1,68 +1,15 @@
 using System.Collections.ObjectModel;
-using System.Data.Common;
-using System.Diagnostics;
-using ExternalLibraries.Clipboard;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
-using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.PackageClasses;
-using Windows.Storage;
-using Windows.Storage.Pickers;
-using Windows.UI;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace UniGetUI.Interface.Pages
 {
-    public class AdvancedOperationHistoryEntry
-    {
-        public required string Title { get; set; }
-        public required string Content { get; set; }
-    }
-
-    public class SimplePackage
-    {
-        public string Description { get; }
-        public string[] Tags { get; }
-        public string Name { get; }
-        public string Id { get; }
-        public string VersionString { get; }
-        public string NewVersionString { get; }
-        public string IconId { get; }
-        public string ManagerName { get; }
-        public string ManagerDisplayName { get; }
-        public string SourceName { get; }
-        public Uri SourceUrl { get; }
-        public IconType SourceIconId { get; }
-
-        public SimplePackage(IPackage Source)
-        {
-            // Load the details first
-            Source.Details.Load();
-
-            // Now assign the values
-            Description = Source.Details.Description ?? "No description";
-            Tags = Source.Details.Tags;
-            Name = Source.Name;
-            Id = Source.Id;
-            VersionString = Source.VersionString;
-            NewVersionString = Source.NewVersionString;
-            IconId = Package.GetPackageIconId(Source.Id, Source.Manager.Name, Source.Source.Name);
-            ManagerName = Source.Manager.Name;
-            ManagerDisplayName = Source.Manager.DisplayName;
-            SourceName = Source.Source.Name;
-            SourceUrl = Source.Source.Url;
-            SourceIconId = Source.Source.IconId;
-        }
-    }
-
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
     {
-        private readonly ObservableCollection<AdvancedOperationHistoryEntry> Items = [];
+        private readonly ObservableCollection<SimplePackage> Items = [];
 
         public AdvancedOperationHistoryPage()
         {
@@ -74,12 +21,6 @@ namespace UniGetUI.Interface.Pages
         private void LoadOperationHistory()
         {
             Items.Clear();
-
-            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 1", Content = "Content 1" });
-            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 2", Content = "Content 2" });
-            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 3", Content = "Content 3" });
-            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 4", Content = "Content 4" });
-            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 5", Content = "Content 5" });
         }
 
         public void ReloadTriggered()

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -1,9 +1,14 @@
 using System.Collections.ObjectModel;
+using System.Data.Common;
 using System.Diagnostics;
 using ExternalLibraries.Clipboard;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.PackageClasses;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.UI;
@@ -19,9 +24,45 @@ namespace UniGetUI.Interface.Pages
         public required string Content { get; set; }
     }
 
+    public class SimplePackage
+    {
+        public string Description { get; }
+        public string[] Tags { get; }
+        public string Name { get; }
+        public string Id { get; }
+        public string VersionString { get; }
+        public string NewVersionString { get; }
+        public string IconId { get; }
+        public string ManagerName { get; }
+        public string ManagerDisplayName { get; }
+        public string SourceName { get; }
+        public Uri SourceUrl { get; }
+        public IconType SourceIconId { get; }
+
+        public SimplePackage(IPackage Source)
+        {
+            // Load the details first
+            Source.Details.Load();
+
+            // Now assign the values
+            Description = Source.Details.Description ?? "No description";
+            Tags = Source.Details.Tags;
+            Name = Source.Name;
+            Id = Source.Id;
+            VersionString = Source.VersionString;
+            NewVersionString = Source.NewVersionString;
+            IconId = Package.GetPackageIconId(Source.Id, Source.Manager.Name, Source.Source.Name);
+            ManagerName = Source.Manager.Name;
+            ManagerDisplayName = Source.Manager.DisplayName;
+            SourceName = Source.Source.Name;
+            SourceUrl = Source.Source.Url;
+            SourceIconId = Source.Source.IconId;
+        }
+    }
+
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
     {
-        private ObservableCollection<AdvancedOperationHistoryEntry> Items = new ();
+        private readonly ObservableCollection<AdvancedOperationHistoryEntry> Items = [];
 
         public AdvancedOperationHistoryPage()
         {

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -9,9 +9,16 @@ using UniGetUI.PackageEngine.PackageClasses;
 
 namespace UniGetUI.Interface.Pages
 {
-    public class AdvancedOperationHistoryEntry(IPackage Source, OperationType Operation) : SimplePackage(Source)
+    public class AdvancedOperationHistoryEntry(
+        IPackage Source,
+        OperationType Type,
+        OperationStatus Status,
+        string Logs
+    ) : SimplePackage(Source)
     {
-        public OperationType Operation { get; } = Operation;
+        public OperationType Type { get; } = Type;
+        public OperationStatus Status { get; } = Status;
+        public string Logs { get; } = Logs;
     };
 
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using ExternalLibraries.Clipboard;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using UniGetUI.Core.Tools;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.UI;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace UniGetUI.Interface.Pages
+{
+    public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
+    {
+
+
+        public void ReloadTriggered()
+        { }
+        public void SelectAllTriggered()
+        { }
+        public void SearchTriggered()
+        { }
+        public void OnEnter()
+        { }
+        public void OnLeave()
+        { }
+    }
+}

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -13,15 +13,15 @@ using Windows.UI;
 
 namespace UniGetUI.Interface.Pages
 {
-    public class OperationHistoryEntry
+    public class AdvancedOperationHistoryEntry
     {
-        public string Title { get; set; }
-        public string Content { get; set; }
+        public required string Title { get; set; }
+        public required string Content { get; set; }
     }
 
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
     {
-        private ObservableCollection<OperationHistoryEntry> Items = new ();
+        private ObservableCollection<AdvancedOperationHistoryEntry> Items = new ();
 
         public AdvancedOperationHistoryPage()
         {
@@ -34,11 +34,11 @@ namespace UniGetUI.Interface.Pages
         {
             Items.Clear();
 
-            Items.Add(new OperationHistoryEntry { Title = "Test 1", Content = "Content 1" });
-            Items.Add(new OperationHistoryEntry { Title = "Test 2", Content = "Content 2" });
-            Items.Add(new OperationHistoryEntry { Title = "Test 3", Content = "Content 3" });
-            Items.Add(new OperationHistoryEntry { Title = "Test 4", Content = "Content 4" });
-            Items.Add(new OperationHistoryEntry { Title = "Test 5", Content = "Content 5" });
+            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 1", Content = "Content 1" });
+            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 2", Content = "Content 2" });
+            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 3", Content = "Content 3" });
+            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 4", Content = "Content 4" });
+            Items.Add(new AdvancedOperationHistoryEntry { Title = "Test 5", Content = "Content 5" });
         }
 
         public void ReloadTriggered()

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -3,13 +3,20 @@ using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.PackageClasses;
 
 namespace UniGetUI.Interface.Pages
 {
+    public class AdvancedOperationHistoryEntry(IPackage Source, OperationType Operation) : SimplePackage(Source)
+    {
+        public OperationType Operation { get; } = Operation;
+    };
+
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
     {
-        private readonly ObservableCollection<SimplePackage> Items = [];
+        private readonly ObservableCollection<AdvancedOperationHistoryEntry> Items = [];
 
         public AdvancedOperationHistoryPage()
         {

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -4,22 +4,10 @@ using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Enums;
-using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.PackageClasses;
 
 namespace UniGetUI.Interface.Pages
 {
-    public class AdvancedOperationHistoryEntry(
-        IPackage Source,
-        OperationType Type,
-        OperationStatus Status,
-        string Logs
-    ) : SimplePackage(Source)
-    {
-        public OperationType Type { get; } = Type;
-        public OperationStatus Status { get; } = Status;
-        public string Logs { get; } = Logs;
-    };
 
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
     {

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using ExternalLibraries.Clipboard;
 using Microsoft.UI.Xaml;
@@ -12,9 +13,28 @@ using Windows.UI;
 
 namespace UniGetUI.Interface.Pages
 {
+    public class OperationHistoryEntry
+    {
+        public string Title { get; set; }
+        public string Content { get; set; }
+    }
+
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
     {
+        private ObservableCollection<OperationHistoryEntry> Items = new ();
 
+        public AdvancedOperationHistoryPage()
+        {
+            InitializeComponent();
+
+            Items.Add(new OperationHistoryEntry { Title = "Test 1", Content = "Content 1" });
+            Items.Add(new OperationHistoryEntry { Title = "Test 2", Content = "Content 2" });
+            Items.Add(new OperationHistoryEntry { Title = "Test 3", Content = "Content 3" });
+            Items.Add(new OperationHistoryEntry { Title = "Test 4", Content = "Content 4" });
+            Items.Add(new OperationHistoryEntry { Title = "Test 5", Content = "Content 5" });
+
+            AdvancedOperationHistoryList.ItemsSource = Items;
+        }
 
         public void ReloadTriggered()
         { }

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -27,23 +27,28 @@ namespace UniGetUI.Interface.Pages
         {
             InitializeComponent();
 
+            AdvancedOperationHistoryList.ItemsSource = Items;
+        }
+
+        private void LoadOperationHistory()
+        {
+            Items.Clear();
+
             Items.Add(new OperationHistoryEntry { Title = "Test 1", Content = "Content 1" });
             Items.Add(new OperationHistoryEntry { Title = "Test 2", Content = "Content 2" });
             Items.Add(new OperationHistoryEntry { Title = "Test 3", Content = "Content 3" });
             Items.Add(new OperationHistoryEntry { Title = "Test 4", Content = "Content 4" });
             Items.Add(new OperationHistoryEntry { Title = "Test 5", Content = "Content 5" });
-
-            AdvancedOperationHistoryList.ItemsSource = Items;
         }
 
         public void ReloadTriggered()
-        { }
+            => LoadOperationHistory();
         public void SelectAllTriggered()
         { }
         public void SearchTriggered()
         { }
         public void OnEnter()
-        { }
+            => LoadOperationHistory();
         public void OnLeave()
         { }
     }

--- a/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
+++ b/src/UniGetUI/Pages/AdvancedOperationHistoryPage.xaml.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Enums;
@@ -11,18 +12,21 @@ namespace UniGetUI.Interface.Pages
 
     public partial class AdvancedOperationHistoryPage : IKeyboardShortcutListener, IEnterLeaveListener
     {
-        private readonly ObservableCollection<AdvancedOperationHistoryEntry> Items = [];
+        private ObservableCollection<AdvancedOperationHistoryEntry> Items = [];
 
         public AdvancedOperationHistoryPage()
         {
             InitializeComponent();
 
-            AdvancedOperationHistoryList.ItemsSource = Items;
+            LoadOperationHistory();
         }
 
         private void LoadOperationHistory()
         {
             Items.Clear();
+
+            Items = [.. Settings.GetList<AdvancedOperationHistoryEntry>("AdvancedOperationHistory") ?? []];
+            AdvancedOperationHistoryList.ItemsSource = Items;
         }
 
         public void ReloadTriggered()

--- a/src/UniGetUI/Pages/MainView.xaml
+++ b/src/UniGetUI/Pages/MainView.xaml
@@ -23,7 +23,13 @@
                 <MenuFlyoutSeparator Height="5"/>
                 <widgets:BetterMenuItem Text="WingetUI Log" IconName="buggy" Name="WingetUILogs" Click="UniGetUILogs_Click" />
                 <widgets:BetterMenuItem Text="Package Manager logs" IconName="console" Name="ManagerLogsMenu" Click="ManagerLogsMenu_Click" />
-                <widgets:BetterMenuItem Text="Operation history" IconName="history" Name="OperationHistoryMenu" Click="OperationHistoryMenu_Click" />
+                <MenuFlyoutSubItem x:Name="OperationHistorySubMenu" Text="Operation history">
+                    <MenuFlyoutSubItem.Icon>
+                        <widgets:LocalIcon FontSize="24" Icon="History" />
+                    </MenuFlyoutSubItem.Icon>
+                    <widgets:BetterMenuItem Text="Operation logs" Name="OperationHistoryMenu" Click="OperationHistoryMenu_Click" />
+                    <widgets:BetterMenuItem Text="Advanced operation history" Name="AdvancedOperationHistoryMenu" Click="AdvancedOperationHistoryMenu_Click" />
+                </MenuFlyoutSubItem>
                 <MenuFlyoutSeparator Height="5"/>
                 <widgets:BetterMenuItem x:Name="VersionMenuItem" IconName="info_round" IsEnabled="False" />
                 <widgets:BetterMenuItem Text="Release notes" IconName="megaphone" Name="ReleaseNotesMenu" Click="ReleaseNotesMenu_Click" />

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -31,6 +31,7 @@ namespace UniGetUI.Interface
         OwnLog,
         ManagerLog,
         OperationHistory,
+        AdvancedOperationHistory,
         Help,
         Null // Used for initializers
     }
@@ -45,6 +46,7 @@ namespace UniGetUI.Interface
         private UniGetUILogPage? UniGetUILogPage;
         private ManagerLogsPage? ManagerLogPage;
         private OperationHistoryPage? OperationHistoryPage;
+        private AdvancedOperationHistoryPage? AdvancedOperationHistoryPage;
         private HelpPage? HelpPage;
 
         private PageType OldPage_t = PageType.Null;
@@ -172,6 +174,7 @@ namespace UniGetUI.Interface
                 PageType.OwnLog => UniGetUILogPage ??= new UniGetUILogPage(),
                 PageType.ManagerLog => ManagerLogPage ??= new ManagerLogsPage(),
                 PageType.OperationHistory => OperationHistoryPage ??= new OperationHistoryPage(),
+                PageType.AdvancedOperationHistory => AdvancedOperationHistoryPage ??= new AdvancedOperationHistoryPage(),
                 PageType.Help => HelpPage ??= new HelpPage(),
                 PageType.Null => throw new InvalidCastException("Page type is Null"),
                 _ => throw new InvalidDataException($"Unknown page type {type}")
@@ -189,6 +192,7 @@ namespace UniGetUI.Interface
 
                 // "Extra" pages
                 PageType.OperationHistory => PageType.Discover,
+                PageType.AdvancedOperationHistory => PageType.Discover,
                 PageType.OwnLog => PageType.Discover,
                 PageType.ManagerLog => PageType.Discover,
                 PageType.Help => PageType.Discover,
@@ -208,6 +212,7 @@ namespace UniGetUI.Interface
 
                 // "Extra" pages
                 PageType.OperationHistory => PageType.Discover,
+                PageType.AdvancedOperationHistory => PageType.Discover,
                 PageType.OwnLog => PageType.Discover,
                 PageType.ManagerLog => PageType.Discover,
                 PageType.Help => PageType.Discover,
@@ -227,7 +232,7 @@ namespace UniGetUI.Interface
 
             SettingsNavButton.IsChecked = page is PageType.Settings;
             AboutNavButton.IsChecked = false;
-            MoreNavButton.IsChecked = page is PageType.Help or PageType.ManagerLog or PageType.OperationHistory or PageType.OwnLog;
+            MoreNavButton.IsChecked = page is PageType.Help or PageType.ManagerLog or PageType.OperationHistory or PageType.AdvancedOperationHistory or PageType.OwnLog;
         }
 
         private async void AboutNavButton_Click(object sender, EventArgs e)
@@ -278,6 +283,9 @@ namespace UniGetUI.Interface
 
         private void OperationHistoryMenu_Click(object sender, RoutedEventArgs e)
             => NavigateTo(PageType.OperationHistory);
+
+        private void AdvancedOperationHistoryMenu_Click(object sender, RoutedEventArgs e)
+            => NavigateTo(PageType.AdvancedOperationHistory);
 
         private void ManagerLogsMenu_Click(object sender, RoutedEventArgs e)
             => OpenManagerLogs();

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -139,6 +139,7 @@ namespace UniGetUI.Interface
                 "installed" => PageType.Installed,
                 "bundles" => PageType.Bundles,
                 "settings" => PageType.Settings,
+                "ophist" => PageType.AdvancedOperationHistory,
                 _ => MainApp.Tooltip.AvailableUpdates > 0 ? PageType.Updates : PageType.Discover
             };
             NavigateTo(type);

--- a/src/UniGetUI/Pages/SettingsPage.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPage.xaml.cs
@@ -103,6 +103,7 @@ namespace UniGetUI.Interface
                 StartupPageSelector.AddItem(CoreTools.AutoTranslated("Installed Packages"), "installed");
                 StartupPageSelector.AddItem(CoreTools.AutoTranslated("Package Bundles"), "bundles");
                 StartupPageSelector.AddItem(CoreTools.AutoTranslated("Settings"), "settings");
+                StartupPageSelector.AddItem(CoreTools.AutoTranslated("Operation History"), "ophist");
                 StartupPageSelector.ShowAddedItems();
 
                 for (int i = 1; i <= 10; i++)

--- a/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
@@ -5,6 +5,7 @@ using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
+using UniGetUI.Interface.Pages;
 using UniGetUI.Interface.Telemetry;
 using UniGetUI.Interface.Widgets;
 using UniGetUI.PackageEngine;

--- a/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
@@ -5,7 +5,6 @@ using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
-using UniGetUI.Interface.Pages;
 using UniGetUI.Interface.Telemetry;
 using UniGetUI.Interface.Widgets;
 using UniGetUI.PackageEngine;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

This PR adds an 'advanced operation history' page, where you can see a list of recent operations and view more advanced details about each.

- [ ] Trim the history (and allow configuring how many entries to keep)

Fixes #1023 
Fixes #3770
Fixes #4292
Hopefully allows for functionality for #1824 