### PR TITLE
Single-Character Fix in CLI Arguments Docs

### DIFF
--- a/cli-arguments.md
+++ b/cli-arguments.md
@@ -44,7 +44,7 @@ The installer is inno-setup based. It supports [all Inno Setup command-line para
 | Parameter                                           | Description |
 | --------------------------------------------------- | ---------- |
 | `/NoAutoStart` | Will not launch UniGetUI after installation |
-| `/NoRunOnStartup` | Will nor register UniGetUI to start minimized at login (v3.1.6+) |
+| `/NoRunOnStartup` | Will not register UniGetUI to start minimized at login (v3.1.6+) |
 | `/NoVCRedist` | Will not install MS Visual C++ Redistributable x64 (v3.1.2+) |
 | `/NoEdgeWebView` | Will not install Microsoft Edge WebView Runtime (v3.1.2+) |
 | `/NoChocolatey` | Do NOT install chocolatey within UniGetUI | 


### PR DESCRIPTION
Just a single character replacement from 'nor' to 'not' :)