### PR TITLE
a11y: improve screen reader labels and settings keyboard navigation

### DIFF
--- a/src/UniGetUI.Core.Tools.Tests/AccessibilityXamlTests.cs
+++ b/src/UniGetUI.Core.Tools.Tests/AccessibilityXamlTests.cs
@@ -38,7 +38,8 @@ public class AccessibilityXamlTests
             [
                 "AutomationProperties.Name=\"{x:Bind OperationOptionsAutomationName, Mode=OneWay}\"",
                 "AutomationProperties.Name=\"{x:Bind OperationsListActionsAutomationName, Mode=OneWay}\"",
-                "AutomationProperties.Name=\"{x:Bind ExpandCollapseOperationsAutomationName, Mode=OneWay}\""
+                "AutomationProperties.Name=\"{x:Bind ExpandCollapseOperationsAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind ResizeOperationsAreaAutomationName, Mode=OneWay}\""
             ],
             ["src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml"] =
             [
@@ -58,6 +59,14 @@ public class AccessibilityXamlTests
             [
                 "AutomationProperties.Name=\"{x:Bind MorePackageActionsAutomationName, Mode=OneWay}\""
             ],
+            ["src/UniGetUI/Pages/DialogPages/OperationFailedDialog.xaml"] =
+            [
+                "AutomationProperties.Name=\"Command-line output\""
+            ],
+            ["src/UniGetUI/Pages/DialogPages/OperationLiveLogPage.xaml"] =
+            [
+                "AutomationProperties.Name=\"Operation live log output\""
+            ],
             ["src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml"] =
             [
                 "AutomationProperties.Name=\"{x:Bind PackageOptionsAutomationName, Mode=OneWay}\"",
@@ -66,7 +75,20 @@ public class AccessibilityXamlTests
                 "AutomationProperties.Name=\"{x:Bind SelectPackageAutomationName, Mode=OneWay}\"",
                 "AutomationProperties.Name=\"{x:Bind OrderByAutomationName, Mode=OneWay}\"",
                 "AutomationProperties.Name=\"{x:Bind ViewModeAutomationName, Mode=OneWay}\"",
-                "AutomationProperties.Name=\"{x:Bind SearchPackagesAutomationName, Mode=OneWay}\""
+                "AutomationProperties.Name=\"{x:Bind SearchPackagesAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SelectAllSourcesAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind ClearSourceSelectionAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind InstantSearchAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind DistinguishUpperLowerCaseAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind IgnoreSpecialCharactersAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind ToggleFiltersAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind MainSelectionActionAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SearchModeOptionsAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SearchModeByNameAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SearchModeByIdAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SearchModeByBothAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SearchModeExactMatchAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SearchModeSimilarResultsAutomationName, Mode=OneWay}\""
             ],
             ["src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml"] =
             [
@@ -149,6 +171,76 @@ public class AccessibilityXamlTests
             foreach (Match match in matches)
             {
                 Assert.Contains("AutomationProperties.Name", match.Value);
+            }
+        }
+    }
+
+    [Fact]
+    public void AccessibilityCriticalCodePathsSetNamesAndTabFocus()
+    {
+        Dictionary<string, string[]> requiredSnippets = new()
+        {
+            ["src/UniGetUI/Controls/CustomNavViewItem.cs"] =
+            [
+                "AutomationProperties.SetName(this, text);"
+            ],
+            ["src/UniGetUI/Services/UserAvatar.cs"] =
+            [
+                "AutomationProperties.SetName(profileButton, CoreTools.Translate(\"Open backup profile\"));"
+            ],
+            ["src/UniGetUI/Controls/SettingsWidgets/SettingsPageButton.cs"] =
+            [
+                "AutomationProperties.SetName(this, name);",
+                "IsTabStop = true;",
+                "UseSystemFocusVisuals = true;"
+            ],
+            ["src/UniGetUI/Controls/SettingsWidgets/CheckboxCard.cs"] =
+            [
+                "AutomationProperties.SetName(_checkbox, name);",
+                "AutomationProperties.SetName(this, name);"
+            ],
+            ["src/UniGetUI/Controls/SettingsWidgets/SecureCheckboxCard.cs"] =
+            [
+                "AutomationProperties.SetName(_checkbox, name);",
+                "AutomationProperties.SetName(this, name);"
+            ],
+            ["src/UniGetUI/Controls/SettingsWidgets/CheckboxButtonCard.cs"] =
+            [
+                "AutomationProperties.SetName(_checkbox, _translatedCheckboxText);",
+                "AutomationProperties.SetName(Button, buttonName);"
+            ],
+            ["src/UniGetUI/Controls/SettingsWidgets/ButtonCard.cs"] =
+            [
+                "AutomationProperties.SetName(_button, buttonName);",
+                "AutomationProperties.SetName(this, cardName);"
+            ],
+            ["src/UniGetUI/Controls/SettingsWidgets/ComboboxCard.cs"] =
+            [
+                "AutomationProperties.SetName(_combobox, _translatedText);",
+                "AutomationProperties.SetName(this, _translatedText);"
+            ],
+            ["src/UniGetUI/Controls/SettingsWidgets/TextboxCard.cs"] =
+            [
+                "AutomationProperties.SetName(_textbox, textboxName);",
+                "AutomationProperties.SetName(this, textboxName);"
+            ],
+            ["src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml.cs"] =
+            [
+                "BackButton.PreviewKeyDown += BackButton_PreviewKeyDown;",
+                "root.TabFocusNavigation = KeyboardNavigationMode.Local;",
+                "MainNavigationFrame.TabFocusNavigation = KeyboardNavigationMode.Local;",
+                "scroller.TabFocusNavigation = KeyboardNavigationMode.Local;",
+                "NeedsContextualName(currentName, toggle.OnContent, toggle.OffContent)",
+                "AutomationProperties.SetName(card, cardName);"
+            ]
+        };
+
+        foreach (var (file, snippets) in requiredSnippets)
+        {
+            string content = ReadFile(file);
+            foreach (string snippet in snippets)
+            {
+                Assert.Contains(snippet, content);
             }
         }
     }

--- a/src/UniGetUI.Core.Tools.Tests/AccessibilityXamlTests.cs
+++ b/src/UniGetUI.Core.Tools.Tests/AccessibilityXamlTests.cs
@@ -1,0 +1,155 @@
+using System.Text.RegularExpressions;
+
+namespace UniGetUI.Core.Tools.Tests;
+
+public class AccessibilityXamlTests
+{
+    private static readonly string RepoRoot =
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, @"..\..\..\..\..\..\.."));
+
+    private static string ReadFile(string relativePath)
+    {
+        string path = Path.Combine(RepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void IconOnlyControlsHaveAutomationNames()
+    {
+        Dictionary<string, string[]> requiredSnippets = new()
+        {
+            ["src/UniGetUI/Controls/DialogCloseButton.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind CloseAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Controls/SourceManager.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind RemoveSourceAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind ReloadSourcesAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/HelpPage.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind HelpBackAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind HelpForwardAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind HelpHomeAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind HelpReloadAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/MainView.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind OperationOptionsAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind OperationsListActionsAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind ExpandCollapseOperationsAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind BackAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/DialogPages/DesktopShortcuts.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind DeleteShortcutAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind OpenShortcutLocationAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind RemoveShortcutFromListAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind StopIgnoringUpdatesAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind MorePackageActionsAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind PackageOptionsAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind ReloadPackagesAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind MoreToolbarActionsAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SelectPackageAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind OrderByAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind ViewModeAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind SearchPackagesAutomationName, Mode=OneWay}\""
+            ],
+            ["src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml"] =
+            [
+                "AutomationProperties.Name=\"{x:Bind ResetBackupDirectoryAutomationName, Mode=OneWay}\"",
+                "AutomationProperties.Name=\"{x:Bind OpenBackupDirectoryAutomationName, Mode=OneWay}\""
+            ]
+        };
+
+        foreach (var (file, snippets) in requiredSnippets)
+        {
+            string content = ReadFile(file);
+            foreach (string snippet in snippets)
+            {
+                Assert.Contains(snippet, content);
+            }
+        }
+    }
+
+    [Fact]
+    public void CriticalListTemplatesHaveAutomationNames()
+    {
+        Dictionary<string, string[]> requiredSnippets = new()
+        {
+            ["src/UniGetUI/Controls/SourceManager.xaml"] =
+            [
+                "<ItemContainer AutomationProperties.Name=\"{x:Bind Source.Name}\">"
+            ],
+            ["src/UniGetUI/Pages/AboutPages/Contributors.xaml"] =
+            [
+                "<ItemContainer AutomationProperties.Name=\"{x:Bind Name}\">"
+            ],
+            ["src/UniGetUI/Pages/AboutPages/Translators.xaml"] =
+            [
+                "<ItemContainer AutomationProperties.Name=\"{x:Bind Name}\">"
+            ],
+            ["src/UniGetUI/Pages/AboutPages/ThirdPartyLicenses.xaml"] =
+            [
+                "<ItemContainer AutomationProperties.Name=\"{x:Bind Name}\">"
+            ],
+            ["src/UniGetUI/Pages/DialogPages/DesktopShortcuts.xaml"] =
+            [
+                "<ItemContainer AutomationProperties.Name=\"{x:Bind Name}\">"
+            ],
+            ["src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml"] =
+            [
+                "<ItemContainer AutomationProperties.Name=\"{x:Bind Name}\">"
+            ]
+        };
+
+        foreach (var (file, snippets) in requiredSnippets)
+        {
+            string content = ReadFile(file);
+            foreach (string snippet in snippets)
+            {
+                Assert.Contains(snippet, content);
+            }
+        }
+    }
+
+    [Fact]
+    public void CriticalItemContainersAreNamed()
+    {
+        string[] files =
+        [
+            "src/UniGetUI/Controls/SourceManager.xaml",
+            "src/UniGetUI/Pages/AboutPages/Contributors.xaml",
+            "src/UniGetUI/Pages/AboutPages/Translators.xaml",
+            "src/UniGetUI/Pages/AboutPages/ThirdPartyLicenses.xaml",
+            "src/UniGetUI/Pages/DialogPages/DesktopShortcuts.xaml",
+            "src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml",
+            "src/UniGetUI/Pages/MainView.xaml"
+        ];
+
+        foreach (string file in files)
+        {
+            string content = ReadFile(file);
+            MatchCollection matches = Regex.Matches(content, "<ItemContainer[^>]*>", RegexOptions.Singleline);
+            Assert.NotEmpty(matches);
+
+            foreach (Match match in matches)
+            {
+                Assert.Contains("AutomationProperties.Name", match.Value);
+            }
+        }
+    }
+}

--- a/src/UniGetUI/Controls/CustomNavViewItem.cs
+++ b/src/UniGetUI/Controls/CustomNavViewItem.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface;
@@ -44,6 +45,7 @@ internal partial class CustomNavViewItem : NavigationViewItem
         {
             string text = CoreTools.Translate(value);
             _textBlock.Text = text;
+            AutomationProperties.SetName(this, text);
             ToolTipService.SetToolTip(this, text);
         }
 

--- a/src/UniGetUI/Controls/DialogCloseButton.xaml
+++ b/src/UniGetUI/Controls/DialogCloseButton.xaml
@@ -18,6 +18,7 @@
         Width="46"
         Height="31"
         Padding="0"
+        AutomationProperties.Name="{x:Bind CloseAutomationName, Mode=OneWay}"
         HorizontalAlignment="Stretch"
         VerticalAlignment="Stretch"
         Background="Transparent"

--- a/src/UniGetUI/Controls/DialogCloseButton.xaml.cs
+++ b/src/UniGetUI/Controls/DialogCloseButton.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using UniGetUI.Core.Tools;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -8,6 +9,7 @@ namespace UniGetUI.Interface.Widgets;
 public sealed partial class DialogCloseButton : UserControl
 {
     public event EventHandler<RoutedEventArgs>? Click;
+    public string CloseAutomationName => CoreTools.Translate("Close");
 
     public DialogCloseButton()
     {

--- a/src/UniGetUI/Controls/OperationWidgets/OperationControl.cs
+++ b/src/UniGetUI/Controls/OperationWidgets/OperationControl.cs
@@ -30,6 +30,7 @@ public partial class OperationControl: INotifyPropertyChanged
     public AbstractOperation Operation;
     public BetterMenu OpMenu;
     public OperationStatus? MenuStateOnLoaded;
+    public string OperationOptionsAutomationName => CoreTools.Translate("Operation options");
     public ObservableCollection<OperationBadge> Badges = [];
     private int _errorCount = 0;
 

--- a/src/UniGetUI/Controls/PackageWrapper.cs
+++ b/src/UniGetUI/Controls/PackageWrapper.cs
@@ -59,6 +59,8 @@ namespace UniGetUI.PackageEngine.PackageClasses
 
         public int NewVersionLabelWidth { get => Package.IsUpgradable ? 125 : 0; }
         public int NewVersionIconWidth { get => Package.IsUpgradable ? 24 : 0; }
+        public string PackageOptionsAutomationName => CoreTools.Translate("Package options");
+        public string SelectPackageAutomationName => CoreTools.Translate("Select package {0}", Package.Name);
 
         public int Index { get; set; }
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/UniGetUI/Controls/SettingsWidgets/ButtonCard.cs
+++ b/src/UniGetUI/Controls/SettingsWidgets/ButtonCard.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI.Controls;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.Tools;
 
@@ -10,15 +11,51 @@ namespace UniGetUI.Interface.Widgets
     public sealed partial class ButtonCard : SettingsCard
     {
         private readonly Button _button = new();
+        private string _translatedText = string.Empty;
+        private string _translatedButtonText = string.Empty;
+
+        private void UpdateAutomationNames()
+        {
+            if (!string.IsNullOrWhiteSpace(_translatedButtonText))
+            {
+                string buttonName = string.IsNullOrWhiteSpace(_translatedText)
+                    ? _translatedButtonText
+                    : $"{_translatedButtonText}. {_translatedText}";
+                AutomationProperties.SetName(_button, buttonName);
+            }
+
+            string cardName = _translatedText;
+            if (!string.IsNullOrWhiteSpace(_translatedButtonText))
+            {
+                cardName = string.IsNullOrWhiteSpace(cardName)
+                    ? _translatedButtonText
+                    : $"{cardName}. {_translatedButtonText}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(cardName))
+            {
+                AutomationProperties.SetName(this, cardName);
+            }
+        }
 
         public string ButtonText
         {
-            set => _button.Content = CoreTools.Translate(value);
+            set
+            {
+                _translatedButtonText = CoreTools.Translate(value);
+                _button.Content = _translatedButtonText;
+                UpdateAutomationNames();
+            }
         }
 
         public string Text
         {
-            set => Header = CoreTools.Translate(value);
+            set
+            {
+                _translatedText = CoreTools.Translate(value);
+                Header = _translatedText;
+                UpdateAutomationNames();
+            }
         }
 
         public new event EventHandler<EventArgs>? Click;
@@ -28,6 +65,7 @@ namespace UniGetUI.Interface.Widgets
             _button.MinWidth = 200;
             _button.Click += (_, _) => { Click?.Invoke(this, EventArgs.Empty); };
             Content = _button;
+            UpdateAutomationNames();
         }
     }
 }

--- a/src/UniGetUI/Controls/SettingsWidgets/CheckboxButtonCard.cs
+++ b/src/UniGetUI/Controls/SettingsWidgets/CheckboxButtonCard.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
@@ -18,6 +19,37 @@ namespace UniGetUI.Interface.Widgets
         public TextBlock _textblock;
         public ButtonBase Button;
         private bool IS_INVERTED;
+        private string _translatedCheckboxText = string.Empty;
+        private string _translatedButtonText = string.Empty;
+
+        private void UpdateAutomationNames()
+        {
+            if (!string.IsNullOrWhiteSpace(_translatedCheckboxText))
+            {
+                AutomationProperties.SetName(_checkbox, _translatedCheckboxText);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_translatedButtonText))
+            {
+                string buttonName = string.IsNullOrWhiteSpace(_translatedCheckboxText)
+                    ? _translatedButtonText
+                    : $"{_translatedButtonText}. {_translatedCheckboxText}";
+                AutomationProperties.SetName(Button, buttonName);
+            }
+
+            string cardName = _translatedCheckboxText;
+            if (!string.IsNullOrWhiteSpace(_translatedButtonText))
+            {
+                cardName = string.IsNullOrWhiteSpace(cardName)
+                    ? _translatedButtonText
+                    : $"{cardName}. {_translatedButtonText}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(cardName))
+            {
+                AutomationProperties.SetName(this, cardName);
+            }
+        }
 
         private Settings.K setting_name = Settings.K.Unset;
         public Settings.K SettingName
@@ -42,12 +74,22 @@ namespace UniGetUI.Interface.Widgets
 
         public string CheckboxText
         {
-            set => _textblock.Text = CoreTools.Translate(value);
+            set
+            {
+                _translatedCheckboxText = CoreTools.Translate(value);
+                _textblock.Text = _translatedCheckboxText;
+                UpdateAutomationNames();
+            }
         }
 
         public string ButtonText
         {
-            set => Button.Content = CoreTools.Translate(value);
+            set
+            {
+                _translatedButtonText = CoreTools.Translate(value);
+                Button.Content = _translatedButtonText;
+                UpdateAutomationNames();
+            }
         }
 
         private bool _buttonAlwaysOn;
@@ -96,6 +138,7 @@ namespace UniGetUI.Interface.Widgets
             };
 
             Button.Click += (s, e) => Click?.Invoke(s, e);
+            UpdateAutomationNames();
         }
     }
 }

--- a/src/UniGetUI/Controls/SettingsWidgets/CheckboxCard.cs
+++ b/src/UniGetUI/Controls/SettingsWidgets/CheckboxCard.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using UniGetUI.Core.SettingsEngine;
@@ -16,6 +17,25 @@ namespace UniGetUI.Interface.Widgets
         public TextBlock _textblock;
         public TextBlock _warningBlock;
         protected bool IS_INVERTED;
+        private string _translatedText = string.Empty;
+        private string _translatedWarningText = string.Empty;
+
+        private void UpdateAutomationName()
+        {
+            string name = _translatedText;
+            if (!string.IsNullOrWhiteSpace(_translatedWarningText))
+            {
+                name = string.IsNullOrWhiteSpace(name)
+                    ? _translatedWarningText
+                    : $"{name}. {_translatedWarningText}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                AutomationProperties.SetName(_checkbox, name);
+                AutomationProperties.SetName(this, name);
+            }
+        }
 
         private Settings.K setting_name = Settings.K.Unset;
         public Settings.K SettingName
@@ -39,15 +59,22 @@ namespace UniGetUI.Interface.Widgets
 
         public string Text
         {
-            set => _textblock.Text = CoreTools.Translate(value);
+            set
+            {
+                _translatedText = CoreTools.Translate(value);
+                _textblock.Text = _translatedText;
+                UpdateAutomationName();
+            }
         }
 
         public string WarningText
         {
             set
             {
-                _warningBlock.Text = CoreTools.Translate(value);
+                _translatedWarningText = CoreTools.Translate(value);
+                _warningBlock.Text = _translatedWarningText;
                 _warningBlock.Visibility = value.Any() ? Visibility.Visible : Visibility.Collapsed;
+                UpdateAutomationName();
             }
         }
 
@@ -95,6 +122,7 @@ namespace UniGetUI.Interface.Widgets
 
             _checkbox.HorizontalAlignment = HorizontalAlignment.Stretch;
             _checkbox.Toggled += _checkbox_Toggled;
+            UpdateAutomationName();
         }
         protected virtual void _checkbox_Toggled(object sender, RoutedEventArgs e)
         {

--- a/src/UniGetUI/Controls/SettingsWidgets/ComboboxCard.cs
+++ b/src/UniGetUI/Controls/SettingsWidgets/ComboboxCard.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.WinUI.Controls;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using UniGetUI.Core.Logging;
@@ -17,6 +18,16 @@ namespace UniGetUI.Interface.Widgets
         private readonly ObservableCollection<string> _elements = [];
         private readonly Dictionary<string, string> _values_ref = [];
         private readonly Dictionary<string, string> _inverted_val_ref = [];
+        private string _translatedText = string.Empty;
+
+        private void UpdateAutomationNames()
+        {
+            if (!string.IsNullOrWhiteSpace(_translatedText))
+            {
+                AutomationProperties.SetName(_combobox, _translatedText);
+                AutomationProperties.SetName(this, _translatedText);
+            }
+        }
 
         private Settings.K settings_name = Settings.K.Unset;
         public Settings.K SettingName
@@ -29,7 +40,12 @@ namespace UniGetUI.Interface.Widgets
 
         public string Text
         {
-            set => Header = CoreTools.Translate(value);
+            set
+            {
+                _translatedText = CoreTools.Translate(value);
+                Header = _translatedText;
+                UpdateAutomationNames();
+            }
         }
 
         public event EventHandler<EventArgs>? ValueChanged;
@@ -39,6 +55,7 @@ namespace UniGetUI.Interface.Widgets
             _combobox.MinWidth = 200;
             _combobox.SetBinding(ItemsControl.ItemsSourceProperty, new Binding { Source = _elements });
             Content = _combobox;
+            UpdateAutomationNames();
         }
 
         public void AddItem(string name, string value)

--- a/src/UniGetUI/Controls/SettingsWidgets/SecureCheckboxCard.cs
+++ b/src/UniGetUI/Controls/SettingsWidgets/SecureCheckboxCard.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using UniGetUI.Core.Logging;
@@ -18,6 +19,25 @@ namespace UniGetUI.Interface.Widgets
         public TextBlock _warningBlock;
         public ProgressRing _loading;
         private bool IS_INVERTED;
+        private string _translatedText = string.Empty;
+        private string _translatedWarningText = string.Empty;
+
+        private void UpdateAutomationName()
+        {
+            string name = _translatedText;
+            if (!string.IsNullOrWhiteSpace(_translatedWarningText))
+            {
+                name = string.IsNullOrWhiteSpace(name)
+                    ? _translatedWarningText
+                    : $"{name}. {_translatedWarningText}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                AutomationProperties.SetName(_checkbox, name);
+                AutomationProperties.SetName(this, name);
+            }
+        }
 
         private SecureSettings.K setting_name = SecureSettings.K.Unset;
         public SecureSettings.K SettingName
@@ -53,15 +73,22 @@ namespace UniGetUI.Interface.Widgets
 
         public string Text
         {
-            set => _textblock.Text = CoreTools.Translate(value);
+            set
+            {
+                _translatedText = CoreTools.Translate(value);
+                _textblock.Text = _translatedText;
+                UpdateAutomationName();
+            }
         }
 
         public string WarningText
         {
             set
             {
-                _warningBlock.Text = CoreTools.Translate(value);
+                _translatedWarningText = CoreTools.Translate(value);
+                _warningBlock.Text = _translatedWarningText;
                 _warningBlock.Visibility = value.Any() ? Visibility.Visible : Visibility.Collapsed;
+                UpdateAutomationName();
             }
         }
 
@@ -107,6 +134,7 @@ namespace UniGetUI.Interface.Widgets
 
             _checkbox.HorizontalAlignment = HorizontalAlignment.Stretch;
             _checkbox.Toggled += (s, e) => _ = _checkbox_Toggled();
+            UpdateAutomationName();
         }
         protected virtual async Task _checkbox_Toggled()
         {

--- a/src/UniGetUI/Controls/SettingsWidgets/SettingsPageButton.cs
+++ b/src/UniGetUI/Controls/SettingsWidgets/SettingsPageButton.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
 
@@ -10,14 +11,35 @@ namespace UniGetUI.Interface.Widgets
 {
     public partial class SettingsPageButton : SettingsCard
     {
+        private string _headerText = string.Empty;
+        private string _descriptionText = string.Empty;
+
+        private void UpdateAutomationName()
+        {
+            string name = string.IsNullOrWhiteSpace(_descriptionText)
+                ? _headerText
+                : $"{_headerText}. {_descriptionText}";
+            AutomationProperties.SetName(this, name);
+        }
+
         public string Text
         {
-            set => Header = CoreTools.Translate(value);
+            set
+            {
+                _headerText = CoreTools.Translate(value);
+                Header = _headerText;
+                UpdateAutomationName();
+            }
         }
 
         public string UnderText
         {
-            set => Description = CoreTools.Translate(value);
+            set
+            {
+                _descriptionText = CoreTools.Translate(value);
+                Description = _descriptionText;
+                UpdateAutomationName();
+            }
         }
 
         public IconType Icon
@@ -30,6 +52,8 @@ namespace UniGetUI.Interface.Widgets
             CornerRadius = new CornerRadius(8);
             HorizontalAlignment = HorizontalAlignment.Stretch;
             IsClickEnabled = true;
+            IsTabStop = true;
+            UseSystemFocusVisuals = true;
         }
     }
 }

--- a/src/UniGetUI/Controls/SettingsWidgets/TextboxCard.cs
+++ b/src/UniGetUI/Controls/SettingsWidgets/TextboxCard.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -13,6 +14,25 @@ namespace UniGetUI.Interface.Widgets
     {
         private readonly TextBox _textbox;
         private readonly HyperlinkButton _helpbutton;
+        private string _translatedText = string.Empty;
+        private string _translatedPlaceholder = string.Empty;
+
+        private void UpdateAutomationNames()
+        {
+            string textboxName = _translatedText;
+            if (!string.IsNullOrWhiteSpace(_translatedPlaceholder))
+            {
+                textboxName = string.IsNullOrWhiteSpace(textboxName)
+                    ? _translatedPlaceholder
+                    : $"{textboxName}. {_translatedPlaceholder}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(textboxName))
+            {
+                AutomationProperties.SetName(_textbox, textboxName);
+                AutomationProperties.SetName(this, textboxName);
+            }
+        }
 
         private Settings.K setting_name = Settings.K.Unset;
         public Settings.K SettingName
@@ -26,12 +46,22 @@ namespace UniGetUI.Interface.Widgets
 
         public string Placeholder
         {
-            set => _textbox.PlaceholderText = CoreTools.Translate(value);
+            set
+            {
+                _translatedPlaceholder = CoreTools.Translate(value);
+                _textbox.PlaceholderText = _translatedPlaceholder;
+                UpdateAutomationNames();
+            }
         }
 
         public string Text
         {
-            set => Header = CoreTools.Translate(value);
+            set
+            {
+                _translatedText = CoreTools.Translate(value);
+                Header = _translatedText;
+                UpdateAutomationNames();
+            }
         }
 
         public Uri HelpUrl
@@ -41,6 +71,7 @@ namespace UniGetUI.Interface.Widgets
                 _helpbutton.NavigateUri = value;
                 _helpbutton.Visibility = Visibility.Visible;
                 _helpbutton.Content = CoreTools.Translate("More info");
+                AutomationProperties.SetName(_helpbutton, CoreTools.Translate("More info"));
             }
         }
 
@@ -68,6 +99,7 @@ namespace UniGetUI.Interface.Widgets
             s.Children.Add(_textbox);
 
             Content = s;
+            UpdateAutomationNames();
         }
 
         public void SaveValue()

--- a/src/UniGetUI/Controls/SourceManager.xaml
+++ b/src/UniGetUI/Controls/SourceManager.xaml
@@ -11,56 +11,59 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <DataTemplate x:Key="ManagerSourceTemplate" x:DataType="widgets:SourceItem">
-            <Grid ColumnSpacing="5">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="40" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="32" />
-                    <ColumnDefinition Width="90" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="130" />
-                    <ColumnDefinition Width="40" />
-                    <ColumnDefinition Width="32" />
-                </Grid.ColumnDefinitions>
-                <FontIcon
-                    Grid.Row="0"
-                    Grid.Column="0"
-                    VerticalAlignment="Center"
-                    Glyph="&#xE74C;" />
-                <TextBlock
-                    Grid.Row="0"
-                    Grid.Column="1"
-                    VerticalAlignment="Center"
-                    Text="{x:Bind Source.Name}" />
-                <HyperlinkButton
-                    Grid.Row="0"
-                    Grid.Column="2"
-                    VerticalAlignment="Center"
-                    Content="{x:Bind Source.Url}"
-                    NavigateUri="{x:Bind Source.Url}" />
-                <TextBlock
-                    Grid.Row="0"
-                    Grid.Column="3"
-                    VerticalAlignment="Center"
-                    Text="{x:Bind Source.UpdateDate}"
-                    Visibility="{x:Bind Source.Manager.Capabilities.Sources.KnowsUpdateDate}" />
-                <TextBlock
-                    Grid.Row="0"
-                    Grid.Column="4"
-                    VerticalAlignment="Center"
-                    Text="{x:Bind Source.PackageCount}"
-                    Visibility="{x:Bind Source.Manager.Capabilities.Sources.KnowsUpdateDate}" />
-                <Button
-                    Grid.Row="0"
-                    Grid.Column="5"
-                    Width="32"
-                    Height="32"
-                    Padding="0,0,0,0"
-                    Click="{x:Bind Remove}">
-                    <FontIcon FontSize="16" Glyph="&#xE74D;" />
-                </Button>
-            </Grid>
+            <ItemContainer AutomationProperties.Name="{x:Bind Source.Name}">
+                <Grid ColumnSpacing="5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="40" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="32" />
+                        <ColumnDefinition Width="90" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="130" />
+                        <ColumnDefinition Width="40" />
+                        <ColumnDefinition Width="32" />
+                    </Grid.ColumnDefinitions>
+                    <FontIcon
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Glyph="&#xE74C;" />
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="{x:Bind Source.Name}" />
+                    <HyperlinkButton
+                        Grid.Row="0"
+                        Grid.Column="2"
+                        VerticalAlignment="Center"
+                        Content="{x:Bind Source.Url}"
+                        NavigateUri="{x:Bind Source.Url}" />
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="3"
+                        VerticalAlignment="Center"
+                        Text="{x:Bind Source.UpdateDate}"
+                        Visibility="{x:Bind Source.Manager.Capabilities.Sources.KnowsUpdateDate}" />
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="4"
+                        VerticalAlignment="Center"
+                        Text="{x:Bind Source.PackageCount}"
+                        Visibility="{x:Bind Source.Manager.Capabilities.Sources.KnowsUpdateDate}" />
+                    <Button
+                        Grid.Row="0"
+                        Grid.Column="5"
+                        Width="32"
+                        Height="32"
+                        Padding="0,0,0,0"
+                        AutomationProperties.Name="{x:Bind RemoveSourceAutomationName, Mode=OneWay}"
+                        Click="{x:Bind Remove}">
+                        <FontIcon FontSize="16" Glyph="&#xE74D;" />
+                    </Button>
+                </Grid>
+            </ItemContainer>
         </DataTemplate>
     </UserControl.Resources>
 
@@ -109,6 +112,7 @@
                 Height="30"
                 Padding="0,0,0,0"
                 HorizontalAlignment="Right"
+                AutomationProperties.Name="{x:Bind ReloadSourcesAutomationName, Mode=OneWay}"
                 Click="ReloadButton_Click"
                 CornerRadius="4">
                 <FontIcon

--- a/src/UniGetUI/Controls/SourceManager.xaml.cs
+++ b/src/UniGetUI/Controls/SourceManager.xaml.cs
@@ -18,6 +18,7 @@ namespace UniGetUI.Interface.Widgets
     {
         public SourceManager Parent;
         public IManagerSource Source;
+        public string RemoveSourceAutomationName => CoreTools.Translate("Remove source");
 
         public SourceItem(SourceManager Parent, IManagerSource Source)
         {
@@ -36,6 +37,7 @@ namespace UniGetUI.Interface.Widgets
     public sealed partial class SourceManager : UserControl
     {
         private IPackageManager Manager { get; set; }
+        public string ReloadSourcesAutomationName => CoreTools.Translate("Reload sources");
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         private ObservableCollection<SourceItem> Sources = [];
 

--- a/src/UniGetUI/Pages/AboutPages/Contributors.xaml
+++ b/src/UniGetUI/Pages/AboutPages/Contributors.xaml
@@ -26,44 +26,46 @@
             <ListView ItemsSource="{x:Bind ContributorList}" SelectionMode="None">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="local:Person">
-                        <Grid
-                            Margin="0"
-                            Padding="0"
-                            ColumnSpacing="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Border
-                                Grid.Column="0"
-                                Height="32"
-                                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                                CornerRadius="16">
-                                <Image
-                                    Width="32"
+                        <ItemContainer AutomationProperties.Name="{x:Bind Name}">
+                            <Grid
+                                Margin="0"
+                                Padding="0"
+                                ColumnSpacing="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Border
+                                    Grid.Column="0"
                                     Height="32"
+                                    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                                    CornerRadius="16">
+                                    <Image
+                                        Width="32"
+                                        Height="32"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center">
+                                        <Image.Source>
+                                            <BitmapImage UriSource="{x:Bind ProfilePicture}" />
+                                        </Image.Source>
+                                    </Image>
+                                </Border>
+                                <TextBlock
+                                    Grid.Column="1"
                                     HorizontalAlignment="Left"
-                                    VerticalAlignment="Center">
-                                    <Image.Source>
-                                        <BitmapImage UriSource="{x:Bind ProfilePicture}" />
-                                    </Image.Source>
-                                </Image>
-                            </Border>
-                            <TextBlock
-                                Grid.Column="1"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Text="{x:Bind Name}" />
-                            <HyperlinkButton
-                                Grid.Column="2"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                NavigateUri="{x:Bind GitHubUrl}"
-                                Visibility="{x:Bind HasGitHubProfile}">
-                                <widgets:TranslatedTextBlock Text="View GitHub Profile" />
-                            </HyperlinkButton>
-                        </Grid>
+                                    VerticalAlignment="Center"
+                                    Text="{x:Bind Name}" />
+                                <HyperlinkButton
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    NavigateUri="{x:Bind GitHubUrl}"
+                                    Visibility="{x:Bind HasGitHubProfile}">
+                                    <widgets:TranslatedTextBlock Text="View GitHub Profile" />
+                                </HyperlinkButton>
+                            </Grid>
+                        </ItemContainer>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>

--- a/src/UniGetUI/Pages/AboutPages/SupportMe.xaml
+++ b/src/UniGetUI/Pages/AboutPages/SupportMe.xaml
@@ -28,7 +28,10 @@
             <widgets:TranslatedTextBlock Text="WingetUI is free, and it will be free forever. No ads, no credit card, no premium version. 100% free, forever." />
             <widgets:TranslatedTextBlock Text="Thank you ❤" />
             <TextBlock />
-            <HyperlinkButton HorizontalAlignment="Stretch" NavigateUri="https://ko-fi.com/martinet101">
+            <HyperlinkButton
+                HorizontalAlignment="Stretch"
+                AutomationProperties.Name="{x:Bind SupportKofiAutomationName, Mode=OneWay}"
+                NavigateUri="https://ko-fi.com/martinet101">
                 <StackPanel Orientation="Horizontal">
                     <Image Height="48" Source="https://storage.ko-fi.com/cdn/kofi3.png?v=3" />
                 </StackPanel>

--- a/src/UniGetUI/Pages/AboutPages/SupportMe.xaml.cs
+++ b/src/UniGetUI/Pages/AboutPages/SupportMe.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml.Controls;
+using UniGetUI.Core.Tools;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -10,6 +11,8 @@ namespace UniGetUI.Interface.Pages.AboutPages
     /// </summary>
     public sealed partial class SupportMe : Page
     {
+        public string SupportKofiAutomationName => CoreTools.Translate("Support the developer on Ko-fi");
+
         public SupportMe()
         {
             InitializeComponent();

--- a/src/UniGetUI/Pages/AboutPages/ThirdPartyLicenses.xaml
+++ b/src/UniGetUI/Pages/AboutPages/ThirdPartyLicenses.xaml
@@ -35,33 +35,35 @@
             <ListView ItemsSource="{x:Bind Licenses}" SelectionMode="None">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="local:LibraryLicense">
-                        <Grid
-                            Margin="0"
-                            Padding="0"
-                            ColumnSpacing="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="140" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="240" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock
-                                Grid.Column="0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Text="{x:Bind Name}" />
-                            <HyperlinkButton
-                                Grid.Column="1"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                Content="{x:Bind License}"
-                                NavigateUri="{x:Bind LicenseURL}" />
-                            <HyperlinkButton
-                                Grid.Column="2"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Center"
-                                Content="{x:Bind HomepageText}"
-                                NavigateUri="{x:Bind HomepageUrl}" />
-                        </Grid>
+                        <ItemContainer AutomationProperties.Name="{x:Bind Name}">
+                            <Grid
+                                Margin="0"
+                                Padding="0"
+                                ColumnSpacing="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="140" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="240" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock
+                                    Grid.Column="0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Text="{x:Bind Name}" />
+                                <HyperlinkButton
+                                    Grid.Column="1"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Content="{x:Bind License}"
+                                    NavigateUri="{x:Bind LicenseURL}" />
+                                <HyperlinkButton
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Content="{x:Bind HomepageText}"
+                                    NavigateUri="{x:Bind HomepageUrl}" />
+                            </Grid>
+                        </ItemContainer>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>

--- a/src/UniGetUI/Pages/AboutPages/Translators.xaml
+++ b/src/UniGetUI/Pages/AboutPages/Translators.xaml
@@ -34,50 +34,52 @@
             <ListView ItemsSource="{x:Bind TranslatorList}" SelectionMode="None">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="local:Person">
-                        <Grid
-                            Margin="0"
-                            Padding="0"
-                            ColumnSpacing="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*" />
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="2*" />
-                                <ColumnDefinition Width="67" />
-                            </Grid.ColumnDefinitions>
-                            <Border
-                                Grid.Column="1"
-                                Height="32"
-                                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                                CornerRadius="16">
-                                <Image
-                                    Width="32"
+                        <ItemContainer AutomationProperties.Name="{x:Bind Name}">
+                            <Grid
+                                Margin="0"
+                                Padding="0"
+                                ColumnSpacing="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="67" />
+                                </Grid.ColumnDefinitions>
+                                <Border
+                                    Grid.Column="1"
                                     Height="32"
+                                    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                                    CornerRadius="16">
+                                    <Image
+                                        Width="32"
+                                        Height="32"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center">
+                                        <Image.Source>
+                                            <BitmapImage UriSource="{x:Bind ProfilePicture}" />
+                                        </Image.Source>
+                                    </Image>
+                                </Border>
+                                <TextBlock
+                                    Grid.Column="0"
                                     HorizontalAlignment="Left"
-                                    VerticalAlignment="Center">
-                                    <Image.Source>
-                                        <BitmapImage UriSource="{x:Bind ProfilePicture}" />
-                                    </Image.Source>
-                                </Image>
-                            </Border>
-                            <TextBlock
-                                Grid.Column="0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Text="{x:Bind Language}" />
-                            <TextBlock
-                                Grid.Column="2"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Text="{x:Bind Name}" />
-                            <HyperlinkButton
-                                Grid.Column="3"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                NavigateUri="{x:Bind GitHubUrl}"
-                                Visibility="{x:Bind HasGitHubProfile}">
-                                <TextBlock Text="GitHub" />
-                            </HyperlinkButton>
-                        </Grid>
+                                    VerticalAlignment="Center"
+                                    Text="{x:Bind Language}" />
+                                <TextBlock
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Text="{x:Bind Name}" />
+                                <HyperlinkButton
+                                    Grid.Column="3"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    NavigateUri="{x:Bind GitHubUrl}"
+                                    Visibility="{x:Bind HasGitHubProfile}">
+                                    <TextBlock Text="GitHub" />
+                                </HyperlinkButton>
+                            </Grid>
+                        </ItemContainer>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>

--- a/src/UniGetUI/Pages/DialogPages/DesktopShortcuts.xaml
+++ b/src/UniGetUI/Pages/DialogPages/DesktopShortcuts.xaml
@@ -133,7 +133,7 @@
             </ItemsView.Layout>
             <ItemsView.ItemTemplate>
                 <DataTemplate x:DataType="local:ShortcutEntry">
-                    <ItemContainer>
+                    <ItemContainer AutomationProperties.Name="{x:Bind Name}">
                         <Grid Margin="8,0" ColumnSpacing="4">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
@@ -152,6 +152,7 @@
                                 <CheckBox
                                     MaxWidth="10"
                                     Margin="0,8,0,0"
+                                    AutomationProperties.Name="{x:Bind DeleteShortcutAutomationName, Mode=OneWay}"
                                     IsChecked="{x:Bind IsDeletable, Mode=TwoWay}" />
                             </Border>
                             <widgets:TranslatedTextBlock
@@ -185,6 +186,7 @@
                                 Width="32"
                                 Height="32"
                                 Padding="0"
+                                AutomationProperties.Name="{x:Bind OpenShortcutLocationAutomationName, Mode=OneWay}"
                                 Click="{x:Bind OpenShortcutPath}"
                                 IsEnabled="{x:Bind ExistsOnDisk}">
                                 <widgets:LocalIcon
@@ -197,6 +199,7 @@
                                 Width="32"
                                 Height="32"
                                 Padding="0"
+                                AutomationProperties.Name="{x:Bind RemoveShortcutFromListAutomationName, Mode=OneWay}"
                                 Click="{x:Bind ResetShortcut}">
                                 <FontIcon FontSize="16" Glyph="&#xE74D;" />
                             </Button>

--- a/src/UniGetUI/Pages/DialogPages/DesktopShortcuts.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/DesktopShortcuts.xaml.cs
@@ -152,6 +152,12 @@ namespace UniGetUI.Interface
             get => File.Exists(Path);
         }
 
+        public string OpenShortcutLocationAutomationName => CoreTools.Translate("Open shortcut location");
+
+        public string RemoveShortcutFromListAutomationName => CoreTools.Translate("Remove shortcut from this list");
+
+        public string DeleteShortcutAutomationName => CoreTools.Translate("Delete shortcut {0}", Name);
+
         public ShortcutEntry(string path, bool isDeletable)
         {
             Path = path;

--- a/src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml
+++ b/src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml
@@ -87,7 +87,7 @@
             </ItemsView.Layout>
             <ItemsView.ItemTemplate>
                 <DataTemplate x:DataType="local:IgnoredPackageEntry">
-                    <ItemContainer>
+                    <ItemContainer AutomationProperties.Name="{x:Bind Name}">
                         <Grid Padding="8,0" ColumnSpacing="4">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
@@ -157,6 +157,7 @@
                                 Width="32"
                                 Height="32"
                                 Padding="0"
+                                AutomationProperties.Name="{x:Bind StopIgnoringUpdatesAutomationName, Mode=OneWay}"
                                 Click="{x:Bind RemoveFromIgnoredUpdates}">
                                 <FontIcon FontSize="16" Glyph="&#xE74D;" />
                             </Button>

--- a/src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml.cs
@@ -91,6 +91,7 @@ namespace UniGetUI.Interface
         public string Version { get; }
         public string NewVersion { get; }
         public IPackageManager Manager { get; }
+        public string StopIgnoringUpdatesAutomationName => CoreTools.Translate("Stop ignoring updates for this package");
         private ObservableCollection<IgnoredPackageEntry> List { get; }
         public IgnoredPackageEntry(string id, string version, IPackageManager manager, ObservableCollection<IgnoredPackageEntry> list)
         {

--- a/src/UniGetUI/Pages/DialogPages/InstallOptions_Manager.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/InstallOptions_Manager.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.Language;
 using UniGetUI.Core.SettingsEngine.SecureSettings;
@@ -23,11 +24,22 @@ public sealed partial class InstallOptions_Manager : UserControl
     {
         Manager = manager;
         InitializeComponent();
-        AdminCheckBox.Content = CoreTools.Translate("Run as admin");
-        InteractiveCheckBox.Content = CoreTools.Translate("Interactive installation");
-        HashCheckBox.Content = CoreTools.Translate("Skip hash check");
-        UninstallPreviousVerOnUpdate.Content = CoreTools.Translate("Uninstall previous versions when updated");
-        PreReleaseCheckBox.Content = CoreTools.Translate("Allow pre-release versions");
+        string runAsAdminText = CoreTools.Translate("Run as admin");
+        string interactiveInstallText = CoreTools.Translate("Interactive installation");
+        string skipHashText = CoreTools.Translate("Skip hash check");
+        string uninstallPreviousText = CoreTools.Translate("Uninstall previous versions when updated");
+        string allowPreReleaseText = CoreTools.Translate("Allow pre-release versions");
+
+        AdminCheckBox.Content = runAsAdminText;
+        AutomationProperties.SetName(AdminCheckBox, runAsAdminText);
+        InteractiveCheckBox.Content = interactiveInstallText;
+        AutomationProperties.SetName(InteractiveCheckBox, interactiveInstallText);
+        HashCheckBox.Content = skipHashText;
+        AutomationProperties.SetName(HashCheckBox, skipHashText);
+        UninstallPreviousVerOnUpdate.Content = uninstallPreviousText;
+        AutomationProperties.SetName(UninstallPreviousVerOnUpdate, uninstallPreviousText);
+        PreReleaseCheckBox.Content = allowPreReleaseText;
+        AutomationProperties.SetName(PreReleaseCheckBox, allowPreReleaseText);
         ArchLabel.Text = CoreTools.Translate("Architecture to install:");
         ScopeLabel.Text = CoreTools.Translate("Installation scope:");
         LocationLabel.Text = CoreTools.Translate("Install location:");

--- a/src/UniGetUI/Pages/DialogPages/InstallOptions_Package.xaml
+++ b/src/UniGetUI/Pages/DialogPages/InstallOptions_Package.xaml
@@ -15,7 +15,9 @@
     mc:Ignorable="d">
     <Page.Resources>
         <DataTemplate x:Key="ProcessTemplate" x:DataType="local:IOP_Proc">
-            <StackPanel Orientation="Horizontal">
+            <StackPanel
+                Orientation="Horizontal"
+                AutomationProperties.Name="{x:Bind Name}">
                 <Viewbox Width="16">
                     <FontIcon Glyph="&#xECAA;" />
                 </Viewbox>

--- a/src/UniGetUI/Pages/DialogPages/OperationFailedDialog.xaml
+++ b/src/UniGetUI/Pages/DialogPages/OperationFailedDialog.xaml
@@ -22,14 +22,19 @@
             Grid.Row="0"
             TextWrapping="WrapWholeWords" />
         <ScrollViewer
+            Name="CommandLineOutputScrollViewer"
             Grid.Row="1"
             Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
             CornerRadius="6"
-            HorizontalScrollMode="Disabled">
+            HorizontalScrollMode="Disabled"
+            IsTabStop="True"
+            AutomationProperties.Name="Command-line output">
             <RichTextBlock
                 Name="CommandLineOutput"
                 Padding="6"
                 FontFamily="Consolas"
+                IsTextSelectionEnabled="True"
+                AutomationProperties.Name="Command-line output text"
                 TextWrapping="Wrap" />
         </ScrollViewer>
         <widgets:DialogCloseButton Margin="0,-64,-24,0" Click="CloseButton_Click" />

--- a/src/UniGetUI/Pages/DialogPages/OperationLiveLogPage.xaml
+++ b/src/UniGetUI/Pages/DialogPages/OperationLiveLogPage.xaml
@@ -22,12 +22,16 @@
             Grid.Column="0"
             x:FieldModifier="public"
             Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-            CornerRadius="6">
+            CornerRadius="6"
+            IsTabStop="True"
+            AutomationProperties.Name="Operation live log output">
             <RichTextBlock
                 Name="TextBlock"
                 Margin="8"
                 x:FieldModifier="public"
                 FontFamily="Consolas"
+                IsTextSelectionEnabled="True"
+                AutomationProperties.Name="Operation live log text"
                 TextWrapping="Wrap" />
         </ScrollViewer>
         <widgets:DialogCloseButton

--- a/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml
+++ b/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml
@@ -85,6 +85,7 @@
                                     Margin="2"
                                     Padding="8,2,8,2"
                                     VerticalAlignment="Center"
+                                    AutomationProperties.Name="{x:Bind Text}"
                                     Background="{ThemeResource AccentAAFillColorDefaultBrush}"
                                     CornerRadius="12">
                                     <TextBlock Foreground="{ThemeResource TextOnAccentAAFillColorPrimary}" Text="{x:Bind Text}" />
@@ -188,6 +189,7 @@
                             Height="40"
                             Margin="1,0,0,0"
                             Padding="0,0,2,0"
+                            AutomationProperties.Name="{x:Bind MorePackageActionsAutomationName, Mode=OneWay}"
                             CornerRadius="0,8,8,0"
                             Style="{StaticResource AccentButtonStyle}">
                             <DropDownButton.Content>

--- a/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml.cs
@@ -31,6 +31,7 @@ namespace UniGetUI.Interface.Dialogs
         public IPackage? AvailablePackage;
         public IPackage? UpgradablePackage;
         public IPackage? InstalledPackage;
+        public string MorePackageActionsAutomationName => CoreTools.Translate("More package actions");
 
         private readonly InstallOptionsPage InstallOptionsPage;
         public event EventHandler? Close;

--- a/src/UniGetUI/Pages/HelpPage.xaml
+++ b/src/UniGetUI/Pages/HelpPage.xaml
@@ -50,6 +50,7 @@
                 Width="35"
                 Height="35"
                 Padding="5"
+                AutomationProperties.Name="{x:Bind HelpBackAutomationName, Mode=OneWay}"
                 Click="BackButton_Click"
                 CornerRadius="4,0,0,4">
                 <FontIcon FontSize="20" Glyph="&#xE76B;" />
@@ -60,6 +61,7 @@
                 Width="35"
                 Height="35"
                 Padding="5"
+                AutomationProperties.Name="{x:Bind HelpForwardAutomationName, Mode=OneWay}"
                 Click="RightButton_Click"
                 CornerRadius="0">
                 <FontIcon FontSize="20" Glyph="&#xE76C;" />
@@ -70,6 +72,7 @@
                 Width="35"
                 Height="35"
                 Padding="5"
+                AutomationProperties.Name="{x:Bind HelpHomeAutomationName, Mode=OneWay}"
                 Click="HomeButton_Click"
                 CornerRadius="0">
                 <FontIcon FontSize="16" Glyph="&#xE80F;" />
@@ -80,6 +83,7 @@
                 Width="35"
                 Height="35"
                 Padding="5"
+                AutomationProperties.Name="{x:Bind HelpReloadAutomationName, Mode=OneWay}"
                 Click="ReloadButton_Click"
                 CornerRadius="0,4,4,0">
                 <FontIcon FontSize="16" Glyph="&#xE72C;" />

--- a/src/UniGetUI/Pages/HelpPage.xaml.cs
+++ b/src/UniGetUI/Pages/HelpPage.xaml.cs
@@ -17,6 +17,10 @@ namespace UniGetUI.Interface.Dialogs
         private bool Initialized;
         private WebView2? webView;
         private Uri? lastUri;
+        public string HelpBackAutomationName => CoreTools.Translate("Go back");
+        public string HelpForwardAutomationName => CoreTools.Translate("Go forward");
+        public string HelpHomeAutomationName => CoreTools.Translate("Go to help home");
+        public string HelpReloadAutomationName => CoreTools.Translate("Reload page");
 
         public HelpPage()
         {

--- a/src/UniGetUI/Pages/MainView.xaml
+++ b/src/UniGetUI/Pages/MainView.xaml
@@ -375,6 +375,7 @@
                 Height="12"
                 Margin="1,0,1,0"
                 Padding="0,0,0,0"
+                AutomationProperties.Name="{x:Bind ResizeOperationsAreaAutomationName, Mode=OneWay}"
                 CornerRadius="4"
                 Orientation="Horizontal" />
             <Grid Grid.Row="1" Grid.Column="0">

--- a/src/UniGetUI/Pages/MainView.xaml
+++ b/src/UniGetUI/Pages/MainView.xaml
@@ -95,6 +95,7 @@
                     Height="32"
                     Margin="6,0,0,0"
                     Padding="0"
+                    AutomationProperties.Name="{x:Bind Tooltip, Mode=OneWay}"
                     CornerRadius="6"
                     ToolTipService.ToolTip="{x:Bind Tooltip}">
                     <widgets:LocalIcon Icon="{x:Bind Icon}" />
@@ -224,6 +225,7 @@
                             Padding="0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Center"
+                            AutomationProperties.Name="{x:Bind OperationOptionsAutomationName, Mode=OneWay}"
                             BorderThickness="0"
                             CornerRadius="0,6,6,0"
                             Flyout="{x:Bind OpMenu}"
@@ -387,6 +389,7 @@
                     Grid.Column="1"
                     Height="12"
                     Padding="12,0,12,0"
+                    AutomationProperties.Name="{x:Bind ExpandCollapseOperationsAutomationName, Mode=OneWay}"
                     Click="ExpandCollapseOpList_Click"
                     CornerRadius="4"
                     Foreground="{ThemeResource ScrollBarButtonPointerOverBackgroundThemeBrush}">
@@ -397,6 +400,7 @@
                     Grid.Column="2"
                     Height="12"
                     Padding="12,0,12,0"
+                    AutomationProperties.Name="{x:Bind OperationsListActionsAutomationName, Mode=OneWay}"
                     Click="OperationSplitterMenuButton_Click"
                     CornerRadius="4"
                     Foreground="{ThemeResource ScrollBarButtonPointerOverBackgroundThemeBrush}">
@@ -408,6 +412,7 @@
                 Grid.Row="2"
                 Grid.Column="0"
                 x:FieldModifier="public"
+                AutomationProperties.Name="{x:Bind OperationsListAutomationName, Mode=OneWay}"
                 ItemTemplate="{StaticResource OperationTemplate}"
                 SelectionMode="None"
                 SizeChanged="OperationScrollView_SizeChanged">

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -57,6 +57,9 @@ namespace UniGetUI.Interface
         private PageType OldPage_t = PageType.Null;
         private PageType CurrentPage_t = PageType.Null;
         private List<PageType> NavigationHistory = new();
+        public string ExpandCollapseOperationsAutomationName => CoreTools.Translate("Expand or collapse operations list");
+        public string OperationsListActionsAutomationName => CoreTools.Translate("Operation list actions");
+        public string OperationsListAutomationName => CoreTools.Translate("Operations list");
 
         AutoSuggestBox MainTextBlock;
         public event EventHandler<bool>? CanGoBackChanged;

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -60,6 +60,7 @@ namespace UniGetUI.Interface
         public string ExpandCollapseOperationsAutomationName => CoreTools.Translate("Expand or collapse operations list");
         public string OperationsListActionsAutomationName => CoreTools.Translate("Operation list actions");
         public string OperationsListAutomationName => CoreTools.Translate("Operations list");
+        public string ResizeOperationsAreaAutomationName => CoreTools.Translate("Resize operations area");
 
         AutoSuggestBox MainTextBlock;
         public event EventHandler<bool>? CanGoBackChanged;

--- a/src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml
+++ b/src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml
@@ -184,8 +184,14 @@
                 <Toolkit:SettingsCard.Description>
                     <StackPanel Orientation="Horizontal" Spacing="5">
                         <TextBlock Name="BackupDirectoryLabel" VerticalAlignment="Center" />
-                        <HyperlinkButton Name="ResetBackupDirectory" Click="ResetBackupPath_Click" />
-                        <HyperlinkButton Name="OpenBackupDirectory" Click="OpenBackupPath_Click" />
+                        <HyperlinkButton
+                            Name="ResetBackupDirectory"
+                            AutomationProperties.Name="{x:Bind ResetBackupDirectoryAutomationName, Mode=OneWay}"
+                            Click="ResetBackupPath_Click" />
+                        <HyperlinkButton
+                            Name="OpenBackupDirectory"
+                            AutomationProperties.Name="{x:Bind OpenBackupDirectoryAutomationName, Mode=OneWay}"
+                            Click="OpenBackupPath_Click" />
                     </StackPanel>
                 </Toolkit:SettingsCard.Description>
             </widgets:ButtonCard>

--- a/src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml.cs
@@ -28,6 +28,9 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
         private readonly GitHubBackupService _backupService;
         private bool _isLoggedIn;
         private bool _isLoading;
+        public string ResetBackupDirectoryAutomationName => CoreTools.Translate("Reset backup directory");
+        public string OpenBackupDirectoryAutomationName => CoreTools.Translate("Open backup directory");
+
         public Backup()
         {
             this.InitializeComponent();

--- a/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml
+++ b/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml
@@ -57,6 +57,7 @@
                 Width="40"
                 Height="40"
                 Padding="6"
+                AutomationProperties.Name="{x:Bind BackAutomationName, Mode=OneWay}"
                 VerticalAlignment="Center"
                 Background="Transparent"
                 BorderThickness="0">

--- a/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml.cs
@@ -19,6 +19,8 @@ namespace UniGetUI.Pages.SettingsPages
     public sealed partial class SettingsBasePage : Page, IEnterLeaveListener, IInnerNavigationPage
     {
         bool IsManagers;
+        public string BackAutomationName => CoreTools.Translate("Back");
+
         public SettingsBasePage(bool isManagers)
         {
             IsManagers = isManagers;

--- a/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml.cs
@@ -1,12 +1,21 @@
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using UniGetUI.Core.Tools;
 using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Input;
+using CommunityToolkit.WinUI.Controls;
 using UniGetUI.PackageEngine.ManagerClasses.Manager;
 using UniGetUI.Pages.SettingsPages.GeneralPages;
 using UniGetUI.Interface.Pages;
 using UniGetUI.PackageEngine.Interfaces;
+using Windows.System;
+using Windows.UI.Core;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -25,6 +34,9 @@ namespace UniGetUI.Pages.SettingsPages
         {
             IsManagers = isManagers;
             this.InitializeComponent();
+            MainNavigationFrame.IsTabStop = false;
+            MainNavigationFrame.TabFocusNavigation = KeyboardNavigationMode.Local;
+            BackButton.PreviewKeyDown += BackButton_PreviewKeyDown;
             BackButton.Click += (_, _) =>
             {
                 if (MainNavigationFrame.Content is ManagersHomepage or SettingsHomepage) MainApp.Instance.MainWindow.GoBack();
@@ -67,6 +79,288 @@ namespace UniGetUI.Pages.SettingsPages
             page.NavigationRequested += Page_NavigationRequested;
             page.RestartRequired += Page_RestartRequired;
             if (page is PackageManagerPage pmpage) pmpage.ReapplyProperties += SettingsBasePage_ReapplyProperties;
+
+            if (e.Content is FrameworkElement root)
+            {
+                DispatcherQueue.TryEnqueue(() => ApplyAccessibilityMetadata(root));
+            }
+        }
+
+        private static void ApplyAccessibilityMetadata(FrameworkElement root)
+        {
+            root.TabFocusNavigation = KeyboardNavigationMode.Local;
+            ApplyAccessibilityMetadataToNode(root);
+        }
+
+        private static void ApplyAccessibilityMetadataToNode(DependencyObject node)
+        {
+            if (node is ScrollViewer scroller)
+            {
+                EnsureScrollViewerAccessibility(scroller);
+            }
+
+            if (node is SettingsCard card)
+            {
+                EnsureSettingsCardAccessibility(card);
+            }
+
+            if (node is ToggleSwitch toggle)
+            {
+                EnsureToggleSwitchAccessibility(toggle);
+            }
+
+            if (node is ButtonBase button)
+            {
+                EnsureButtonAccessibility(button);
+            }
+
+            int childCount = VisualTreeHelper.GetChildrenCount(node);
+            for (int i = 0; i < childCount; i++)
+            {
+                ApplyAccessibilityMetadataToNode(VisualTreeHelper.GetChild(node, i));
+            }
+        }
+
+        private static void EnsureScrollViewerAccessibility(ScrollViewer scroller)
+        {
+            scroller.IsTabStop = false;
+            scroller.TabFocusNavigation = KeyboardNavigationMode.Local;
+        }
+
+        private void BackButton_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (e.Key != VirtualKey.Tab)
+            {
+                return;
+            }
+
+            bool isShiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            if (isShiftPressed)
+            {
+                return;
+            }
+
+            if (TryFocusMainContent())
+            {
+                e.Handled = true;
+            }
+        }
+
+        private bool TryFocusMainContent()
+        {
+            if (MainNavigationFrame.Content is not FrameworkElement root)
+            {
+                return false;
+            }
+
+            FrameworkElement? target = FindFirstFocusableMainContentElement(root, allowHyperlinks: false)
+                ?? FindFirstFocusableMainContentElement(root, allowHyperlinks: true);
+            return target?.Focus(FocusState.Programmatic) ?? false;
+        }
+
+        private static FrameworkElement? FindFirstFocusableMainContentElement(DependencyObject node, bool allowHyperlinks)
+        {
+            if (node is SettingsCard card && card.IsClickEnabled && IsFocusable(card, allowHyperlinks))
+            {
+                return card;
+            }
+
+            if (node is FrameworkElement element && IsFocusable(element, allowHyperlinks))
+            {
+                return element;
+            }
+
+            int childCount = VisualTreeHelper.GetChildrenCount(node);
+            for (int i = 0; i < childCount; i++)
+            {
+                FrameworkElement? candidate = FindFirstFocusableMainContentElement(VisualTreeHelper.GetChild(node, i), allowHyperlinks);
+                if (candidate is not null)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsFocusable(FrameworkElement element, bool allowHyperlinks)
+        {
+            if (element is not (SettingsCard or ButtonBase or ToggleSwitch or ComboBox or TextBox or PasswordBox or CheckBox or RadioButton))
+            {
+                return false;
+            }
+
+            if (!allowHyperlinks && element is HyperlinkButton)
+            {
+                return false;
+            }
+
+            if (element is not Control control)
+            {
+                return false;
+            }
+
+            return control.IsEnabled && control.IsTabStop && control.Visibility == Visibility.Visible;
+        }
+
+        private static void EnsureSettingsCardAccessibility(SettingsCard card)
+        {
+            string headerText = ExtractTextFromObject(card.Header);
+            string descriptionText = ExtractTextFromObject(card.Description);
+            string cardName = BuildCombinedText(headerText, descriptionText);
+            if (!string.IsNullOrWhiteSpace(cardName) && string.IsNullOrWhiteSpace(AutomationProperties.GetName(card)))
+            {
+                AutomationProperties.SetName(card, cardName);
+            }
+
+            if (card.IsClickEnabled)
+            {
+                card.IsTabStop = true;
+                card.UseSystemFocusVisuals = true;
+            }
+        }
+
+        private static void EnsureToggleSwitchAccessibility(ToggleSwitch toggle)
+        {
+            string currentName = (AutomationProperties.GetName(toggle) ?? string.Empty).Trim();
+            if (!NeedsContextualName(currentName, toggle.OnContent, toggle.OffContent))
+            {
+                return;
+            }
+
+            string fallbackName = FindAncestorSettingsCardName(toggle);
+            if (!string.IsNullOrWhiteSpace(fallbackName))
+            {
+                AutomationProperties.SetName(toggle, fallbackName);
+            }
+        }
+
+        private static void EnsureButtonAccessibility(ButtonBase button)
+        {
+            string currentName = (AutomationProperties.GetName(button) ?? string.Empty).Trim();
+            if (!NeedsContextualName(currentName))
+            {
+                return;
+            }
+
+            string name = ExtractTextFromObject(button.Content);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = ExtractTextFromObject(ToolTipService.GetToolTip(button));
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = FindAncestorSettingsCardName(button);
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                AutomationProperties.SetName(button, name);
+            }
+        }
+
+        private static bool NeedsContextualName(string currentName, params object?[] alternatives)
+        {
+            if (string.IsNullOrWhiteSpace(currentName))
+            {
+                return true;
+            }
+
+            foreach (object? alternative in alternatives)
+            {
+                string alternativeText = ExtractTextFromObject(alternative);
+                if (!string.IsNullOrWhiteSpace(alternativeText)
+                    && string.Equals(currentName, alternativeText, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            if (currentName.StartsWith("ms-resource://", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            string translatedEnabled = CoreTools.Translate("Enabled");
+            string translatedDisabled = CoreTools.Translate("Disabled");
+            string[] genericNames =
+            [
+                "button",
+                "on",
+                "off",
+                "enabled",
+                "disabled",
+                translatedEnabled,
+                translatedDisabled
+            ];
+
+            return genericNames
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Any(name => string.Equals(currentName, name.Trim(), StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string FindAncestorSettingsCardName(DependencyObject node)
+        {
+            for (DependencyObject? current = VisualTreeHelper.GetParent(node); current is not null; current = VisualTreeHelper.GetParent(current))
+            {
+                if (current is not SettingsCard card)
+                {
+                    continue;
+                }
+
+                EnsureSettingsCardAccessibility(card);
+                string name = AutomationProperties.GetName(card);
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    return name;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static string ExtractTextFromObject(object? value)
+        {
+            return value switch
+            {
+                string s => s.Trim(),
+                TextBlock textBlock => textBlock.Text.Trim(),
+                Run run => run.Text.Trim(),
+                FrameworkElement element => ExtractTextFromElement(element),
+                _ => string.Empty
+            };
+        }
+
+        private static string ExtractTextFromElement(FrameworkElement element)
+        {
+            List<string> parts = [];
+            CollectTextParts(element, parts);
+            return BuildCombinedText(parts.ToArray());
+        }
+
+        private static void CollectTextParts(DependencyObject node, List<string> parts)
+        {
+            switch (node)
+            {
+                case TextBlock textBlock when !string.IsNullOrWhiteSpace(textBlock.Text):
+                    parts.Add(textBlock.Text.Trim());
+                    break;
+                case Run run when !string.IsNullOrWhiteSpace(run.Text):
+                    parts.Add(run.Text.Trim());
+                    break;
+            }
+
+            int childCount = VisualTreeHelper.GetChildrenCount(node);
+            for (int i = 0; i < childCount; i++)
+            {
+                CollectTextParts(VisualTreeHelper.GetChild(node, i), parts);
+            }
+        }
+
+        private static string BuildCombinedText(params string[] parts)
+        {
+            return string.Join(". ", parts.Where(p => !string.IsNullOrWhiteSpace(p)).Select(p => p.Trim()).Distinct());
         }
 
         private void SettingsBasePage_ReapplyProperties(object? sender, EventArgs e)

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
@@ -629,6 +629,7 @@
                         Margin="1,4"
                         Padding="8,4"
                         x:FieldModifier="protected"
+                        AutomationProperties.Name="{x:Bind ToggleFiltersAutomationName, Mode=OneWay}"
                         Background="Transparent"
                         BorderThickness="0"
                         Click="ToggleFiltersButton_Click"
@@ -662,6 +663,7 @@
                         Height="36"
                         Margin="0,0,1,0"
                         x:FieldModifier="protected"
+                        AutomationProperties.Name="{x:Bind MainSelectionActionAutomationName, Mode=OneWay}"
                         BorderThickness="0"
                         CornerRadius="4,0,0,4">
                         <StackPanel
@@ -793,6 +795,7 @@
                                             Padding="2"
                                             HorizontalAlignment="Stretch"
                                             HorizontalContentAlignment="Center"
+                                            AutomationProperties.Name="{x:Bind SelectAllSourcesAutomationName, Mode=OneWay}"
                                             Click="SelectAllSourcesButton_Click">
                                             <widgets:TranslatedTextBlock
                                                 FontSize="12"
@@ -805,6 +808,7 @@
                                             Padding="2"
                                             HorizontalAlignment="Stretch"
                                             HorizontalContentAlignment="Center"
+                                            AutomationProperties.Name="{x:Bind ClearSourceSelectionAutomationName, Mode=OneWay}"
                                             Click="ClearSourceSelectionButton_Click">
                                             <widgets:TranslatedTextBlock
                                                 FontSize="12"
@@ -853,6 +857,7 @@
                                     <CheckBox
                                         x:Name="InstantSearchCheckbox"
                                         x:FieldModifier="protected"
+                                        AutomationProperties.Name="{x:Bind InstantSearchAutomationName, Mode=OneWay}"
                                         Checked="InstantSearchValueChanged"
                                         Unchecked="InstantSearchValueChanged">
                                         <CheckBox.Content>
@@ -861,6 +866,7 @@
                                     </CheckBox>
                                     <CheckBox
                                         x:Name="UpperLowerCaseCheckbox"
+                                        AutomationProperties.Name="{x:Bind DistinguishUpperLowerCaseAutomationName, Mode=OneWay}"
                                         Checked="FilterOptionsChanged"
                                         Unchecked="FilterOptionsChanged">
                                         <CheckBox.Content>
@@ -869,6 +875,7 @@
                                     </CheckBox>
                                     <CheckBox
                                         x:Name="IgnoreSpecialCharsCheckbox"
+                                        AutomationProperties.Name="{x:Bind IgnoreSpecialCharactersAutomationName, Mode=OneWay}"
                                         Checked="FilterOptionsChanged"
                                         IsChecked="True"
                                         Unchecked="FilterOptionsChanged">
@@ -908,12 +915,14 @@
                                         Name="QueryOptionsGroup"
                                         Margin="0,-4,0,6"
                                         x:FieldModifier="protected"
+                                        AutomationProperties.Name="{x:Bind SearchModeOptionsAutomationName, Mode=OneWay}"
                                         CharacterSpacing="0"
                                         SelectionChanged="FilterOptionsChanged">
                                         <RadioButton
                                             x:Name="QueryNameRadio"
                                             Height="30"
                                             Margin="0,-2,0,-2"
+                                            AutomationProperties.Name="{x:Bind SearchModeByNameAutomationName, Mode=OneWay}"
                                             x:FieldModifier="protected">
                                             <RadioButton.Content>
                                                 <widgets:TranslatedTextBlock Text="Package Name" WrappingMode="Wrap" />
@@ -923,6 +932,7 @@
                                             x:Name="QueryIdRadio"
                                             Height="30"
                                             Margin="0,-2,0,-2"
+                                            AutomationProperties.Name="{x:Bind SearchModeByIdAutomationName, Mode=OneWay}"
                                             x:FieldModifier="protected">
                                             <RadioButton.Content>
                                                 <widgets:TranslatedTextBlock Text="Package ID" WrappingMode="Wrap" />
@@ -932,6 +942,7 @@
                                             x:Name="QueryBothRadio"
                                             Height="30"
                                             Margin="0,-2,0,-2"
+                                            AutomationProperties.Name="{x:Bind SearchModeByBothAutomationName, Mode=OneWay}"
                                             x:FieldModifier="protected"
                                             IsChecked="True">
                                             <RadioButton.Content>
@@ -942,6 +953,7 @@
                                             x:Name="QueryExactMatch"
                                             Height="30"
                                             Margin="0,-2,0,-2"
+                                            AutomationProperties.Name="{x:Bind SearchModeExactMatchAutomationName, Mode=OneWay}"
                                             x:FieldModifier="protected">
                                             <RadioButton.Content>
                                                 <widgets:TranslatedTextBlock Text="Exact match" WrappingMode="Wrap" />
@@ -951,6 +963,7 @@
                                             x:Name="QuerySimilarResultsRadio"
                                             Height="30"
                                             Margin="0,-2,0,-2"
+                                            AutomationProperties.Name="{x:Bind SearchModeSimilarResultsAutomationName, Mode=OneWay}"
                                             x:FieldModifier="protected">
                                             <RadioButton.Content>
                                                 <widgets:TranslatedTextBlock Text="Show similar packages" WrappingMode="Wrap" />

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
@@ -55,6 +55,7 @@
                     <CheckBox
                         Grid.Row="0"
                         Grid.Column="0"
+                        AutomationProperties.Name="{x:Bind SelectPackageAutomationName, Mode=OneWay}"
                         VerticalAlignment="Center"
                         IsChecked="{x:Bind IsChecked, Mode=TwoWay}" />
 
@@ -273,6 +274,7 @@
                         Grid.Column="2"
                         Margin="1,-4,0,0"
                         HorizontalAlignment="Left"
+                        AutomationProperties.Name="{x:Bind SelectPackageAutomationName, Mode=OneWay}"
                         VerticalAlignment="Top"
                         IsChecked="{x:Bind IsChecked, Mode=TwoWay}" />
 
@@ -282,6 +284,7 @@
                         Height="22"
                         Padding="0"
                         VerticalAlignment="Bottom"
+                        AutomationProperties.Name="{x:Bind PackageOptionsAutomationName, Mode=OneWay}"
                         Background="Transparent"
                         BorderThickness="0"
                         Click="{x:Bind RightClick}"
@@ -396,6 +399,7 @@
                         Grid.Row="0"
                         Margin="1,-4,0,0"
                         HorizontalAlignment="Left"
+                        AutomationProperties.Name="{x:Bind SelectPackageAutomationName, Mode=OneWay}"
                         VerticalAlignment="Top"
                         IsChecked="{x:Bind IsChecked, Mode=TwoWay}" />
                     <Button
@@ -405,6 +409,7 @@
                         Padding="0"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
+                        AutomationProperties.Name="{x:Bind PackageOptionsAutomationName, Mode=OneWay}"
                         Background="Transparent"
                         BorderThickness="0"
                         Click="{x:Bind RightClick}"
@@ -542,7 +547,9 @@
                     Orientation="Horizontal"
                     Spacing="4">
                     <widgets:TranslatedTextBlock VerticalAlignment="Center" Text="Order by:" />
-                    <DropDownButton x:Name="OrderByButton">
+                    <DropDownButton
+                        x:Name="OrderByButton"
+                        AutomationProperties.Name="{x:Bind OrderByAutomationName, Mode=OneWay}">
                         <DropDownButton.Flyout>
                             <widgets:BetterMenu Placement="Bottom">
                                 <widgets:BetterToggleMenuItem x:Name="OrderByName_Menu" Text="Name" />
@@ -571,6 +578,7 @@
                     <widgets:TranslatedTextBlock VerticalAlignment="Center" Text="View mode:" />
                     <Toolkit:Segmented
                         x:Name="ViewModeSelector"
+                        AutomationProperties.Name="{x:Bind ViewModeAutomationName, Mode=OneWay}"
                         SelectionChanged="ViewModeSelector_SelectionChanged"
                         SelectionMode="Single">
                         <Toolkit:SegmentedItem x:Name="Selector_List">
@@ -593,6 +601,7 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
                     x:FieldModifier="protected"
+                    AutomationProperties.Name="{x:Bind ReloadPackagesAutomationName, Mode=OneWay}"
                     AutomationProperties.HelpText="Reload packages"
                     CornerRadius="4">
                     <FontIcon FontSize="16" Glyph="&#xE72C;" />
@@ -677,6 +686,7 @@
                         Height="36"
                         Padding="4"
                         x:FieldModifier="protected"
+                        AutomationProperties.Name="{x:Bind MoreToolbarActionsAutomationName, Mode=OneWay}"
                         BorderThickness="0"
                         CornerRadius="0,4,4,0">
                         <FontIcon FontSize="14" Glyph="&#xE70D;" />
@@ -736,7 +746,7 @@
                             Padding="4,4,4,8"
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Stretch"
-                            AutomationProperties.Name="Filter by sources"
+                            AutomationProperties.Name="{x:Bind FilterBySourcesAutomationName, Mode=OneWay}"
                             Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
                             CornerRadius="8"
                             IsExpanded="True">
@@ -822,7 +832,7 @@
                             Padding="16,8,16,8"
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Stretch"
-                            AutomationProperties.Name="Filter options"
+                            AutomationProperties.Name="{x:Bind FilterOptionsAutomationName, Mode=OneWay}"
                             Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
                             CornerRadius="8"
                             IsExpanded="False">
@@ -876,7 +886,7 @@
                             Padding="16,8,16,8"
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Stretch"
-                            AutomationProperties.Name="Search mode"
+                            AutomationProperties.Name="{x:Bind SearchModeAutomationName, Mode=OneWay}"
                             Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
                             CornerRadius="8"
                             IsExpanded="True">
@@ -1004,11 +1014,13 @@
                             Grid.ColumnSpan="3"
                             Padding="0"
                             HorizontalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Bind SelectAllPackagesAutomationName, Mode=OneWay}"
                             BorderThickness="0"
                             CornerRadius="4,0,0,4">
                             <CheckBox
                                 Name="SelectAllCheckBox"
                                 Margin="12,4,4,4"
+                                AutomationProperties.Name="{x:Bind SelectAllPackagesAutomationName, Mode=OneWay}"
                                 Checked="SelectAllCheckBox_ValueChanged"
                                 Unchecked="SelectAllCheckBox_ValueChanged" />
                         </Button>
@@ -1018,6 +1030,7 @@
                             Grid.ColumnSpan="1"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Bind SortByPackageNameAutomationName, Mode=OneWay}"
                             BorderThickness="0"
                             CornerRadius="0" />
                         <Button
@@ -1026,6 +1039,7 @@
                             Grid.ColumnSpan="2"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Bind SortByPackageIdAutomationName, Mode=OneWay}"
                             BorderThickness="0"
                             CornerRadius="0" />
                         <Button
@@ -1034,6 +1048,7 @@
                             Grid.ColumnSpan="2"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Bind SortByVersionAutomationName, Mode=OneWay}"
                             BorderThickness="0"
                             CornerRadius="0" />
                         <Button
@@ -1042,6 +1057,7 @@
                             Grid.ColumnSpan="2"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Bind SortByNewVersionAutomationName, Mode=OneWay}"
                             BorderThickness="0"
                             CornerRadius="0"
                             Visibility="{x:Bind RoleIsUpdateLike}" />
@@ -1051,6 +1067,7 @@
                             Grid.ColumnSpan="3"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Bind SortBySourceAutomationName, Mode=OneWay}"
                             BorderThickness="0"
                             CornerRadius="0,4,4,0" />
                     </Grid>
@@ -1179,6 +1196,7 @@
                         Height="80"
                         Padding="12"
                         x:FieldModifier="protected"
+                        AutomationProperties.Name="{x:Bind SearchPackagesAutomationName, Mode=OneWay}"
                         AutomationProperties.HelpText="Search"
                         CornerRadius="0,8,8,0">
                         <AnimatedIcon>

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using UniGetUI.Core.SettingsEngine;
@@ -203,6 +204,20 @@ namespace UniGetUI.Interface
 
         private string _searchPlaceholder;
         public string SearchBoxPlaceholder => _searchPlaceholder;
+        public string ReloadPackagesAutomationName => CoreTools.Translate("Reload packages");
+        public string MoreToolbarActionsAutomationName => CoreTools.Translate("More toolbar actions");
+        public string FilterBySourcesAutomationName => CoreTools.Translate("Filter by sources");
+        public string FilterOptionsAutomationName => CoreTools.Translate("Filter options");
+        public string SearchModeAutomationName => CoreTools.Translate("Search mode");
+        public string SelectAllPackagesAutomationName => CoreTools.Translate("Select all packages");
+        public string SortByPackageNameAutomationName => CoreTools.Translate("Sort by package name");
+        public string SortByPackageIdAutomationName => CoreTools.Translate("Sort by package ID");
+        public string SortByVersionAutomationName => CoreTools.Translate("Sort by version");
+        public string SortByNewVersionAutomationName => CoreTools.Translate("Sort by new version");
+        public string SortBySourceAutomationName => CoreTools.Translate("Sort by source");
+        public string SearchPackagesAutomationName => CoreTools.Translate("Search packages");
+        public string OrderByAutomationName => CoreTools.Translate("Order by");
+        public string ViewModeAutomationName => CoreTools.Translate("View mode");
 
         private string TypeQuery = "";
         private int LastKeyDown;
@@ -243,6 +258,9 @@ namespace UniGetUI.Interface
             ToolTipService.SetToolTip(Selector_List, CoreTools.Translate("List"));
             ToolTipService.SetToolTip(Selector_Grid, CoreTools.Translate("Grid"));
             ToolTipService.SetToolTip(Selector_Icons, CoreTools.Translate("Icons"));
+            AutomationProperties.SetName(Selector_List, CoreTools.Translate("List"));
+            AutomationProperties.SetName(Selector_Grid, CoreTools.Translate("Grid"));
+            AutomationProperties.SetName(Selector_Icons, CoreTools.Translate("Icons"));
 
             MainTitle.Text = data.PageTitle;
             HeaderIcon.Glyph = data.Glyph;

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -218,6 +218,25 @@ namespace UniGetUI.Interface
         public string SearchPackagesAutomationName => CoreTools.Translate("Search packages");
         public string OrderByAutomationName => CoreTools.Translate("Order by");
         public string ViewModeAutomationName => CoreTools.Translate("View mode");
+        public string SelectAllSourcesAutomationName => CoreTools.Translate("Select all sources");
+        public string ClearSourceSelectionAutomationName => CoreTools.Translate("Clear source selection");
+        public string InstantSearchAutomationName => CoreTools.Translate("Instant search");
+        public string DistinguishUpperLowerCaseAutomationName => CoreTools.Translate("Distinguish between uppercase and lowercase");
+        public string IgnoreSpecialCharactersAutomationName => CoreTools.Translate("Ignore special characters");
+        public string ToggleFiltersAutomationName => CoreTools.Translate("Toggle filters");
+        public string MainSelectionActionAutomationName => PAGE_ROLE switch
+        {
+            OperationType.Install => CoreTools.Translate("Install selection"),
+            OperationType.Update => CoreTools.Translate("Update selection"),
+            OperationType.Uninstall => CoreTools.Translate("Uninstall selection"),
+            _ => CoreTools.Translate("Apply action to selection")
+        };
+        public string SearchModeOptionsAutomationName => CoreTools.Translate("Search mode options");
+        public string SearchModeByNameAutomationName => CoreTools.Translate("Search by package name");
+        public string SearchModeByIdAutomationName => CoreTools.Translate("Search by package ID");
+        public string SearchModeByBothAutomationName => CoreTools.Translate("Search by package name or ID");
+        public string SearchModeExactMatchAutomationName => CoreTools.Translate("Search exact match");
+        public string SearchModeSimilarResultsAutomationName => CoreTools.Translate("Show similar packages");
 
         private string TypeQuery = "";
         private int LastKeyDown;

--- a/src/UniGetUI/Services/UserAvatar.cs
+++ b/src/UniGetUI/Services/UserAvatar.cs
@@ -2,6 +2,7 @@ using Windows.UI;
 using Microsoft.UI;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
@@ -135,6 +136,7 @@ namespace UniGetUI.Services
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 Content = CoreTools.Translate("Log in")
             };
+            AutomationProperties.SetName(loginButton, CoreTools.Translate("Log in with GitHub"));
             loginButton.Click += LoginButton_Click;
 
             var stackPanel = new StackPanel
@@ -155,7 +157,7 @@ namespace UniGetUI.Services
                 Content = stackPanel
             };
 
-            return new PointButton
+            PointButton profileButton = new PointButton
             {
                 Margin = new Thickness(0),
                 Padding = new Thickness(4),
@@ -165,6 +167,8 @@ namespace UniGetUI.Services
                 Content = personPicture,
                 Flyout = flyout
             };
+            AutomationProperties.SetName(profileButton, CoreTools.Translate("Open backup profile"));
+            return profileButton;
         }
 
         private async Task<PointButton> GenerateLogoutControl()
@@ -246,6 +250,7 @@ namespace UniGetUI.Services
                 Background = new SolidColorBrush(ActualTheme is ElementTheme.Dark? Colors.DarkRed: Colors.PaleVioletRed),
                 BorderThickness = new(0)
             };
+            AutomationProperties.SetName(loginButton, CoreTools.Translate("Log out from GitHub"));
             loginButton.Click += LogoutButton_Click;
 
             var stackPanel = new StackPanel
@@ -268,7 +273,7 @@ namespace UniGetUI.Services
                 Content = stackPanel
             };
 
-            return new PointButton
+            PointButton profileButton = new PointButton
             {
                 Margin = new Thickness(0),
                 Padding = new Thickness(4),
@@ -278,6 +283,8 @@ namespace UniGetUI.Services
                 Content = personPicture,
                 Flyout = flyout
             };
+            AutomationProperties.SetName(profileButton, CoreTools.Translate("Open backup profile"));
+            return profileButton;
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR improves screen reader accessibility and keyboard navigation across key UI surfaces (main pages, dialogs, filters, and settings), while keeping the visual interface and behavior intact.

## Why These Changes
Several controls were reachable by keyboard but had no accessible name, so screen readers announced generic text like “button”, “unchecked”, or resource keys.
Settings navigation also had inconsistent tab behavior (some items only reachable with Shift+Tab), which made the page difficult to use non-visually.
This PR addresses those issues by improving automation metadata and focus flow without redesigning the UI.

## What Changed
- Added/standardized `AutomationProperties` labels on previously unlabeled controls.
- Improved accessibility labeling in package list/filter areas and related dialogs.
- Improved settings card/toggle/button labeling so screen readers announce meaningful control names and context.
- Fixed settings tab navigation flow so keyboard focus can consistently move into category/content controls.
- Added/updated XAML accessibility tests to prevent regressions.

## Key Areas Updated
- `src/UniGetUI/Pages/MainView.xaml`
- `src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml.cs`
- `src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml`
- `src/UniGetUI/Controls/SettingsWidgets/*.cs`
- `src/UniGetUI/Pages/DialogPages/OperationFailedDialog.xaml`
- `src/UniGetUI/Pages/DialogPages/OperationLiveLogPage.xaml`
- `src/UniGetUI.Core.Tools.Tests/AccessibilityXamlTests.cs`

## Validation
- Ran accessibility-focused tests:
  - `dotnet test src/UniGetUI.Core.Tools.Tests/UniGetUI.Core.Tools.Tests.csproj -p:Platform=x64 --filter FullyQualifiedName~AccessibilityXamlTests --nologo -v q`
- No integrity/build-system fixes are included in this PR (a11y-only scope).

## Risk
Low to moderate. Changes are mostly automation/focus metadata and keyboard navigation handling, with minimal UI behavior impact.