### PR TITLE
Add toggle to enable/disable insecure settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The main goal of this project is to create an intuitive GUI for the most common 
 With this app, you can easily download, install, update, and uninstall any software published on the supported package managers — and much more!
 
 ![image](https://github.com/user-attachments/assets/7cb447ca-ee8b-4bce-8561-b9332fb0139a)
-
+View more screenshots [here](#screenthots)
 
 Check out the [Supported Package Managers Table](#supported-package-managers) for more details!
 


### PR DESCRIPTION
Certain features, such as custom command-line arguments, and future ones such as pre-install and post-install scripts, pose an important security risk. They should be disabled by default, and in a way that a remote, unauthorized agent cannot manually enable this features.

 - [ ] Implement _secure settings_ (can only be changed with administrator permissions, yet they should be user-based)
 - [ ] Create a settings page to handle these secure settings. Create a UI warning to enable and disable them.