### PR TITLE
Fix icon database load on .NET 10

### DIFF
--- a/src/UniGetUI.Core.Tools.Tests/MetaTests.cs
+++ b/src/UniGetUI.Core.Tools.Tests/MetaTests.cs
@@ -67,6 +67,34 @@ public class MetaTests
         }
     }
 
+    [Fact]
+    public void TestJsonSerializerContextsDoNotReuseSharedOptions()
+    {
+        var solutionDirectory = FindRepositoryRoot();
+        var csFiles = Directory
+            .GetFiles(solutionDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(file =>
+                !file.Contains(@"bin\")
+                && !file.Contains(@"obj\")
+                && !file.EndsWith(".g.cs")
+                && !file.EndsWith("Tests.cs")
+            );
+
+        Regex forbiddenPattern = new(
+            @"JsonContext\s+\w+\s*=\s*new\(\s*SerializationHelpers\.DefaultOptions\s*\)",
+            RegexOptions.Multiline
+        );
+
+        foreach (var file in csFiles)
+        {
+            var fileContent = File.ReadAllText(file);
+            Assert.False(
+                forbiddenPattern.IsMatch(fileContent),
+                $"File {file} reuses SerializationHelpers.DefaultOptions when constructing a generated JsonSerializerContext. Clone the options first to avoid rebinding the shared resolver."
+            );
+        }
+    }
+
     private static string FindRepositoryRoot()
     {
         DirectoryInfo? currentDirectory = new(AppDomain.CurrentDomain.BaseDirectory);

--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -40,7 +40,7 @@ public partial class AutoUpdater
     ];
 
     private static readonly AutoUpdaterJsonContext ProductInfoJsonContext = new(
-        SerializationHelpers.DefaultOptions
+        new JsonSerializerOptions(SerializationHelpers.DefaultOptions)
     );
 
     public static Window Window = null!;


### PR DESCRIPTION
## Summary
- stop reusing the shared JSON serializer options when constructing the updater source-generated context
- keep the shared serializer options resolver generic so the icon screenshot database can still deserialize on .NET 10
- add a regression meta-test to prevent future JsonSerializerContext construction from rebinding the shared options instance

## Validation
- dotnet test 'src/UniGetUI.Core.Tools.Tests/UniGetUI.Core.Tools.Tests.csproj' --no-restore --verbosity minimal
- dotnet build 'src/UniGetUI/UniGetUI.csproj' --no-restore -v q