### PR TITLE
Stabilize WinGet fetch in test workflow

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -51,6 +51,28 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
 
+    - name: Restore WinGet CLI cache
+      id: winget-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: src/UniGetUI.PackageEngine.Managers.WinGet/winget-cli_x64
+        key: winget-cli-${{ runner.os }}-x64-${{ hashFiles('scripts/fetch-winget-cli.ps1') }}
+
+    - name: Fetch WinGet CLI bundle
+      if: steps.winget-cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        .\scripts\fetch-winget-cli.ps1 -Architectures @('x64') -Force
+
+    - name: Save WinGet CLI cache
+      if: steps.winget-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: src/UniGetUI.PackageEngine.Managers.WinGet/winget-cli_x64
+        key: ${{ steps.winget-cache.outputs.cache-primary-key }}
+
     - name: Install dependencies
       working-directory: src
       run: dotnet restore UniGetUI.sln
@@ -64,5 +86,7 @@ jobs:
 
     - name: Run Tests
       working-directory: src
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: dotnet test UniGetUI.sln --no-restore --verbosity q --nologo
 


### PR DESCRIPTION
## Summary
- restore a cached WinGet CLI bundle in the .NET test workflow before running tests
- fetch the WinGet CLI bundle explicitly with GITHUB_TOKEN when the cache is missing
- pass GITHUB_TOKEN into the test step as a fallback for the WinGet manager build target

## Problem
The .NET test workflow could fail on clean runners while building the WinGet manager project. When the bundled WinGet payload was missing, MSBuild invoked scripts/fetch-winget-cli.ps1 during dotnet test, but the workflow had not prepared the payload the same way build-release.yml already does.

## Validation
- dispatched .NET Tests on fix-tests after the change
- passing run: https://github.com/Devolutions/UniGetUI/actions/runs/23087403120