### PR TITLE
Fix DPI sizing issues

### DIFF
--- a/src/UniGetUI/Controls/CustomNavViewItem.cs
+++ b/src/UniGetUI/Controls/CustomNavViewItem.cs
@@ -9,7 +9,7 @@ namespace UniGetUI.Controls;
 
 internal sealed partial class CustomNavViewItem : NavigationViewItem
 {
-    int _iconSize = 28;
+    int _iconSize = 24;
     public IconType LocalIcon
     {
         set => base.Icon = new LocalIcon(value);
@@ -62,15 +62,15 @@ internal sealed partial class CustomNavViewItem : NavigationViewItem
 
     public CustomNavViewItem()
     {
-        Height = 60;
+        Height = 54;
         Resources["NavigationViewItemOnLeftIconBoxHeight"] = _iconSize;
         Resources["NavigationViewItemContentPresenterMargin"] = new Thickness(0);
 
-        var grid = new Grid { Height = 50 };
+        var grid = new Grid { Height = 44 };
 
         _progressRing = new ProgressRing
         {
-            Margin = new Thickness(-46, 0, 0, 0),
+            Margin = new Thickness(-42, 0, 0, 0),
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Center,
             IsIndeterminate = true,

--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -748,6 +748,27 @@ namespace UniGetUI.Interface
             return WinRT.Interop.WindowNative.GetWindowHandle(this);
         }
 
+        private double GetWindowRasterizationScale()
+        {
+            uint dpi = NativeHelpers.GetDpiForWindow(GetWindowHandle());
+            if (dpi > 0)
+            {
+                return dpi / 96.0;
+            }
+
+            return MainContentGrid.XamlRoot?.RasterizationScale ?? 1.0;
+        }
+
+        private int ConvertPhysicalPixelsToDips(int physicalPixels)
+        {
+            return (int)Math.Round(physicalPixels / Math.Max(GetWindowRasterizationScale(), 0.01));
+        }
+
+        private int ConvertDipsToPhysicalPixels(int dips)
+        {
+            return Math.Max(1, (int)Math.Round(dips * GetWindowRasterizationScale()));
+        }
+
         public async Task HandleMissingDependencies(IReadOnlyList<ManagerDependency> dependencies)
         {
             int current = 1;
@@ -803,7 +824,7 @@ namespace UniGetUI.Interface
                 }
 
                 string geometry =
-                    $"{AppWindow.Position.X},{AppWindow.Position.Y},{AppWindow.Size.Width},{AppWindow.Size.Height},{windowState}";
+                    $"v2,{AppWindow.Position.X},{AppWindow.Position.Y},{ConvertPhysicalPixelsToDips(AppWindow.Size.Width)},{ConvertPhysicalPixelsToDips(AppWindow.Size.Height)},{windowState}";
 
                 Logger.Debug($"Saving window geometry {geometry}");
                 Settings.SetValue(Settings.K.WindowGeometry, geometry);
@@ -818,10 +839,10 @@ namespace UniGetUI.Interface
         {
             string geometry = Settings.GetValue(Settings.K.WindowGeometry);
             string[] items = geometry.Split(",");
-            if (items.Length != 5)
+            if (items.Length is not (5 or 6))
             {
                 Logger.Warn(
-                    $"The restored geometry did not have exactly 5 items (found length was {items.Length})"
+                    $"The restored geometry did not have a supported item count (found length was {items.Length})"
                 );
                 return;
             }
@@ -833,11 +854,22 @@ namespace UniGetUI.Interface
                 State;
             try
             {
-                X = int.Parse(items[0]);
-                Y = int.Parse(items[1]);
-                Width = int.Parse(items[2]);
-                Height = int.Parse(items[3]);
-                State = int.Parse(items[4]);
+                if (items.Length == 6 && items[0] == "v2")
+                {
+                    X = int.Parse(items[1]);
+                    Y = int.Parse(items[2]);
+                    Width = ConvertDipsToPhysicalPixels(int.Parse(items[3]));
+                    Height = ConvertDipsToPhysicalPixels(int.Parse(items[4]));
+                    State = int.Parse(items[5]);
+                }
+                else
+                {
+                    X = int.Parse(items[0]);
+                    Y = int.Parse(items[1]);
+                    Width = int.Parse(items[2]);
+                    Height = int.Parse(items[3]);
+                    State = int.Parse(items[4]);
+                }
             }
             catch (Exception ex)
             {
@@ -936,7 +968,7 @@ namespace UniGetUI.Interface
             if (NavigationPage is null)
                 return;
 
-            if (this.AppWindow.Size.Width >= 1600)
+            if (MainContentGrid.ActualWidth >= 1600)
             {
                 Settings.Set(
                     Settings.K.CollapseNavMenuOnWideScreen,
@@ -1004,6 +1036,9 @@ namespace UniGetUI.Interface
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        public static extern uint GetDpiForWindow(IntPtr hWnd);
 
         public const int MONITORINFOF_PRIMARY = 0x00000001;
 

--- a/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml
+++ b/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml
@@ -39,13 +39,13 @@
           </Grid.ColumnDefinitions>
           <Border
             Grid.Column="0"
-            Width="128"
-            Height="128"
+            Width="112"
+            Height="112"
             Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-            BorderThickness="10"
-            CornerRadius="24"
+            BorderThickness="8"
+            CornerRadius="20"
           >
-            <Image Name="PackageIcon" Width="80" Height="80" Margin="8" />
+            <Image Name="PackageIcon" Width="72" Height="72" Margin="8" />
           </Border>
 
           <TextBlock
@@ -54,7 +54,7 @@
             HorizontalAlignment="Left"
             VerticalAlignment="Center"
             FontFamily="Segoe UI Variable Display"
-            FontSize="50"
+            FontSize="40"
             FontWeight="Bold"
             TextWrapping="Wrap"
           />

--- a/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml.cs
@@ -581,7 +581,7 @@ namespace UniGetUI.Interface.Dialogs
             SizeChangedEventArgs? e = null
         )
         {
-            if (MainApp.Instance.MainWindow.AppWindow.Size.Width < 950)
+            if (ActualWidth < 950)
             {
                 if (__layout_mode != LayoutMode.Normal)
                 {

--- a/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml
+++ b/src/UniGetUI/Pages/SettingsPages/SettingsBasePage.xaml
@@ -44,8 +44,8 @@
       </Grid.ColumnDefinitions>
       <Button
         Name="BackButton"
-        Width="40"
-        Height="40"
+        Width="36"
+        Height="36"
         Padding="6"
         VerticalAlignment="Center"
         Background="Transparent"
@@ -65,7 +65,7 @@
         Grid.Column="1"
         HorizontalAlignment="Stretch"
         VerticalAlignment="Center"
-        FontSize="30"
+        FontSize="24"
         FontWeight="Bold"
         Text=""
         TextWrapping="Wrap"

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
@@ -509,21 +509,21 @@
         x:Name="HeaderIcon"
         Grid.Row="0"
         Grid.Column="0"
-        Width="60"
-        MinHeight="60"
-        Margin="0,0,-8,0"
-        FontSize="50"
+        Width="52"
+        MinHeight="52"
+        Margin="0,0,-6,0"
+        FontSize="40"
         FontWeight="Normal"
       />
 
       <StackPanel Grid.Column="1" VerticalAlignment="Center" Orientation="Vertical" Spacing="0">
         <TextBlock
           x:Name="MainTitle"
-          MaxHeight="70"
+          MaxHeight="60"
           HorizontalAlignment="Left"
           x:FieldModifier="protected"
           FontFamily="Segoe UI Variable Display"
-          FontSize="30"
+          FontSize="24"
           FontWeight="Bold"
           TextWrapping="Wrap"
         />
@@ -532,7 +532,7 @@
           MaxHeight="40"
           HorizontalAlignment="Left"
           x:FieldModifier="protected"
-          FontSize="11"
+          FontSize="12"
           FontWeight="Normal"
           Foreground="{ThemeResource AppBarItemDisabledForegroundThemeBrush}"
           TextWrapping="Wrap"
@@ -1228,31 +1228,31 @@
         >
           <Grid.RowDefinitions>
             <RowDefinition Height="*" />
-            <RowDefinition Height="80" />
+            <RowDefinition Height="64" />
             <RowDefinition Height="*" />
           </Grid.RowDefinitions>
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="8*" MaxWidth="800" />
-            <ColumnDefinition Width="80" />
+            <ColumnDefinition Width="8*" MaxWidth="720" />
+            <ColumnDefinition Width="64" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
           <TextBox
             x:Name="MegaQueryBlock"
             Grid.Row="1"
             Grid.Column="1"
-            Padding="20,11,10,11"
+            Padding="16,8,10,8"
             x:FieldModifier="protected"
             CornerRadius="8,0,0,8"
-            FontSize="40"
+            FontSize="28"
             FontWeight="SemiBold"
           />
           <Button
             x:Name="MegaFindButton"
             Grid.Row="1"
             Grid.Column="2"
-            Width="80"
-            Height="80"
+            Width="64"
+            Height="64"
             Padding="12"
             x:FieldModifier="protected"
             AutomationProperties.HelpText="Search"

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -1680,14 +1680,14 @@ namespace UniGetUI.Interface
                 if (_pageIsWide != false)
                 {
                     _pageIsWide = false;
-                    MainTitle.FontSize = 20;
+                    MainTitle.FontSize = 18;
                 }
             }
             else
             {
                 if (_pageIsWide != true)
                 {
-                    MainTitle.FontSize = 30;
+                    MainTitle.FontSize = 24;
                     _pageIsWide = true;
                 }
             }


### PR DESCRIPTION
## Summary

Fix issues found with DPI-scaling, it's more balanced now:

<img width="1424" height="834" alt="image" src="https://github.com/user-attachments/assets/84d65ab7-1436-484c-90d2-bd642d45f808" />

### Fixes included
- Make saved window geometry DPI-aware so window size restores correctly across mixed-DPI monitors.
- Use DIP-based width checks instead of AppWindow pixel width for layout-sensitive UI decisions.
- Reduce the oversized discover-page mega search box.
- Tighten oversized headers and navigation item sizing that were disproportionately large at higher display scale factors.
