### PR TITLE
Fix GitHub cloud backup OAuth configuration

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -89,6 +89,8 @@ jobs:
     permissions:
       contents: read
     env:
+      UNIGETUI_GITHUB_CLIENT_ID: ${{ secrets.UNIGETUI_GITHUB_CLIENT_ID }}
+      UNIGETUI_GITHUB_CLIENT_SECRET: ${{ secrets.UNIGETUI_GITHUB_CLIENT_SECRET }}
       NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
     strategy:
       fail-fast: false
@@ -98,6 +100,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Validate GitHub OAuth secrets
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:UNIGETUI_GITHUB_CLIENT_ID)) {
+            throw "UNIGETUI_GITHUB_CLIENT_ID is not configured for this build environment."
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:UNIGETUI_GITHUB_CLIENT_SECRET)) {
+            throw "UNIGETUI_GITHUB_CLIENT_SECRET is not configured for this build environment."
+          }
+
+          Write-Host "::notice::GitHub OAuth secrets are configured for this build."
 
       - name: Install .NET
         uses: actions/setup-dotnet@v5

--- a/src/UniGetUI/Pages/DialogPages/DialogHelper_Generic.cs
+++ b/src/UniGetUI/Pages/DialogPages/DialogHelper_Generic.cs
@@ -488,7 +488,7 @@ public static partial class DialogHelper
         p.Inlines.Add(new LineBreak());
         var link = new Hyperlink
         {
-            NavigateUri = new Uri("https://www.marticliment.com/unigetui/privacy/"),
+            NavigateUri = new Uri("https://devolutions.net/legal/"),
         };
         link.Inlines.Add(
             new Run

--- a/src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/GeneralPages/Backup.xaml.cs
@@ -354,7 +354,7 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
 
         private void MoreInfoBtn_OnClick(object sender, RoutedEventArgs e)
         {
-            MainApp.Instance.MainWindow.NavigationPage.ShowHelp("cloud-backup-overview/");
+            CoreTools.Launch("https://devolutions.net/unigetui");
         }
     }
 }

--- a/src/UniGetUI/Services/GitHubAuthService.cs
+++ b/src/UniGetUI/Services/GitHubAuthService.cs
@@ -12,6 +12,9 @@ namespace UniGetUI.Services
 {
     public class GitHubAuthService
     {
+        private const string MissingClientId = "CLIENT_ID_UNSET";
+        private const string MissingClientSecret = "CLIENT_SECRET_UNSET";
+        private static readonly TimeSpan LoginTimeout = TimeSpan.FromMinutes(2);
         private readonly string GitHubClientId = Secrets.GetGitHubClientId();
         private readonly string GitHubClientSecret = Secrets.GetGitHubClientSecret();
         private const string RedirectUri = "http://127.0.0.1:58642/";
@@ -47,6 +50,15 @@ namespace UniGetUI.Services
         {
             try
             {
+                if (!HasConfiguredOAuthClient())
+                {
+                    Logger.Error(
+                        "GitHub sign-in is not configured for this build. Missing OAuth client ID or client secret."
+                    );
+                    AuthStatusChanged?.Invoke(this, EventArgs.Empty);
+                    return false;
+                }
+
                 Logger.Info("Initiating GitHub sign-in process using loopback redirect...");
 
                 var request = new OauthLoginRequest(GitHubClientId)
@@ -74,15 +86,25 @@ namespace UniGetUI.Services
                 loginBackend = new GHAuthApiRunner();
                 loginBackend.OnLogin += BackgroundApiOnOnLogin;
                 await loginBackend.Start();
-                await Launcher.LaunchUriAsync(oauthLoginUrl);
 
-                while (codeFromAPI is null)
+                bool launchSucceeded = await Launcher.LaunchUriAsync(oauthLoginUrl);
+                if (!launchSucceeded)
+                {
+                    Logger.Error("Failed to launch the browser for GitHub sign-in.");
+                    AuthStatusChanged?.Invoke(this, EventArgs.Empty);
+                    return false;
+                }
+
+                DateTime timeoutAt = DateTime.UtcNow.Add(LoginTimeout);
+                while (codeFromAPI is null && DateTime.UtcNow < timeoutAt)
                     await Task.Delay(100);
 
-                loginBackend.OnLogin -= BackgroundApiOnOnLogin;
-                await loginBackend.Stop();
-                loginBackend.Dispose();
-                loginBackend = null;
+                if (string.IsNullOrEmpty(codeFromAPI))
+                {
+                    Logger.Error("GitHub sign-in timed out before the loopback callback was received.");
+                    AuthStatusChanged?.Invoke(this, EventArgs.Empty);
+                    return false;
+                }
 
                 return await _completeSignInAsync(codeFromAPI);
             }
@@ -94,6 +116,26 @@ namespace UniGetUI.Services
                 AuthStatusChanged?.Invoke(this, EventArgs.Empty);
                 return false;
             }
+            finally
+            {
+                if (loginBackend is not null)
+                {
+                    try
+                    {
+                        loginBackend.OnLogin -= BackgroundApiOnOnLogin;
+                        await loginBackend.Stop();
+                        loginBackend.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(ex);
+                    }
+                    finally
+                    {
+                        loginBackend = null;
+                    }
+                }
+            }
         }
 
         private string? codeFromAPI;
@@ -101,6 +143,18 @@ namespace UniGetUI.Services
         private void BackgroundApiOnOnLogin(object? sender, string c)
         {
             codeFromAPI = c;
+        }
+
+        private bool HasConfiguredOAuthClient()
+        {
+            return !string.IsNullOrWhiteSpace(GitHubClientId)
+                && !string.IsNullOrWhiteSpace(GitHubClientSecret)
+                && !string.Equals(GitHubClientId, MissingClientId, StringComparison.Ordinal)
+                && !string.Equals(
+                    GitHubClientSecret,
+                    MissingClientSecret,
+                    StringComparison.Ordinal
+                );
         }
 
         private async Task<bool> _completeSignInAsync(string code)

--- a/src/UniGetUI/Services/UserAvatar.cs
+++ b/src/UniGetUI/Services/UserAvatar.cs
@@ -68,7 +68,14 @@ namespace UniGetUI.Services
                     return;
                 }
 
-                await client.SignInAsync();
+                bool success = await client.SignInAsync();
+                if (!success)
+                {
+                    DialogHelper.ShowDismissableBalloon(
+                        CoreTools.Translate("Failed"),
+                        CoreTools.Translate("An error occurred while logging in: ")
+                    );
+                }
             }
             catch (Exception ex)
             {
@@ -132,7 +139,7 @@ namespace UniGetUI.Services
                 FontSize = 12,
             };
             hyperlinkButton.Click += (_, _) =>
-                MainApp.Instance.MainWindow.NavigationPage.ShowHelp("cloud-backup-overview/");
+                CoreTools.Launch("https://devolutions.net/unigetui");
 
             var loginButton = new PointButton
             {
@@ -235,7 +242,7 @@ namespace UniGetUI.Services
                 FontSize = 12,
             };
             hyperlinkButton.Click += (_, _) =>
-                MainApp.Instance.MainWindow.NavigationPage.ShowHelp("cloud-backup-overview/");
+                CoreTools.Launch("https://devolutions.net/unigetui");
 
             var hyperlinkButton2 = new HyperlinkButton
             {

--- a/src/UniGetUI/Services/generate-secrets.ps1
+++ b/src/UniGetUI/Services/generate-secrets.ps1
@@ -12,14 +12,14 @@ if (-not (Test-Path -Path "Generated Files")) {
 }
 
 
-$clientId = $env:GH_UGUI_CLIENT_ID
-$clientSecret = $env:GH_UGUI_CLIENT_SECRET
+$clientId = $env:UNIGETUI_GITHUB_CLIENT_ID
+$clientSecret = $env:UNIGETUI_GITHUB_CLIENT_SECRET
 
 if (-not $clientId) { $clientId = "CLIENT_ID_UNSET" }
 if (-not $clientSecret) { $clientSecret = "CLIENT_SECRET_UNSET" }
 
 @"
-// Auto-generated file - do not modidy
+// Auto-generated file - do not modify
 namespace UniGetUI.Services
 {
     internal static partial class Secrets
@@ -29,4 +29,4 @@ namespace UniGetUI.Services
     }
 }
 "@ | Set-Content -Encoding UTF8 "Generated Files\Secrets.Generated.cs"
-cp "Generated Files\Secrets.Generated.cs" "$OutputPath\Generated Files\Secrets.Generated.cs"
+Copy-Item "Generated Files\Secrets.Generated.cs" "$OutputPath\Generated Files\Secrets.Generated.cs"


### PR DESCRIPTION
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----
This fixes the GitHub cloud backup login break introduced during the repository migration.

Changes included:
- wire the OAuth client ID and secret into the release workflow using the normalized UNIGETUI_GITHUB_* secret names
- fail early in CI when those secrets are missing
- harden the GitHub login flow so it fails clearly when OAuth credentials are unset or the loopback callback never arrives
- update the affected login/backup help and privacy links away from the old marticliment.com targets

Validation:
- dotnet build d:/dev/unigetui-github-app/src/UniGetUI/UniGetUI.csproj -p:Platform=x64 -p:Configuration=Debug -nologo -v minimal

Manual OAuth end-to-end validation still requires a valid GitHub OAuth app client ID and secret.

<img width="1912" height="1068" alt="image" src="https://github.com/user-attachments/assets/1abbfacc-3309-46f2-89fe-56473e196fa5" />
<img width="1424" height="891" alt="image" src="https://github.com/user-attachments/assets/eb9f3b80-975c-4004-bc5a-e85518d34a91" />

-----
Closes #4461