### PR TITLE
Speed up CI Windows metadata setup

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -84,6 +84,8 @@ jobs:
     environment: ${{ needs.preflight.outputs.package-env }}
     permissions:
       contents: read
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
     strategy:
       fail-fast: false
       matrix:
@@ -93,23 +95,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Windows SDK UAP platform
-        shell: pwsh
-        run: |
-          # CsWinRT in WindowsPackageManager.Interop requires UAP 10.0.19041.0 platform metadata
-          $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $VsInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
-          $InstallPath = & $VsWhere -latest -property installationPath
-          & $VsInstaller modify --installPath $InstallPath `
-            --add Microsoft.VisualStudio.Component.UWP.Support `
-            --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
-            --quiet --norestart --nocache | Out-Default
-          Write-Host "Windows SDK UAP platform installed"
-
       - name: Install .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/**/*.props', 'src/**/*.targets', 'src/**/*.sln') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
 
       - name: Install Python
         uses: actions/setup-python@v6

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   test-codebase:
     runs-on: windows-latest
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
 
     steps:
     - name: Checkout the repository
@@ -28,35 +30,22 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
 
-    - name: Install Windows SDK UAP platform
-      shell: pwsh
-      run: |
-        # CsWinRT in WindowsPackageManager.Interop requires UAP 10.0.19041.0 platform metadata
-        $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-        $VsInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
-        $InstallPath = & $VsWhere -latest -property installationPath
-        & $VsInstaller modify --installPath $InstallPath `
-          --add Microsoft.VisualStudio.Component.UWP.Support `
-          --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
-          --quiet --norestart --nocache | Out-Default
-        Write-Host "Windows SDK UAP platform installed"
-
-    # - name: Install WinGet
-    #   uses: Cyberboss/install-winget@v1
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.NUGET_PACKAGES }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/**/*.props', 'src/**/*.targets', 'src/**/*.sln') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Install dependencies
       working-directory: src
       run: dotnet restore UniGetUI.sln
-
-    # - name: Test build
-    #   working-directory: src
-    #   run: dotnet build --configuration Release
 
     - name: Run Tests
       working-directory: src

--- a/src/WindowsPackageManager.Interop/ExternalLibraries.WindowsPackageManager.Interop.csproj
+++ b/src/WindowsPackageManager.Interop/ExternalLibraries.WindowsPackageManager.Interop.csproj
@@ -17,7 +17,8 @@
   https://github.com/microsoft/CsWinRT/blob/master/nuget/readme.md
   -->
   <PropertyGroup>
-    <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata Condition="'$(PkgMicrosoft_Windows_SDK_Contracts)' != ''">$(PkgMicrosoft_Windows_SDK_Contracts)\ref\netstandard2.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata Condition="'$(PkgMicrosoft_Windows_SDK_Contracts)' == ''">10.0.26100.0</CsWinRTWindowsMetadata>
     <CsWinRTIncludes>Microsoft.Management.Deployment</CsWinRTIncludes>
   </PropertyGroup>
 
@@ -29,6 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.26100.4948">
+      <GeneratePathProperty>true</GeneratePathProperty>
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.183">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
## Summary
- replace the hosted-runner Visual Studio UAP SDK install with NuGet-provided Windows metadata for CsWinRT
- add workspace-scoped NuGet caching to the test and release workflows
- remove stale commented-out lines from the test workflow

## Validation
- local: dotnet restore src/UniGetUI.sln
- local: dotnet test src/UniGetUI.sln --no-restore --verbosity q --nologo
- GitHub Actions dry run after rebase: https://github.com/Devolutions/UniGetUI/actions/runs/22974519179

## Notes
- rebase onto main completed cleanly with no conflicts
- dry run succeeded for preflight, both build matrix jobs, and publish-in-dry-run flow