### PR TITLE
Clamp filters column width, collapse earlier

### DIFF
--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -1067,7 +1067,7 @@ namespace UniGetUI.Interface
 
             int newWidth = Math.Clamp(rawWidth, 0, (int)this.ActualWidth - 250);
 
-            if (newWidth < 204)
+            if (newWidth < 100)
             {
                 HideFilteringPane();
                 Settings.SetDictionaryItem(Settings.K.SidepanelWidths, PAGE_NAME, 250);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.

> [!IMPORTANT]  
> Hello Martí, thank you so much for creating this tool! Since I have stumbled upon it one day, I cannot imagine managing installed packages and apps on Windows without it! 🙏 

# Why

I have played with UniGet UI one day and resized the filters pane over the maximum grid container width which due to storing the last set value in setting made the one of the view unusable for me (reinstall/update did not help, so I decided to build app from the source and adjust ActualWidth value via Property Explorer, which inspired that PR).

![2](https://github.com/user-attachments/assets/c49dc40a-2b10-4cd5-958d-3e525a2209fe)

I have also spotted that width at which filters pane collapses could be higher, since below 200 pixels buttons and radios labels break line or become trimmed. Under ~150 pixels the content becomes almost fully overlapped via container spacing and other elements, so is seems reasonable to collapse filters pane earlier.

# How

The following PR introduces the following changes:
* sets max width of filters pane to 600 pixels via value clamping in `onSizeChanged` listener to prevent situation like on the recording above
* changes the width at which filters pane collapses from 100 pixels to 204 pixels, to make sure that content is fully visible in minimal allowed pane width

I'm happy to adjust the values if you think that other ones would work better, especially 600 pixels max width is a quite arbitrary choice, and maybe it could be set to even lower value.

# Preview

![1](https://github.com/user-attachments/assets/8ff7c654-efc9-4583-8790-a085eab7bd4a)

