### PR TITLE
feat(avalonia): experimental cross-platform Avalonia port

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - 'global.json'
       - '**.cs'
+      - '**.axaml'
       - '**.csproj'
       - '**.props'
       - '**.targets'
       - '**.sln'
+      - '**.slnx'
       - 'src/.editorconfig'
       - '.github/workflows/dotnet-test.yml'
 
@@ -17,10 +19,12 @@ on:
     paths:
       - 'global.json'
       - '**.cs'
+      - '**.axaml'
       - '**.csproj'
       - '**.props'
       - '**.targets'
       - '**.sln'
+      - '**.slnx'
       - 'src/.editorconfig'
       - '.github/workflows/dotnet-test.yml'
 
@@ -47,7 +51,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ${{ env.NUGET_PACKAGES }}
-        key: ${{ runner.os }}-nuget-${{ hashFiles('global.json', 'src/**/*.csproj', 'src/**/*.props', 'src/**/*.targets', 'src/**/*.sln') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('global.json', 'src/**/*.csproj', 'src/**/*.props', 'src/**/*.targets', 'src/**/*.sln', 'src/**/*.slnx') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
 
@@ -75,14 +79,24 @@ jobs:
 
     - name: Install dependencies
       working-directory: src
-      run: dotnet restore UniGetUI.sln
+      run: |
+        dotnet restore UniGetUI.sln
+        dotnet restore UniGetUI.Avalonia.slnx
 
     - name: Check whitespace formatting
       run: dotnet format whitespace src --folder --verify-no-changes --verbosity minimal
 
-    - name: Check code style formatting
+    - name: Check code style formatting (WinUI solution)
       working-directory: src
       run: dotnet format style UniGetUI.sln --no-restore --verify-no-changes --verbosity minimal
+
+    - name: Check code style formatting (Avalonia solution)
+      working-directory: src
+      run: dotnet format style UniGetUI.Avalonia.slnx --no-restore --verify-no-changes --verbosity minimal
+
+    - name: Build Avalonia solution
+      working-directory: src
+      run: dotnet build UniGetUI.Avalonia.slnx --no-restore --verbosity minimal
 
     - name: Run Tests
       working-directory: src

--- a/src/UniGetUI.Avalonia.slnx
+++ b/src/UniGetUI.Avalonia.slnx
@@ -1,8 +1,14 @@
 <Solution>
   <Configurations>
-    <Platform Name="arm64" />
     <Platform Name="x64" />
+    <Platform Name="arm64" />
   </Configurations>
+  <Folder Name="/UniGetUI.Avalonia/">
+    <Project Path="UniGetUI.Avalonia/UniGetUI.Avalonia.csproj">
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|arm64" Project="arm64" />
+    </Project>
+  </Folder>
   <Folder Name="/UniGetUI.Core.Logger/">
     <Project Path="UniGetUI.Core.Logger/UniGetUI.Core.Logging.csproj">
       <Platform Solution="*|arm64" Project="arm64" />

--- a/src/UniGetUI.Avalonia/App.axaml
+++ b/src/UniGetUI.Avalonia/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.App"
+             RequestedThemeVariant="Default">
+  <Application.Styles>
+    <StyleInclude Source="avares://UniGetUI.Avalonia/Styles/AppStyles.axaml" />
+  </Application.Styles>
+</Application>

--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Devolutions.AvaloniaTheme.DevExpress;
+using Devolutions.AvaloniaTheme.Linux;
+using Devolutions.AvaloniaTheme.MacOS;
+
+namespace UniGetUI.Avalonia;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+
+        Styles.Insert(0, CreatePlatformTheme());
+
+        Name = "UniGetUI.Avalonia";
+    }
+
+    private static Styles CreatePlatformTheme()
+    {
+        Styles styles = OperatingSystem.IsWindows()
+            ? new DevolutionsDevExpressTheme()
+            : OperatingSystem.IsMacOS()
+                ? new DevolutionsMacOsTheme()
+                : OperatingSystem.IsLinux()
+                    ? new DevolutionsLinuxYaruTheme()
+                    : new FluentTheme();
+
+        if (styles is ISupportInitialize initializable)
+        {
+            initializable.BeginInit();
+            initializable.EndInit();
+        }
+
+        return styles;
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/AsyncCommand.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AsyncCommand.cs
@@ -1,0 +1,49 @@
+using System.Windows.Input;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal sealed class AsyncCommand : ICommand
+{
+    private readonly Func<Task> _executeAsync;
+    private readonly Func<bool>? _canExecute;
+    private bool _isExecuting;
+
+    public AsyncCommand(Func<Task> executeAsync, Func<bool>? canExecute = null)
+    {
+        _executeAsync = executeAsync;
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter)
+    {
+        return !_isExecuting && (_canExecute?.Invoke() ?? true);
+    }
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        _isExecuting = true;
+        RaiseCanExecuteChanged();
+
+        try
+        {
+            await _executeAsync();
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public void RaiseCanExecuteChanged()
+    {
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -1,0 +1,618 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using Microsoft.Win32;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Avalonia port of the WinUI AutoUpdater.  Checks for new UniGetUI versions and
+/// lets the user trigger an in-place upgrade.
+/// </summary>
+internal static partial class AvaloniaAutoUpdater
+{
+    // ------------------------------------------------------------------ constants
+    private const string REGISTRY_PATH = @"Software\Devolutions\UniGetUI";
+    private const string DEFAULT_PRODUCTINFO_URL = "https://devolutions.net/productinfo.json";
+    private const string DEFAULT_PRODUCTINFO_KEY = "Devolutions.UniGetUI";
+
+    private const string REG_PRODUCTINFO_URL = "UpdaterProductInfoUrl";
+    private const string REG_PRODUCTINFO_KEY = "UpdaterProductKey";
+    private const string REG_ALLOW_UNSAFE_URLS = "UpdaterAllowUnsafeUrls";
+    private const string REG_SKIP_HASH_VALIDATION = "UpdaterSkipHashValidation";
+    private const string REG_SKIP_SIGNER_THUMBPRINT_CHECK = "UpdaterSkipSignerThumbprintCheck";
+    private const string REG_DISABLE_TLS_VALIDATION = "UpdaterDisableTlsValidation";
+    private const string REG_USE_LEGACY_GITHUB = "UpdaterUseLegacyGithub";
+
+    private const string STABLE_ENDPOINT =
+        "https://www.marticliment.com/versions/unigetui/stable.ver";
+    private const string BETA_ENDPOINT =
+        "https://www.marticliment.com/versions/unigetui/beta.ver";
+    private const string STABLE_INSTALLER_URL =
+        "https://github.com/Devolutions/UniGetUI/releases/latest/download/UniGetUI.Installer.exe";
+    private const string BETA_INSTALLER_URL =
+        "https://github.com/Devolutions/UniGetUI/releases/download/$TAG/UniGetUI.Installer.exe";
+
+    private static readonly string[] DEVOLUTIONS_CERT_THUMBPRINTS =
+    [
+        "3f5202a9432d54293bdfe6f7e46adb0a6f8b3ba6",
+        "8db5a43bb8afe4d2ffb92da9007d8997a4cc4e13",
+        "50f753333811ff11f1920274afde3ffd4468b210",
+    ];
+
+    private static readonly AutoUpdaterJsonContext _jsonContext = new(
+        new JsonSerializerOptions(SerializationHelpers.DefaultOptions)
+    );
+
+    // ------------------------------------------------------------------ public API
+    /// <summary>
+    /// Fired on the UI thread when a validated installer is ready.  Argument is the
+    /// human-readable version string, e.g. "4.2.1".
+    /// </summary>
+    public static event Action<string>? UpdateAvailable;
+
+    private static volatile bool _installRequested;
+    private static string? _pendingInstallerPath;
+
+    /// <summary>
+    /// Set to <c>true</c> when the main window is closing (user quit or hidden path).
+    /// Mirrors WinUI's <c>AutoUpdater.ReleaseLockForAutoupdate_Window</c> — once set,
+    /// a pending installer is allowed to launch even if the user has not yet clicked
+    /// the banner (e.g. user quits via tray while an update is ready).
+    /// </summary>
+    public static bool ReleaseLockForAutoupdate_Window;
+
+    /// <summary>
+    /// Set to <c>true</c> when the user clicks the "Update now" button in the Windows toast
+    /// notification.  Mirrors WinUI's <c>AutoUpdater.ReleaseLockForAutoupdate_Notification</c>.
+    /// </summary>
+    public static bool ReleaseLockForAutoupdate_Notification;
+
+    /// <summary>
+    /// Called by the user when they click "Update now" in the update banner.
+    /// </summary>
+    public static void TriggerInstall() => _installRequested = true;
+    public static async Task UpdateCheckLoopAsync()
+    {
+        if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
+        {
+            Logger.Warn("Auto-updater: disabled by user setting, skipping.");
+            return;
+        }
+
+        await CoreTools.WaitForInternetConnection();
+
+        bool isFirstLaunch = true;
+        while (true)
+        {
+            if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
+            {
+                Logger.Warn("Auto-updater: disabled by user setting, stopping loop.");
+                return;
+            }
+
+            bool success = await CheckAndInstallUpdatesAsync(autoLaunch: isFirstLaunch);
+            isFirstLaunch = false;
+
+            await Task.Delay(TimeSpan.FromMinutes(success ? 60 : 10));
+        }
+    }
+
+    // ------------------------------------------------------------------ core logic
+    internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false)
+    {
+        UpdaterOverrides overrides = LoadUpdaterOverrides();
+
+        try
+        {
+            UpdateCandidate candidate = await GetUpdateCandidateAsync(overrides);
+            Logger.Info(
+                $"Auto-updater source '{candidate.SourceName}' returned version {candidate.VersionName} (upgradable={candidate.IsUpgradable})"
+            );
+
+            if (!candidate.IsUpgradable)
+            {
+                return true;
+            }
+
+            Logger.Info($"Update to UniGetUI {candidate.VersionName} is available.");
+
+            string installerPath = Path.Join(CoreData.UniGetUIDataDirectory, "UniGetUI Updater.exe");
+
+            // Try cached installer first
+            if (
+                File.Exists(installerPath)
+                && await CheckInstallerHashAsync(installerPath, candidate.InstallerHash, overrides)
+                && CheckInstallerSignerThumbprint(installerPath, overrides)
+            )
+            {
+                Logger.Info("Cached valid installer found, preparing to launch...");
+                return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch);
+            }
+
+            // Delete invalid/outdated cached copy
+            try { File.Delete(installerPath); } catch { }
+
+            Logger.Info("Downloading installer...");
+            await DownloadInstallerAsync(candidate.InstallerDownloadUrl, installerPath, overrides);
+
+            if (
+                await CheckInstallerHashAsync(installerPath, candidate.InstallerHash, overrides)
+                && CheckInstallerSignerThumbprint(installerPath, overrides)
+            )
+            {
+                Logger.Info("Downloaded installer is valid, preparing to launch...");
+                return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch);
+            }
+
+            Logger.Error("Installer authenticity could not be verified. Aborting update.");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while checking for updates:");
+            Logger.Error(ex);
+            return false;
+        }
+    }
+
+    // ------------------------------------------------------------------ update flow
+    private static async Task<bool> PrepareAndLaunchAsync(
+        string installerPath,
+        string versionName,
+        bool autoLaunch)
+    {
+        _pendingInstallerPath = installerPath;
+        _installRequested = false;
+        ReleaseLockForAutoupdate_Notification = false;
+
+        // Notify UI (update banner + toast)
+        Dispatcher.UIThread.Post(() => UpdateAvailable?.Invoke(versionName));
+        WindowsAppNotificationBridge.ShowSelfUpdateAvailableNotification(versionName);
+
+        if (autoLaunch)
+        {
+            // On first launch in background we wait for user interaction
+        }
+
+        // Wait until user requests install, clicks the toast, or the window is being closed
+        while (!_installRequested && !ReleaseLockForAutoupdate_Window && !ReleaseLockForAutoupdate_Notification)
+        {
+            if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
+            {
+                Logger.Warn("Auto-updater: disabled while waiting for user \u2014 aborting.");
+                return true;
+            }
+            await Task.Delay(500);
+        }
+
+        Logger.Info("Installing update \u2014 launching installer and quitting.");
+        await LaunchInstallerAndQuitAsync(installerPath);
+        return true;
+    }
+
+    private static async Task LaunchInstallerAndQuitAsync(string installerLocation)
+    {
+        Logger.Info($"Launching installer: {installerLocation}");
+        using Process p = new()
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = installerLocation,
+                Arguments = "/SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NoVCRedist /NoEdgeWebView /NoWinGet /NoChocolatey",
+                UseShellExecute = true,
+                CreateNoWindow = true,
+            },
+        };
+
+        bool started = p.Start();
+        if (!started)
+        {
+            Logger.Error("Failed to start installer process.");
+            return;
+        }
+
+        // Quit the app on the UI thread
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+            {
+                if (lifetime.MainWindow is MainWindow mw)
+                {
+                    mw.QuitApplication();
+                }
+                else
+                {
+                    lifetime.Shutdown();
+                }
+            }
+        });
+
+        await p.WaitForExitAsync();
+    }
+
+    // ------------------------------------------------------------------ update check sources
+    private static async Task<UpdateCandidate> GetUpdateCandidateAsync(UpdaterOverrides overrides)
+    {
+        if (overrides.UseLegacyGithub)
+        {
+            return await CheckFromLegacyGitHubAsync(overrides);
+        }
+
+        try
+        {
+            return await CheckFromProductInfoAsync(overrides);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("ProductInfo source failed; falling back to legacy GitHub source.");
+            Logger.Warn(ex);
+            return await CheckFromLegacyGitHubAsync(overrides);
+        }
+    }
+
+    private static async Task<UpdateCandidate> CheckFromProductInfoAsync(UpdaterOverrides overrides)
+    {
+        Logger.Debug($"Checking updates via ProductInfo: {overrides.ProductInfoUrl}");
+
+        if (!IsSourceUrlAllowed(overrides.ProductInfoUrl, overrides.AllowUnsafeUrls))
+        {
+            throw new InvalidOperationException(
+                $"ProductInfo URL is not allowed: {overrides.ProductInfoUrl}"
+            );
+        }
+
+        string json;
+        using (HttpClient client = new(CreateHttpClientHandler(overrides)))
+        {
+            client.Timeout = TimeSpan.FromSeconds(600);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
+            json = await client.GetStringAsync(overrides.ProductInfoUrl);
+        }
+
+        Dictionary<string, ProductInfoProduct>? root =
+            JsonSerializer.Deserialize(
+                json,
+                typeof(Dictionary<string, ProductInfoProduct>),
+                _jsonContext
+            ) as Dictionary<string, ProductInfoProduct>;
+
+        if (root is null || root.Count == 0)
+        {
+            throw new FormatException("productinfo.json is empty or invalid.");
+        }
+
+        if (!root.TryGetValue(overrides.ProductInfoProductKey, out ProductInfoProduct? product))
+        {
+            throw new KeyNotFoundException(
+                $"Product key '{overrides.ProductInfoProductKey}' not found in productinfo.json"
+            );
+        }
+
+        bool useBeta = Settings.Get(Settings.K.EnableUniGetUIBeta);
+        ProductInfoChannel? channel = useBeta ? product.Beta : product.Current;
+        if (channel is null)
+        {
+            throw new KeyNotFoundException(
+                $"Channel '{(useBeta ? "Beta" : "Current")}' not found for product '{overrides.ProductInfoProductKey}'"
+            );
+        }
+
+        ProductInfoFile installer = SelectInstallerFile(channel.Files);
+        if (!IsSourceUrlAllowed(installer.Url, overrides.AllowUnsafeUrls))
+        {
+            throw new InvalidOperationException($"Installer URL is not allowed: {installer.Url}");
+        }
+
+        Version current = ParseVersionOrFallback(
+            CoreData.VersionName,
+            new Version(0, 0, 0, CoreData.BuildNumber)
+        );
+        Version available = ParseVersionOrFallback(channel.Version, new Version(0, 0, 0, 0));
+        bool upgradable = available > current;
+
+        Logger.Debug(
+            $"ProductInfo check: current={current}, available={available}, upgradable={upgradable}"
+        );
+
+        return new UpdateCandidate(upgradable, channel.Version, installer.Hash, installer.Url, "ProductInfo");
+    }
+
+    private static async Task<UpdateCandidate> CheckFromLegacyGitHubAsync(UpdaterOverrides overrides)
+    {
+        bool useBeta = Settings.Get(Settings.K.EnableUniGetUIBeta);
+        string endpoint = useBeta ? BETA_ENDPOINT : STABLE_ENDPOINT;
+        string installerUrl = useBeta ? BETA_INSTALLER_URL : STABLE_INSTALLER_URL;
+
+        Logger.Debug($"Checking updates via legacy GitHub endpoint: {endpoint}");
+
+        string[] parts;
+        using (HttpClient client = new(CreateHttpClientHandler(overrides)))
+        {
+            client.Timeout = TimeSpan.FromSeconds(600);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
+            parts = (await client.GetStringAsync(endpoint)).Split("////");
+        }
+
+        if (parts.Length >= 3)
+        {
+            int latestBuild = int.Parse(parts[0].Trim());
+            string hash = parts[1].Trim();
+            string versionName = parts[2].Trim();
+
+            return new UpdateCandidate(
+                latestBuild > CoreData.BuildNumber,
+                versionName,
+                hash,
+                installerUrl.Replace("$TAG", versionName),
+                "LegacyGitHub"
+            );
+        }
+
+        throw new FormatException("Legacy update file does not follow the expected format.");
+    }
+
+    // ------------------------------------------------------------------ validation helpers
+    private static async Task<bool> CheckInstallerHashAsync(
+        string path,
+        string expectedHash,
+        UpdaterOverrides overrides)
+    {
+        if (overrides.SkipHashValidation)
+        {
+            Logger.Warn("Registry override: skipping hash validation.");
+            return true;
+        }
+
+        using FileStream fs = File.OpenRead(path);
+        string actual = Convert
+            .ToHexString(await SHA256.Create().ComputeHashAsync(fs))
+            .ToLowerInvariant();
+
+        if (actual == expectedHash.ToLowerInvariant())
+        {
+            Logger.Debug($"Hash match: {actual}");
+            return true;
+        }
+
+        Logger.Warn($"Hash mismatch. Expected: {expectedHash}  Got: {actual}");
+        return false;
+    }
+
+    private static bool CheckInstallerSignerThumbprint(string path, UpdaterOverrides overrides)
+    {
+        if (overrides.SkipSignerThumbprintCheck)
+        {
+            Logger.Warn("Registry override: skipping signer thumbprint validation.");
+            return true;
+        }
+
+        try
+        {
+#pragma warning disable SYSLIB0057
+            X509Certificate signerCert = X509Certificate.CreateFromSignedFile(path);
+#pragma warning restore SYSLIB0057
+            using X509Certificate2 cert2 = new(signerCert);
+            string thumbprint = NormalizeThumbprint(cert2.Thumbprint ?? string.Empty);
+
+            if (string.IsNullOrWhiteSpace(thumbprint))
+            {
+                Logger.Warn($"Could not read signer thumbprint for '{path}'");
+                return false;
+            }
+
+            if (DEVOLUTIONS_CERT_THUMBPRINTS.Contains(thumbprint, StringComparer.OrdinalIgnoreCase))
+            {
+                Logger.Debug($"Installer signer thumbprint is trusted: {thumbprint}");
+                return true;
+            }
+
+            Logger.Warn($"Installer signer thumbprint is NOT trusted: {thumbprint}");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not validate installer signer thumbprint.");
+            Logger.Warn(ex);
+            return false;
+        }
+    }
+
+    // ------------------------------------------------------------------ download
+    private static async Task DownloadInstallerAsync(
+        string url,
+        string destination,
+        UpdaterOverrides overrides)
+    {
+        if (!IsSourceUrlAllowed(url, overrides.AllowUnsafeUrls))
+        {
+            throw new InvalidOperationException($"Download URL is not allowed: {url}");
+        }
+
+        Logger.Debug($"Downloading installer from {url}");
+        using HttpClient client = new(CreateHttpClientHandler(overrides));
+        client.Timeout = TimeSpan.FromSeconds(600);
+        client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
+
+        HttpResponseMessage response = await client.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        using FileStream fs = new(destination, FileMode.OpenOrCreate);
+        await response.Content.CopyToAsync(fs);
+
+        Logger.Debug("Installer download complete.");
+    }
+
+    // ------------------------------------------------------------------ HTTP client
+    private static HttpClientHandler CreateHttpClientHandler(UpdaterOverrides overrides)
+    {
+        var handler = new HttpClientHandler();
+        if (overrides.DisableTlsValidation)
+        {
+            Logger.Warn("Registry override: TLS certificate validation is disabled for updater requests.");
+            handler.ServerCertificateCustomValidationCallback = static (_, _, _, _) => true;
+        }
+        return handler;
+    }
+
+    // ------------------------------------------------------------------ URL / arch helpers
+    private static bool IsSourceUrlAllowed(string url, bool allowUnsafe)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+        {
+            return false;
+        }
+
+        if (allowUnsafe)
+        {
+            Logger.Warn($"Registry override: allowing potentially unsafe URL {url}");
+            return true;
+        }
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return uri.Host.EndsWith("devolutions.net", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.Equals("objects.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.Equals("release-assets.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.Equals("marticliment.com", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.EndsWith("marticliment.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ProductInfoFile SelectInstallerFile(List<ProductInfoFile> files)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.Arm64 => "arm64",
+            _ => "x64",
+        };
+
+        ProductInfoFile? match =
+            files.FirstOrDefault(f => f.Type.Equals("exe", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase))
+            ?? files.FirstOrDefault(f => f.Type.Equals("exe", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals("Any", StringComparison.OrdinalIgnoreCase))
+            ?? files.FirstOrDefault(f => f.Type.Equals("msi", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase))
+            ?? files.FirstOrDefault(f => f.Type.Equals("msi", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals("Any", StringComparison.OrdinalIgnoreCase));
+
+        return match ?? throw new KeyNotFoundException(
+            $"No compatible installer found in productinfo for architecture '{arch}'"
+        );
+    }
+
+    private static Version ParseVersionOrFallback(string raw, Version fallback)
+    {
+        string sanitized = raw.Trim().TrimStart('v', 'V');
+        if (Version.TryParse(sanitized, out Version? parsed))
+        {
+            return CoreTools.NormalizeVersionForComparison(parsed);
+        }
+
+        Logger.Warn($"Could not parse version '{raw}', using fallback '{fallback}'");
+        return fallback;
+    }
+
+    private static string NormalizeThumbprint(string thumbprint) =>
+        new(thumbprint.ToLowerInvariant().Where(char.IsAsciiHexDigit).ToArray());
+
+    // ------------------------------------------------------------------ registry
+    private static UpdaterOverrides LoadUpdaterOverrides()
+    {
+#pragma warning disable CA1416
+        using RegistryKey? key = Registry.CurrentUser.OpenSubKey(REGISTRY_PATH);
+
+        if (key is not null)
+        {
+            Logger.Info($"Updater registry overrides loaded from HKCU\\{REGISTRY_PATH}");
+        }
+
+        return new UpdaterOverrides(
+            GetRegistryString(key, REG_PRODUCTINFO_URL) ?? DEFAULT_PRODUCTINFO_URL,
+            GetRegistryString(key, REG_PRODUCTINFO_KEY) ?? DEFAULT_PRODUCTINFO_KEY,
+            GetRegistryBool(key, REG_ALLOW_UNSAFE_URLS),
+            GetRegistryBool(key, REG_SKIP_HASH_VALIDATION),
+            GetRegistryBool(key, REG_SKIP_SIGNER_THUMBPRINT_CHECK),
+            GetRegistryBool(key, REG_DISABLE_TLS_VALIDATION),
+            GetRegistryBool(key, REG_USE_LEGACY_GITHUB)
+        );
+#pragma warning restore CA1416
+    }
+
+    private static string? GetRegistryString(RegistryKey? key, string valueName)
+    {
+#pragma warning disable CA1416
+        string? parsed = key?.GetValue(valueName)?.ToString();
+#pragma warning restore CA1416
+        return string.IsNullOrWhiteSpace(parsed) ? null : parsed.Trim();
+    }
+
+    private static bool GetRegistryBool(RegistryKey? key, string valueName)
+    {
+#pragma warning disable CA1416
+        object? value = key?.GetValue(valueName);
+#pragma warning restore CA1416
+        if (value is null) return false;
+        if (value is int i) return i != 0;
+        if (value is long l) return l != 0;
+        string s = value.ToString()?.Trim() ?? "";
+        return s == "1"
+            || s.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("on", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ------------------------------------------------------------------ data types
+    private sealed record UpdateCandidate(
+        bool IsUpgradable,
+        string VersionName,
+        string InstallerHash,
+        string InstallerDownloadUrl,
+        string SourceName
+    );
+
+    private sealed record UpdaterOverrides(
+        string ProductInfoUrl,
+        string ProductInfoProductKey,
+        bool AllowUnsafeUrls,
+        bool SkipHashValidation,
+        bool SkipSignerThumbprintCheck,
+        bool DisableTlsValidation,
+        bool UseLegacyGithub
+    );
+
+    private sealed class ProductInfoProduct
+    {
+        public ProductInfoChannel? Current { get; set; }
+        public ProductInfoChannel? Beta { get; set; }
+    }
+
+    private sealed class ProductInfoChannel
+    {
+        public string Version { get; set; } = string.Empty;
+        public List<ProductInfoFile> Files { get; set; } = [];
+    }
+
+    private sealed class ProductInfoFile
+    {
+        public string Arch { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+        public string Hash { get; set; } = string.Empty;
+    }
+
+    [JsonSourceGenerationOptions(AllowTrailingCommas = true)]
+    [JsonSerializable(typeof(Dictionary<string, ProductInfoProduct>))]
+    private sealed partial class AutoUpdaterJsonContext : JsonSerializerContext { }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -1,0 +1,228 @@
+using Avalonia.Threading;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.IconEngine;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.Core.Tools;
+using UniGetUI.Interface;
+using UniGetUI.Interface.Telemetry;
+using UniGetUI.PackageEngine;
+using UniGetUI.PackageEngine.Classes.Manager.Classes;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal static class AvaloniaBootstrapper
+{
+    private static bool _hasStarted;
+    private static BackgroundApiRunner? _backgroundApi;
+
+    public static async Task InitializeAsync()
+    {
+        if (_hasStarted)
+        {
+            return;
+        }
+
+        _hasStarted = true;
+        Logger.Info("Starting Avalonia shell bootstrap");
+
+        await Task.WhenAll(
+            InitializeSharedServicesAsync(),
+            InitializePackageEngineAsync()
+        );
+
+        Logger.Info("Avalonia shell bootstrap completed");
+    }
+
+    private static Task InitializeSharedServicesAsync()
+    {
+        CoreTools.ReloadLanguageEngineInstance();
+        MainWindow.ApplyProxyVariableToProcess();
+        _ = Task.Run(AvaloniaAutoUpdater.UpdateCheckLoopAsync)
+            .ContinueWith(
+                t => Logger.Error(t.Exception!),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        _ = Task.Run(InitializeBackgroundApiAsync)
+            .ContinueWith(
+                t => Logger.Error(t.Exception!),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        _ = TelemetryHandler.InitializeAsync()
+            .ContinueWith(
+                t => Logger.Error(t.Exception!),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        _ = Task.Run(LoadElevatorAsync)
+            .ContinueWith(
+                t => Logger.Error(t.Exception!),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        _ = Task.Run(IconDatabase.Instance.LoadFromCacheAsync)
+            .ContinueWith(
+                t => Logger.Error(t.Exception!),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        _ = Task.Run(IconDatabase.Instance.LoadIconAndScreenshotsDatabaseAsync)
+            .ContinueWith(
+                t => Logger.Error(t.Exception!),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        return Task.CompletedTask;
+    }
+
+    private static async Task InitializePackageEngineAsync()
+    {
+        await Task.Run(PEInterface.LoadLoaders);
+        await Task.Run(PEInterface.LoadManagers);
+    }
+
+    private static async Task InitializeBackgroundApiAsync()
+    {
+        try
+        {
+            if (Settings.Get(Settings.K.DisableApi))
+                return;
+
+            _backgroundApi = new BackgroundApiRunner();
+
+            _backgroundApi.OnOpenWindow += (_, _) =>
+                Dispatcher.UIThread.Post(() => MainWindow.Instance?.ShowFromTray());
+
+            _backgroundApi.OnOpenUpdatesPage += (_, _) =>
+                Dispatcher.UIThread.Post(() =>
+                {
+                    MainWindow.Instance?.NavigateShell(ShellPageType.Updates);
+                    MainWindow.Instance?.ShowFromTray();
+                });
+
+            _backgroundApi.OnShowSharedPackage += (_, pkg) =>
+                Dispatcher.UIThread.Post(() =>
+                {
+                    Logger.Info($"BackgroundApi: ShowSharedPackage {pkg.Key}/{pkg.Value}");
+                    MainWindow.Instance?.ShowFromTray();
+                    if (MainWindow.Instance?.Content is Views.MainShellView shell)
+                    {
+                        shell.OpenSharedPackage(pkg.Key, pkg.Value);
+                    }
+                });
+
+            _backgroundApi.OnUpgradeAll += (_, _) =>
+                Dispatcher.UIThread.Post(() => _ = AvaloniaPackageOperationHelper.UpdateAllAsync());
+
+            _backgroundApi.OnUpgradeAllForManager += (_, managerName) =>
+                Dispatcher.UIThread.Post(() =>
+                    _ = AvaloniaPackageOperationHelper.UpdateAllForManagerAsync(managerName));
+
+            _backgroundApi.OnUpgradePackage += (_, packageId) =>
+                Dispatcher.UIThread.Post(() =>
+                    _ = AvaloniaPackageOperationHelper.UpdateForIdAsync(packageId));
+
+            await _backgroundApi.Start();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Could not initialize Background API:");
+            Logger.Error(ex);
+        }
+    }
+
+    public static void StopBackgroundApi() => _backgroundApi?.Stop();
+
+    private static async Task LoadElevatorAsync()
+    {
+        try
+        {
+            if (Settings.Get(Settings.K.ProhibitElevation))
+            {
+                Logger.Warn("UniGetUI Elevator has been disabled since elevation is prohibited!");
+                return;
+            }
+
+            if (SecureSettings.Get(SecureSettings.K.ForceUserGSudo))
+            {
+                var res = await CoreTools.WhichAsync("gsudo.exe");
+                if (res.Item1)
+                {
+                    CoreData.ElevatorPath = res.Item2;
+                    Logger.Warn($"Using user GSudo (forced by user) at {CoreData.ElevatorPath}");
+                    return;
+                }
+            }
+
+#if DEBUG
+            Logger.Warn($"Using system GSudo since UniGetUI Elevator is not available in DEBUG builds");
+            CoreData.ElevatorPath = (await CoreTools.WhichAsync("gsudo.exe")).Item2;
+#else
+            CoreData.ElevatorPath = Path.Join(
+                CoreData.UniGetUIExecutableDirectory,
+                "Assets",
+                "Utilities",
+                "UniGetUI Elevator.exe"
+            );
+            Logger.Debug($"Using built-in UniGetUI Elevator at {CoreData.ElevatorPath}");
+#endif
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Elevator/GSudo failed to be loaded!");
+            Logger.Error(ex);
+        }
+    }
+
+    /// <summary>
+    /// Checks all ready package managers for missing dependencies.
+    /// Returns the list of dependencies whose installation was not skipped by the user.
+    /// </summary>
+    public static async Task<IReadOnlyList<ManagerDependency>> GetMissingDependenciesAsync()
+    {
+        var missing = new List<ManagerDependency>();
+
+        foreach (var manager in PEInterface.Managers)
+        {
+            if (!manager.IsReady()) continue;
+
+            foreach (var dep in manager.Dependencies)
+            {
+                bool isInstalled = true;
+                try
+                {
+                    isInstalled = await dep.IsInstalled();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Error checking dependency {dep.Name}: {ex.Message}");
+                }
+
+                if (!isInstalled)
+                {
+                    if (Settings.GetDictionaryItem<string, string>(
+                            Settings.K.DependencyManagement, dep.Name) == "skipped")
+                    {
+                        Logger.Info($"Dependency {dep.Name} skipped by user preference.");
+                    }
+                    else
+                    {
+                        Logger.Warn(
+                            $"Dependency {dep.Name} not found for manager {manager.Name}.");
+                        missing.Add(dep);
+                    }
+                }
+                else
+                {
+                    Logger.Info($"Dependency {dep.Name} for {manager.Name} is present.");
+                }
+            }
+        }
+
+        return missing;
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
@@ -1,0 +1,231 @@
+using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Classes.Packages.Classes;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Global registry of <see cref="AbstractOperation"/> instances for the Avalonia shell.
+/// The operations panel in <see cref="UniGetUI.Avalonia.Views.MainShellView"/> binds to
+/// <see cref="Operations"/> to show active, queued, or recently finished operations.
+/// </summary>
+public static class AvaloniaOperationRegistry
+{
+    public static readonly ObservableCollection<AbstractOperation> Operations = new();
+
+    /// <summary>
+    /// Register an operation. Must be called before <c>operation.MainThread()</c>.
+    /// </summary>
+    public static void Add(AbstractOperation op)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (!Operations.Contains(op))
+                Operations.Add(op);
+        });
+
+        op.OperationStarting += (_, _) =>
+        {
+            Dispatcher.UIThread.Post(() => ShowOperationProgressNotification(op));
+        };
+
+        op.OperationSucceeded += (_, _) =>
+        {
+            if (!Settings.Get(Settings.K.MaintainSuccessfulInstalls))
+                _ = RemoveAfterDelayAsync(op, milliseconds: 4000);
+
+            _ = Task.Run(() => AppendOperationHistory(op));
+
+            Dispatcher.UIThread.Post(() => ShowOperationSuccessNotification(op));
+
+            _ = RunPostOperationChecksAsync();
+            Dispatcher.UIThread.Post(UpdateTrayStatus);
+        };
+
+        op.OperationFailed += (_, _) =>
+        {
+            _ = Task.Run(() => AppendOperationHistory(op));
+            Dispatcher.UIThread.Post(() => ShowOperationFailureNotification(op));
+            Dispatcher.UIThread.Post(UpdateTrayStatus);
+        };
+
+        op.StatusChanged += (_, status) =>
+        {
+            if (status is OperationStatus.Canceled)
+            {
+                WindowsAppNotificationBridge.RemoveProgress(op);
+                _ = RemoveAfterDelayAsync(op, milliseconds: 2500);
+            }
+            Dispatcher.UIThread.Post(UpdateTrayStatus);
+        };
+    }
+
+    private static async Task RemoveAfterDelayAsync(AbstractOperation op, int milliseconds)
+    {
+        await Task.Delay(milliseconds);
+        Dispatcher.UIThread.Post(() => Operations.Remove(op));
+    }
+
+    private static void UpdateTrayStatus()
+    {
+        if (Application.Current?.ApplicationLifetime
+                is IClassicDesktopStyleApplicationLifetime { MainWindow: UniGetUI.Avalonia.MainWindow mw })
+            mw.UpdateSystemTrayStatus();
+    }
+
+    private static void ShowOperationProgressNotification(AbstractOperation op)
+    {
+        if (Settings.AreProgressNotificationsDisabled())
+            return;
+
+        if (WindowsAppNotificationBridge.ShowProgress(op))
+            return;
+
+        if (TryGetMainWindow() is not { } mainWindow)
+            return;
+
+        string title = op.Metadata.Title.Length > 0
+            ? op.Metadata.Title
+            : CoreTools.Translate("Operation in progress");
+
+        string message = op.Metadata.Status.Length > 0
+            ? op.Metadata.Status
+            : CoreTools.Translate("Please wait...");
+
+        mainWindow.ShowRuntimeNotification(
+            title,
+            message,
+            UniGetUI.Avalonia.MainWindow.RuntimeNotificationLevel.Progress);
+    }
+
+    private static void ShowOperationSuccessNotification(AbstractOperation op)
+    {
+        if (Settings.AreSuccessNotificationsDisabled())
+            return;
+
+        WindowsAppNotificationBridge.RemoveProgress(op);
+
+        if (WindowsAppNotificationBridge.ShowSuccess(op))
+            return;
+
+        if (TryGetMainWindow() is not { } mainWindow)
+            return;
+
+        string title = op.Metadata.SuccessTitle.Length > 0
+            ? op.Metadata.SuccessTitle
+            : CoreTools.Translate("Success!");
+
+        string message = op.Metadata.SuccessMessage.Length > 0
+            ? op.Metadata.SuccessMessage
+            : CoreTools.Translate("Success!");
+
+        mainWindow.ShowRuntimeNotification(
+            title,
+            message,
+            UniGetUI.Avalonia.MainWindow.RuntimeNotificationLevel.Success);
+    }
+
+    private static void ShowOperationFailureNotification(AbstractOperation op)
+    {
+        if (Settings.AreErrorNotificationsDisabled())
+            return;
+
+        WindowsAppNotificationBridge.RemoveProgress(op);
+
+        if (WindowsAppNotificationBridge.ShowError(op))
+            return;
+
+        if (TryGetMainWindow() is not { } mainWindow)
+            return;
+
+        string title = op.Metadata.FailureTitle.Length > 0
+            ? op.Metadata.FailureTitle
+            : CoreTools.Translate("Failed");
+
+        string message = op.Metadata.FailureMessage.Length > 0
+            ? op.Metadata.FailureMessage
+            : CoreTools.Translate("An error occurred while processing this package");
+
+        mainWindow.ShowRuntimeNotification(
+            title,
+            message,
+            UniGetUI.Avalonia.MainWindow.RuntimeNotificationLevel.Error);
+    }
+
+    private static UniGetUI.Avalonia.MainWindow? TryGetMainWindow()
+    {
+        return Application.Current?.ApplicationLifetime
+            is IClassicDesktopStyleApplicationLifetime { MainWindow: UniGetUI.Avalonia.MainWindow mw }
+            ? mw
+            : null;
+    }
+
+    private static void AppendOperationHistory(AbstractOperation op)
+    {
+        try
+        {
+            var rawOutput = new List<string>
+            {
+                "                           ",
+                "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄",
+            };
+            foreach (var (text, _) in op.GetOutput())
+                rawOutput.Add(text);
+
+            var oldLines = Settings.GetValue(Settings.K.OperationHistory).Split('\n');
+            if (oldLines.Length > 300)
+                oldLines = oldLines.Take(300).ToArray();
+
+            Settings.SetValue(
+                Settings.K.OperationHistory,
+                string.Join('\n', rawOutput.Concat(oldLines)));
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Failed to write operation history");
+            Logger.Warn(ex);
+        }
+    }
+
+    private static async Task RunPostOperationChecksAsync()
+    {
+        // Let all remaining operations settle before making decisions
+        await Task.Delay(500);
+
+        bool anyStillRunning = Operations.Any(
+            o => o.Status is OperationStatus.Running or OperationStatus.InQueue);
+
+        // Clear UAC cache after the last operation in a batch finishes
+        if (!anyStillRunning && Settings.Get(Settings.K.DoCacheAdminRightsForBatches))
+        {
+            Logger.Info("Clearing UAC prompt since there are no remaining operations");
+            await CoreTools.ResetUACForCurrentProcess();
+        }
+
+        // Show desktop shortcut dialog if applicable
+        if (!anyStillRunning
+            && Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts)
+            && DesktopShortcutsDatabase.GetUnknownShortcuts().Count > 0)
+        {
+            var unknownShortcuts = DesktopShortcutsDatabase.GetUnknownShortcuts().ToList();
+            WindowsAppNotificationBridge.ShowNewShortcutsNotification(unknownShortcuts);
+            Dispatcher.UIThread.Post(() =>
+            {
+                var window = new UniGetUI.Avalonia.Views.Pages.DesktopShortcutsWindow(unknownShortcuts);
+                if (Application.Current?.ApplicationLifetime
+                        is IClassicDesktopStyleApplicationLifetime { MainWindow: Window mainWin })
+                    _ = window.ShowDialog(mainWin);
+                else
+                    window.Show();
+            });
+        }
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaPackageOperationHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaPackageOperationHelper.cs
@@ -1,0 +1,56 @@
+using UniGetUI.Core.Logging;
+using UniGetUI.Interface.Enums;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Operations;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.PackageLoader;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Avalonia-side helpers for bulk package update operations, consumed by
+/// the BackgroundApi event handlers and the --updateapps CLI flag.
+/// </summary>
+internal static class AvaloniaPackageOperationHelper
+{
+    public static async Task UpdateAllAsync()
+    {
+        foreach (var pkg in UpgradablePackagesLoader.Instance.Packages.ToList())
+        {
+            if (pkg.Tag is PackageTag.BeingProcessed or PackageTag.OnQueue) continue;
+            var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+            var op = new UpdatePackageOperation(pkg, opts);
+            AvaloniaOperationRegistry.Add(op);
+            _ = op.MainThread();
+        }
+    }
+
+    public static async Task UpdateAllForManagerAsync(string managerName)
+    {
+        foreach (var pkg in UpgradablePackagesLoader.Instance.Packages
+            .Where(p => p.Manager.Name == managerName || p.Manager.DisplayName == managerName)
+            .ToList())
+        {
+            if (pkg.Tag is PackageTag.BeingProcessed or PackageTag.OnQueue) continue;
+            var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+            var op = new UpdatePackageOperation(pkg, opts);
+            AvaloniaOperationRegistry.Add(op);
+            _ = op.MainThread();
+        }
+    }
+
+    public static async Task UpdateForIdAsync(string packageId)
+    {
+        var pkg = UpgradablePackagesLoader.Instance.Packages.FirstOrDefault(p => p.Id == packageId);
+        if (pkg is null)
+        {
+            Logger.Warn($"BackgroundApi: no upgradable package found with id={packageId}");
+            return;
+        }
+
+        var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+        var op = new UpdatePackageOperation(pkg, opts);
+        AvaloniaOperationRegistry.Add(op);
+        _ = op.MainThread();
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/GitHubCloudBackupService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/GitHubCloudBackupService.cs
@@ -1,0 +1,127 @@
+using Octokit;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.SecureSettings;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal static class GitHubCloudBackupService
+{
+    private const string GistDescriptionEndingKey = "@[UNIGETUI_BACKUP_V1]";
+    private const string PackageBackupStartingKey = "@[PACKAGES]";
+    private const string GistDescription = "UniGetUI package backups - DO NOT RENAME OR MODIFY " + GistDescriptionEndingKey;
+    private const string ReadMeContents = "This special Gist is used by UniGetUI to store your package backups.\n"
+        + "Please DO NOT EDIT the contents or the description of this gist, or unexpected behaviours may occur.\n"
+        + "Learn more about UniGetUI at https://github.com/Devolutions/UniGetUI\n";
+
+    internal sealed class CloudBackupEntry
+    {
+        public required string Key { get; init; }
+        public required string Display { get; init; }
+    }
+
+    public static GitHubClient? CreateGitHubClient()
+    {
+        string? token = SecureGHTokenManager.GetToken();
+        if (string.IsNullOrWhiteSpace(token))
+            return null;
+
+        return new GitHubClient(new ProductHeaderValue("UniGetUI", CoreData.VersionName))
+        {
+            Credentials = new Credentials(token),
+        };
+    }
+
+    public static async Task<(string Login, string DisplayName)> GetCurrentUserAsync()
+    {
+        var client = CreateGitHubClient()
+            ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
+
+        var user = await client.User.Current();
+        string login = user.Login ?? string.Empty;
+        string displayName = string.IsNullOrWhiteSpace(user.Name) ? login : user.Name;
+        return (login, displayName);
+    }
+
+    public static async Task UploadPackageBundleAsync(string bundleContents)
+    {
+        var client = CreateGitHubClient()
+            ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
+
+        var user = await client.User.Current();
+        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: true)
+            ?? throw new InvalidOperationException(CoreTools.Translate("Backup Failed"));
+
+        string fileKey = BuildGistFileKey();
+        var update = new GistUpdate { Description = GistDescription };
+
+        if (backupGist.Files.ContainsKey(fileKey))
+            update.Files[fileKey] = new GistFileUpdate { Content = bundleContents };
+        else
+            update.Files.Add(fileKey, new GistFileUpdate { Content = bundleContents });
+
+        await client.Gist.Edit(backupGist.Id, update);
+    }
+
+    public static async Task<IReadOnlyList<CloudBackupEntry>> GetAvailableBackupsAsync()
+    {
+        var client = CreateGitHubClient()
+            ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
+
+        var user = await client.User.Current();
+        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: false);
+        if (backupGist is null)
+            return [];
+
+        return backupGist.Files
+            .Where(f => f.Key.StartsWith(PackageBackupStartingKey, StringComparison.Ordinal))
+            .Select(f => new CloudBackupEntry
+            {
+                Key = f.Key.Split(' ')[^1],
+                Display = f.Key.Split(' ')[^1] + " (" + CoreTools.FormatAsSize(f.Value.Size) + ")",
+            })
+            .ToArray();
+    }
+
+    public static async Task<string> GetBackupContentsAsync(string backupKey)
+    {
+        var client = CreateGitHubClient()
+            ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
+
+        var user = await client.User.Current();
+        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: false);
+
+        if (backupGist is null)
+            throw new KeyNotFoundException(CoreTools.Translate("Log in to enable cloud backup"));
+
+        var fullGist = await client.Gist.Get(backupGist.Id);
+        var file = fullGist.Files.FirstOrDefault(f =>
+            f.Key.StartsWith(PackageBackupStartingKey, StringComparison.Ordinal)
+            && f.Key.EndsWith(backupKey, StringComparison.Ordinal));
+
+        if (file.Value?.Content is null)
+            throw new KeyNotFoundException(CoreTools.Translate("Downloading backup..."));
+
+        return file.Value.Content;
+    }
+
+    private static async Task<Gist?> GetBackupGistAsync(GitHubClient client, string userLogin, bool createIfMissing)
+    {
+        var candidates = await client.Gist.GetAllForUser(userLogin);
+        var backupGist = candidates.FirstOrDefault(g =>
+            g.Description?.EndsWith(GistDescriptionEndingKey, StringComparison.Ordinal) == true);
+
+        if (backupGist is not null || !createIfMissing)
+            return backupGist;
+
+        var newGist = new NewGist { Description = GistDescription, Public = false };
+        newGist.Files.Add("- UniGetUI Package Backups", ReadMeContents);
+        return await client.Gist.Create(newGist);
+    }
+
+    private static string BuildGistFileKey()
+    {
+        string deviceUser = (Environment.MachineName + "\\" + Environment.UserName).Replace(" ", string.Empty);
+        return PackageBackupStartingKey + " " + deviceUser;
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/RelayCommand.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/RelayCommand.cs
@@ -1,0 +1,19 @@
+using System.Windows.Input;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal sealed class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+
+    public RelayCommand(Action execute)
+    {
+        _execute = execute;
+    }
+
+    public event EventHandler? CanExecuteChanged { add { } remove { } }
+
+    public bool CanExecute(object? parameter) => true;
+
+    public void Execute(object? parameter) => _execute();
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
@@ -1,0 +1,99 @@
+using System.IO.Pipes;
+using System.Text;
+using Avalonia.Threading;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Forwards command-line arguments from a second UniGetUI instance to the already-running
+/// first instance via a named pipe, mirroring WinUI3's AppInstance.RedirectActivationToAsync().
+///
+/// The first instance calls <see cref="StartListener"/> immediately after acquiring the
+/// single-instance mutex.  Any subsequent launch that cannot acquire the mutex calls
+/// <see cref="TryForwardToFirstInstance"/> and exits.
+/// </summary>
+internal static class SingleInstanceRedirector
+{
+    // One pipe name per user session (the MainWindowIdentifier is a stable constant).
+    private static readonly string PipeName =
+        $"UniGetUI_Pipe_{CoreData.MainWindowIdentifier}_{Environment.UserName}";
+
+    private static Thread? _listener;
+
+    /// <summary>
+    /// Start a background listener thread.  When a second instance forwards its args,
+    /// <paramref name="onArgsReceived"/> is invoked on the Avalonia UI thread.
+    /// </summary>
+    public static void StartListener(Action<string[]> onArgsReceived)
+    {
+        _listener = new Thread(() =>
+        {
+            while (true)
+            {
+                try
+                {
+                    using var pipe = new NamedPipeServerStream(
+                        PipeName,
+                        PipeDirection.In,
+                        maxNumberOfServerInstances: 1,
+                        transmissionMode: PipeTransmissionMode.Byte);
+
+                    pipe.WaitForConnection();
+
+                    using var reader = new StreamReader(pipe, Encoding.UTF8);
+                    string payload = reader.ReadToEnd();
+
+                    // Args are newline-delimited.
+                    var args = payload.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                    Dispatcher.UIThread.Post(() => onArgsReceived(args));
+                }
+                catch (Exception ex) when (ex is not ThreadAbortException)
+                {
+                    // Keep the listener alive through errors (the pipe breaks on disconnect, etc.)
+                    Logger.Warn($"SingleInstanceRedirector listener error: {ex.Message}");
+                }
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "SingleInstancePipeListener",
+        };
+
+        _listener.Start();
+    }
+
+    /// <summary>
+    /// Try to forward <paramref name="args"/> to the already-running first instance.
+    /// </summary>
+    /// <returns><c>true</c> if the message was delivered successfully.</returns>
+    public static bool TryForwardToFirstInstance(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            // Nothing to forward — still show the window by sending an empty payload.
+        }
+
+        try
+        {
+            using var pipe = new NamedPipeClientStream(
+                serverName: ".",
+                pipeName: PipeName,
+                direction: PipeDirection.Out);
+
+            pipe.Connect(500);
+
+            using var writer = new StreamWriter(pipe, Encoding.UTF8);
+            // Newline-delimited args payload.
+            writer.Write(string.Join('\n', args));
+            writer.Flush();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Could not forward args to first instance: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/UninstallConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/UninstallConfirmationDialog.cs
@@ -1,0 +1,136 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal static class UninstallConfirmationDialog
+{
+    public static Task<bool> ConfirmAsync(Window owner, IPackage package)
+    {
+        return ConfirmAsync(owner, [package]);
+    }
+
+    public static async Task<bool> ConfirmAsync(Window owner, IReadOnlyList<IPackage> packages)
+    {
+        if (packages.Count == 0)
+        {
+            return false;
+        }
+
+        bool isConfirmed = false;
+        var dialog = new Window
+        {
+            Width = packages.Count == 1 ? 520 : 560,
+            Height = packages.Count == 1 ? 220 : 380,
+            MinWidth = 420,
+            MinHeight = packages.Count == 1 ? 220 : 300,
+            CanResize = packages.Count > 1,
+            ShowInTaskbar = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Title = CoreTools.Translate("Are you sure?"),
+        };
+
+        var titleBlock = new TextBlock
+        {
+            Text = CoreTools.Translate("Are you sure?"),
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        var messageBlock = new TextBlock
+        {
+            Text = packages.Count == 1
+                ? CoreTools.Translate("Do you really want to uninstall {0}?", packages[0].Name)
+                : CoreTools.Translate(
+                    "Do you really want to uninstall the following {0} packages?",
+                    packages.Count),
+            Opacity = 0.82,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        var root = new Grid
+        {
+            Margin = new Thickness(20),
+            RowDefinitions = new RowDefinitions("Auto,*,Auto"),
+            RowSpacing = 14,
+        };
+
+        var headerPanel = new StackPanel
+        {
+            Spacing = 8,
+            Children =
+            {
+                titleBlock,
+                messageBlock,
+            },
+        };
+        Grid.SetRow(headerPanel, 0);
+        root.Children.Add(headerPanel);
+
+        if (packages.Count > 1)
+        {
+            string packageListText = string.Join(
+                Environment.NewLine,
+                packages
+                    .OrderBy(package => package.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(package => "* " + package.Name));
+
+            var packageListBlock = new TextBlock
+            {
+                Text = packageListText,
+                FontFamily = new FontFamily("Consolas"),
+                TextWrapping = TextWrapping.Wrap,
+            };
+
+            var packageListViewer = new ScrollViewer
+            {
+                MaxHeight = 220,
+                Content = packageListBlock,
+            };
+            Grid.SetRow(packageListViewer, 1);
+            root.Children.Add(packageListViewer);
+        }
+
+        var noButton = new Button
+        {
+            Content = CoreTools.Translate("No"),
+            MinWidth = 100,
+        };
+        noButton.Click += (_, _) => dialog.Close();
+
+        var yesButton = new Button
+        {
+            Content = CoreTools.Translate("Yes"),
+            MinWidth = 100,
+        };
+        yesButton.Classes.Add("accent");
+        yesButton.Click += (_, _) =>
+        {
+            isConfirmed = true;
+            dialog.Close();
+        };
+
+        var footerPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Children =
+            {
+                noButton,
+                yesButton,
+            },
+        };
+        Grid.SetRow(footerPanel, 2);
+        root.Children.Add(footerPanel);
+
+        dialog.Content = root;
+        await dialog.ShowDialog(owner);
+        return isConfirmed;
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -1,0 +1,508 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal static class WindowsAppNotificationBridge
+{
+    private const string ScenarioDefault = "Default";
+    private const string ScenarioUrgent = "Urgent";
+
+    private static readonly object _registrationLock = new();
+    private static bool _registrationAttempted;
+    private static bool _isRegistered;
+    private static object? _managerDefault;
+    private static Type? _builderType;
+    private static Type? _scenarioType;
+    private static Type? _buttonType;
+    private static MethodInfo? _removeByTagAsyncMethod;
+    private static MethodInfo? _showMethod;
+
+    // ── B2: action callback ────────────────────────────────────────────────
+    /// <summary>Invoked on a thread-pool thread when a toast notification button is clicked.</summary>
+    public static event Action<string>? NotificationActivated;
+
+    private static readonly string[] _assemblyCandidates =
+    {
+        "Microsoft.Windows.AppNotifications",
+        "Microsoft.WindowsAppSDK",
+    };
+
+    public static bool ShowProgress(AbstractOperation operation)
+    {
+        if (!EnsureRegistered())
+            return false;
+
+        try
+        {
+            string title = operation.Metadata.Title.Length > 0
+                ? operation.Metadata.Title
+                : CoreTools.Translate("Operation in progress");
+
+            string message = operation.Metadata.Status.Length > 0
+                ? operation.Metadata.Status
+                : CoreTools.Translate("Please wait...");
+
+            return ShowTextToast(
+                tag: operation.Metadata.Identifier + "progress",
+                scenario: ScenarioDefault,
+                title: title,
+                message: message,
+                suppressDisplay: true);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Windows toast progress notification failed");
+            Logger.Warn(ex);
+            return false;
+        }
+    }
+
+    public static bool ShowSuccess(AbstractOperation operation)
+    {
+        if (!EnsureRegistered())
+            return false;
+
+        try
+        {
+            string title = operation.Metadata.SuccessTitle.Length > 0
+                ? operation.Metadata.SuccessTitle
+                : CoreTools.Translate("Success!");
+
+            string message = operation.Metadata.SuccessMessage.Length > 0
+                ? operation.Metadata.SuccessMessage
+                : CoreTools.Translate("Success!");
+
+            return ShowTextToast(
+                tag: operation.Metadata.Identifier,
+                scenario: ScenarioDefault,
+                title: title,
+                message: message,
+                suppressDisplay: false);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Windows toast success notification failed");
+            Logger.Warn(ex);
+            return false;
+        }
+    }
+
+    public static bool ShowError(AbstractOperation operation)
+    {
+        if (!EnsureRegistered())
+            return false;
+
+        try
+        {
+            string title = operation.Metadata.FailureTitle.Length > 0
+                ? operation.Metadata.FailureTitle
+                : CoreTools.Translate("Failed");
+
+            string message = operation.Metadata.FailureMessage.Length > 0
+                ? operation.Metadata.FailureMessage
+                : CoreTools.Translate("An error occurred while processing this package");
+
+            return ShowTextToast(
+                tag: operation.Metadata.Identifier,
+                scenario: ScenarioUrgent,
+                title: title,
+                message: message,
+                suppressDisplay: false);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Windows toast error notification failed");
+            Logger.Warn(ex);
+            return false;
+        }
+    }
+
+    public static void RemoveProgress(AbstractOperation operation)
+    {
+        if (!EnsureRegistered())
+            return;
+
+        try
+        {
+            _removeByTagAsyncMethod?.Invoke(_managerDefault, [operation.Metadata.Identifier + "progress"]);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Windows toast progress cleanup failed");
+            Logger.Warn(ex);
+        }
+    }
+
+    // ── B2: updates-available notification ────────────────────────────────
+
+    /// <summary>
+    /// Shows a Windows toast notification listing available package updates, with action buttons
+    /// ("Open UniGetUI" / "Update all").  No-op on non-Windows or when toast registration fails.
+    /// </summary>
+    public static void ShowUpdatesAvailableNotification(IReadOnlyList<IPackage> upgradable)
+    {
+        if (!EnsureRegistered()) return;
+        if (Settings.AreUpdatesNotificationsDisabled()) return;
+
+        bool sendNotification = upgradable.Any(p =>
+            !Settings.GetDictionaryItem<string, bool>(
+                Settings.K.DisabledPackageManagerNotifications, p.Manager.Name));
+        if (!sendNotification) return;
+
+        try
+        {
+            _removeByTagAsyncMethod?.Invoke(_managerDefault,
+                [CoreData.UpdatesAvailableNotificationTag.ToString()]);
+
+            if (upgradable.Count == 1)
+            {
+                ShowTextToast(
+                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
+                    scenario: ScenarioDefault,
+                    title: CoreTools.Translate("An update was found!"),
+                    message: CoreTools.Translate("{0} can be updated to version {1}",
+                        upgradable[0].Name, upgradable[0].NewVersionString),
+                    suppressDisplay: false,
+                    defaultAction: NotificationArguments.ShowOnUpdatesTab,
+                    buttons:
+                    [
+                        (CoreTools.Translate("View on UniGetUI").Replace("'", "\u00b4"),
+                            NotificationArguments.ShowOnUpdatesTab),
+                        (CoreTools.Translate("Update").Replace("'", "\u00b4"),
+                            NotificationArguments.UpdateAllPackages),
+                    ]);
+            }
+            else
+            {
+                string attribution = string.Join(", ", upgradable
+                    .Where(p => !Settings.GetDictionaryItem<string, bool>(
+                        Settings.K.DisabledPackageManagerNotifications, p.Manager.Name))
+                    .Select(p => p.Name));
+
+                ShowTextToast(
+                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
+                    scenario: ScenarioDefault,
+                    title: CoreTools.Translate("Updates found!"),
+                    message: CoreTools.Translate("{0} packages can be updated", upgradable.Count),
+                    suppressDisplay: false,
+                    defaultAction: NotificationArguments.ShowOnUpdatesTab,
+                    buttons:
+                    [
+                        (CoreTools.Translate("Open UniGetUI").Replace("'", "\u00b4"),
+                            NotificationArguments.ShowOnUpdatesTab),
+                        (CoreTools.Translate("Update all").Replace("'", "\u00b4"),
+                            NotificationArguments.UpdateAllPackages),
+                    ]);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not show updates-available notification");
+            Logger.Warn(ex);
+        }
+    }
+
+    /// <summary>
+    /// Shows a Windows toast offering a UniGetUI self-update with an "Update now" button.
+    /// </summary>
+    public static void ShowSelfUpdateAvailableNotification(string newVersion)
+    {
+        if (!EnsureRegistered()) return;
+        try
+        {
+            _removeByTagAsyncMethod?.Invoke(_managerDefault,
+                [CoreData.UniGetUICanBeUpdated.ToString()]);
+
+            ShowTextToast(
+                tag: CoreData.UniGetUICanBeUpdated.ToString(),
+                scenario: ScenarioDefault,
+                title: CoreTools.Translate("{0} can be updated to version {1}", "UniGetUI", newVersion),
+                message: CoreTools.Translate("You have currently version {0} installed", CoreData.VersionName),
+                suppressDisplay: false,
+                defaultAction: NotificationArguments.Show,
+                buttons:
+                [
+                    (CoreTools.Translate("Update now").Replace("'", "\u00b4"),
+                        NotificationArguments.ReleaseSelfUpdateLock),
+                ]);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not show self-update notification");
+            Logger.Warn(ex);
+        }
+    }
+
+    /// <summary>
+    /// Shows a Windows toast notification after new desktop shortcuts are detected.
+    /// </summary>
+    public static void ShowNewShortcutsNotification(IReadOnlyList<string> shortcuts)
+    {
+        if (!EnsureRegistered()) return;
+        if (Settings.AreNotificationsDisabled()) return;
+
+        try
+        {
+            _removeByTagAsyncMethod?.Invoke(_managerDefault,
+                [CoreData.NewShortcutsNotificationTag.ToString()]);
+
+            string title;
+            string message;
+
+            if (shortcuts.Count == 1)
+            {
+                title = CoreTools.Translate("Desktop shortcut created");
+                message = CoreTools.Translate(
+                    "UniGetUI has detected a new desktop shortcut that can be deleted automatically.")
+                    + "\n" + shortcuts[0].Split('\\')[^1];
+            }
+            else
+            {
+                string names = string.Join(", ", shortcuts.Select(s => s.Split('\\')[^1]));
+                title = CoreTools.Translate("{0} desktop shortcuts created", shortcuts.Count);
+                message = CoreTools.Translate(
+                    "UniGetUI has detected {0} new desktop shortcuts that can be deleted automatically.",
+                    shortcuts.Count) + "\n" + names;
+            }
+
+            ShowTextToast(
+                tag: CoreData.NewShortcutsNotificationTag.ToString(),
+                scenario: ScenarioDefault,
+                title: title,
+                message: message,
+                suppressDisplay: false,
+                defaultAction: NotificationArguments.Show,
+                buttons:
+                [
+                    (CoreTools.Translate("Open UniGetUI").Replace("'", "\u00b4"),
+                        NotificationArguments.Show),
+                ]);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not show new shortcuts notification");
+            Logger.Warn(ex);
+        }
+    }
+
+    private static bool EnsureRegistered()
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        lock (_registrationLock)
+        {
+            if (_registrationAttempted)
+                return _isRegistered;
+
+            _registrationAttempted = true;
+            try
+            {
+                var managerType = ResolveType(
+                    "Microsoft.Windows.AppNotifications.AppNotificationManager",
+                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationManager");
+                _builderType = ResolveType(
+                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationBuilder");
+                _scenarioType = ResolveType(
+                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationScenario");
+                _buttonType = ResolveType(
+                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationButton");
+
+                if (managerType is null || _builderType is null || _scenarioType is null)
+                {
+                    _isRegistered = false;
+                    return _isRegistered;
+                }
+
+                _managerDefault = managerType.GetProperty("Default", BindingFlags.Public | BindingFlags.Static)
+                    ?.GetValue(null);
+
+                if (_managerDefault is null)
+                {
+                    _isRegistered = false;
+                    return _isRegistered;
+                }
+
+                managerType.GetMethod("Register", BindingFlags.Public | BindingFlags.Instance)
+                    ?.Invoke(_managerDefault, null);
+
+                _removeByTagAsyncMethod = managerType.GetMethod(
+                    "RemoveByTagAsync",
+                    BindingFlags.Public | BindingFlags.Instance,
+                    binder: null,
+                    types: [typeof(string)],
+                    modifiers: null);
+
+                _showMethod = managerType.GetMethod("Show", BindingFlags.Public | BindingFlags.Instance);
+
+                // ── B2: subscribe to NotificationInvoked via Expression lambda ──────
+                var notifEventInfo = managerType.GetEvent("NotificationInvoked");
+                if (notifEventInfo is not null)
+                {
+                    var handlerType = notifEventInfo.EventHandlerType!;
+                    var invokeParams = handlerType.GetMethod("Invoke")!
+                        .GetParameters()
+                        .Select(p => Expression.Parameter(p.ParameterType, p.Name))
+                        .ToArray();
+                    var handlerMi = typeof(WindowsAppNotificationBridge)
+                        .GetMethod(nameof(OnNotificationInvoked),
+                            BindingFlags.Static | BindingFlags.NonPublic)!;
+                    var body = Expression.Call(
+                        handlerMi,
+                        Expression.Convert(invokeParams[0], typeof(object)),
+                        Expression.Convert(invokeParams[1], typeof(object)));
+                    var lambda = Expression.Lambda(handlerType, body, invokeParams);
+                    notifEventInfo.AddEventHandler(_managerDefault, lambda.Compile());
+                }
+
+                _isRegistered = _showMethod is not null;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn("Windows app notification registration failed in Avalonia host");
+                Logger.Warn(ex);
+                _isRegistered = false;
+            }
+
+            return _isRegistered;
+        }
+    }
+
+    private static bool ShowTextToast(
+        string tag,
+        string scenario,
+        string title,
+        string message,
+        bool suppressDisplay,
+        string? defaultAction = null,
+        IReadOnlyList<(string label, string action)>? buttons = null)
+    {
+        if (_managerDefault is null || _builderType is null || _scenarioType is null || _showMethod is null)
+            return false;
+
+        _removeByTagAsyncMethod?.Invoke(_managerDefault, [tag]);
+
+        object builder = Activator.CreateInstance(_builderType)
+            ?? throw new InvalidOperationException("Could not construct AppNotificationBuilder via reflection.");
+
+        object? scenarioValue = Enum.Parse(_scenarioType, scenario, ignoreCase: true);
+
+        builder = InvokeFluent(builder, "SetScenario", scenarioValue);
+        builder = InvokeFluent(builder, "SetTag", tag);
+        builder = InvokeFluent(builder, "AddText", title);
+        builder = InvokeFluent(builder, "AddText", message);
+
+        if (defaultAction is not null)
+            builder = InvokeFluent(builder, "AddArgument", "action", defaultAction);
+
+        // ── B2: add action buttons ─────────────────────────────────────────
+        if (buttons is not null && _buttonType is not null)
+        {
+            foreach (var (label, action) in buttons)
+            {
+                try
+                {
+                    object? btn = Activator.CreateInstance(_buttonType, label);
+                    if (btn is null) continue;
+                    // btn.AddArgument("action", action) returns AppNotificationButton
+                    btn = _buttonType
+                        .GetMethod("AddArgument", BindingFlags.Public | BindingFlags.Instance,
+                            null, [typeof(string), typeof(string)], null)
+                        ?.Invoke(btn, ["action", action]) ?? btn;
+                    builder = InvokeFluent(builder, "AddButton", btn);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn($"Could not add notification button '{label}': {ex.Message}");
+                }
+            }
+        }
+
+        object? notification = builder
+            .GetType()
+            .GetMethod("BuildNotification", BindingFlags.Public | BindingFlags.Instance)
+            ?.Invoke(builder, null);
+
+        if (notification is null)
+            return false;
+
+        SetPropertyIfPresent(notification, "ExpiresOnReboot", true);
+        SetPropertyIfPresent(notification, "SuppressDisplay", suppressDisplay);
+        _showMethod.Invoke(_managerDefault, [notification]);
+        return true;
+    }
+
+    private static object InvokeFluent(object instance, string methodName, params object?[] args)
+    {
+        return instance.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)
+            ?.Invoke(instance, args)
+            ?? instance;
+    }
+
+    private static void SetPropertyIfPresent(object instance, string propertyName, object value)
+    {
+        instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)
+            ?.SetValue(instance, value);
+    }
+
+    private static Type? ResolveType(params string[] possibleTypeNames)
+    {
+        foreach (var typeName in possibleTypeNames)
+        {
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var t = asm.GetType(typeName, throwOnError: false);
+                if (t is not null)
+                    return t;
+            }
+
+            foreach (var asmName in _assemblyCandidates)
+            {
+                try
+                {
+                    var asm = Assembly.Load(asmName);
+                    var t = asm.GetType(typeName, throwOnError: false);
+                    if (t is not null)
+                        return t;
+                }
+                catch
+                {
+                    // Keep probing candidates.
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // ── B2: notification activation handler ───────────────────────────────
+
+    private static void OnNotificationInvoked(object _, object args)
+    {
+        try
+        {
+            var arguments = args.GetType()
+                .GetProperty("Arguments", BindingFlags.Public | BindingFlags.Instance)
+                ?.GetValue(args) as IDictionary<string, string>;
+
+            if (arguments?.TryGetValue("action", out var action) == true && action is not null)
+            {
+                NotificationActivated?.Invoke(action);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("NotificationInvoked handler error");
+            Logger.Warn(ex);
+        }
+    }
+}

--- a/src/UniGetUI.Avalonia/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/MainWindow.axaml
@@ -1,0 +1,18 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        x:Class="UniGetUI.Avalonia.MainWindow"
+        Width="1440"
+        Height="900"
+        MinWidth="1100"
+        MinHeight="700"
+        Title="UniGetUI"
+        Icon="/Assets/icon.ico"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="SystemChrome"
+        TransparencyLevelHint="Mica, Blur"
+        d:DesignWidth="1440"
+        d:DesignHeight="900"
+        mc:Ignorable="d">
+</Window>

--- a/src/UniGetUI.Avalonia/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/MainWindow.axaml.cs
@@ -1,0 +1,735 @@
+using System.Net;
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Avalonia.Views;
+using UniGetUI.Avalonia.Views.Pages;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
+
+namespace UniGetUI.Avalonia;
+
+public partial class MainWindow : Window
+{
+    /// <summary>Gets the currently active <see cref="MainWindow"/> instance.</summary>
+    public static MainWindow? Instance { get; private set; }
+
+    private bool _initialized;
+    private TrayIcon? _trayIcon;
+    private WindowNotificationManager? _notificationManager;
+    private bool _isExplicitQuit;
+    private CancellationTokenSource? _geometrySaveCts;
+
+    public MainWindow()
+    {
+        Instance = this;
+        ApplyTheme();
+        InitializeComponent();
+        InitializeNotificationManager();
+        Title = BuildWindowTitle();
+        Opened += OnOpened;
+        SizeChanged += (_, _) => _ = SaveGeometryDebounced();
+        PositionChanged += (_, _) => _ = SaveGeometryDebounced();
+    }
+
+    private void InitializeNotificationManager()
+    {
+        _notificationManager = new WindowNotificationManager(this)
+        {
+            Position = NotificationPosition.TopRight,
+            MaxItems = 4,
+        };
+
+        // ── B2: hook notification activation callback ──────────────────────
+        WindowsAppNotificationBridge.NotificationActivated += OnNotificationActivated;
+    }
+
+    private void OnNotificationActivated(string action)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            try
+            {
+                if (action == NotificationArguments.UpdateAllPackages)
+                {
+                    _ = AvaloniaPackageOperationHelper.UpdateAllAsync();
+                }
+                else if (action == NotificationArguments.ShowOnUpdatesTab)
+                {
+                    ShowFromTray();
+                    if (Content is Views.MainShellView shell)
+                        shell.OpenPage(Models.ShellPageType.Updates);
+                }
+                else if (action == NotificationArguments.Show)
+                {
+                    ShowFromTray();
+                }
+                else if (action == NotificationArguments.ReleaseSelfUpdateLock)
+                {
+                    AvaloniaAutoUpdater.ReleaseLockForAutoupdate_Notification = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("OnNotificationActivated error:");
+                Logger.Error(ex);
+            }
+        });
+    }
+
+    private async void OnOpened(object? sender, EventArgs e)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+        RestoreGeometry();
+
+        // Handle --daemon: launch straight to tray without showing the window
+        if (Environment.GetCommandLineArgs().Contains("--daemon"))
+        {
+            Hide();
+        }
+
+        Content = new LoadingView();
+
+        try
+        {
+            await AvaloniaBootstrapper.InitializeAsync();
+            Content = new MainShellView();
+            Closing += OnWindowClosing;
+            Closed += OnWindowClosed;
+            InitTrayIcon();
+
+            // Background integrity check (non-blocking)
+            _ = Task.Run(() => IntegrityTester.CheckIntegrity()).ContinueWith(async t =>
+            {
+                if (!t.Result.Passed && !Settings.Get(Settings.K.DisableIntegrityChecks))
+                    await Dispatcher.UIThread.InvokeAsync(() => ShowIntegrityWarningAsync(this));
+            }, TaskScheduler.Default);
+
+            // Check for missing package manager dependencies (non-blocking — runs after shell is shown)
+            _ = Task.Run(AvaloniaBootstrapper.GetMissingDependenciesAsync)
+                .ContinueWith(async t =>
+                {
+                    if (t.IsCompletedSuccessfully && t.Result.Count > 0)
+                        await Dispatcher.UIThread.InvokeAsync(() => HandleMissingDependenciesAsync(t.Result));
+                    else if (t.IsFaulted)
+                        Logger.Error(t.Exception!);
+                }, TaskScheduler.Default);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("UniGetUI initialization failed");
+            Logger.Error(ex);
+            Content = new ErrorView(
+                CoreTools.Translate("An error occurred"),
+                ex.Message
+            );
+        }
+    }
+
+    /// <summary>Sequentially shows a <see cref="MissingDependencyDialog"/> for each missing dependency.</summary>
+    private async Task HandleMissingDependenciesAsync(
+        IReadOnlyList<UniGetUI.PackageEngine.Classes.Manager.Classes.ManagerDependency> dependencies)
+    {
+        int current = 1, total = dependencies.Count;
+        foreach (var dep in dependencies)
+        {
+            var dialog = new Views.Pages.MissingDependencyDialog(dep, current++, total);
+            await dialog.ShowDialog(this);
+        }
+    }
+
+    private void InitTrayIcon()
+    {
+        try
+        {
+            using var iconStream = AssetLoader.Open(new Uri("avares://UniGetUI.Avalonia/Assets/icon.ico"));
+            var windowIcon = new WindowIcon(iconStream);
+
+            _trayIcon = new TrayIcon
+            {
+                Icon = windowIcon,
+                ToolTipText = "UniGetUI",
+                IsVisible = !Settings.Get(Settings.K.DisableSystemTray),
+            };
+
+            var menu = new NativeMenu();
+
+            var showItem = new NativeMenuItem(CoreTools.Translate("Open UniGetUI"));
+            showItem.Click += (_, _) => ShowFromTray();
+            menu.Items.Add(showItem);
+
+            menu.Items.Add(new NativeMenuItemSeparator());
+
+            var discoverItem = new NativeMenuItem(CoreTools.Translate("Discover packages"));
+            discoverItem.Click += (_, _) => { ShowFromTray(); NavigateShell(ShellPageType.Discover); };
+            menu.Items.Add(discoverItem);
+
+            var updatesItem = new NativeMenuItem(CoreTools.Translate("Software Updates"));
+            updatesItem.Click += (_, _) => { ShowFromTray(); NavigateShell(ShellPageType.Updates); };
+            menu.Items.Add(updatesItem);
+
+            var installedItem = new NativeMenuItem(CoreTools.Translate("Installed packages"));
+            installedItem.Click += (_, _) => { ShowFromTray(); NavigateShell(ShellPageType.Installed); };
+            menu.Items.Add(installedItem);
+
+            menu.Items.Add(new NativeMenuItemSeparator());
+
+            var releaseNotesItem = new NativeMenuItem(CoreTools.Translate("Release notes"));
+            releaseNotesItem.Click += (_, _) =>
+            {
+                ShowFromTray();
+                var win = new ReleaseNotesWindow();
+                _ = win.ShowDialog(this);
+            };
+            menu.Items.Add(releaseNotesItem);
+
+            var aboutItem = new NativeMenuItem(CoreTools.Translate("About WingetUI"));
+            aboutItem.Click += (_, _) => new AboutPageWindow().Show();
+            menu.Items.Add(aboutItem);
+
+            menu.Items.Add(new NativeMenuItemSeparator());
+
+            var quitItem = new NativeMenuItem(CoreTools.Translate("Quit"));
+            quitItem.Click += (_, _) => QuitApplication();
+            menu.Items.Add(quitItem);
+
+            _trayIcon.Menu = menu;
+            _trayIcon.Clicked += (_, _) => ShowFromTray();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Failed to initialize system tray icon:");
+            Logger.Error(ex);
+        }
+    }
+
+    internal void NavigateShell(ShellPageType pageType)
+    {
+        if (Content is MainShellView shell)
+            shell.OpenPage(pageType);
+    }
+
+    private string _lastTrayIconVariant = "";
+
+    public void UpdateSystemTrayStatus()
+    {
+        if (_trayIcon is null) return;
+        try
+        {
+            bool anyRunning = AvaloniaOperationRegistry.Operations.Any(
+                o => o.Status is UniGetUI.PackageEngine.Enums.OperationStatus.Running
+                    or UniGetUI.PackageEngine.Enums.OperationStatus.InQueue);
+
+            bool anyFailed = AvaloniaOperationRegistry.Operations.Any(
+                o => o.Status == UniGetUI.PackageEngine.Enums.OperationStatus.Failed);
+
+            int updates = UniGetUI.PackageEngine.PackageLoader.UpgradablePackagesLoader.Instance.Count();
+
+            string modifier;
+            string tooltip;
+
+            if (anyRunning)
+            {
+                modifier = "blue";
+                tooltip = CoreTools.Translate("Operation in progress") + " — UniGetUI";
+            }
+            else if (anyFailed)
+            {
+                modifier = "orange";
+                tooltip = CoreTools.Translate("Failed") + " — UniGetUI";
+            }
+            else if (updates == 1)
+            {
+                modifier = "green";
+                tooltip = CoreTools.Translate("1 update is available") + " — UniGetUI";
+            }
+            else if (updates > 1)
+            {
+                modifier = "green";
+                tooltip = CoreTools.Translate("{0} updates are available", updates) + " — UniGetUI";
+            }
+            else
+            {
+                modifier = "empty";
+                tooltip = CoreTools.Translate("Everything is up to date") + " — UniGetUI";
+            }
+
+            _trayIcon.ToolTipText = tooltip;
+
+            // Determine light/dark theme from registry to pick black/white icon variant
+            string themeSuffix = "white"; // default: dark taskbar → white icon
+#pragma warning disable CA1416
+            try
+            {
+                using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(
+                    @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
+                if (key?.GetValue("SystemUsesLightTheme") is int val && val > 0)
+                    themeSuffix = "black";
+            }
+            catch { /* registry unavailable; keep default */ }
+#pragma warning restore CA1416
+
+            string variant = $"tray_{modifier}_{themeSuffix}";
+            if (variant == _lastTrayIconVariant) return;
+            _lastTrayIconVariant = variant;
+
+            using var stream = AssetLoader.Open(new Uri($"avares://UniGetUI.Avalonia/Assets/{variant}.ico"));
+            _trayIcon.Icon = new WindowIcon(stream);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Failed to update system tray status");
+            Logger.Warn(ex);
+        }
+    }
+
+    public void ApplyTrayIconVisibility()
+    {
+        if (_trayIcon is null) return;
+        _trayIcon.IsVisible = !Settings.Get(Settings.K.DisableSystemTray);
+    }
+
+    internal void ShowFromTray()
+    {
+        SetEfficiencyMode(false); // B3: leave EcoQoS when coming back to foreground
+        Show();
+        Activate();
+        WindowState = WindowState.Normal;
+
+        // Silently reload the Installed packages list so changes made outside
+        // UniGetUI while it was minimized/hidden are reflected immediately.
+        if (!UniGetUI.PackageEngine.PackageLoader.InstalledPackagesLoader.Instance.IsLoading)
+            _ = UniGetUI.PackageEngine.PackageLoader.InstalledPackagesLoader.Instance.ReloadPackagesSilently();
+    }
+
+    public void ShowRuntimeNotification(string title, string message, RuntimeNotificationLevel level)
+    {
+        if (_notificationManager is null)
+        {
+            return;
+        }
+
+        NotificationType type = level switch
+        {
+            RuntimeNotificationLevel.Success => NotificationType.Success,
+            RuntimeNotificationLevel.Error => NotificationType.Error,
+            _ => NotificationType.Information,
+        };
+
+        TimeSpan expiration = level == RuntimeNotificationLevel.Error
+            ? TimeSpan.FromSeconds(8)
+            : TimeSpan.FromSeconds(5);
+
+        _notificationManager.Show(new Notification(title, message, type, expiration));
+    }
+
+    public void QuitApplication()
+    {
+        // A3: release the auto-updater window lock so a pending installer can proceed
+        AvaloniaAutoUpdater.ReleaseLockForAutoupdate_Window = true;
+        _isExplicitQuit = true;
+        Close();
+    }
+
+    /// <summary>
+    /// Restart the application by spawning a fresh process and exiting immediately.
+    /// Mirrors WinUI3's <c>MainApp.Instance.KillAndRestart()</c>.
+    /// </summary>
+    public static void KillAndRestart()
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(CoreData.UniGetUIExecutableFile);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("KillAndRestart: failed to start new process");
+            Logger.Error(ex);
+        }
+        finally
+        {
+            Instance?.QuitApplication();
+        }
+    }
+
+    private static async Task ShowIntegrityWarningAsync(Window owner)
+    {
+        try
+        {
+            var dialog = new Window
+            {
+                Title = CoreTools.Translate("An error occurred"),
+                Width = 520,
+                SizeToContent = SizeToContent.Height,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Content = new StackPanel
+                {
+                    Margin = new Thickness(20),
+                    Spacing = 12,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = CoreTools.Translate("UniGetUI or some of its components are missing or corrupt.")
+                                   + " " + CoreTools.Translate("It is strongly recommended to reinstall UniGetUI to adress the situation."),
+                            TextWrapping = TextWrapping.Wrap,
+                            FontWeight = FontWeight.SemiBold,
+                        },
+                        new TextBlock
+                        {
+                            Text = " ● " + CoreTools.Translate("Refer to the UniGetUI Logs to get more details regarding the affected file(s)"),
+                            TextWrapping = TextWrapping.Wrap,
+                        },
+                        new TextBlock
+                        {
+                            Text = " ● " + CoreTools.Translate("Integrity checks can be disabled from the Experimental Settings"),
+                            TextWrapping = TextWrapping.Wrap,
+                        },
+                        new Button
+                        {
+                            Content = CoreTools.Translate("Close"),
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                        },
+                    },
+                },
+            };
+            // Wire close button
+            if (dialog.Content is StackPanel sp
+                && sp.Children[^1] is Button btn)
+                btn.Click += (_, _) => dialog.Close();
+
+            await dialog.ShowDialog(owner);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Failed to show integrity warning dialog");
+            Logger.Warn(ex);
+        }
+    }
+
+    private void OnWindowClosing(object? sender, WindowClosingEventArgs e)
+    {
+        if (!_isExplicitQuit && !Settings.Get(Settings.K.DisableSystemTray))
+        {
+            e.Cancel = true;
+            Hide();
+            SetEfficiencyMode(true); // B3: enter EcoQoS while hidden to tray
+            return;
+        }
+
+        // When tray is disabled (or user did an explicit quit via tray menu),
+        // check for active operations and ask for confirmation.
+        if (!_isExplicitQuit && HasRunningOperations())
+        {
+            e.Cancel = true;
+            Dispatcher.UIThread.Post(async () => await ConfirmQuitWithRunningOpsAsync());
+        }
+    }
+
+    private static bool HasRunningOperations()
+    {
+        return AvaloniaOperationRegistry.Operations.Any(
+            o => o.Status is UniGetUI.PackageEngine.Enums.OperationStatus.Running
+                or UniGetUI.PackageEngine.Enums.OperationStatus.InQueue);
+    }
+
+    private async Task ConfirmQuitWithRunningOpsAsync()
+    {
+        try
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var dialog = new Window
+            {
+                Title = CoreTools.Translate("Operation in progress"),
+                Width = 460,
+                SizeToContent = SizeToContent.Height,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Content = new StackPanel
+                {
+                    Margin = new Thickness(20),
+                    Spacing = 16,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = CoreTools.Translate("There are ongoing operations. Quitting WingetUI may cause them to fail. Do you want to continue?"),
+                            TextWrapping = TextWrapping.Wrap,
+                        },
+                        new StackPanel
+                        {
+                            Orientation = Orientation.Horizontal,
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            Spacing = 8,
+                            Children =
+                            {
+                                new Button { Content = CoreTools.Translate("Quit") },
+                                new Button { Content = CoreTools.Translate("Cancel") },
+                            },
+                        },
+                    },
+                },
+            };
+
+            if (dialog.Content is StackPanel sp
+                && sp.Children[1] is StackPanel btns)
+            {
+                ((Button)btns.Children[0]).Click += (_, _) => { tcs.TrySetResult(true); dialog.Close(); };
+                ((Button)btns.Children[1]).Click += (_, _) => { tcs.TrySetResult(false); dialog.Close(); };
+            }
+
+            dialog.Closed += (_, _) => tcs.TrySetResult(false);
+
+            await dialog.ShowDialog(this);
+            if (await tcs.Task)
+            {
+                QuitApplication();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Failed to show quit-confirmation dialog:");
+            Logger.Error(ex);
+        }
+    }
+
+    private void OnWindowClosed(object? sender, EventArgs e)
+    {
+        _trayIcon?.Dispose();
+        _trayIcon = null;
+    }
+
+    // ── B3: Windows EcoQoS / efficiency mode ──────────────────────────────
+    // Applied when the window hides to tray to reduce CPU/battery consumption;
+    // reverted when the window is brought back to the foreground.
+    // P/Invoke is guarded by RuntimeInformation so it compiles on all platforms.
+
+#pragma warning disable CA1416
+    private const int ProcessPowerThrottling = 4;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_POWER_THROTTLING_STATE
+    {
+        public uint Version;
+        public uint ControlMask;
+        public uint StateMask;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetProcessInformation(
+        IntPtr hProcess,
+        int ProcessInformationClass,
+        ref PROCESS_POWER_THROTTLING_STATE ProcessInformation,
+        uint ProcessInformationSize);
+#pragma warning restore CA1416
+
+    private static void SetEfficiencyMode(bool enable)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+        try
+        {
+            var state = new PROCESS_POWER_THROTTLING_STATE
+            {
+                Version = 1,
+                ControlMask = 1, // PROCESS_POWER_THROTTLING_EXECUTION_SPEED
+                StateMask = enable ? 1u : 0u,
+            };
+            SetProcessInformation(
+                System.Diagnostics.Process.GetCurrentProcess().Handle,
+                ProcessPowerThrottling,
+                ref state,
+                (uint)Marshal.SizeOf<PROCESS_POWER_THROTTLING_STATE>());
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("EcoQoS efficiency mode change failed:");
+            Logger.Warn(ex);
+        }
+    }
+
+    private static string BuildWindowTitle()
+    {
+        var details = new List<string>();
+
+        if (
+            Settings.Get(Settings.K.ShowVersionNumberOnTitlebar)
+            && !string.IsNullOrWhiteSpace(CoreData.VersionName)
+        )
+        {
+            details.Add(CoreTools.Translate("version {0}", CoreData.VersionName));
+        }
+
+        if (CoreTools.IsAdministrator())
+        {
+            details.Add(CoreTools.Translate("[RAN AS ADMINISTRATOR]"));
+        }
+
+        if (CoreData.IsPortable)
+        {
+            details.Add(CoreTools.Translate("Portable mode"));
+        }
+
+#if DEBUG
+        details.Add(CoreTools.Translate("DEBUG BUILD"));
+#endif
+
+        return details.Count == 0 ? "UniGetUI" : $"UniGetUI - {string.Join(" - ", details)}";
+    }
+
+    public void RefreshWindowTitle()
+    {
+        Title = BuildWindowTitle();
+    }
+
+    public static void ApplyProxyVariableToProcess()
+    {
+        try
+        {
+            var proxyUri = Settings.GetProxyUrl();
+            if (proxyUri is null || !Settings.Get(Settings.K.EnableProxy))
+            {
+                Environment.SetEnvironmentVariable(
+                    "HTTP_PROXY",
+                    string.Empty,
+                    EnvironmentVariableTarget.Process
+                );
+                return;
+            }
+
+            string content;
+            if (!Settings.Get(Settings.K.EnableProxyAuth))
+            {
+                content = proxyUri.ToString();
+            }
+            else
+            {
+                var credentials = Settings.GetProxyCredentials();
+                if (credentials is null)
+                {
+                    content = proxyUri.ToString();
+                }
+                else
+                {
+                    content =
+                        $"{proxyUri.Scheme}://{Uri.EscapeDataString(credentials.UserName)}"
+                        + $":{Uri.EscapeDataString(credentials.Password)}"
+                        + $"@{proxyUri.AbsoluteUri.Replace($"{proxyUri.Scheme}://", string.Empty)}";
+                }
+            }
+
+            Environment.SetEnvironmentVariable(
+                "HTTP_PROXY",
+                content,
+                EnvironmentVariableTarget.Process
+            );
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Failed to apply proxy settings:");
+            Logger.Error(ex);
+        }
+    }
+
+    private void ApplyTheme()
+    {
+        RequestedThemeVariant = Settings.GetValue(Settings.K.PreferredTheme) switch
+        {
+            "dark" => ThemeVariant.Dark,
+            "light" => ThemeVariant.Light,
+            _ => ThemeVariant.Default,
+        };
+    }
+
+    private async Task SaveGeometryDebounced()
+    {
+        _geometrySaveCts?.Cancel();
+        _geometrySaveCts = new CancellationTokenSource();
+        var token = _geometrySaveCts.Token;
+        try
+        {
+            await Task.Delay(300, token);
+            if (token.IsCancellationRequested) return;
+            SaveGeometry();
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    private void SaveGeometry()
+    {
+        try
+        {
+            if (WindowState == WindowState.Minimized) return;
+            int state = WindowState == WindowState.Maximized ? 1 : 0;
+            string geometry = $"v2,{Position.X},{Position.Y},{(int)Width},{(int)Height},{state}";
+            Logger.Debug($"Saving window geometry: {geometry}");
+            Settings.SetValue(Settings.K.WindowGeometry, geometry);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Failed to save window geometry:");
+            Logger.Error(ex);
+        }
+    }
+
+    private void RestoreGeometry()
+    {
+        try
+        {
+            var geometry = Settings.GetValue(Settings.K.WindowGeometry);
+            var parts = geometry.Split(',');
+            if (parts.Length == 6 && parts[0] == "v2")
+            {
+                int x = int.Parse(parts[1]);
+                int y = int.Parse(parts[2]);
+                int w = int.Parse(parts[3]);
+                int h = int.Parse(parts[4]);
+                int state = int.Parse(parts[5]);
+
+                if (w > 200 && h > 100)
+                {
+                    Width = w;
+                    Height = h;
+                    Position = new PixelPoint(x, y);
+                }
+                if (state == 1)
+                    WindowState = WindowState.Maximized;
+
+                Logger.Debug($"Restored window geometry: {geometry}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Failed to restore window geometry:");
+            Logger.Warn(ex);
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public enum RuntimeNotificationLevel
+    {
+        Progress,
+        Success,
+        Error,
+    }
+}

--- a/src/UniGetUI.Avalonia/Models/PackagePageMode.cs
+++ b/src/UniGetUI.Avalonia/Models/PackagePageMode.cs
@@ -1,0 +1,9 @@
+namespace UniGetUI.Avalonia.Models;
+
+public enum PackagePageMode
+{
+    None,
+    Discover,
+    Updates,
+    Installed,
+}

--- a/src/UniGetUI.Avalonia/Models/PackageRowModel.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageRowModel.cs
@@ -1,0 +1,191 @@
+using System.ComponentModel;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Avalonia.Media.Imaging;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Models;
+
+internal sealed class PackageRowModel : INotifyPropertyChanged, IDisposable
+{
+    private static readonly HttpClient _iconHttpClient = new(CoreTools.GenericHttpClientParameters)
+    {
+        Timeout = TimeSpan.FromSeconds(8),
+    };
+
+    private readonly PackagePageMode _pageMode;
+    private readonly AsyncCommand _primaryActionCommand;
+    private bool _isSelected;
+    private bool _isChecked;
+    private Bitmap? _iconBitmap;
+
+    public PackageRowModel(
+        IPackage package,
+        bool showNewVersionColumn,
+        PackagePageMode pageMode,
+        Func<IPackage, Task> runPrimaryActionAsync
+    )
+    {
+        Package = package;
+        _pageMode = pageMode;
+        Name = package.Name;
+        Id = package.Id;
+        Version = string.IsNullOrWhiteSpace(package.VersionString) ? "-" : package.VersionString;
+        Status = showNewVersionColumn
+            ? (string.IsNullOrWhiteSpace(package.NewVersionString) ? "-" : package.NewVersionString)
+            : package.Manager.DisplayName;
+        Source = package.Source.AsString_DisplayName;
+
+        _primaryActionCommand = new AsyncCommand(
+            () => runPrimaryActionAsync(Package),
+            () => CanExecutePrimaryAction
+        );
+
+        Package.PropertyChanged += Package_OnPropertyChanged;
+
+        if (!Settings.Get(Settings.K.DisableIconsOnPackageLists))
+            _ = LoadIconAsync();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public IPackage Package { get; }
+
+    public string Name { get; }
+
+    public string Id { get; }
+
+    public string Version { get; }
+
+    public string Status { get; }
+
+    public string Source { get; }
+
+    public ICommand PrimaryActionCommand => _primaryActionCommand;
+
+    public Bitmap? IconBitmap
+    {
+        get => _iconBitmap;
+        private set { _iconBitmap = value; OnPropertyChanged(); }
+    }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected == value) return;
+            _isSelected = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsChecked
+    {
+        get => _isChecked;
+        set
+        {
+            if (_isChecked == value) return;
+            _isChecked = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string PrimaryActionLabel => GetPrimaryActionLabel();
+
+    public bool CanExecutePrimaryAction => CanExecutePrimaryActionInternal();
+
+    private void Package_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(e.PropertyName) && e.PropertyName != nameof(IPackage.Tag))
+        {
+            return;
+        }
+
+        OnPropertyChanged(nameof(PrimaryActionLabel));
+        OnPropertyChanged(nameof(CanExecutePrimaryAction));
+        _primaryActionCommand.RaiseCanExecuteChanged();
+    }
+
+    private string GetPrimaryActionLabel()
+    {
+        return Package.Tag switch
+        {
+            PackageTag.OnQueue => CoreTools.Translate("This package is on the queue"),
+            PackageTag.BeingProcessed => _pageMode switch
+            {
+                PackagePageMode.Discover => CoreTools.Translate("installing"),
+                PackagePageMode.Updates => CoreTools.Translate("updating"),
+                PackagePageMode.Installed => CoreTools.Translate("uninstalling"),
+                _ => CoreTools.Translate("Operation in progress"),
+            },
+            PackageTag.AlreadyInstalled when _pageMode == PackagePageMode.Discover => CoreTools.Translate("installed"),
+            PackageTag.Failed => CoreTools.Translate("Retry"),
+            _ => _pageMode switch
+            {
+                PackagePageMode.Discover => CoreTools.Translate("Install"),
+                PackagePageMode.Updates => CoreTools.Translate("Update"),
+                PackagePageMode.Installed => CoreTools.Translate("Uninstall"),
+                _ => CoreTools.Translate("Open"),
+            },
+        };
+    }
+
+    private bool CanExecutePrimaryActionInternal()
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => Package.Tag is not PackageTag.AlreadyInstalled
+                and not PackageTag.OnQueue
+                and not PackageTag.BeingProcessed
+                and not PackageTag.Unavailable,
+            PackagePageMode.Updates => Package.Tag is not PackageTag.OnQueue
+                and not PackageTag.BeingProcessed
+                and not PackageTag.Unavailable,
+            PackagePageMode.Installed => Package.Tag is not PackageTag.OnQueue
+                and not PackageTag.BeingProcessed
+                and not PackageTag.Unavailable,
+            _ => false,
+        };
+    }
+
+    public void Dispose()
+    {
+        Package.PropertyChanged -= Package_OnPropertyChanged;
+    }
+
+    private async Task LoadIconAsync()
+    {
+        try
+        {
+            var uri = Package.GetIconUrlIfAny();
+            if (uri is null) return;
+
+            Bitmap bitmap;
+            if (uri.IsFile)
+            {
+                bitmap = new Bitmap(uri.LocalPath);
+            }
+            else if (uri.Scheme is "http" or "https")
+            {
+                var bytes = await _iconHttpClient.GetByteArrayAsync(uri);
+                using var ms = new MemoryStream(bytes);
+                bitmap = new Bitmap(ms);
+            }
+            else return;
+
+            IconBitmap = bitmap;
+        }
+        catch { /* ignore — no icon is fine */ }
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/UniGetUI.Avalonia/Models/ShellPageType.cs
+++ b/src/UniGetUI.Avalonia/Models/ShellPageType.cs
@@ -1,0 +1,13 @@
+namespace UniGetUI.Avalonia.Models;
+
+internal enum ShellPageType
+{
+    Discover,
+    Updates,
+    Installed,
+    Bundles,
+    Settings,
+    Managers,
+    Help,
+    Logs,
+}

--- a/src/UniGetUI.Avalonia/Program.cs
+++ b/src/UniGetUI.Avalonia/Program.cs
@@ -1,0 +1,284 @@
+using System.Threading;
+using Avalonia;
+using AvaloniaUI.DiagnosticsProtocol;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia;
+
+internal sealed class Program
+{
+    // Kept alive for the lifetime of the process to enforce single-instance
+    // ReSharper disable once NotAccessedField.Local
+    private static Mutex? _singleInstanceMutex;
+
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        // ── Pre-UI headless CLI dispatch (A1) ──────────────────────────────
+        // These commands operate purely on settings/files and exit without
+        // showing any UI.  They mirror WinUI's EntryPoint.cs dispatch block.
+        if (args.Contains("--import-settings"))
+        {
+            Environment.Exit(RunCli_ImportSettings(args));
+            return;
+        }
+        if (args.Contains("--export-settings"))
+        {
+            Environment.Exit(RunCli_ExportSettings(args));
+            return;
+        }
+        if (args.Contains("--enable-setting"))
+        {
+            Environment.Exit(RunCli_EnableSetting(args));
+            return;
+        }
+        if (args.Contains("--disable-setting"))
+        {
+            Environment.Exit(RunCli_DisableSetting(args));
+            return;
+        }
+        if (args.Contains("--set-setting-value"))
+        {
+            Environment.Exit(RunCli_SetSettingValue(args));
+            return;
+        }
+
+        // ── A6: WinGetUI→UniGetUI shortcut migration (called by installer) ──
+        if (args.Contains("--migrate-wingetui-to-unigetui"))
+        {
+            Environment.Exit(RunCli_MigrateWingetUI());
+            return;
+        }
+
+        // ── Stub: prevents re-launch during MSI/MSIX uninstall ────────────
+        if (args.Contains("--uninstall-unigetui") || args.Contains("--uninstall-wingetui"))
+        {
+            Environment.Exit(0);
+            return;
+        }
+
+        // ── Single-instance enforcement ────────────────────────────────────
+        _singleInstanceMutex = new Mutex(
+            initiallyOwned: true,
+            name: "UniGetUI_" + CoreData.MainWindowIdentifier,
+            createdNew: out bool createdNew);
+
+        if (!createdNew)
+        {
+            // Forward args to the first instance then exit (mirrors WinUI3's AppInstance.RedirectActivationToAsync).
+            Logger.Warn("UniGetUI is already running. Forwarding args to first instance.");
+            SingleInstanceRedirector.TryForwardToFirstInstance(args);
+            _singleInstanceMutex.Close();
+            _singleInstanceMutex = null;
+            return;
+        }
+
+        // Start the pipe listener so future second instances can forward their args.
+        SingleInstanceRedirector.StartListener(OnIncomingArgs);
+
+        // Register global exception handlers for logging and crash reporting
+        RegisterErrorHandling();
+
+        try
+        {
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        }
+        catch (Exception ex)
+        {
+            // A7: top-level crash handler
+            ReportFatalException(ex);
+        }
+        finally
+        {
+            _singleInstanceMutex.ReleaseMutex();
+            _singleInstanceMutex.Dispose();
+            _singleInstanceMutex = null;
+        }
+    }
+
+    // ── Second-instance arg handler ──────────────────────────────────────
+
+    private static void OnIncomingArgs(string[] incomingArgs)
+    {
+        // Show the main window.
+        MainWindow.Instance?.ShowFromTray();
+
+        // Route the forwarded arguments through the shell's arg processor.
+        if (MainWindow.Instance?.Content is Views.MainShellView shell)
+            shell.ProcessIncomingArgs(incomingArgs);
+    }
+
+    // ── Headless CLI helpers ───────────────────────────────────────────────
+
+    private static int RunCli_ImportSettings(string[] args)
+    {
+        int pos = Array.IndexOf(args, "--import-settings");
+        if (pos < 0 || pos + 1 >= args.Length) return -1073741811; // STATUS_INVALID_PARAMETER
+        string file = args[pos + 1].Trim('"').Trim('\'');
+        if (!File.Exists(file)) return -1073741809; // STATUS_NO_SUCH_FILE
+        try { Settings.ImportFromFile_JSON(file); return 0; }
+        catch (Exception ex) { return ex.HResult; }
+    }
+
+    private static int RunCli_ExportSettings(string[] args)
+    {
+        int pos = Array.IndexOf(args, "--export-settings");
+        if (pos < 0 || pos + 1 >= args.Length) return -1073741811;
+        string file = args[pos + 1].Trim('"').Trim('\'');
+        try { Settings.ExportToFile_JSON(file); return 0; }
+        catch (Exception ex) { return ex.HResult; }
+    }
+
+    private static int RunCli_EnableSetting(string[] args)
+    {
+        int pos = Array.IndexOf(args, "--enable-setting");
+        if (pos < 0 || pos + 1 >= args.Length) return -1073741811;
+        string name = args[pos + 1].Trim('"').Trim('\'');
+        if (!Enum.TryParse(name, out Settings.K key)) return -2; // STATUS_UNKNOWN_SETTINGS_KEY
+        try { Settings.Set(key, true); return 0; }
+        catch (Exception ex) { return ex.HResult; }
+    }
+
+    private static int RunCli_DisableSetting(string[] args)
+    {
+        int pos = Array.IndexOf(args, "--disable-setting");
+        if (pos < 0 || pos + 1 >= args.Length) return -1073741811;
+        string name = args[pos + 1].Trim('"').Trim('\'');
+        if (!Enum.TryParse(name, out Settings.K key)) return -2;
+        try { Settings.Set(key, false); return 0; }
+        catch (Exception ex) { return ex.HResult; }
+    }
+
+    private static int RunCli_SetSettingValue(string[] args)
+    {
+        int pos = Array.IndexOf(args, "--set-setting-value");
+        if (pos < 0 || pos + 2 >= args.Length) return -1073741811;
+        string name = args[pos + 1].Trim('"').Trim('\'');
+        string value = args[pos + 2];
+        if (!Enum.TryParse(name, out Settings.K key)) return -2;
+        try { Settings.SetValue(key, value); return 0; }
+        catch (Exception ex) { return ex.HResult; }
+    }
+
+    // ── A6: WinGetUI→UniGetUI shortcut migrator ────────────────────────────
+
+    private static int RunCli_MigrateWingetUI()
+    {
+        try
+        {
+            string[] basePaths =
+            [
+                Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
+                Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory),
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu),
+            ];
+
+            foreach (string basePath in basePaths)
+            {
+                foreach (string oldName in new[]
+                {
+                    "WingetUI.lnk",
+                    "WingetUI .lnk",
+                    "UniGetUI (formerly WingetUI) .lnk",
+                    "UniGetUI (formerly WingetUI).lnk",
+                })
+                {
+                    try
+                    {
+                        string oldFile = Path.Join(basePath, oldName);
+                        string newFile = Path.Join(basePath, "UniGetUI.lnk");
+                        if (!File.Exists(oldFile))
+                            continue;
+
+                        if (File.Exists(newFile))
+                        {
+                            Logger.Info($"Deleting old shortcut '{oldFile}' (new one already exists)");
+                            File.Delete(oldFile);
+                        }
+                        else
+                        {
+                            Logger.Info($"Renaming shortcut '{oldFile}' → '{newFile}'");
+                            File.Move(oldFile, newFile);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn($"Could not migrate shortcut '{Path.Join(basePath, oldName)}'");
+                        Logger.Warn(ex);
+                    }
+                }
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+            return ex.HResult;
+        }
+    }
+
+    // ── A7: crash reporter ─────────────────────────────────────────────────
+
+    private static void RegisterErrorHandling()
+    {
+        // Log unobserved task exceptions and mark them as observed to
+        // prevent .NET from terminating the process on GC finalization.
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            Logger.Error("Unobserved task exception:");
+            Logger.Error(e.Exception);
+            e.SetObserved();
+        };
+
+        // Log truly unhandled exceptions on any thread. These are fatal —
+        // the process is about to terminate (e.IsTerminating == true).
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+        {
+            if (e.ExceptionObject is Exception ex)
+                ReportFatalException(ex);
+        };
+    }
+
+    private static void ReportFatalException(Exception ex)
+    {
+        try
+        {
+            // Write a crash log next to the settings directory
+            string crashPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "UniGetUI",
+                $"crash_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
+            Directory.CreateDirectory(Path.GetDirectoryName(crashPath)!);
+            File.WriteAllText(crashPath,
+                $"UniGetUI fatal crash at {DateTime.UtcNow:O}\n\n{ex}");
+            Logger.Error("FATAL EXCEPTION — crash log written to: " + crashPath);
+            Logger.Error(ex);
+        }
+        catch { /* best-effort */ }
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        var builder = AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+
+#if DEBUG
+        builder = builder.WithDeveloperTools(options =>
+        {
+            options.ApplicationName = "UniGetUI.Avalonia";
+            options.ConnectOnStartup = true;
+            options.EnableDiscovery = true;
+            options.DiagnosticLogger = DiagnosticLogger.CreateConsole();
+        });
+#endif
+
+        return builder;
+    }
+}

--- a/src/UniGetUI.Avalonia/Styles/AppStyles.axaml
+++ b/src/UniGetUI.Avalonia/Styles/AppStyles.axaml
@@ -1,0 +1,238 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Style Selector="TextBlock.hero-title">
+    <Setter Property="FontWeight" Value="Black" />
+  </Style>
+
+  <Style Selector="Border.surface-card">
+    <Setter Property="Background" Value="#0A000000" />
+    <Setter Property="BorderBrush" Value="#14000000" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="18" />
+  </Style>
+
+  <Style Selector="Border.surface-card.flat-shell-panel">
+    <Setter Property="CornerRadius" Value="0" />
+  </Style>
+
+  <Style Selector="Border.surface-card.subtle-panel">
+    <Setter Property="Background" Value="#06000000" />
+    <Setter Property="BorderBrush" Value="#12000000" />
+    <Setter Property="CornerRadius" Value="14" />
+  </Style>
+
+  <Style Selector="Border.surface-card.badge-panel">
+    <Setter Property="Background" Value="#0F000000" />
+    <Setter Property="BorderBrush" Value="#16000000" />
+    <Setter Property="CornerRadius" Value="999" />
+  </Style>
+
+  <Style Selector="Border.surface-card.warning-panel">
+    <Setter Property="Background" Value="#3A2E14" />
+    <Setter Property="BorderBrush" Value="#7A5D20" />
+  </Style>
+
+  <Style Selector="Border.surface-card.success-panel">
+    <Setter Property="Background" Value="#11311F" />
+    <Setter Property="BorderBrush" Value="#295C3D" />
+  </Style>
+
+  <Style Selector="Border.surface-card.danger-panel">
+    <Setter Property="Background" Value="#402028" />
+    <Setter Property="BorderBrush" Value="#8A3E4E" />
+  </Style>
+
+  <Style Selector="Border.surface-card.info-panel">
+    <Setter Property="Background" Value="#1E2940" />
+    <Setter Property="BorderBrush" Value="#35588D" />
+  </Style>
+
+  <Style Selector="Button.nav">
+    <Setter Property="BorderBrush" Value="#00000000" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="Padding" Value="10,9" />
+    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="MinHeight" Value="40" />
+    <Setter Property="Opacity" Value="0.9" />
+  </Style>
+
+  <Style Selector="Button.nav:pointerover">
+    <Setter Property="Opacity" Value="1" />
+  </Style>
+
+  <Style Selector="Button.nav.selected">
+    <Setter Property="Background" Value="#12000000" />
+    <Setter Property="BorderBrush" Value="#22000000" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Opacity" Value="1" />
+  </Style>
+
+  <Style Selector="Button.icon-shell">
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="MinWidth" Value="34" />
+    <Setter Property="MinHeight" Value="34" />
+  </Style>
+
+  <Style Selector="Button.caption-button">
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="FontSize" Value="14" />
+    <Setter Property="MinWidth" Value="38" />
+    <Setter Property="MinHeight" Value="30" />
+  </Style>
+
+  <Style Selector="Button.caption-close:pointerover">
+    <Setter Property="Background" Value="#8D2E3E" />
+    <Setter Property="BorderBrush" Value="#A94152" />
+  </Style>
+
+  <Style Selector="Button.toolbar-primary">
+    <Setter Property="Padding" Value="14,8" />
+    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="MinHeight" Value="36" />
+  </Style>
+
+  <Style Selector="Button.toolbar-secondary">
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="12,8" />
+    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="MinHeight" Value="36" />
+  </Style>
+
+  <Style Selector="Button.inline-row-action">
+    <Setter Property="Padding" Value="10,6" />
+    <Setter Property="MinWidth" Value="92" />
+    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="HorizontalAlignment" Value="Right" />
+  </Style>
+
+  <Style Selector="Button.settings-tile">
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderBrush" Value="#16000000" />
+    <Setter Property="Background" Value="#06000000" />
+    <Setter Property="Padding" Value="18" />
+    <Setter Property="CornerRadius" Value="16" />
+    <Setter Property="MinHeight" Value="92" />
+  </Style>
+
+  <Style Selector="Button.settings-tile:pointerover">
+    <Setter Property="Background" Value="#0C000000" />
+    <Setter Property="BorderBrush" Value="#22000000" />
+  </Style>
+
+  <Style Selector="Button.settings-tile:pressed">
+    <Setter Property="Background" Value="#12000000" />
+  </Style>
+
+  <Style Selector="Button.manager-row-button">
+    <Setter Property="Background" Value="#00000000" />
+    <Setter Property="BorderBrush" Value="#00000000" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Padding" Value="0" />
+  </Style>
+
+  <Style Selector="Button.manager-row-button:pointerover">
+    <Setter Property="Opacity" Value="1" />
+  </Style>
+
+  <Style Selector="Button.manager-row-button /template/ ContentPresenter">
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+  </Style>
+
+  <Style Selector="Border.manager-avatar">
+    <Setter Property="CornerRadius" Value="14" />
+  </Style>
+
+  <Style Selector="Border.manager-status.ready">
+    <Setter Property="Background" Value="#11311F" />
+    <Setter Property="BorderBrush" Value="#295C3D" />
+  </Style>
+
+  <Style Selector="Border.manager-status.disabled">
+    <Setter Property="Background" Value="#3A2E14" />
+    <Setter Property="BorderBrush" Value="#7A5D20" />
+  </Style>
+
+  <Style Selector="Border.manager-status.missing">
+    <Setter Property="Background" Value="#402028" />
+    <Setter Property="BorderBrush" Value="#8A3E4E" />
+  </Style>
+
+  <Style Selector="Border.manager-status.loading">
+    <Setter Property="Background" Value="#1E2940" />
+    <Setter Property="BorderBrush" Value="#35588D" />
+  </Style>
+
+  <Style Selector="TextBlock.manager-path">
+    <Setter Property="MaxWidth" Value="520" />
+  </Style>
+
+  <Style Selector="TextBlock.data-header">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Opacity" Value="0.7" />
+    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+  </Style>
+
+  <Style Selector="TextBlock.data-primary">
+    <Setter Property="FontSize" Value="13" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+  </Style>
+
+  <Style Selector="TextBlock.data-secondary">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="Opacity" Value="0.84" />
+    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+  </Style>
+
+  <Style Selector="Border.data-row">
+    <Setter Property="Padding" Value="0,10" />
+    <Setter Property="BorderBrush" Value="#12000000" />
+    <Setter Property="BorderThickness" Value="0,0,0,1" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+
+  <Style Selector="Border.data-row.selected">
+    <Setter Property="Background" Value="#18007FD4" />
+    <Setter Property="BorderBrush" Value="#40007FD4" />
+    <Setter Property="CornerRadius" Value="6" />
+  </Style>
+
+  <Style Selector="TextBlock.mono-data">
+    <Setter Property="FontFamily" Value="Consolas, Cascadia Mono, Courier New" />
+  </Style>
+
+  <Style Selector="Button.sort-header">
+    <Setter Property="Background" Value="#00000000" />
+    <Setter Property="BorderBrush" Value="#00000000" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Opacity" Value="0.7" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="MinHeight" Value="0" />
+    <Setter Property="MinWidth" Value="0" />
+  </Style>
+
+  <Style Selector="Button.sort-header:pointerover">
+    <Setter Property="Background" Value="#00000000" />
+    <Setter Property="BorderBrush" Value="#00000000" />
+    <Setter Property="Opacity" Value="1.0" />
+  </Style>
+
+  <Style Selector="Button.sort-header:pressed">
+    <Setter Property="Background" Value="#00000000" />
+  </Style>
+
+  <Style Selector="Button.sort-header.active">
+    <Setter Property="Opacity" Value="1.0" />
+  </Style>
+</Styles>

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks />
+        <OutputType>WinExe</OutputType>
+        <RootNamespace>UniGetUI.Avalonia</RootNamespace>
+        <AssemblyName>UniGetUI.Avalonia</AssemblyName>
+        <ApplicationIcon>..\UniGetUI\icon.ico</ApplicationIcon>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia" Version="11.3.7" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.7" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.7" />
+        <PackageReference Include="Devolutions.AvaloniaTheme.DevExpress" Version="2026.3.13" />
+        <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.3.13" />
+        <PackageReference Include="Devolutions.AvaloniaTheme.Linux" Version="2026.3.11" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3" Condition="'$(Configuration)' == 'Debug'" />
+        <PackageReference Include="Octokit" Version="14.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\UniGetUI.Core.Data\UniGetUI.Core.Data.csproj" />
+        <ProjectReference Include="..\UniGetUI.Core.LanguageEngine\UniGetUI.Core.LanguageEngine.csproj" />
+        <ProjectReference Include="..\UniGetUI.Core.Logger\UniGetUI.Core.Logging.csproj" />
+        <ProjectReference Include="..\UniGetUI.Core.SecureSettings\UniGetUI.Core.SecureSettings.csproj" />
+        <ProjectReference Include="..\UniGetUI.Core.Settings\UniGetUI.Core.Settings.csproj" />
+        <ProjectReference Include="..\UniGetUI.Core.Tools\UniGetUI.Core.Tools.csproj" />
+        <ProjectReference Include="..\UniGetUI.Interface.Enums\UniGetUI.Interface.Enums.csproj" />
+        <ProjectReference Include="..\UniGetUI.Interface.BackgroundApi\UniGetUI.Interface.BackgroundApi.csproj" />
+        <ProjectReference Include="..\UniGetUI.Interface.Telemetry\UniGetUI.Interface.Telemetry.csproj" />
+        <ProjectReference Include="..\UniGetUI.PackageEngine.PackageEngine\UniGetUI.PackageEngine.PEInterface.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AvaloniaResource Include="..\UniGetUI\icon.ico" Link="Assets\icon.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\icon_unsquare.png" Link="Assets\icon_unsquare.png" />
+        <!-- Tray status icon variants -->
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_empty_black.ico"      Link="Assets\tray_empty_black.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_empty_white.ico"      Link="Assets\tray_empty_white.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_blue_black.ico"       Link="Assets\tray_blue_black.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_blue_white.ico"       Link="Assets\tray_blue_white.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_green_black.ico"      Link="Assets\tray_green_black.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_green_white.ico"      Link="Assets\tray_green_white.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_orange_black.ico"     Link="Assets\tray_orange_black.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_orange_white.ico"     Link="Assets\tray_orange_white.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_turquoise_black.ico"  Link="Assets\tray_turquoise_black.ico" />
+        <AvaloniaResource Include="..\UniGetUI\Assets\Images\tray_turquoise_white.ico"  Link="Assets\tray_turquoise_white.ico" />
+    </ItemGroup>
+ </Project>

--- a/src/UniGetUI.Avalonia/Views/ErrorView.axaml
+++ b/src/UniGetUI.Avalonia/Views/ErrorView.axaml
@@ -1,0 +1,27 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.ErrorView">
+  <Grid>
+    <Border Width="640"
+            Padding="28"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Classes="surface-card"
+            BorderBrush="#7A3646"
+            CornerRadius="24">
+      <StackPanel Spacing="14">
+        <TextBlock x:Name="ErrorHeadingBlock"
+                   FontSize="30"
+                   FontWeight="Bold"
+                   Text="Shell Error" />
+        <TextBlock x:Name="ErrorTitleBlock"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   TextWrapping="Wrap" />
+        <TextBlock x:Name="ErrorDescriptionBlock"
+                   Opacity="0.8"
+                   TextWrapping="Wrap" />
+      </StackPanel>
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/ErrorView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/ErrorView.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views;
+
+public partial class ErrorView : UserControl
+{
+    private TextBlock ErrorHeadingText => GetControl<TextBlock>("ErrorHeadingBlock");
+
+    private TextBlock ErrorTitleText => GetControl<TextBlock>("ErrorTitleBlock");
+
+    private TextBlock ErrorDescriptionText => GetControl<TextBlock>("ErrorDescriptionBlock");
+
+    public ErrorView()
+        : this("Error", string.Empty)
+    {
+    }
+
+    public ErrorView(string title, string description)
+    {
+        InitializeComponent();
+        ErrorHeadingText.Text = CoreTools.Translate("Error");
+        ErrorTitleText.Text = title;
+        ErrorDescriptionText.Text = description;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/IShellPage.cs
+++ b/src/UniGetUI.Avalonia/Views/IShellPage.cs
@@ -1,0 +1,14 @@
+namespace UniGetUI.Avalonia.Views;
+
+internal interface IShellPage
+{
+    string Title { get; }
+
+    string Subtitle { get; }
+
+    bool SupportsSearch { get; }
+
+    string SearchPlaceholder { get; }
+
+    void UpdateSearchQuery(string query);
+}

--- a/src/UniGetUI.Avalonia/Views/LoadingView.axaml
+++ b/src/UniGetUI.Avalonia/Views/LoadingView.axaml
@@ -1,0 +1,40 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.LoadingView">
+  <Grid>
+    <Border Width="520"
+            Padding="32"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Classes="surface-card"
+            CornerRadius="28">
+      <Grid ColumnDefinitions="Auto,*"
+            ColumnSpacing="24">
+        <Image Width="96"
+               Height="96"
+               Source="/Assets/icon_unsquare.png"
+               Stretch="Uniform" />
+        <StackPanel Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Spacing="6">
+          <TextBlock FontSize="42"
+                     Text="UniGetUI"
+                     Classes="hero-title" />
+          <TextBlock FontSize="18"
+                     Opacity="0.85"
+                     x:Name="TaglineBlock"
+                     Text="Package management made easy" />
+          <StackPanel Margin="0,18,0,0"
+                      Orientation="Horizontal"
+                      Spacing="12">
+            <ProgressBar Width="220"
+                         IsIndeterminate="True" />
+            <TextBlock VerticalAlignment="Center"
+                       x:Name="StatusBlock"
+                       Text="Preparing..." />
+          </StackPanel>
+        </StackPanel>
+      </Grid>
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/LoadingView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/LoadingView.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views;
+
+public partial class LoadingView : UserControl
+{
+    public LoadingView()
+    {
+        InitializeComponent();
+        this.FindControl<TextBlock>("TaglineBlock")!.Text = CoreTools.Translate("Package management made easy");
+        this.FindControl<TextBlock>("StatusBlock")!.Text = CoreTools.Translate("Loading packages, please wait...");
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/MainShellView.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainShellView.axaml
@@ -1,0 +1,291 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:pages="using:UniGetUI.Avalonia.Views.Pages"
+             x:Class="UniGetUI.Avalonia.Views.MainShellView">
+  <Grid ColumnDefinitions="Auto,*"
+        RowDefinitions="*">
+    <Border x:Name="SidebarBorder"
+            Width="232"
+            Padding="12"
+            Classes="surface-card flat-shell-panel"
+            BorderThickness="0,0,1,0">
+      <Grid RowDefinitions="Auto,*,Auto">
+        <StackPanel Spacing="16">
+          <Grid ColumnDefinitions="*,Auto"
+                PointerPressed="TitleRegion_OnPointerPressed"
+                DoubleTapped="TitleRegion_OnDoubleTapped">
+            <StackPanel Spacing="3">
+              <TextBlock FontSize="16"
+                         FontWeight="Bold"
+                         Text="UniGetUI" />
+              <TextBlock x:Name="ShellSubtitleBlock"
+                         Opacity="0.68"
+                         TextTrimming="CharacterEllipsis"
+                         Text="" />
+            </StackPanel>
+            <Button x:Name="ToggleNavigationButton"
+                    Grid.Column="1"
+                  Width="32"
+                  Height="32"
+                    Padding="0"
+                    Classes="icon-shell"
+                    Click="ToggleNavigationButton_OnClick"
+                    Content="☰" />
+          </Grid>
+
+          <StackPanel Spacing="6">
+            <Button x:Name="DiscoverButton"
+                    Classes="nav"
+                    Click="DiscoverButton_OnClick">
+              <Grid ColumnDefinitions="20,*"
+                ColumnSpacing="10">
+                <TextBlock Text="◎" />
+                <TextBlock x:Name="DiscoverLabel"
+                           Grid.Column="1"
+                           Text="Discover Packages" />
+              </Grid>
+            </Button>
+            <Button x:Name="UpdatesButton"
+                    Classes="nav"
+                    Click="UpdatesButton_OnClick">
+              <Grid ColumnDefinitions="20,*,Auto"
+                ColumnSpacing="10">
+                <TextBlock Text="↻" />
+                <TextBlock x:Name="UpdatesLabel"
+                           Grid.Column="1"
+                           Text="Software Updates" />
+                <Border x:Name="UpdatesBadge"
+                        Grid.Column="2"
+                        IsVisible="False"
+                        CornerRadius="10"
+                        Padding="5,2"
+                        Background="{DynamicResource SystemAccentColor}">
+                  <TextBlock x:Name="UpdatesBadgeCount"
+                             FontSize="10"
+                             FontWeight="Bold"
+                             Foreground="White"
+                             Text="0" />
+                </Border>
+              </Grid>
+            </Button>
+            <Button x:Name="InstalledButton"
+                    Classes="nav"
+                    Click="InstalledButton_OnClick">
+              <Grid ColumnDefinitions="20,*"
+                ColumnSpacing="10">
+                <TextBlock Text="▣" />
+                <TextBlock x:Name="InstalledLabel"
+                           Grid.Column="1"
+                           Text="Installed Packages" />
+              </Grid>
+            </Button>
+            <Button x:Name="BundlesButton"
+                    Classes="nav"
+                    Click="BundlesButton_OnClick">
+              <Grid ColumnDefinitions="20,*"
+                ColumnSpacing="10">
+                <TextBlock Text="☷" />
+                <TextBlock x:Name="BundlesLabel"
+                           Grid.Column="1"
+                           Text="Package Bundles" />
+              </Grid>
+            </Button>
+          </StackPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2"
+                    Spacing="6">
+          <Button x:Name="SettingsButton"
+                  Classes="nav"
+                  Click="SettingsButton_OnClick">
+            <Grid ColumnDefinitions="20,*"
+              ColumnSpacing="10">
+              <TextBlock Text="⚙" />
+              <TextBlock x:Name="SettingsLabel"
+                         Grid.Column="1"
+                         Text="Settings" />
+            </Grid>
+          </Button>
+          <Button x:Name="ManagersButton"
+                  Classes="nav"
+                  Click="ManagersButton_OnClick">
+            <Grid ColumnDefinitions="20,*"
+              ColumnSpacing="10">
+              <TextBlock Text="⌘" />
+              <TextBlock x:Name="ManagersLabel"
+                         Grid.Column="1"
+                         Text="Package Managers" />
+            </Grid>
+          </Button>
+          <Button x:Name="HelpButton"
+                  Classes="nav"
+                  Click="HelpButton_OnClick">
+            <Grid ColumnDefinitions="20,*"
+              ColumnSpacing="10">
+              <TextBlock Text="?" />
+              <TextBlock x:Name="HelpLabel"
+                         Grid.Column="1"
+                         Text="Help" />
+            </Grid>
+          </Button>
+          <Button x:Name="LogsButton"
+                  Classes="nav"
+                  Click="LogsButton_OnClick">
+            <Grid ColumnDefinitions="20,*"
+              ColumnSpacing="10">
+              <TextBlock Text="📋" />
+              <TextBlock x:Name="LogsLabel"
+                         Grid.Column="1"
+                         Text="Logs" />
+            </Grid>
+          </Button>
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <Grid Grid.Column="1"
+          RowDefinitions="Auto,Auto,*,Auto">
+      <Border Padding="18,14,18,14"
+        Classes="surface-card flat-shell-panel"
+        BorderThickness="0,0,0,1"
+        PointerPressed="TitleRegion_OnPointerPressed"
+        DoubleTapped="TitleRegion_OnDoubleTapped">
+        <Grid ColumnDefinitions="Auto,*,Auto"
+              ColumnSpacing="14">
+          <Button x:Name="BackButton"
+                  Width="36"
+                  Height="36"
+                  Padding="0"
+                  IsVisible="False"
+                  Classes="icon-shell"
+                  Click="BackButton_OnClick"
+                  Content="←" />
+
+          <Grid Grid.Column="1"
+                ColumnDefinitions="*,Auto"
+                ColumnSpacing="14">
+            <StackPanel Spacing="1">
+              <TextBlock x:Name="CurrentPageTitleBlock"
+                         FontSize="24"
+                         FontWeight="Bold"
+                         Text="" />
+              <TextBlock x:Name="CurrentPageSubtitleBlock"
+                         Opacity="0.68"
+                         Text="" />
+            </StackPanel>
+            <TextBox x:Name="GlobalSearchBox"
+                     Grid.Column="1"
+                     MaxWidth="500"
+                     MinWidth="280"
+                     Margin="14,0,0,0"
+                     HorizontalAlignment="Right"
+                     VerticalAlignment="Center"
+                     Watermark="Search for packages"
+                     TextChanged="GlobalSearchBox_OnTextChanged" />
+          </Grid>
+
+          <StackPanel Grid.Column="2"
+                      Orientation="Horizontal"
+                  Spacing="6">
+              <Button x:Name="MinimizeWindowButton"
+                  Width="38"
+                  Height="30"
+                      Padding="0"
+                      Classes="caption-button"
+                      Click="MinimizeWindowButton_OnClick"
+                      Content="−" />
+              <Button x:Name="ToggleMaximizeWindowButton"
+                      Width="38"
+                      Height="30"
+                      Padding="0"
+                      Classes="caption-button"
+                      Click="ToggleMaximizeWindowButton_OnClick"
+                      Content="□" />
+              <Button x:Name="CloseWindowButton"
+                      Width="38"
+                      Height="30"
+                      Padding="0"
+                      Classes="caption-button caption-close"
+                      Click="CloseWindowButton_OnClick"
+                      Content="✕" />
+          </StackPanel>
+        </Grid>
+      </Border>
+
+      <!-- Auto-update banner (shown when a new installer is ready) -->
+      <Border x:Name="UpdateBannerBorder"
+              Grid.Row="1"
+              IsVisible="False"
+              Padding="16,10"
+              Background="{DynamicResource SystemAccentColor}">
+        <Grid ColumnDefinitions="*,Auto,Auto"
+              ColumnSpacing="12">
+          <TextBlock x:Name="UpdateBannerText"
+                     VerticalAlignment="Center"
+                     Foreground="White"
+                     TextWrapping="Wrap"
+                     Text="" />
+          <Button x:Name="UpdateBannerButton"
+                  Grid.Column="1"
+                  Classes="accent"
+                  Content="Update now"
+                  Click="UpdateBannerButton_OnClick" />
+          <Button x:Name="UpdateBannerDismissButton"
+                  Grid.Column="2"
+                  Padding="6"
+                  Classes="icon-shell"
+                  Content="✕"
+                  Click="UpdateBannerDismissButton_OnClick" />
+        </Grid>
+      </Border>
+
+      <ContentControl x:Name="PageHost"
+                      Grid.Row="2"
+                      Margin="16" />
+
+      <!-- Operations panel -->
+      <Border x:Name="OperationsPanelBorder"
+              Grid.Row="3"
+              IsVisible="False"
+              Classes="surface-card flat-shell-panel"
+              BorderThickness="0,1,0,0"
+              Padding="0">
+        <Grid RowDefinitions="Auto,Auto">
+          <Border Grid.Row="0"
+                  Padding="16,6"
+                  BorderThickness="0,0,0,1">
+            <Border.BorderBrush>
+              <SolidColorBrush Color="{DynamicResource SystemBaseMediumLowColor}" />
+            </Border.BorderBrush>
+            <Grid ColumnDefinitions="*,Auto">
+              <TextBlock x:Name="ActiveOperationsHeaderBlock"
+                         Grid.Column="0"
+                         VerticalAlignment="Center"
+                         FontSize="12"
+                         Opacity="0.7"
+                         Text="Active operations" />
+              <Button x:Name="OperationsBulkMenuButton"
+                      Grid.Column="1"
+                      Padding="6,2"
+                      VerticalAlignment="Center"
+                      Classes="icon-button"
+                      Content="⋯"
+                      ToolTip.Tip="More actions" />
+            </Grid>
+          </Border>
+          <ScrollViewer Grid.Row="1"
+                        MaxHeight="220"
+                        Padding="8">
+            <ItemsControl x:Name="OperationListControl">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <pages:OperationWidgetView />
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+        </Grid>
+      </Border>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/MainShellView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainShellView.axaml.cs
@@ -1,0 +1,1055 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Controls.ApplicationLifetimes;
+using global::Avalonia.Input;
+using global::Avalonia.Interactivity;
+using global::Avalonia.Markup.Xaml;
+using global::Avalonia.Threading;
+using global::Avalonia.VisualTree;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Avalonia.Views.Pages;
+using UniGetUI.Avalonia.Views.Pages.ManagersPages;
+using UniGetUI.Avalonia.Views.Pages.SettingsPages;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Telemetry;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.PackageLoader;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views;
+
+public partial class MainShellView : UserControl
+{
+    private readonly Dictionary<ShellPageType, IShellPage> _pageCache = [];
+    private readonly Dictionary<ShellPageType, (Button Button, TextBlock Label)> _navButtons = [];
+    private readonly List<ShellPageType> _history = [];
+
+    private ShellPageType _currentPage;
+    private bool _navigationExpanded = !Settings.Get(Settings.K.CollapseNavMenuOnWideScreen);
+    private ContextMenu? _searchSuggestionsMenu;
+    private bool _isApplyingSearchSuggestion;
+
+    private Border Sidebar => GetControl<Border>("SidebarBorder");
+
+    private TextBlock ShellSubtitleText => GetControl<TextBlock>("ShellSubtitleBlock");
+
+    private Button DiscoverNavButton => GetControl<Button>("DiscoverButton");
+
+    private TextBlock DiscoverNavLabel => GetControl<TextBlock>("DiscoverLabel");
+
+    private Button UpdatesNavButton => GetControl<Button>("UpdatesButton");
+
+    private TextBlock UpdatesNavLabel => GetControl<TextBlock>("UpdatesLabel");
+
+    private Button InstalledNavButton => GetControl<Button>("InstalledButton");
+
+    private TextBlock InstalledNavLabel => GetControl<TextBlock>("InstalledLabel");
+
+    private Button BundlesNavButton => GetControl<Button>("BundlesButton");
+
+    private TextBlock BundlesNavLabel => GetControl<TextBlock>("BundlesLabel");
+
+    private Button SettingsNavButton => GetControl<Button>("SettingsButton");
+
+    private TextBlock SettingsNavLabel => GetControl<TextBlock>("SettingsLabel");
+
+    private Button ManagersNavButton => GetControl<Button>("ManagersButton");
+
+    private TextBlock ManagersNavLabel => GetControl<TextBlock>("ManagersLabel");
+
+    private Button HelpNavButton => GetControl<Button>("HelpButton");
+
+    private TextBlock HelpNavLabel => GetControl<TextBlock>("HelpLabel");
+
+    private Button LogsNavButton => GetControl<Button>("LogsButton");
+
+    private TextBlock LogsNavLabel => GetControl<TextBlock>("LogsLabel");
+
+    private Button BackNavigationButton => GetControl<Button>("BackButton");
+
+    private TextBlock CurrentPageTitleText => GetControl<TextBlock>("CurrentPageTitleBlock");
+
+    private TextBlock CurrentPageSubtitleText => GetControl<TextBlock>("CurrentPageSubtitleBlock");
+
+    private Button ToggleMaximizeWindowControl => GetControl<Button>("ToggleMaximizeWindowButton");
+
+    private TextBox GlobalSearchHost => GetControl<TextBox>("GlobalSearchBox");
+
+    private TextBox GlobalSearchTextBox => GetControl<TextBox>("GlobalSearchBox");
+
+    private ContentControl PageContentHost => GetControl<ContentControl>("PageHost");
+
+    private Border UpdatesBadgeHost => GetControl<Border>("UpdatesBadge");
+
+    private TextBlock UpdatesBadgeCountText => GetControl<TextBlock>("UpdatesBadgeCount");
+
+    private Border UpdateBannerBorderHost => GetControl<Border>("UpdateBannerBorder");
+
+    private TextBlock UpdateBannerTextBlock => GetControl<TextBlock>("UpdateBannerText");
+
+    private ItemsControl OperationsListControl => GetControl<ItemsControl>("OperationListControl");
+
+    private Border OperationsPanelHost => GetControl<Border>("OperationsPanelBorder");
+
+    private Button OperationsBulkMenuBtn => GetControl<Button>("OperationsBulkMenuButton");
+
+    // Ctrl+Tab / Ctrl+Shift+Tab cycle order (excludes log-like extra pages)
+    private static readonly ShellPageType[] _cyclePages =
+    [
+        ShellPageType.Discover,
+        ShellPageType.Updates,
+        ShellPageType.Installed,
+        ShellPageType.Bundles,
+        ShellPageType.Settings,
+        ShellPageType.Managers,
+    ];
+
+    public MainShellView()
+    {
+        InitializeComponent();
+
+        ApplyLocalizedShellText();
+        ShellSubtitleText.Text = BuildShellSubtitle();
+        RegisterNavigationButtons();
+        ApplyNavigationWidth();
+        NavigateTo(GetDefaultPage(), false);
+        AttachedToVisualTree += (_, _) =>
+        {
+            UpdateWindowButtons();
+            AttachKeyboardShortcuts();
+            AttachUpdatesBadge();
+            AttachOperationsPanel();
+            AttachUpdateBanner();
+            AttachStartupChecks();
+        };
+    }
+
+    private void ApplyLocalizedShellText()
+    {
+        DiscoverNavLabel.Text = CoreTools.Translate("Discover Packages");
+        UpdatesNavLabel.Text = CoreTools.Translate("Software Updates");
+        InstalledNavLabel.Text = CoreTools.Translate("Installed Packages");
+        BundlesNavLabel.Text = CoreTools.Translate("Package Bundles");
+        SettingsNavLabel.Text = CoreTools.Translate("Settings");
+        ManagersNavLabel.Text = CoreTools.Translate("Package Managers");
+        HelpNavLabel.Text = CoreTools.Translate("Help");
+        LogsNavLabel.Text = CoreTools.Translate("Package Manager logs");
+        GetControl<TextBlock>("ActiveOperationsHeaderBlock").Text = CoreTools.Translate("Operation in progress");
+    }
+
+    private void RegisterNavigationButtons()
+    {
+        _navButtons[ShellPageType.Discover] = (DiscoverNavButton, DiscoverNavLabel);
+        _navButtons[ShellPageType.Updates] = (UpdatesNavButton, UpdatesNavLabel);
+        _navButtons[ShellPageType.Installed] = (InstalledNavButton, InstalledNavLabel);
+        _navButtons[ShellPageType.Bundles] = (BundlesNavButton, BundlesNavLabel);
+        _navButtons[ShellPageType.Settings] = (SettingsNavButton, SettingsNavLabel);
+        _navButtons[ShellPageType.Managers] = (ManagersNavButton, ManagersNavLabel);
+        _navButtons[ShellPageType.Help] = (HelpNavButton, HelpNavLabel);
+        _navButtons[ShellPageType.Logs] = (LogsNavButton, LogsNavLabel);
+    }
+
+    private static string BuildShellSubtitle()
+    {
+        var labels = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(CoreData.VersionName))
+        {
+            labels.Add(CoreTools.Translate("version {0}", CoreData.VersionName));
+        }
+
+#if DEBUG
+        labels.Add(CoreTools.Translate("DEBUG BUILD"));
+#endif
+
+        return string.Join("  •  ", labels);
+    }
+
+    private static ShellPageType GetDefaultPage()
+    {
+        return Settings.GetValue(Settings.K.StartupPage) switch
+        {
+            "updates" => ShellPageType.Updates,
+            "installed" => ShellPageType.Installed,
+            "bundles" => ShellPageType.Bundles,
+            "settings" => ShellPageType.Settings,
+            _ => ShellPageType.Discover,
+        };
+    }
+
+    private void NavigateTo(ShellPageType pageType, bool toHistory = true)
+    {
+        if (_currentPage == pageType && PageContentHost.Content is not null)
+        {
+            return;
+        }
+
+        if (toHistory && PageContentHost.Content is not null)
+        {
+            _history.Add(_currentPage);
+        }
+
+        IShellPage page;
+
+        try
+        {
+            page = GetPage(pageType);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to create shell page {pageType}");
+            Logger.Error(ex);
+            ShowNavigationError(pageType, ex);
+            return;
+        }
+
+        _currentPage = pageType;
+        PageContentHost.Content = (Control)page;
+        CurrentPageTitleText.Text = page.Title;
+        CurrentPageSubtitleText.Text = page.Subtitle;
+        GlobalSearchHost.IsVisible = page.SupportsSearch;
+        GlobalSearchTextBox.IsEnabled = page.SupportsSearch;
+        GlobalSearchTextBox.Watermark = page.SearchPlaceholder;
+
+        if (!page.SupportsSearch)
+        {
+            GlobalSearchTextBox.Text = string.Empty;
+        }
+
+        page.UpdateSearchQuery(GlobalSearchTextBox.Text ?? string.Empty);
+        UpdateSearchSuggestions();
+
+        BackNavigationButton.IsVisible = _history.Count > 0;
+        UpdateNavigationSelection();
+    }
+
+    private void ShowNavigationError(ShellPageType pageType, Exception ex)
+    {
+        _currentPage = pageType;
+        PageContentHost.Content = new ErrorView(
+            CoreTools.Translate("Something went wrong"),
+            ex.Message
+        );
+        CurrentPageTitleText.Text = CoreTools.Translate("Error");
+        CurrentPageSubtitleText.Text = CoreTools.Translate("An unexpected error occurred:");
+        GlobalSearchHost.IsVisible = false;
+        GlobalSearchTextBox.IsEnabled = false;
+        GlobalSearchTextBox.Watermark = string.Empty;
+        GlobalSearchTextBox.Text = string.Empty;
+        BackNavigationButton.IsVisible = _history.Count > 0;
+        UpdateNavigationSelection();
+    }
+
+    private IShellPage GetPage(ShellPageType pageType)
+    {
+        if (_pageCache.TryGetValue(pageType, out var existingPage))
+        {
+            return existingPage;
+        }
+
+        IShellPage page = pageType switch
+        {
+            ShellPageType.Discover => new PackagePageView(
+                title: CoreTools.Translate("Discover Packages"),
+                subtitle: CoreTools.Translate("Search for packages"),
+                searchPlaceholder: CoreTools.Translate("Search for packages"),
+                primaryActionLabel: CoreTools.Translate("Install selection"),
+                pageGlyph: "◎",
+                emptyStateTitle: CoreTools.Translate("Search for packages"),
+                emptyStateDescription: CoreTools.Translate("Search for packages to start"),
+                showUpgradeColumn: false,
+                filtersTitle: CoreTools.Translate("Search mode"),
+                pageMode: PackagePageMode.Discover
+            ),
+            ShellPageType.Updates => new PackagePageView(
+                title: CoreTools.Translate("Software Updates"),
+                subtitle: CoreTools.Translate("Search on available updates"),
+                searchPlaceholder: CoreTools.Translate("Search on available updates"),
+                primaryActionLabel: CoreTools.Translate("Update selection"),
+                pageGlyph: "↻",
+                emptyStateTitle: CoreTools.Translate("No packages were found"),
+                emptyStateDescription: CoreTools.Translate("No updates are available"),
+                showUpgradeColumn: true,
+                filtersTitle: CoreTools.Translate("Search mode"),
+                pageMode: PackagePageMode.Updates
+            ),
+            ShellPageType.Installed => new PackagePageView(
+                title: CoreTools.Translate("Installed Packages"),
+                subtitle: CoreTools.Translate("Search on your software"),
+                searchPlaceholder: CoreTools.Translate("Search on your software"),
+                primaryActionLabel: CoreTools.Translate("Uninstall selection"),
+                pageGlyph: "▣",
+                emptyStateTitle: CoreTools.Translate("No packages were found"),
+                emptyStateDescription: CoreTools.Translate("No packages were found"),
+                showUpgradeColumn: false,
+                filtersTitle: CoreTools.Translate("Search mode"),
+                pageMode: PackagePageMode.Installed
+            ),
+            ShellPageType.Bundles => new BundlesPageView(),
+            ShellPageType.Settings => new SettingsPageView(),
+            ShellPageType.Managers => new ManagersPageView(),
+            ShellPageType.Help => new HelpPageView(),
+            ShellPageType.Logs => new LogsPageView(),
+            _ => throw new InvalidOperationException($"Unsupported page type {pageType}"),
+        };
+
+        _pageCache[pageType] = page;
+        return page;
+    }
+
+    private void UpdateNavigationSelection()
+    {
+        foreach (var (pageType, nav) in _navButtons)
+        {
+            nav.Button.Classes.Set("selected", pageType == _currentPage);
+        }
+    }
+
+    private void ApplyNavigationWidth()
+    {
+        Sidebar.Width = _navigationExpanded ? 232 : 72;
+
+        foreach (var nav in _navButtons.Values)
+        {
+            nav.Label.IsVisible = _navigationExpanded;
+        }
+
+        ShellSubtitleText.IsVisible = _navigationExpanded;
+    }
+
+    public void SetNavigationCollapsedPreference(bool collapseNavigation)
+    {
+        _navigationExpanded = !collapseNavigation;
+        ApplyNavigationWidth();
+    }
+
+    internal void OpenPage(ShellPageType pageType) => NavigateTo(pageType);
+
+    internal void OpenSettingsSection(SettingsSectionRoute route)
+    {
+        NavigateTo(ShellPageType.Settings);
+        if (_pageCache.TryGetValue(ShellPageType.Settings, out var page)
+            && page is SettingsPageView settingsPage)
+        {
+            settingsPage.OpenSection(route);
+        }
+    }
+
+    internal void OpenManagerLogs(IPackageManager manager, bool verbose = false)
+    {
+        NavigateTo(ShellPageType.Logs);
+        if (_pageCache.TryGetValue(ShellPageType.Logs, out var page)
+            && page is LogsPageView logsPage)
+        {
+            logsPage.ShowManagerLogs(manager, verbose);
+        }
+    }
+
+    internal async Task OpenBundleFromFileAsync(string filePath)
+    {
+        NavigateTo(ShellPageType.Bundles);
+        if (_pageCache.TryGetValue(ShellPageType.Bundles, out var page)
+            && page is BundlesPageView bundlesPage)
+        {
+            await bundlesPage.OpenFromFileAsync(filePath);
+        }
+    }
+
+    internal void OpenSharedPackage(string id, string combinedSourceName)
+    {
+        string[] contents = combinedSourceName.Split(':', 2);
+        string managerName = contents[0];
+        string sourceName = contents.Length > 1 ? contents[1] : string.Empty;
+        _ = ShowSharedPackageAsync(id, managerName, sourceName, eventSource: "LEGACY_COMBINEDSOURCE");
+    }
+
+    internal void OpenSharedPackage(string id, string managerName, string sourceName)
+    {
+        _ = ShowSharedPackageAsync(id, managerName, sourceName, eventSource: "DEFAULT");
+    }
+
+    private void ToggleNavigationButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _navigationExpanded = !_navigationExpanded;
+        ApplyNavigationWidth();
+    }
+
+    private void BackButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_history.Count == 0)
+        {
+            return;
+        }
+
+        var target = _history[^1];
+        _history.RemoveAt(_history.Count - 1);
+        NavigateTo(target, false);
+    }
+
+    private void GlobalSearchBox_OnTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_isApplyingSearchSuggestion)
+        {
+            return;
+        }
+
+        if (_pageCache.TryGetValue(_currentPage, out var page) && page.SupportsSearch)
+        {
+            page.UpdateSearchQuery(GlobalSearchTextBox.Text ?? string.Empty);
+        }
+
+        UpdateSearchSuggestions();
+    }
+
+    private void UpdateSearchSuggestions()
+    {
+        if (!_pageCache.TryGetValue(_currentPage, out var page) || !page.SupportsSearch)
+        {
+            CloseSearchSuggestions();
+            return;
+        }
+
+        string query = GlobalSearchTextBox.Text?.Trim() ?? string.Empty;
+        if (query.Length < 2)
+        {
+            CloseSearchSuggestions();
+            return;
+        }
+
+        var suggestions = GetSearchSuggestions(query).ToArray();
+        if (suggestions.Length == 0)
+        {
+            CloseSearchSuggestions();
+            return;
+        }
+
+        CloseSearchSuggestions();
+
+        var menu = new ContextMenu
+        {
+            PlacementTarget = GlobalSearchTextBox,
+            Placement = PlacementMode.Bottom,
+        };
+
+        foreach (string suggestion in suggestions)
+        {
+            var item = new MenuItem { Header = suggestion };
+            item.Click += (_, _) => ApplySearchSuggestion(suggestion);
+            menu.Items.Add(item);
+        }
+
+        _searchSuggestionsMenu = menu;
+        GlobalSearchTextBox.ContextMenu = menu;
+        menu.Open(GlobalSearchTextBox);
+    }
+
+    private IEnumerable<string> GetSearchSuggestions(string query)
+    {
+        IEnumerable<IPackage> packages = _currentPage switch
+        {
+            ShellPageType.Discover => DiscoverablePackagesLoader.Instance.Packages,
+            ShellPageType.Updates => UpgradablePackagesLoader.Instance.Packages,
+            ShellPageType.Installed => InstalledPackagesLoader.Instance.Packages,
+            _ => [],
+        };
+
+        return packages
+            .SelectMany(package => new[] { package.Name, package.Id })
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(value => value.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(value => value.StartsWith(query, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+            .ThenBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .Take(8);
+    }
+
+    private void ApplySearchSuggestion(string suggestion)
+    {
+        _isApplyingSearchSuggestion = true;
+        try
+        {
+            GlobalSearchTextBox.Text = suggestion;
+            GlobalSearchTextBox.CaretIndex = suggestion.Length;
+
+            if (_pageCache.TryGetValue(_currentPage, out var page) && page.SupportsSearch)
+            {
+                page.UpdateSearchQuery(suggestion);
+            }
+        }
+        finally
+        {
+            _isApplyingSearchSuggestion = false;
+            CloseSearchSuggestions();
+        }
+    }
+
+    private void CloseSearchSuggestions()
+    {
+        if (_searchSuggestionsMenu is not null)
+        {
+            _searchSuggestionsMenu.Close();
+            if (ReferenceEquals(GlobalSearchTextBox.ContextMenu, _searchSuggestionsMenu))
+            {
+                GlobalSearchTextBox.ContextMenu = null;
+            }
+            _searchSuggestionsMenu = null;
+        }
+    }
+
+    private void TitleRegion_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed || IsInteractiveSource(e.Source))
+        {
+            return;
+        }
+
+        if (GetHostWindow() is { } window)
+        {
+            window.BeginMoveDrag(e);
+        }
+    }
+
+    private void TitleRegion_OnDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (IsInteractiveSource(e.Source) || GetHostWindow() is not { CanResize: true } window)
+        {
+            return;
+        }
+
+        ToggleWindowState(window);
+    }
+
+    private void MinimizeWindowButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (GetHostWindow() is { } window)
+        {
+            window.WindowState = WindowState.Minimized;
+            UpdateWindowButtons();
+        }
+    }
+
+    private void ToggleMaximizeWindowButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (GetHostWindow() is { } window)
+        {
+            ToggleWindowState(window);
+        }
+    }
+
+    private void CloseWindowButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        GetHostWindow()?.Close();
+    }
+
+    private void ToggleWindowState(Window window)
+    {
+        window.WindowState = window.WindowState == WindowState.Maximized
+            ? WindowState.Normal
+            : WindowState.Maximized;
+
+        UpdateWindowButtons();
+    }
+
+    private void UpdateWindowButtons()
+    {
+        if (GetHostWindow() is not { } window)
+        {
+            return;
+        }
+
+        ToggleMaximizeWindowControl.Content = window.WindowState == WindowState.Maximized ? "❐" : "□";
+    }
+
+    private Window? GetHostWindow()
+    {
+        return TopLevel.GetTopLevel(this) as Window;
+    }
+
+    private static bool IsInteractiveSource(object? source)
+    {
+        if (source is not global::Avalonia.Visual visual)
+        {
+            return false;
+        }
+
+        return visual.GetSelfAndVisualAncestors().Any(control => control is Button || control is TextBox);
+    }
+
+    private void DiscoverButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Discover);
+
+    private void UpdatesButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Updates);
+
+    private void InstalledButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Installed);
+
+    private void BundlesButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Bundles);
+
+    private void SettingsButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Settings);
+
+    private void ManagersButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Managers);
+
+    private void HelpButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Help);
+
+    private void LogsButton_OnClick(object? sender, RoutedEventArgs e) => NavigateTo(ShellPageType.Logs);
+
+    // ── Keyboard shortcuts ────────────────────────────────────────────────────
+
+    private void AttachKeyboardShortcuts()
+    {
+        if (TopLevel.GetTopLevel(this) is not { } topLevel) return;
+        topLevel.AddHandler(InputElement.KeyDownEvent, OnWindowKeyDown, RoutingStrategies.Tunnel);
+    }
+
+    private void OnWindowKeyDown(object? sender, KeyEventArgs e)
+    {
+        bool ctrl = e.KeyModifiers.HasFlag(KeyModifiers.Control);
+        bool shift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+        if (ctrl && e.Key == Key.Tab)
+        {
+            e.Handled = true;
+            NavigateCycle(shift ? -1 : +1);
+        }
+        else if (e.Key == Key.F1 && !ctrl && !shift)
+        {
+            e.Handled = true;
+            NavigateTo(ShellPageType.Help);
+        }
+        else if (ctrl && !shift && (e.Key == Key.Q || e.Key == Key.W))
+        {
+            GetHostWindow()?.Close();
+            e.Handled = true;
+        }
+        else if (!ctrl && !shift && e.Key == Key.F5 || ctrl && !shift && e.Key == Key.R)
+        {
+            // Reload: re-create the current page by evicting the cache
+            if (_pageCache.Remove(_currentPage))
+            {
+                var current = _currentPage;
+                _currentPage = default;
+                NavigateTo(current, false);
+            }
+            e.Handled = true;
+        }
+        else if (ctrl && !shift && e.Key == Key.F)
+        {
+            if (GlobalSearchHost.IsVisible)
+            {
+                GlobalSearchHost.Focus();
+                e.Handled = true;
+            }
+        }
+        else if (ctrl && !shift && e.Key == Key.A)
+        {
+            if (_pageCache.TryGetValue(_currentPage, out var page) && page is PackagePageView ppv)
+            {
+                ppv.TriggerSelectAll();
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void NavigateCycle(int direction)
+    {
+        int idx = Array.IndexOf(_cyclePages, _currentPage);
+        if (idx < 0) idx = 0;
+        int next = ((idx + direction) % _cyclePages.Length + _cyclePages.Length) % _cyclePages.Length;
+        NavigateTo(_cyclePages[next]);
+    }
+
+    // ── Updates badge ─────────────────────────────────────────────────────────
+
+    private void AttachUpdatesBadge()
+    {
+        UpgradablePackagesLoader.Instance.PackagesChanged += OnUpgradablePackagesChanged;
+        OnUpgradablePackagesChanged(null, default!);
+    }
+
+    private void OnUpgradablePackagesChanged(object? sender, PackagesChangedEvent e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            int count = UpgradablePackagesLoader.Instance.Packages.Count;
+            UpdatesBadgeHost.IsVisible = count > 0;
+            UpdatesBadgeCountText.Text = count > 99 ? "99+" : count.ToString();
+
+            // Refresh tray tooltip whenever the update count changes
+            if (Application.Current?.ApplicationLifetime
+                    is IClassicDesktopStyleApplicationLifetime { MainWindow: UniGetUI.Avalonia.MainWindow mw })
+                mw.UpdateSystemTrayStatus();
+        });
+    }
+
+    // ── Operations panel ──────────────────────────────────────────────────────
+
+    private void AttachOperationsPanel()
+    {
+        OperationsListControl.ItemsSource = AvaloniaOperationRegistry.Operations;
+        AvaloniaOperationRegistry.Operations.CollectionChanged += (_, _) =>
+            Dispatcher.UIThread.Post(UpdateOperationsPanelVisibility);
+        UpdateOperationsPanelVisibility();
+        OperationsBulkMenuBtn.Click += OperationsBulkMenuBtn_OnClick;
+    }
+
+    private void OperationsBulkMenuBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var menu = new ContextMenu
+        {
+            Items =
+            {
+                new MenuItem
+                {
+                    Header = CoreTools.Translate("Retry failed operations"),
+                    Command = new RelayCommand(RetryFailedOps)
+                },
+                new MenuItem
+                {
+                    Header = CoreTools.Translate("Clear successful operations"),
+                    Command = new RelayCommand(ClearSuccessfulOps)
+                },
+                new MenuItem
+                {
+                    Header = CoreTools.Translate("Clear finished operations"),
+                    Command = new RelayCommand(ClearFinishedOps)
+                },
+                new Separator(),
+                new MenuItem
+                {
+                    Header = CoreTools.Translate("Cancel all operations"),
+                    Command = new RelayCommand(CancelAllOps)
+                }
+            }
+        };
+        menu.Open(OperationsBulkMenuBtn);
+    }
+
+    private void CancelAllOps()
+    {
+        foreach (var op in AvaloniaOperationRegistry.Operations.ToList())
+        {
+            if (op.Status is OperationStatus.InQueue or OperationStatus.Running)
+                op.Cancel();
+        }
+    }
+
+    private void RetryFailedOps()
+    {
+        foreach (var op in AvaloniaOperationRegistry.Operations.ToList())
+        {
+            if (op.Status == OperationStatus.Failed)
+                op.Retry(AbstractOperation.RetryMode.Retry);
+        }
+    }
+
+    private void ClearSuccessfulOps()
+    {
+        foreach (var op in AvaloniaOperationRegistry.Operations.ToList())
+        {
+            if (op.Status == OperationStatus.Succeeded)
+                AvaloniaOperationRegistry.Operations.Remove(op);
+        }
+    }
+
+    private void ClearFinishedOps()
+    {
+        foreach (var op in AvaloniaOperationRegistry.Operations.ToList())
+        {
+            if (op.Status is OperationStatus.Succeeded or OperationStatus.Failed or OperationStatus.Canceled)
+                AvaloniaOperationRegistry.Operations.Remove(op);
+        }
+    }
+
+    private void UpdateOperationsPanelVisibility()
+    {
+        OperationsPanelHost.IsVisible = AvaloniaOperationRegistry.Operations.Count > 0;
+    }
+
+    // ── Auto-update banner ────────────────────────────────────────────────────
+
+    private void AttachUpdateBanner()
+    {
+        AvaloniaAutoUpdater.UpdateAvailable += OnUpdateAvailable;
+    }
+
+    private void OnUpdateAvailable(string versionName)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            UpdateBannerTextBlock.Text = CoreTools.Translate(
+                "UniGetUI {0} is ready to be installed. Click \"Update now\" to restart and update.",
+                versionName
+            );
+            UpdateBannerBorderHost.IsVisible = true;
+        });
+    }
+
+    private void UpdateBannerButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        AvaloniaAutoUpdater.TriggerInstall();
+        UpdateBannerBorderHost.IsVisible = false;
+    }
+
+    private void UpdateBannerDismissButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        UpdateBannerBorderHost.IsVisible = false;
+    }
+
+    // ── Startup checks ────────────────────────────────────────────────────────
+
+    private void AttachStartupChecks()
+    {
+        if (CoreTools.IsAdministrator() && !Settings.Get(Settings.K.AlreadyWarnedAboutAdmin))
+        {
+            Settings.Set(Settings.K.AlreadyWarnedAboutAdmin, true);
+            _ = ShowStartupDialogAsync(new AdminWarningWindow());
+        }
+
+        if (!Settings.Get(Settings.K.ShownTelemetryBanner))
+        {
+            _ = ShowStartupDialogAsync(new TelemetryConsentWindow());
+        }
+
+        ProcessStartupArgs();
+    }
+
+    /// <summary>
+    /// Called by <c>Program.OnIncomingArgs</c> when a second instance forwards its
+    /// command-line arguments via the named pipe.  Must be invoked on the UI thread.
+    /// </summary>
+    public void ProcessIncomingArgs(string[] args) => ProcessArgs(args);
+
+    private void ProcessStartupArgs() => ProcessArgs(Environment.GetCommandLineArgs().Skip(1));
+
+    private void ProcessArgs(IEnumerable<string> rawArgs)
+    {
+        foreach (var rawArg in rawArgs)
+        {
+            string arg = rawArg.Trim('\'').Trim('"');
+            if (string.IsNullOrWhiteSpace(arg)) continue;
+
+            if (arg.StartsWith("--"))
+            {
+                if (arg == "--help")
+                    NavigateTo(ShellPageType.Help);
+                else if (arg == "--updateapps")
+                    _ = AvaloniaPackageOperationHelper.UpdateAllAsync();
+                // --daemon and other startup-only flags are handled in MainWindow
+            }
+            else if (arg.StartsWith("unigetui://", StringComparison.OrdinalIgnoreCase))
+            {
+                HandleDeepLink(arg);
+            }
+            else if (Path.IsPathFullyQualified(arg) && File.Exists(arg))
+            {
+                string ext = Path.GetExtension(arg).ToLowerInvariant();
+                if (ext is ".ubundle" or ".json" or ".xml" or ".yaml")
+                {
+                    NavigateTo(ShellPageType.Bundles);
+                    if (_pageCache.TryGetValue(ShellPageType.Bundles, out var page)
+                        && page is BundlesPageView bpv)
+                    {
+                        _ = bpv.OpenFromFileAsync(arg);
+                    }
+                }
+                else
+                {
+                    Logger.Warn($"Attempted to open unrecognized file: {arg}");
+                }
+            }
+        }
+    }
+
+    private void HandleDeepLink(string link)
+    {
+        try
+        {
+            string baseUrl = Uri.UnescapeDataString(link["unigetui://".Length..]);
+
+            if (baseUrl.StartsWith("showPackage", StringComparison.OrdinalIgnoreCase))
+            {
+                string id = TryGetDeepLinkParam(baseUrl, "id");
+                string combinedManagerName = TryGetDeepLinkParam(baseUrl, "combinedManagerName");
+                string managerName = TryGetDeepLinkParam(baseUrl, "managerName");
+                string sourceName = TryGetDeepLinkParam(baseUrl, "sourceName");
+
+                if (id.Length > 0 && combinedManagerName.Length > 0
+                    && managerName.Length == 0 && sourceName.Length == 0)
+                {
+                    Logger.Warn($"URI {link} follows old showPackage scheme");
+                    OpenSharedPackage(id, combinedManagerName);
+                }
+                else if (id.Length > 0 && managerName.Length > 0 && sourceName.Length > 0)
+                {
+                    OpenSharedPackage(id, managerName, sourceName);
+                }
+                else
+                {
+                    throw new UriFormatException($"Malformed showPackage deep link: {link}");
+                }
+            }
+            else if (baseUrl.StartsWith("showDiscoverPage", StringComparison.OrdinalIgnoreCase))
+            {
+                NavigateTo(ShellPageType.Discover);
+            }
+            else if (baseUrl.StartsWith("showUpdatesPage", StringComparison.OrdinalIgnoreCase))
+            {
+                NavigateTo(ShellPageType.Updates);
+            }
+            else if (baseUrl.StartsWith("showInstalledPage", StringComparison.OrdinalIgnoreCase))
+            {
+                NavigateTo(ShellPageType.Installed);
+            }
+            else
+            {
+                Logger.Warn($"Unhandled deep link: {link}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to handle deep link: {link}");
+            Logger.Error(ex);
+        }
+    }
+
+    private static string TryGetDeepLinkParam(string baseUrl, string parameterName)
+    {
+        var match = Regex.Match(
+            baseUrl,
+            parameterName + "=([^&]+)",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant
+        );
+
+        return match.Success ? Uri.UnescapeDataString(match.Groups[1].Value) : string.Empty;
+    }
+
+    private async Task ShowSharedPackageAsync(
+        string id,
+        string managerName,
+        string sourceName,
+        string eventSource
+    )
+    {
+        if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(managerName))
+        {
+            Logger.Warn("ShowSharedPackage requested with incomplete parameters.");
+            return;
+        }
+
+        try
+        {
+            NavigateTo(ShellPageType.Discover);
+            MainWindow.Instance?.ShowFromTray();
+
+            var findResult = await Task.Run(() =>
+                DiscoverablePackagesLoader.Instance.GetPackageFromIdAndManager(
+                    id,
+                    managerName,
+                    sourceName
+                )
+            );
+
+            if (findResult.Item1 is null)
+            {
+                throw new KeyNotFoundException(findResult.Item2 ?? CoreTools.Translate("An unexpected error occurred:"));
+            }
+
+            TelemetryHandler.SharedPackage(findResult.Item1, eventSource);
+
+            var detailsWindow = new PackageDetailsWindow(findResult.Item1, PackagePageMode.Discover);
+            if (GetHostWindow() is { } owner)
+            {
+                await detailsWindow.ShowDialog(owner);
+            }
+            else
+            {
+                detailsWindow.Show();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"An error occurred while attempting to show the package with id {id}");
+            Logger.Error(ex);
+
+            await ShowSimpleDialogAsync(
+                CoreTools.Translate("Package not found"),
+                CoreTools.Translate(
+                    "An error occurred when attempting to show the package with Id {0}",
+                    id
+                ) + "\n" + ex.Message
+            );
+        }
+    }
+
+    private async Task ShowSimpleDialogAsync(string title, string message)
+    {
+        if (GetHostWindow() is not { } owner)
+        {
+            return;
+        }
+
+        var dialog = new Window
+        {
+            Width = 520,
+            Height = 220,
+            CanResize = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Title = title,
+            Content = new StackPanel
+            {
+                Spacing = 14,
+                Margin = new Thickness(18),
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = message,
+                        TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                    },
+                    new Button
+                    {
+                        Content = CoreTools.Translate("OK"),
+                        HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right,
+                        MinWidth = 100,
+                    },
+                },
+            },
+        };
+
+        if (dialog.Content is StackPanel sp && sp.Children.LastOrDefault() is Button okButton)
+        {
+            okButton.Click += (_, _) => dialog.Close();
+        }
+
+        await dialog.ShowDialog(owner);
+    }
+
+    private async Task ShowStartupDialogAsync(Window dialog)
+    {
+        if (GetHostWindow() is { } owner)
+        {
+            await dialog.ShowDialog(owner);
+        }
+        else
+        {
+            dialog.Show();
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/AboutPageWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/AboutPageWindow.axaml
@@ -1,0 +1,163 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.AboutPageWindow"
+        Width="740"
+        Height="580"
+        MinWidth="520"
+        MinHeight="400"
+        Title="About UniGetUI"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+
+    <Grid RowDefinitions="Auto,*,Auto"
+          Margin="16"
+          RowSpacing="12">
+
+        <!-- Tab strip -->
+        <StackPanel Grid.Row="0"
+                    Orientation="Horizontal"
+                    Spacing="6">
+            <Button x:Name="TabAboutButton"
+                    Classes="toolbar-primary accent"
+                    Tag="0"
+                    Click="TabButton_OnClick"
+                    Content="About" />
+            <Button x:Name="TabLicensesButton"
+                    Classes="toolbar-secondary"
+                    Tag="1"
+                    Click="TabButton_OnClick"
+                    Content="Third-party licenses" />
+            <Button x:Name="TabContributorsButton"
+                    Classes="toolbar-secondary"
+                    Tag="2"
+                    Click="TabButton_OnClick"
+                    Content="Contributors" />
+            <Button x:Name="TabTranslatorsButton"
+                    Classes="toolbar-secondary"
+                    Tag="3"
+                    Click="TabButton_OnClick"
+                    Content="Translators" />
+        </StackPanel>
+
+        <!-- Content area -->
+        <Border Grid.Row="1"
+                Classes="surface-card"
+                Padding="0">
+            <ScrollViewer Padding="12">
+                <StackPanel Spacing="12">
+
+                    <!-- ── About tab ─────────────────────────────────────────── -->
+                    <StackPanel x:Name="AboutPanel"
+                                Spacing="12">
+                        <StackPanel Spacing="4">
+                            <TextBlock x:Name="VersionBlock"
+                                       FontSize="18"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="Wrap" />
+                            <TextBlock x:Name="LicenseBlock"
+                                       Opacity="0.7"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+
+                        <Border Padding="14"
+                                Classes="surface-card subtle-panel"
+                                CornerRadius="10">
+                            <TextBlock x:Name="DisclaimerBlock"
+                                       TextWrapping="Wrap"
+                                       Opacity="0.85" />
+                        </Border>
+                    </StackPanel>
+
+                    <!-- ── Third-party licenses tab ───────────────────────────── -->
+                    <ItemsControl x:Name="LicensesPanel"
+                                  IsVisible="False">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Padding="12,8"
+                                        BorderThickness="0,0,0,1">
+                                    <Border.BorderBrush>
+                                        <SolidColorBrush Color="{DynamicResource SystemBaseMediumLowColor}" />
+                                    </Border.BorderBrush>
+                                    <Grid ColumnDefinitions="2*,1.2*,Auto,Auto"
+                                          ColumnSpacing="8">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding Name}"
+                                                   VerticalAlignment="Center"
+                                                   FontWeight="SemiBold" />
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding License}"
+                                                   VerticalAlignment="Center"
+                                                   Opacity="0.7" />
+                                        <Button Grid.Column="2"
+                                                Classes="toolbar-secondary"
+                                                Content="{Binding HomepageText}"
+                                                Tag="{Binding HomepageUrl}"
+                                                Click="LinkButton_OnClick" />
+                                        <Button Grid.Column="3"
+                                                Classes="toolbar-secondary"
+                                                Content="{Binding LicenseButtonText}"
+                                                Tag="{Binding LicenseURL}"
+                                                Click="LinkButton_OnClick" />
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- ── Contributors tab ──────────────────────────────────── -->
+                    <ItemsControl x:Name="ContributorsPanel"
+                                  IsVisible="False">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button Classes="toolbar-secondary"
+                                        Margin="3"
+                                        Content="{Binding Name}"
+                                        Tag="{Binding GitHubUrl}"
+                                        Click="LinkButton_OnClick" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- ── Translators tab ───────────────────────────────────── -->
+                    <ItemsControl x:Name="TranslatorsPanel"
+                                  IsVisible="False">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Padding="8,5"
+                                        BorderThickness="0,0,0,1">
+                                    <Border.BorderBrush>
+                                        <SolidColorBrush Color="{DynamicResource SystemBaseMediumLowColor}" />
+                                    </Border.BorderBrush>
+                                    <Grid ColumnDefinitions="*,Auto"
+                                          ColumnSpacing="8">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding Name}"
+                                                   VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding Language}"
+                                                   VerticalAlignment="Center"
+                                                   Opacity="0.65" />
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Footer close button -->
+        <Button Grid.Row="2"
+                HorizontalAlignment="Right"
+                Classes="toolbar-primary accent"
+                Content="Close"
+                Click="CloseButton_OnClick" />
+
+    </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/AboutPageWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/AboutPageWindow.axaml.cs
@@ -1,0 +1,153 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Language;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>View model for a third-party library license row.</summary>
+public sealed class LibraryLicenseModel
+{
+    public string Name { get; init; } = string.Empty;
+    public string License { get; init; } = string.Empty;
+    public Uri? LicenseURL { get; init; }
+    public string HomepageText { get; init; } = string.Empty;
+    public Uri? HomepageUrl { get; init; }
+    public string LicenseButtonText { get; init; } = string.Empty;
+}
+
+/// <summary>View model for a contributor (GitHub username → link button).</summary>
+public sealed class ContributorItem
+{
+    public string Name { get; init; } = string.Empty;
+    public Uri? GitHubUrl { get; init; }
+}
+
+/// <summary>View model for a translator row (name + language).</summary>
+public sealed class TranslatorItem
+{
+    public string Name { get; init; } = string.Empty;
+    public string Language { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// About dialog window with four tabs: About, Third-party licenses, Contributors, Translators.
+/// </summary>
+public partial class AboutPageWindow : Window
+{
+    private readonly ObservableCollection<LibraryLicenseModel> _licenses = [];
+    private readonly ObservableCollection<ContributorItem> _contributors = [];
+    private readonly ObservableCollection<TranslatorItem> _translators = [];
+
+    public AboutPageWindow()
+    {
+        InitializeComponent();
+
+        Title = CoreTools.Translate("About WingetUI");
+
+        // Populate About tab
+        VersionBlock.Text = CoreTools.Translate("About WingetUI version {0}", CoreData.VersionName);
+        LicenseBlock.Text = CoreTools.Translate("Using WingetUI implies the acceptation of the MIT License");
+        DisclaimerBlock.Text = CoreTools.Translate(
+            "UniGetUI is not related to any of the compatible package managers. UniGetUI is an independent project."
+        );
+
+        // Apply translations to tab buttons
+        TabAboutButton.Content = CoreTools.Translate("About");
+        TabLicensesButton.Content = CoreTools.Translate("Third-party licenses");
+        TabContributorsButton.Content = CoreTools.Translate("Contributors");
+        TabTranslatorsButton.Content = CoreTools.Translate("Translators");
+
+        // Populate licenses
+        foreach (var name in LicenseData.LicenseNames.Keys)
+        {
+            _licenses.Add(new LibraryLicenseModel
+            {
+                Name = name,
+                License = LicenseData.LicenseNames[name],
+                LicenseURL = LicenseData.LicenseURLs.GetValueOrDefault(name),
+                HomepageUrl = LicenseData.HomepageUrls.GetValueOrDefault(name),
+                HomepageText = CoreTools.Translate("{0} homepage", name),
+                LicenseButtonText = CoreTools.Translate("License"),
+            });
+        }
+        LicensesPanel.ItemsSource = _licenses;
+
+        // Populate contributors (string[] of GitHub handles)
+        foreach (var handle in ContributorsData.Contributors)
+        {
+            _contributors.Add(new ContributorItem
+            {
+                Name = "@" + handle,
+                GitHubUrl = new Uri("https://github.com/" + handle),
+            });
+        }
+        ContributorsPanel.ItemsSource = _contributors;
+
+        // Populate translators — Person is a struct with fields, so map to TranslatorItem
+        foreach (var person in LanguageData.TranslatorsList)
+        {
+            _translators.Add(new TranslatorItem
+            {
+                Name = person.Name,
+                Language = person.Language,
+            });
+        }
+        TranslatorsPanel.ItemsSource = _translators;
+
+        // Default tab
+        SwitchTab(0);
+    }
+
+    // ── Tab switching ─────────────────────────────────────────────────────────
+
+    private void SwitchTab(int tab)
+    {
+        AboutPanel.IsVisible = tab == 0;
+        LicensesPanel.IsVisible = tab == 1;
+        ContributorsPanel.IsVisible = tab == 2;
+        TranslatorsPanel.IsVisible = tab == 3;
+
+        TabAboutButton.Classes.Set("accent", tab == 0);
+        TabAboutButton.Classes.Set("toolbar-primary", tab == 0);
+        TabAboutButton.Classes.Set("toolbar-secondary", tab != 0);
+
+        TabLicensesButton.Classes.Set("accent", tab == 1);
+        TabLicensesButton.Classes.Set("toolbar-primary", tab == 1);
+        TabLicensesButton.Classes.Set("toolbar-secondary", tab != 1);
+
+        TabContributorsButton.Classes.Set("accent", tab == 2);
+        TabContributorsButton.Classes.Set("toolbar-primary", tab == 2);
+        TabContributorsButton.Classes.Set("toolbar-secondary", tab != 2);
+
+        TabTranslatorsButton.Classes.Set("accent", tab == 3);
+        TabTranslatorsButton.Classes.Set("toolbar-primary", tab == 3);
+        TabTranslatorsButton.Classes.Set("toolbar-secondary", tab != 3);
+    }
+
+    // ── Event handlers ────────────────────────────────────────────────────────
+
+    private void TabButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: string tag } && int.TryParse(tag, out int tab))
+            SwitchTab(tab);
+    }
+
+    private void LinkButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: Uri url }) return;
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = url.ToString(), UseShellExecute = true });
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+
+    private void CloseButton_OnClick(object? sender, RoutedEventArgs e) => Close();
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/AdminWarningWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/AdminWarningWindow.axaml
@@ -1,0 +1,47 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.AdminWarningWindow"
+        Width="500"
+        Height="220"
+        MinWidth="360"
+        MinHeight="180"
+        Title="Administrator privileges"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <Grid RowDefinitions="Auto,*,Auto"
+        Margin="20">
+
+    <!-- Title -->
+    <TextBlock x:Name="TitleBlock"
+               Grid.Row="0"
+               FontSize="18"
+               FontWeight="SemiBold"
+               TextWrapping="Wrap"
+               Margin="0,0,0,12" />
+
+    <!-- Message -->
+    <TextBlock x:Name="MessageBlock"
+               Grid.Row="1"
+               TextWrapping="Wrap"
+               Opacity="0.82"
+               FontSize="13"
+               VerticalAlignment="Top" />
+
+    <!-- Footer -->
+    <Grid Grid.Row="2"
+          Margin="0,14,0,0"
+          ColumnDefinitions="*,Auto">
+      <Button x:Name="UnderstandBtn"
+              Grid.Column="1"
+              MinWidth="110"
+              Classes="accent"
+              Content="I understand"
+              Click="UnderstandBtn_OnClick" />
+    </Grid>
+
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/AdminWarningWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/AdminWarningWindow.axaml.cs
@@ -1,0 +1,26 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class AdminWarningWindow : Window
+{
+    public AdminWarningWindow()
+    {
+        InitializeComponent();
+
+        Title = CoreTools.Translate("Administrator privileges");
+        TitleBlock.Text = CoreTools.Translate("Administrator privileges");
+        MessageBlock.Text = CoreTools.Translate(
+            "UniGetUI has been run as administrator, which is not recommended. When running UniGetUI as administrator, EVERY operation launched from UniGetUI will have administrator privileges. You can still use the program, but we highly recommend not running UniGetUI with administrator privileges."
+        );
+        UnderstandBtn.Content = CoreTools.Translate("I understand");
+    }
+
+    private void UnderstandBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/BundlesPageView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/BundlesPageView.axaml
@@ -1,0 +1,240 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.BundlesPageView">
+  <UserControl.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </UserControl.Styles>
+
+  <Grid RowDefinitions="Auto,Auto,*"
+        RowSpacing="12">
+
+    <!-- Header card -->
+    <Border Padding="18"
+            Classes="surface-card">
+      <Grid ColumnDefinitions="Auto,*,Auto"
+            ColumnSpacing="14">
+        <Border Width="48"
+                Height="48"
+                Classes="surface-card subtle-panel"
+                CornerRadius="14">
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     Text="⊞" />
+        </Border>
+
+        <StackPanel Grid.Column="1"
+                    Spacing="2">
+          <TextBlock x:Name="BundlesTitleBlock"
+                     FontSize="28"
+                     FontWeight="Black"
+                     Classes="hero-title"
+                     Text="Package Bundles" />
+          <TextBlock x:Name="BundlesSubtitleBlock"
+                     Opacity="0.72"
+                     Text="Create, save and install sets of packages" />
+        </StackPanel>
+
+        <Border Grid.Column="2"
+                Padding="10,4"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Classes="surface-card badge-panel">
+          <TextBlock x:Name="BundleStatusBlock"
+                     Opacity="0.8"
+                     Text="" />
+        </Border>
+      </Grid>
+    </Border>
+
+    <!-- Toolbar card -->
+    <Border Grid.Row="1"
+            Padding="12"
+            Classes="surface-card">
+      <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,12,Auto,Auto,Auto,Auto,Auto,*,Auto,Auto,Auto"
+            ColumnSpacing="6">
+
+        <!-- File operations -->
+        <Button x:Name="NewBundleButton"
+                Classes="toolbar-secondary"
+                Content="New" />
+        <Button x:Name="OpenBundleButton"
+                Grid.Column="1"
+                Classes="toolbar-secondary"
+                Content="Open" />
+        <Button x:Name="SaveBundleButton"
+                Grid.Column="2"
+                Classes="toolbar-secondary"
+                Content="Save as" />
+        <Button x:Name="CreateScriptButton"
+                Grid.Column="3"
+                Classes="toolbar-secondary"
+                Content="Create .ps1 script" />
+        <!-- How to add packages to bundle info button -->
+        <Button x:Name="AddToBundleInfoButton"
+                Grid.Column="4"
+                Classes="toolbar-secondary"
+                Content="?" />
+
+        <!-- Separator gap is the ColumnDefinitions="12" at index 5 -->
+
+        <!-- Package actions -->
+        <Button x:Name="InstallSelectedButton"
+                Grid.Column="6"
+                Classes="toolbar-primary accent"
+                IsEnabled="False"
+                Content="Install checked" />
+        <!-- Install-options dropdown -->
+        <Button x:Name="InstallDropdownButton"
+                Grid.Column="7"
+                Classes="toolbar-secondary"
+                IsEnabled="False"
+                Content="▾" />
+        <Button x:Name="RemoveSelectedButton"
+                Grid.Column="8"
+                Classes="toolbar-secondary"
+                IsEnabled="False"
+                Content="Remove from bundle" />
+        <Button x:Name="BundleDetailsButton"
+                Grid.Column="9"
+                Classes="toolbar-secondary"
+                IsEnabled="False"
+                Content="Details" />
+        <Button x:Name="BundleShareButton"
+                Grid.Column="10"
+                Classes="toolbar-secondary"
+                IsEnabled="False"
+                Content="Share" />
+
+        <!-- Status / operation feedback -->
+        <TextBlock x:Name="BundleStateBlock"
+                   Grid.Column="11"
+                   VerticalAlignment="Center"
+                   Margin="8,0,0,0"
+                   Opacity="0.76"
+                   TextTrimming="CharacterEllipsis" />
+
+        <!-- View output button (visible after an install/operation is started) -->
+        <Button x:Name="BundleViewOutputButton"
+                Grid.Column="12"
+                Classes="toolbar-secondary"
+                IsVisible="False"
+                Click="BundleViewOutputButton_OnClick"
+                Content="View output" />
+
+        <!-- Help button -->
+        <Button x:Name="BundleHelpButton"
+                Grid.Column="13"
+                Classes="toolbar-secondary"
+                Content="Help" />
+
+        <!-- Search -->
+        <TextBox x:Name="BundleSearchBox"
+                 Grid.Column="14"
+                 Width="220"
+                 VerticalAlignment="Center"
+                 Watermark="Search" />
+      </Grid>
+    </Border>
+
+    <!-- Package list -->
+    <Border Grid.Row="2"
+            Padding="0"
+            Classes="surface-card">
+      <Grid RowDefinitions="Auto,*">
+
+        <!-- Column headers -->
+        <Grid Margin="16,16,16,8"
+              ColumnDefinitions="32,2.5*,2.2*,1.1*,1.8*"
+              ColumnSpacing="14">
+          <CheckBox x:Name="CheckAllCheckBox"
+                    VerticalAlignment="Center"
+                    Width="28"
+                    Height="28"
+                    Padding="0" />
+          <TextBlock x:Name="BundleColNameBlock"
+                     Grid.Column="1"
+                     Classes="data-header"
+                     Text="Package name" />
+          <TextBlock x:Name="BundleColIdBlock"
+                     Grid.Column="2"
+                     Classes="data-header"
+                     Text="Package ID" />
+          <TextBlock x:Name="BundleColVersionBlock"
+                     Grid.Column="3"
+                     Classes="data-header"
+                     Text="Version" />
+          <TextBlock x:Name="BundleColSourceBlock"
+                     Grid.Column="4"
+                     Classes="data-header"
+                     Text="Source" />
+        </Grid>
+
+        <!-- Rows area -->
+        <Grid Grid.Row="1"
+              Margin="16,0,16,16">
+
+          <ScrollViewer x:Name="BundleRowsScrollViewer"
+                        IsVisible="False">
+            <ItemsControl x:Name="BundleRowsItemsControl">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <Border Classes="data-row"
+                          Classes.selected="{Binding IsSelected}">
+                    <Grid ColumnDefinitions="32,2.5*,2.2*,1.1*,1.8*"
+                          ColumnSpacing="14">
+                      <CheckBox IsChecked="{Binding IsChecked}"
+                                Width="28"
+                                Height="28"
+                                Padding="0"
+                                VerticalAlignment="Center" />
+                      <TextBlock Grid.Column="1"
+                                 Text="{Binding Name}"
+                                 Classes="data-primary" />
+                      <TextBlock Grid.Column="2"
+                                 Text="{Binding Id}"
+                                 Classes="data-secondary" />
+                      <TextBlock Grid.Column="3"
+                                 Text="{Binding Version}"
+                                 Classes="data-secondary" />
+                      <TextBlock Grid.Column="4"
+                                 Text="{Binding Source}"
+                                 Classes="data-secondary" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+
+          <!-- Empty state -->
+          <Border x:Name="BundleEmptyStateCard"
+                  Padding="24"
+                  Classes="surface-card subtle-panel"
+                  CornerRadius="18">
+            <StackPanel HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Spacing="10">
+              <TextBlock x:Name="BundleEmptyTitleBlock"
+                         HorizontalAlignment="Center"
+                         FontSize="22"
+                         FontWeight="Bold"
+                         TextAlignment="Center"
+                         Text="No packages in bundle" />
+              <TextBlock x:Name="BundleEmptyDescBlock"
+                         MaxWidth="520"
+                         HorizontalAlignment="Center"
+                         Opacity="0.74"
+                         TextAlignment="Center"
+                         TextWrapping="Wrap"
+                         Text="Add packages to start, or open an existing bundle file." />
+            </StackPanel>
+          </Border>
+
+        </Grid>
+      </Grid>
+    </Border>
+
+  </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/BundlesPageView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/BundlesPageView.axaml.cs
@@ -1,0 +1,1058 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Avalonia.Views;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Telemetry;
+using UniGetUI.PackageEngine;
+using UniGetUI.PackageEngine.Classes.Serializable;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Operations;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.PackageLoader;
+using UniGetUI.PackageEngine.Serializable;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>
+/// Row view-model for the bundle package list.
+/// </summary>
+public sealed class BundleRowModel : INotifyPropertyChanged
+{
+    public IPackage Package { get; }
+    public string Name => Package.Name;
+    public string Id => Package.Id;
+    public string Version => Package.VersionString;
+    public string Source => Package.Source.AsString_DisplayName;
+    public bool IsValid => Package is ImportedPackage;
+
+    private bool _isSelected;
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            _isSelected = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+        }
+    }
+
+    private bool _isChecked;
+    public bool IsChecked
+    {
+        get => _isChecked;
+        set
+        {
+            _isChecked = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked)));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public BundleRowModel(IPackage package)
+    {
+        Package = package;
+    }
+}
+
+public partial class BundlesPageView : UserControl, IShellPage
+{
+    // ── IShellPage ──────────────────────────────────────────────────────────
+    public string Title { get; } = string.Empty;
+    public string Subtitle { get; } = string.Empty;
+    public bool SupportsSearch => true;
+    public string SearchPlaceholder { get; } = string.Empty;
+
+    public void UpdateSearchQuery(string query)
+    {
+        _searchQuery = query.Trim();
+        RefreshRows();
+    }
+
+    // ── State ────────────────────────────────────────────────────────────────
+    private readonly ObservableCollection<BundleRowModel> _visibleRows = [];
+    private BundleRowModel? _selectedRow;
+    private string _searchQuery = string.Empty;
+    private AbstractOperation? _lastOperation;
+
+    private bool _hasUnsavedChanges;
+    private bool HasUnsavedChanges
+    {
+        get => _hasUnsavedChanges;
+        set
+        {
+            _hasUnsavedChanges = value;
+            Dispatcher.UIThread.Post(UpdateStatusBadge);
+        }
+    }
+
+    // ── Control accessors ────────────────────────────────────────────────────
+    private Button NewBtn => GetControl<Button>("NewBundleButton");
+    private Button OpenBtn => GetControl<Button>("OpenBundleButton");
+    private Button SaveBtn => GetControl<Button>("SaveBundleButton");
+    private Button CreateScriptBtn => GetControl<Button>("CreateScriptButton");
+    private Button InstallBtn => GetControl<Button>("InstallSelectedButton");
+    private Button InstallDropdownBtn => GetControl<Button>("InstallDropdownButton");
+    private Button RemoveBtn => GetControl<Button>("RemoveSelectedButton");
+    private Button DetailsBtn => GetControl<Button>("BundleDetailsButton");
+    private Button ShareBtn => GetControl<Button>("BundleShareButton");
+    private Button ViewOutputBtn => GetControl<Button>("BundleViewOutputButton");
+    private Button AddToBundleInfoBtn => GetControl<Button>("AddToBundleInfoButton");
+    private Button HelpBtn => GetControl<Button>("BundleHelpButton");
+    private TextBlock StateText => GetControl<TextBlock>("BundleStateBlock");
+    private TextBlock StatusBadge => GetControl<TextBlock>("BundleStatusBlock");
+    private TextBox SearchBox => GetControl<TextBox>("BundleSearchBox");
+    private CheckBox CheckAll => GetControl<CheckBox>("CheckAllCheckBox");
+    private ItemsControl Rows => GetControl<ItemsControl>("BundleRowsItemsControl");
+    private ScrollViewer RowsHost => GetControl<ScrollViewer>("BundleRowsScrollViewer");
+    private Border EmptyCard => GetControl<Border>("BundleEmptyStateCard");
+    private TextBlock TitleBlock => GetControl<TextBlock>("BundlesTitleBlock");
+    private TextBlock SubtitleBlock => GetControl<TextBlock>("BundlesSubtitleBlock");
+
+    // ── Constructor ──────────────────────────────────────────────────────────
+    public BundlesPageView()
+    {
+        InitializeComponent();
+        ApplyTranslations();
+        Rows.ItemsSource = _visibleRows;
+
+        // Toolbar wiring
+        NewBtn.Click += NewBtn_OnClick;
+        OpenBtn.Click += OpenBtn_OnClick;
+        SaveBtn.Click += SaveBtn_OnClick;
+        InstallBtn.Click += async (_, _) => await QueueInstallCheckedAsync();
+        InstallDropdownBtn.Click += InstallDropdownBtn_OnClick;
+        RemoveBtn.Click += RemoveBtn_OnClick;
+        DetailsBtn.Click += DetailsBtn_OnClick;
+        ShareBtn.Click += ShareBtn_OnClick;
+        AddToBundleInfoBtn.Click += AddToBundleInfoBtn_OnClick;
+        HelpBtn.Click += HelpBtn_OnClick;
+        CreateScriptBtn.Click += async (_, _) => await CreateBatchScriptAsync();
+        CheckAll.IsCheckedChanged += CheckAll_OnChanged;
+
+        SearchBox.TextChanged += (_, _) =>
+        {
+            _searchQuery = SearchBox.Text?.Trim() ?? string.Empty;
+            RefreshRows();
+        };
+
+        // Row pointer-press for selection
+        Rows.AddHandler(
+            InputElement.PointerPressedEvent,
+            OnRowsPointerPressed,
+            RoutingStrategies.Bubble
+        );
+
+        // Loader events
+        var loader = PackageBundlesLoader.Instance;
+        loader.PackagesChanged += (_, _) =>
+        {
+            HasUnsavedChanges = true;
+            Dispatcher.UIThread.Post(RefreshRows);
+        };
+        loader.FinishedLoading += (_, _) => Dispatcher.UIThread.Post(RefreshRows);
+
+        RefreshRows();
+    }
+
+    private void ApplyTranslations()
+    {
+        TitleBlock.Text = CoreTools.Translate("Package Bundles");
+        SubtitleBlock.Text = CoreTools.Translate("Add packages or open an existing bundle");
+
+        NewBtn.Content = CoreTools.Translate("New");
+        OpenBtn.Content = CoreTools.Translate("Open");
+        SaveBtn.Content = CoreTools.Translate("Save as");
+        InstallBtn.Content = CoreTools.Translate("Install selection");
+        RemoveBtn.Content = CoreTools.Translate("Remove selection from bundle");
+        DetailsBtn.Content = CoreTools.Translate("Package details");
+        ShareBtn.Content = CoreTools.Translate("Share");
+        HelpBtn.Content = CoreTools.Translate("Help");
+        ToolTip.SetTip(AddToBundleInfoBtn, CoreTools.Translate(
+            "To add packages to a bundle, right-click on a package in the Discover, Updates or Installed pages and select \"Add to bundle\"."));
+        CreateScriptBtn.Content = CoreTools.Translate("Create .ps1 script");
+        SearchBox.Watermark = CoreTools.Translate("Search");
+
+        GetControl<TextBlock>("BundleEmptyTitleBlock").Text =
+            CoreTools.Translate("Add packages or open an existing package bundle");
+        GetControl<TextBlock>("BundleEmptyDescBlock").Text =
+            CoreTools.Translate("The current bundle has no packages. Add some packages to get started");
+        GetControl<TextBlock>("BundleColNameBlock").Text = CoreTools.Translate("Package Name");
+        GetControl<TextBlock>("BundleColIdBlock").Text = CoreTools.Translate("Package ID");
+        GetControl<TextBlock>("BundleColVersionBlock").Text = CoreTools.Translate("Version");
+        GetControl<TextBlock>("BundleColSourceBlock").Text = CoreTools.Translate("Source");
+    }
+
+    // ── PS1 script export ────────────────────────────────────────────────────
+
+    private async Task CreateBatchScriptAsync()
+    {
+        try
+        {
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel is null) return;
+
+            var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            {
+                Title = CoreTools.Translate("Create .ps1 script"),
+                SuggestedFileName = CoreTools.Translate("Install script") + ".ps1",
+                FileTypeChoices = [new FilePickerFileType("PowerShell script") { Patterns = ["*.ps1"] }],
+            });
+            if (file is null) return;
+
+            var packages = new List<string>();
+            var commands = new List<string>();
+            var forceKill = Settings.Get(Settings.K.KillProcessesThatRefuseToDie);
+
+            foreach (var pkg in PackageBundlesLoader.Instance.Packages)
+            {
+                if (pkg is not ImportedPackage package) continue;
+
+                packages.Add(package.Name + " from " + package.Manager.DisplayName);
+
+                foreach (var process in package.installation_options.KillBeforeOperation)
+                    commands.Add($"taskkill /im \"{process}\"" + (forceKill ? " /f" : ""));
+
+                if (package.installation_options.PreInstallCommand != "")
+                    commands.Add(package.installation_options.PreInstallCommand);
+
+                var exeName = package.Manager.Properties.ExecutableFriendlyName;
+                var param = package.Manager.OperationHelper.GetParameters(
+                    package,
+                    package.installation_options,
+                    OperationType.Install
+                );
+                commands.Add($"{exeName} {string.Join(' ', param)}");
+
+                if (package.installation_options.PostInstallCommand != "")
+                    commands.Add(package.installation_options.PostInstallCommand);
+            }
+
+            await using var stream = await file.OpenWriteAsync();
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync(GeneratePowerShellScript(packages, commands));
+
+            TelemetryHandler.ExportBatch();
+            StateText.Text = CoreTools.Translate("The installation script saved to {0}", file.Name);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Failed to create batch script:");
+            Logger.Error(ex);
+        }
+    }
+
+    private static string GeneratePowerShellScript(
+        IReadOnlyList<string> names,
+        IReadOnlyList<string> commands)
+    {
+        return $$"""
+            Clear-Host
+            Write-Host ""
+            Write-Host "========================================================"
+            Write-Host ""
+            Write-Host "        __  __      _ ______     __  __  ______" -ForegroundColor Cyan
+            Write-Host "       / / / /___  (_) ____/__  / /_/ / / /  _/" -ForegroundColor Cyan
+            Write-Host "      / / / / __ \/ / / __/ _ \/ __/ / / // /" -ForegroundColor Cyan
+            Write-Host "     / /_/ / / / / / /_/ /  __/ /_/ /_/ // /" -ForegroundColor Cyan
+            Write-Host "     \____/_/ /_/_/\____/\___/\__/\____/___/" -ForegroundColor Cyan
+            Write-Host "          UniGetUI Package Installer Script" 
+            Write-Host "        Created with UniGetUI Version {{CoreData.VersionName}}"
+            Write-Host ""
+            Write-Host "========================================================"
+            Write-Host ""
+            Write-Host "NOTES:" -ForegroundColor Yellow
+            Write-Host "  - The install process will not be as reliable as importing a bundle with UniGetUI. Expect issues and errors." -ForegroundColor Yellow
+            Write-Host "  - Packages will be installed with the install options specified at the time of creation of this script." -ForegroundColor Yellow
+            Write-Host "  - Error/Sucess detection may not be 100% accurate." -ForegroundColor Yellow
+            Write-Host "  - Some of the packages may require elevation. Some of them may ask for permission, but others may fail. Consider running this script elevated." -ForegroundColor Yellow
+            Write-Host "  - You can skip confirmation prompts by running this script with the parameter `/DisablePausePrompts` " -ForegroundColor Yellow
+            Write-Host ""
+            Write-Host ""
+            if ($args[0] -ne "/DisablePausePrompts") { pause }
+            Write-Host ""
+            Write-Host "This script will attempt to install the following packages:"
+            {{string.Join('\n', names.Select(x => $"Write-Host \"  - {x}\""))}}
+            Write-Host ""
+            if ($args[0] -ne "/DisablePausePrompts") { pause }
+            Clear-Host
+
+            $success_count=0
+            $failure_count=0
+            $commands_run=0
+            $results=""
+
+            $commands= @(
+                {{string.Join(
+                ",\n    ",
+                commands.Select(x => $"'cmd.exe /C {x.Replace("'", "''")}'"))}}
+            )
+
+            foreach ($command in $commands) {
+                Write-Host "Running: $command" -ForegroundColor Yellow
+                cmd.exe /C $command
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "[  OK  ] $command" -ForegroundColor Green
+                    $success_count++
+                    $results += "$([char]0x1b)[32m[  OK  ] $command`n"
+                }
+                else {
+                    Write-Host "[ FAIL ] $command" -ForegroundColor Red
+                    $failure_count++
+                    $results += "$([char]0x1b)[31m[ FAIL ] $command`n"
+                }
+                $commands_run++
+                Write-Host ""
+            }
+
+            Write-Host "========================================================"
+            Write-Host "                  OPERATION SUMMARY"
+            Write-Host "========================================================"
+            Write-Host "Total commands run: $commands_run"
+            Write-Host "Successful: $success_count"
+            Write-Host "Failed: $failure_count"
+            Write-Host ""
+            Write-Host "Details:"
+            Write-Host "$results$([char]0x1b)[37m"
+            Write-Host "========================================================"
+
+            if ($failure_count -gt 0) {
+                Write-Host "Some commands failed. Please check the log above." -ForegroundColor Yellow
+            }
+            else {
+                Write-Host "All commands executed successfully!" -ForegroundColor Green
+            }
+            Write-Host ""
+            if ($args[0] -ne "/DisablePausePrompts") { pause }
+            exit $failure_count
+            """;
+    }
+
+    // ── Row management ───────────────────────────────────────────────────────
+
+    private void RefreshRows()
+    {
+        var packages = GetFilteredPackages();
+
+        // Deselect removed row
+        if (_selectedRow is not null && !packages.Any(r => r.Package == _selectedRow.Package))
+        {
+            _selectedRow.IsSelected = false;
+            _selectedRow = null;
+        }
+
+        _visibleRows.Clear();
+        foreach (var row in packages)
+            _visibleRows.Add(row);
+
+        RowsHost.IsVisible = _visibleRows.Count > 0;
+        EmptyCard.IsVisible = _visibleRows.Count == 0;
+
+        UpdateToolbar();
+        UpdateStatusBadge();
+    }
+
+    private List<BundleRowModel> GetFilteredPackages()
+    {
+        var allPackages = PackageBundlesLoader.Instance.Packages;
+        if (string.IsNullOrWhiteSpace(_searchQuery))
+            return allPackages
+                .Select(FindOrCreateRow)
+                .ToList();
+
+        var q = _searchQuery.ToLowerInvariant();
+        return allPackages
+            .Where(p =>
+                p.Name.ToLowerInvariant().Contains(q)
+                || p.Id.ToLowerInvariant().Contains(q))
+            .Select(FindOrCreateRow)
+            .ToList();
+    }
+
+    private readonly Dictionary<IPackage, BundleRowModel> _rowCache = new(ReferenceEqualityComparer.Instance);
+
+    private BundleRowModel FindOrCreateRow(IPackage package)
+    {
+        if (!_rowCache.TryGetValue(package, out var row))
+        {
+            row = new BundleRowModel(package);
+            _rowCache[package] = row;
+        }
+        return row;
+    }
+
+    private void UpdateToolbar()
+    {
+        bool anyRows = _visibleRows.Count > 0;
+        bool anyChecked = _visibleRows.Any(r => r.IsChecked);
+        bool rowSelected = _selectedRow is not null && _visibleRows.Any(r => r == _selectedRow);
+
+        InstallBtn.IsEnabled = anyChecked;
+        InstallDropdownBtn.IsEnabled = anyChecked;
+        RemoveBtn.IsEnabled = anyChecked || rowSelected;
+        DetailsBtn.IsEnabled = rowSelected;
+        ShareBtn.IsEnabled = rowSelected;
+        SaveBtn.IsEnabled = anyRows;
+    }
+
+    private void UpdateStatusBadge()
+    {
+        StatusBadge.Text = _hasUnsavedChanges
+            ? CoreTools.Translate("You may lose unsaved data")
+            : string.Empty;
+    }
+
+    // ── Row selection ────────────────────────────────────────────────────────
+
+    private void OnRowsPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var visual = e.Source as global::Avalonia.Visual;
+        while (visual is not null)
+        {
+            if (visual is Control ctrl && ctrl.DataContext is BundleRowModel row)
+            {
+                SelectRow(row);
+                return;
+            }
+            visual = visual.GetVisualParent();
+        }
+    }
+
+    private void SelectRow(BundleRowModel row)
+    {
+        _selectedRow?.IsSelected = false;
+        _selectedRow = row;
+        _selectedRow.IsSelected = true;
+        UpdateToolbar();
+    }
+
+    // ── Check-all ────────────────────────────────────────────────────────────
+
+    private void CheckAll_OnChanged(object? sender, RoutedEventArgs e)
+    {
+        bool check = CheckAll.IsChecked ?? false;
+        foreach (var row in _visibleRows)
+            row.IsChecked = check;
+        UpdateToolbar();
+    }
+
+    // ── Toolbar handlers ─────────────────────────────────────────────────────
+
+    private async void NewBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (PackageBundlesLoader.Instance.Any() && HasUnsavedChanges)
+        {
+            bool confirmed = await ShowConfirmDialogAsync(
+                CoreTools.Translate("You may lose unsaved data"),
+                CoreTools.Translate("Are you sure you want to create a new package bundle? "),
+                CoreTools.Translate("Continue"),
+                CoreTools.Translate("Cancel")
+            );
+            if (!confirmed) return;
+        }
+
+        _rowCache.Clear();
+        PackageBundlesLoader.Instance.ClearPackages(emitFinishSignal: true);
+        HasUnsavedChanges = false;
+        StateText.Text = CoreTools.Translate("New bundle");
+        RefreshRows();
+    }
+
+    private async void OpenBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (PackageBundlesLoader.Instance.Any() && HasUnsavedChanges)
+        {
+            bool confirmed = await ShowConfirmDialogAsync(
+                CoreTools.Translate("You may lose unsaved data"),
+                CoreTools.Translate("Any unsaved changes will be lost"),
+                CoreTools.Translate("Continue"),
+                CoreTools.Translate("Cancel")
+            );
+            if (!confirmed) return;
+        }
+
+        var topLevel = global::Avalonia.Controls.TopLevel.GetTopLevel(this);
+        if (topLevel is null) return;
+
+        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = CoreTools.Translate("Open existing bundle"),
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("UniGetUI Bundle (*.ubundle)") { Patterns = ["*.ubundle"] },
+                new FilePickerFileType("JSON (*.json)")               { Patterns = ["*.json"]    },
+                new FilePickerFileType("YAML (*.yaml)")               { Patterns = ["*.yaml"]    },
+                new FilePickerFileType("XML  (*.xml)")                { Patterns = ["*.xml"]     },
+            ],
+        });
+
+        if (files.Count == 0) return;
+        await OpenFromFileAsync(files[0].Path.LocalPath);
+    }
+
+    internal async Task OpenFromFileAsync(string filePath)
+    {
+        StateText.Text = CoreTools.Translate("Loading packages, please wait...");
+        try
+        {
+            string ext = filePath.Split('.')[^1].ToLowerInvariant();
+            BundleFormatType format = ext switch
+            {
+                "yaml" => BundleFormatType.YAML,
+                "xml" => BundleFormatType.XML,
+                "json" => BundleFormatType.JSON,
+                _ => BundleFormatType.UBUNDLE,
+            };
+
+            string content = await File.ReadAllTextAsync(filePath);
+            await AddFromBundleStringAsync(content, format);
+            TelemetryHandler.ImportBundle(format);
+            HasUnsavedChanges = false;
+            StateText.Text = CoreTools.Translate("{0} packages found", PackageBundlesLoader.Instance.Packages.Count);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Failed to open bundle file");
+            Logger.Error(ex);
+            StateText.Text = CoreTools.Translate("The package bundle is not valid");
+        }
+    }
+
+    private async void SaveBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var topLevel = global::Avalonia.Controls.TopLevel.GetTopLevel(this);
+        if (topLevel is null) return;
+
+        var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = CoreTools.Translate("Save bundle as"),
+            SuggestedFileName = CoreTools.Translate("Package bundle"),
+            FileTypeChoices =
+            [
+                new FilePickerFileType("UniGetUI Bundle (*.ubundle)") { Patterns = ["*.ubundle"] },
+                new FilePickerFileType("JSON (*.json)")               { Patterns = ["*.json"]    },
+            ],
+        });
+
+        if (file is null) return;
+
+        StateText.Text = CoreTools.Translate("Saving packages, please wait...");
+        try
+        {
+            string serialized = await CreateBundleStringAsync(PackageBundlesLoader.Instance.Packages);
+            string path = file.Path.LocalPath;
+            await File.WriteAllTextAsync(path, serialized);
+            string saveExt = path.Split('.')[^1].ToLowerInvariant();
+            TelemetryHandler.ExportBundle(saveExt == "json" ? BundleFormatType.JSON : BundleFormatType.UBUNDLE);
+            HasUnsavedChanges = false;
+            StateText.Text = CoreTools.Translate("The bundle was created successfully on {0}", path);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Failed to save bundle file");
+            Logger.Error(ex);
+            StateText.Text = CoreTools.Translate("Could not create bundle");
+        }
+    }
+
+    private void AddToBundleInfoBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        StateText.Text = CoreTools.Translate(
+            "To add packages to a bundle, right-click on a package in the Discover, Updates or Installed pages and select \"Add to bundle\".");
+    }
+
+    private void HelpBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var shell = this.FindAncestorOfType<MainShellView>();
+        shell?.OpenPage(ShellPageType.Help);
+    }
+
+    private void InstallDropdownBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var menu = new ContextMenu();
+
+        var adminItem = new MenuItem { Header = CoreTools.Translate("Install as administrator") };
+        adminItem.Click += async (_, _) => await QueueInstallCheckedAsync(elevated: true);
+        menu.Items.Add(adminItem);
+
+        var interactiveItem = new MenuItem { Header = CoreTools.Translate("Interactive installation") };
+        interactiveItem.Click += async (_, _) => await QueueInstallCheckedAsync(interactive: true);
+        menu.Items.Add(interactiveItem);
+
+        var skipHashItem = new MenuItem { Header = CoreTools.Translate("Skip integrity checks") };
+        skipHashItem.Click += async (_, _) => await QueueInstallCheckedAsync(skipHash: true);
+        menu.Items.Add(skipHashItem);
+
+        if (sender is Control anchor)
+        {
+            menu.PlacementTarget = anchor;
+            menu.Placement = PlacementMode.Bottom;
+            menu.Open(anchor);
+        }
+    }
+
+    private async void InstallBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        await QueueInstallCheckedAsync();
+    }
+
+    private async Task QueueInstallCheckedAsync(
+        bool elevated = false,
+        bool interactive = false,
+        bool skipHash = false)
+    {
+        var checkedPackages = _visibleRows
+            .Where(r => r.IsChecked && r.IsValid)
+            .Select(r => r.Package)
+            .ToList();
+
+        if (checkedPackages.Count == 0)
+        {
+            StateText.Text = CoreTools.Translate("No package was selected");
+            return;
+        }
+
+        StateText.Text = CoreTools.Translate("Preparing packages, please wait...");
+        var toInstall = new List<Package>();
+
+        foreach (var pkg in checkedPackages)
+        {
+            if (pkg is ImportedPackage imported)
+            {
+                try
+                {
+                    toInstall.Add(await imported.RegisterAndGetPackageAsync());
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Failed to register bundle package {imported.Id}");
+                    Logger.Error(ex);
+                }
+            }
+        }
+
+        if (toInstall.Count == 0)
+        {
+            StateText.Text = CoreTools.Translate("No package was selected");
+            return;
+        }
+
+        StateText.Text = CoreTools.Translate("{0} packages found", toInstall.Count);
+
+        foreach (var package in toInstall)
+        {
+            try
+            {
+                var options = await InstallOptionsFactory.LoadApplicableAsync(package);
+                if (elevated) options.RunAsAdministrator = true;
+                if (interactive) options.InteractiveInstallation = true;
+                if (skipHash) options.SkipHashCheck = true;
+                var op = new InstallPackageOperation(package, options);
+                _lastOperation = op;
+                ViewOutputBtn.IsVisible = true;
+                AvaloniaOperationRegistry.Add(op);
+                _ = op.MainThread();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to queue installation of {package.Id}");
+                Logger.Error(ex);
+            }
+        }
+    }
+
+    private async void BundleViewOutputButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_lastOperation is null) return;
+        var window = new OperationLogWindow(_lastOperation);
+        if (VisualRoot is Window parentWindow)
+            await window.ShowDialog(parentWindow);
+        else
+            window.Show();
+    }
+
+    private void RemoveBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var checkedPackages = _visibleRows
+            .Where(r => r.IsChecked)
+            .Select(r => r.Package)
+            .ToList();
+
+        if (checkedPackages.Count > 0)
+        {
+            foreach (var pkg in checkedPackages)
+                _rowCache.Remove(pkg);
+            PackageBundlesLoader.Instance.RemoveRange(checkedPackages);
+            HasUnsavedChanges = true;
+            return;
+        }
+
+        // Fall back to selected row
+        if (_selectedRow is not null)
+        {
+            _rowCache.Remove(_selectedRow.Package);
+            PackageBundlesLoader.Instance.RemoveRange([_selectedRow.Package]);
+            _selectedRow = null;
+            HasUnsavedChanges = true;
+        }
+    }
+
+    private async void DetailsBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_selectedRow is null) return;
+        var pkg = _selectedRow.Package;
+        if (pkg.Source.IsVirtualManager)
+        {
+            StateText.Text = CoreTools.Translate("Show package details");
+            return;
+        }
+        var window = new PackageDetailsWindow(pkg, PackagePageMode.None);
+        if (VisualRoot is Window parentWindow)
+            await window.ShowDialog(parentWindow);
+        else
+            window.Show();
+    }
+
+    private async void ShareBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_selectedRow is null) return;
+        var package = _selectedRow.Package;
+        if (package.Source.IsVirtualManager)
+        {
+            StateText.Text = CoreTools.Translate("Share this package");
+            return;
+        }
+        var url = "https://marticliment.com/unigetui/share?"
+            + "name=" + Uri.EscapeDataString(package.Name)
+            + "&id=" + Uri.EscapeDataString(package.Id)
+            + "&sourceName=" + Uri.EscapeDataString(package.Source.Name)
+            + "&managerName=" + Uri.EscapeDataString(package.Manager.DisplayName);
+        var clipboard = global::Avalonia.Controls.TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is not null)
+        {
+            await clipboard.SetTextAsync(url);
+            StateText.Text = CoreTools.Translate("Copy to clipboard");
+        }
+    }
+
+    // ── Bundle serialization helpers ─────────────────────────────────────────
+
+    internal static async Task<string> CreateBundleStringAsync(IReadOnlyList<IPackage> packages)
+    {
+        var bundle = new SerializableBundle();
+        var sorted = packages.ToList();
+        sorted.Sort((a, b) =>
+        {
+            int c = string.Compare(a.Id, b.Id, StringComparison.Ordinal);
+            return c != 0 ? c : string.Compare(a.Name, b.Name, StringComparison.Ordinal);
+        });
+
+        foreach (var pkg in sorted)
+        {
+            if (pkg is Package && !pkg.Source.IsVirtualManager)
+                bundle.packages.Add(await pkg.AsSerializableAsync());
+            else
+                bundle.incompatible_packages.Add(pkg.AsSerializable_Incompatible());
+        }
+
+        return bundle.AsJsonString();
+    }
+
+    private async Task AddFromBundleStringAsync(string content, BundleFormatType format)
+    {
+        if (format is BundleFormatType.YAML)
+            content = await SerializationHelpers.YAML_to_JSON(content);
+
+        if (format is BundleFormatType.XML)
+            content = await SerializationHelpers.XML_to_JSON(content);
+
+        var data = await Task.Run(() =>
+            new SerializableBundle(
+                JsonNode.Parse(content) ?? throw new JsonException("Could not parse JSON")
+            )
+        );
+
+        bool allowCLI = SecureSettings.Get(SecureSettings.K.AllowCLIArguments)
+                         && SecureSettings.Get(SecureSettings.K.AllowImportingCLIArguments);
+        bool allowPrePost = SecureSettings.Get(SecureSettings.K.AllowPrePostOpCommand)
+                         && SecureSettings.Get(SecureSettings.K.AllowImportPrePostOpCommands);
+
+        // Build a security report tracking stripped / allowed-through sensitive settings
+        var report = new UniGetUI.Interface.Enums.BundleReport { IsEmpty = true };
+
+        void AddToReport(string pkgId, string line, bool allowed)
+        {
+            report.IsEmpty = false;
+            if (!report.Contents.ContainsKey(pkgId))
+                report.Contents[pkgId] = new List<UniGetUI.Interface.Enums.BundleReportEntry>();
+            report.Contents[pkgId].Add(new UniGetUI.Interface.Enums.BundleReportEntry(line, allowed));
+        }
+
+        var packages = new List<IPackage>();
+        foreach (var pkg in data.packages)
+        {
+            var opts = pkg.InstallationOptions;
+
+            if (opts.CustomParameters_Install.Any(x => x.Any()))
+            {
+                AddToReport(pkg.Id, $"Custom install arguments: [{string.Join(", ", opts.CustomParameters_Install)}]", allowCLI);
+                if (!allowCLI) opts.CustomParameters_Install.Clear();
+            }
+            if (opts.CustomParameters_Update.Any(x => x.Any()))
+            {
+                AddToReport(pkg.Id, $"Custom update arguments: [{string.Join(", ", opts.CustomParameters_Update)}]", allowCLI);
+                if (!allowCLI) opts.CustomParameters_Update.Clear();
+            }
+            if (opts.CustomParameters_Uninstall.Any(x => x.Any()))
+            {
+                AddToReport(pkg.Id, $"Custom uninstall arguments: [{string.Join(", ", opts.CustomParameters_Uninstall)}]", allowCLI);
+                if (!allowCLI) opts.CustomParameters_Uninstall.Clear();
+            }
+            if (opts.PreInstallCommand.Any())
+            {
+                AddToReport(pkg.Id, $"Pre-install command: {opts.PreInstallCommand}", allowPrePost);
+                if (!allowPrePost) opts.PreInstallCommand = "";
+            }
+            if (opts.PostInstallCommand.Any())
+            {
+                AddToReport(pkg.Id, $"Post-install command: {opts.PostInstallCommand}", allowPrePost);
+                if (!allowPrePost) opts.PostInstallCommand = "";
+            }
+            if (opts.PreUpdateCommand.Any())
+            {
+                AddToReport(pkg.Id, $"Pre-update command: {opts.PreUpdateCommand}", allowPrePost);
+                if (!allowPrePost) opts.PreUpdateCommand = "";
+            }
+            if (opts.PostUpdateCommand.Any())
+            {
+                AddToReport(pkg.Id, $"Post-update command: {opts.PostUpdateCommand}", allowPrePost);
+                if (!allowPrePost) opts.PostUpdateCommand = "";
+            }
+            if (opts.PreUninstallCommand.Any())
+            {
+                AddToReport(pkg.Id, $"Pre-uninstall command: {opts.PreUninstallCommand}", allowPrePost);
+                if (!allowPrePost) opts.PreUninstallCommand = "";
+            }
+            if (opts.PostUninstallCommand.Any())
+            {
+                AddToReport(pkg.Id, $"Post-uninstall command: {opts.PostUninstallCommand}", allowPrePost);
+                if (!allowPrePost) opts.PostUninstallCommand = "";
+            }
+
+            pkg.InstallationOptions = opts;
+            packages.Add(DeserializePackage(pkg));
+        }
+
+        foreach (var inc in data.incompatible_packages)
+            packages.Add(DeserializeIncompatiblePackage(inc));
+
+        _rowCache.Clear();
+        PackageBundlesLoader.Instance.ClearPackages(emitFinishSignal: false);
+        await PackageBundlesLoader.Instance.AddPackagesAsync(packages);
+
+        // Show security report if anything sensitive was found (D1)
+        if (!report.IsEmpty)
+            await ShowBundleSecurityReportAsync(report);
+    }
+
+    private static IPackage DeserializePackage(SerializablePackage raw)
+    {
+        IPackageManager? manager = PackageEngine.PEInterface.Managers
+            .FirstOrDefault(m => m.Name == raw.ManagerName || m.DisplayName == raw.ManagerName);
+
+        IManagerSource? source = null;
+        if (manager?.Capabilities.SupportsCustomSources == true)
+        {
+            string sourceName = raw.Source.Contains(": ")
+                ? raw.Source.Split(": ")[^1]
+                : raw.Source;
+            source = manager.SourcesHelper?.Factory.GetSourceIfExists(sourceName);
+        }
+        else
+        {
+            source = manager?.DefaultSource;
+        }
+
+        if (manager is null || source is null)
+            return DeserializeIncompatiblePackage(raw.GetInvalidEquivalent());
+
+        return new ImportedPackage(raw, manager, source);
+    }
+
+    private static IPackage DeserializeIncompatiblePackage(SerializableIncompatiblePackage raw)
+    {
+        return new InvalidImportedPackage(raw, NullSource.Instance);
+    }
+
+    // ── Confirm dialog helper ─────────────────────────────────────────────────
+
+    private async Task ShowBundleSecurityReportAsync(UniGetUI.Interface.Enums.BundleReport report)
+    {
+        if (VisualRoot is not Window parentWindow)
+            return;
+
+        bool isDark = ActualThemeVariant == global::Avalonia.Styling.ThemeVariant.Dark;
+        var colorIgnored = new global::Avalonia.Media.SolidColorBrush(isDark
+            ? global::Avalonia.Media.Color.Parse("#FFD700") // gold
+            : global::Avalonia.Media.Color.Parse("#B8860B")); // dark golden rod
+        var colorAllowed = new global::Avalonia.Media.SolidColorBrush(isDark
+            ? global::Avalonia.Media.Color.Parse("#FF6B6B") // light red
+            : global::Avalonia.Media.Color.Parse("#CC0000")); // dark red
+
+        var itemsList = new StackPanel { Spacing = 4 };
+
+        foreach (var pair in report.Contents)
+        {
+            itemsList.Children.Add(new TextBlock
+            {
+                Text = $" - {CoreTools.Translate("Package")}: {pair.Key}:",
+                FontFamily = new global::Avalonia.Media.FontFamily("Cascadia Code,Consolas,monospace"),
+                FontWeight = global::Avalonia.Media.FontWeight.SemiBold,
+                TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+            });
+            foreach (var entry in pair.Value)
+            {
+                itemsList.Children.Add(new TextBlock
+                {
+                    Text = $"   * {entry.Line}",
+                    FontFamily = new global::Avalonia.Media.FontFamily("Cascadia Code,Consolas,monospace"),
+                    Foreground = entry.Allowed ? colorAllowed : colorIgnored,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                });
+            }
+        }
+
+        var dialog = new Window
+        {
+            Title = CoreTools.Translate("Bundle security report"),
+            Width = 700,
+            Height = 520,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = true,
+        };
+
+        var closeBtn = new Button { Content = CoreTools.Translate("Close"), HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right };
+        closeBtn.Click += (_, _) => dialog.Close();
+
+        dialog.Content = new StackPanel
+        {
+            Margin = new global::Avalonia.Thickness(20),
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = CoreTools.Translate("This package bundle had some settings that are potentially dangerous, and may be ignored by default."),
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                },
+                new TextBlock
+                {
+                    Text = " - " + CoreTools.Translate("Entries that show in YELLOW will be IGNORED."),
+                    Foreground = colorIgnored,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                },
+                new TextBlock
+                {
+                    Text = " - " + CoreTools.Translate("Entries that show in RED will be IMPORTED."),
+                    Foreground = colorAllowed,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                },
+                new TextBlock
+                {
+                    Text = CoreTools.Translate("You can change this behavior on UniGetUI security settings."),
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                },
+                new TextBlock
+                {
+                    Text = CoreTools.Translate("Details of the report:"),
+                    FontWeight = global::Avalonia.Media.FontWeight.SemiBold,
+                },
+                new ScrollViewer
+                {
+                    HorizontalScrollBarVisibility = global::Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
+                    Content = itemsList,
+                },
+                closeBtn,
+            },
+        };
+
+        await dialog.ShowDialog(parentWindow);
+    }
+
+    private async Task<bool> ShowConfirmDialogAsync(
+        string title,
+        string message,
+        string confirmLabel,
+        string cancelLabel)
+    {
+        if (VisualRoot is not Window parentWindow)
+            return true;
+
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 460,
+            Height = 200,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+        };
+
+        bool result = false;
+        var confirmBtn = new Button { Content = confirmLabel };
+        var cancelBtn = new Button { Content = cancelLabel };
+        confirmBtn.Click += (_, _) => { result = true; dialog.Close(); };
+        cancelBtn.Click += (_, _) => { result = false; dialog.Close(); };
+
+        dialog.Content = new StackPanel
+        {
+            Margin = new global::Avalonia.Thickness(24),
+            Spacing = 16,
+            Children =
+            {
+                new TextBlock { Text = message, TextWrapping = global::Avalonia.Media.TextWrapping.Wrap },
+                new StackPanel
+                {
+                    Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+                    Spacing = 12,
+                    HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right,
+                    Children = { confirmBtn, cancelBtn },
+                },
+            },
+        };
+
+        await dialog.ShowDialog(parentWindow);
+        return result;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name) where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/DesktopShortcutsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/DesktopShortcutsWindow.axaml
@@ -1,0 +1,99 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.DesktopShortcutsWindow"
+        Width="700"
+        Height="520"
+        MinWidth="460"
+        MinHeight="340"
+        Title="Automatic desktop shortcut remover"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <Grid RowDefinitions="Auto,*,Auto,Auto"
+        Margin="16"
+        RowSpacing="12">
+
+    <!-- Header -->
+    <StackPanel Grid.Row="0" Spacing="6">
+      <TextBlock x:Name="TitleBlock"
+                 FontSize="20"
+                 FontWeight="SemiBold" />
+      <TextBlock x:Name="DescriptionBlock"
+                 Opacity="0.7"
+                 TextWrapping="Wrap" />
+    </StackPanel>
+
+    <!-- Shortcuts list -->
+    <Border Grid.Row="1"
+            Classes="surface-card"
+            Padding="0">
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <ItemsControl x:Name="ShortcutsListControl"
+                      Margin="0">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <Border Padding="12,8"
+                      BorderThickness="0,0,0,1">
+                <Grid ColumnDefinitions="Auto,*,Auto"
+                      ColumnSpacing="10">
+                  <CheckBox Grid.Column="0"
+                            IsChecked="{Binding IsDeletable, Mode=TwoWay}"
+                            VerticalAlignment="Center" />
+                  <StackPanel Grid.Column="1"
+                              Spacing="2"
+                              VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Name}"
+                               FontWeight="SemiBold"
+                               TextTrimming="CharacterEllipsis" />
+                    <TextBlock Text="{Binding Path}"
+                               FontSize="11"
+                               Opacity="0.6"
+                               TextTrimming="CharacterEllipsis" />
+                  </StackPanel>
+                  <TextBlock Grid.Column="2"
+                             Text="{Binding NotOnDiskText}"
+                             Opacity="0.5"
+                             FontSize="11"
+                             VerticalAlignment="Center"
+                             IsVisible="{Binding !ExistsOnDisk}" />
+                </Grid>
+              </Border>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+    </Border>
+
+    <!-- Auto-delete all checkbox -->
+    <CheckBox x:Name="AutoDeleteAllCheckBox"
+              Grid.Row="2"
+              Click="AutoDeleteAllCheckBox_OnClick" />
+
+    <!-- Footer buttons -->
+    <Grid Grid.Row="3"
+          ColumnDefinitions="*,Auto,Auto"
+          ColumnSpacing="8">
+      <TextBlock x:Name="EmptyHintBlock"
+                 Grid.Column="0"
+                 VerticalAlignment="Center"
+                 Opacity="0.6"
+                 FontSize="12"
+                 IsVisible="False" />
+      <Button x:Name="CloseBtn"
+              Grid.Column="1"
+              MinWidth="90"
+              Content="Close"
+              Click="CloseBtn_OnClick" />
+      <Button x:Name="SaveCloseBtn"
+              Grid.Column="2"
+              MinWidth="120"
+              Classes="accent"
+              Content="Save and Close"
+              Click="SaveCloseBtn_OnClick" />
+    </Grid>
+
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/DesktopShortcutsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/DesktopShortcutsWindow.axaml.cs
@@ -1,0 +1,150 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Classes.Packages.Classes;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+// ── View model for a single shortcut row ─────────────────────────────────────
+
+public sealed class ShortcutItem : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string Path { get; }
+    public string Name { get; }
+
+    private bool _isDeletable;
+    public bool IsDeletable
+    {
+        get => _isDeletable;
+        set
+        {
+            if (_isDeletable == value) return;
+            _isDeletable = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool ExistsOnDisk => File.Exists(Path);
+
+    public string NotOnDiskText { get; } = CoreTools.Translate("Not found");
+
+    public ShortcutItem(string path, bool isDeletable)
+    {
+        Path = path;
+        Name = string.Join('.', path.Split('\\')[^1].Split('.')[..^1]);
+        _isDeletable = isDeletable;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+// ── Window ────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Lets users review desktop shortcuts detected by UniGetUI and choose
+/// which ones to delete automatically on future upgrades.
+/// </summary>
+public partial class DesktopShortcutsWindow : Window
+{
+    private readonly ObservableCollection<ShortcutItem> _shortcuts = [];
+
+    public DesktopShortcutsWindow()
+        : this(null)
+    {
+    }
+
+    /// <param name="newShortcuts">
+    /// When non-null, only these shortcuts are displayed (new-shortcut flow).
+    /// When null, all known shortcuts from the database are loaded.
+    /// </param>
+    public DesktopShortcutsWindow(IReadOnlyList<string>? newShortcuts)
+    {
+        Title = CoreTools.Translate("Automatic desktop shortcut remover");
+        InitializeComponent();
+
+        TitleBlock.Text = CoreTools.Translate("Automatic desktop shortcut remover");
+        DescriptionBlock.Text = CoreTools.Translate(
+            "Here you can change UniGetUI's behaviour regarding the following shortcuts. " +
+            "Checking a shortcut will make UniGetUI delete it if it gets created on a future upgrade. " +
+            "Unchecking it will keep the shortcut intact.");
+
+        AutoDeleteAllCheckBox.Content = CoreTools.Translate("When new shortcuts are detected, delete them automatically instead of showing this dialog.");
+        AutoDeleteAllCheckBox.IsChecked = Settings.Get(Settings.K.RemoveAllDesktopShortcuts);
+
+        ShortcutsListControl.ItemsSource = _shortcuts;
+        LoadShortcuts(newShortcuts ?? DesktopShortcutsDatabase.GetAllShortcuts());
+
+        if (_shortcuts.Count == 0)
+        {
+            EmptyHintBlock.Text = CoreTools.Translate("No new shortcuts were found during the scan.");
+            EmptyHintBlock.IsVisible = true;
+        }
+
+        CloseBtn.Content = CoreTools.Translate("Close");
+        SaveCloseBtn.Content = CoreTools.Translate("Save and close");
+    }
+
+    // ── Data loading ──────────────────────────────────────────────────────────
+
+    private void LoadShortcuts(IReadOnlyList<string> paths)
+    {
+        _shortcuts.Clear();
+        var items = paths.Select(p =>
+        {
+            var status = DesktopShortcutsDatabase.GetStatus(p);
+            return new ShortcutItem(p, status is DesktopShortcutsDatabase.Status.Delete);
+        })
+        .OrderBy(s => s.Name)
+        .ToList();
+
+        foreach (var item in items)
+            _shortcuts.Add(item);
+    }
+
+    // ── Save ──────────────────────────────────────────────────────────────────
+
+    private void SaveChanges()
+    {
+        foreach (var shortcut in _shortcuts)
+        {
+            DesktopShortcutsDatabase.AddToDatabase(
+                shortcut.Path,
+                shortcut.IsDeletable
+                    ? DesktopShortcutsDatabase.Status.Delete
+                    : DesktopShortcutsDatabase.Status.Maintain);
+
+            DesktopShortcutsDatabase.RemoveFromUnknownShortcuts(shortcut.Path);
+
+            if (shortcut.IsDeletable && File.Exists(shortcut.Path))
+                DesktopShortcutsDatabase.DeleteFromDisk(shortcut.Path);
+        }
+    }
+
+    // ── Event handlers ────────────────────────────────────────────────────────
+
+    private void AutoDeleteAllCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        bool isChecked = AutoDeleteAllCheckBox.IsChecked == true;
+        Settings.Set(Settings.K.RemoveAllDesktopShortcuts, isChecked);
+        if (isChecked)
+        {
+            SaveChanges();
+            Close();
+        }
+    }
+
+    private void CloseBtn_OnClick(object? sender, RoutedEventArgs e) => Close();
+
+    private void SaveCloseBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        SaveChanges();
+        Close();
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/DocumentationBrowserWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/DocumentationBrowserWindow.axaml
@@ -1,0 +1,115 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.DocumentationBrowserWindow"
+        Width="960"
+        Height="680"
+        MinWidth="720"
+        MinHeight="480"
+        Title="Documentation"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <Grid Margin="18"
+        RowDefinitions="Auto,Auto,Auto,*"
+        RowSpacing="10">
+    <TextBlock x:Name="TitleBlock"
+               FontSize="18"
+               FontWeight="SemiBold"
+               TextWrapping="Wrap"
+               Text="Documentation" />
+
+    <Grid Grid.Row="1"
+          ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto"
+          ColumnSpacing="8">
+      <Button x:Name="BackButton"
+              Grid.Column="0"
+              MinWidth="44"
+              Content="←"
+              Click="BackButton_OnClick" />
+
+      <Button x:Name="ForwardButton"
+              Grid.Column="1"
+              MinWidth="44"
+              Content="→"
+              Click="ForwardButton_OnClick" />
+
+      <Button x:Name="HomeButton"
+              Grid.Column="2"
+              MinWidth="88"
+              Content="Home"
+              Click="HomeButton_OnClick" />
+
+      <Button x:Name="ReloadButton"
+              Grid.Column="3"
+              MinWidth="88"
+              Content="Reload"
+              Click="ReloadButton_OnClick" />
+
+      <Button x:Name="BrowserButton"
+              Grid.Column="5"
+              MinWidth="170"
+              Classes="accent"
+              Content="View page on browser"
+              Click="BrowserButton_OnClick" />
+    </Grid>
+
+    <Border Grid.Row="2"
+            Padding="10"
+            Classes="surface-card subtle-panel"
+            CornerRadius="12">
+      <Grid RowDefinitions="Auto,Auto"
+            RowSpacing="8">
+        <TextBox x:Name="UrlTextBox"
+                 IsReadOnly="True"
+                 TextWrapping="NoWrap" />
+
+        <Grid Grid.Row="1"
+              ColumnDefinitions="*,Auto"
+              ColumnSpacing="8">
+          <TextBlock x:Name="StatusBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap"
+                     Text="Loading..." />
+
+          <ProgressBar x:Name="LoadingProgressBar"
+                       Grid.Column="1"
+                       Width="180"
+                       IsIndeterminate="True" />
+        </Grid>
+      </Grid>
+    </Border>
+
+    <Border Grid.Row="3"
+            Padding="14"
+            Classes="surface-card"
+            CornerRadius="14">
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="14">
+          <TextBlock x:Name="PageTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+
+          <SelectableTextBlock x:Name="PageContentBlock"
+                               TextWrapping="Wrap" />
+
+          <Border x:Name="LinksSectionBorder"
+                  Padding="12"
+                  Classes="surface-card subtle-panel"
+                  CornerRadius="12"
+                  IsVisible="False">
+            <StackPanel Spacing="10">
+              <TextBlock x:Name="LinksTitleBlock"
+                         FontWeight="SemiBold"
+                         Text="Related pages" />
+              <StackPanel x:Name="LinksPanel"
+                          Spacing="8" />
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </ScrollViewer>
+    </Border>
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/DocumentationBrowserWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/DocumentationBrowserWindow.axaml.cs
@@ -1,0 +1,510 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class DocumentationBrowserWindow : Window
+{
+    private static readonly Uri _homeUri = new("https://marticliment.com/unigetui/help/");
+    private static readonly Regex _titleRegex = new("<title>(?<value>.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex _migrationNoticeRegex = new("<div class=['\"]unigetui-migrate['\"]>.*?</div>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex _h1Regex = new("<h1[^>]*>(?<value>.*?)</h1>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex _articleLinkRegex = new("<div class=mainArticleEntryDiv onclick=\"location.href='(?<href>[^']+)'\".*?<h3>(?<text>.*?)</h3>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex _anchorRegex = new("<a[^>]*href=['\"](?<href>[^'\"]+)['\"][^>]*>(?<text>.*?)</a>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex _tagRegex = new("<[^>]+>", RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex _scriptRegex = new("<(script|style|noscript)[^>]*>.*?</\\1>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex _breakRegex = new("<br\\s*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex _blockEndRegex = new("</(p|div|section|article|h1|h2|h3|h4|h5|h6|li|ul|ol|pre|blockquote)>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex _lineCollapseRegex = new("\\n{3,}", RegexOptions.Compiled);
+    private static readonly Regex _markdownLinkRegex = new("\\[(?<text>[^\\]]+)\\]\\((?<href>[^)]+)\\)", RegexOptions.Compiled);
+
+    private readonly List<Uri> _history = [];
+
+    private int _historyIndex = -1;
+    private bool _isLoading;
+
+    private TextBlock TitleBlockControl => GetControl<TextBlock>("TitleBlock");
+    private Button BackButtonControl => GetControl<Button>("BackButton");
+    private Button ForwardButtonControl => GetControl<Button>("ForwardButton");
+    private Button HomeButtonControl => GetControl<Button>("HomeButton");
+    private Button ReloadButtonControl => GetControl<Button>("ReloadButton");
+    private Button BrowserButtonControl => GetControl<Button>("BrowserButton");
+    private TextBox UrlTextBoxControl => GetControl<TextBox>("UrlTextBox");
+    private TextBlock StatusBlockControl => GetControl<TextBlock>("StatusBlock");
+    private ProgressBar LoadingProgressBarControl => GetControl<ProgressBar>("LoadingProgressBar");
+    private TextBlock PageTitleBlockControl => GetControl<TextBlock>("PageTitleBlock");
+    private SelectableTextBlock PageContentBlockControl => GetControl<SelectableTextBlock>("PageContentBlock");
+    private Border LinksSectionBorderControl => GetControl<Border>("LinksSectionBorder");
+    private TextBlock LinksTitleBlockControl => GetControl<TextBlock>("LinksTitleBlock");
+    private StackPanel LinksPanelControl => GetControl<StackPanel>("LinksPanel");
+
+    public DocumentationBrowserWindow()
+        : this(_homeUri) { }
+
+    public DocumentationBrowserWindow(Uri initialUri)
+    {
+        InitializeComponent();
+        Opened += DocumentationBrowserWindow_OnOpened;
+
+        Title = CoreTools.Translate("Help");
+        TitleBlockControl.Text = CoreTools.Translate("Help");
+        HomeButtonControl.Content = CoreTools.Translate("Help");
+        ReloadButtonControl.Content = CoreTools.Translate("Reload");
+        BrowserButtonControl.Content = CoreTools.Translate("View page on browser");
+        LinksTitleBlockControl.Text = CoreTools.Translate("Help");
+
+        if (initialUri != _homeUri)
+        {
+            _history.Add(initialUri);
+            _historyIndex = 0;
+        }
+    }
+
+    private async void DocumentationBrowserWindow_OnOpened(object? sender, EventArgs e)
+    {
+        if (_historyIndex >= 0)
+        {
+            await NavigateToAsync(_history[_historyIndex], addToHistory: false);
+        }
+        else
+        {
+            await NavigateToAsync(_homeUri);
+        }
+    }
+
+    private async Task NavigateToAsync(Uri uri, bool addToHistory = true)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        _isLoading = true;
+        SetLoadingState(true, CoreTools.Translate("Loading..."));
+
+        try
+        {
+            DocumentationPage page = await LoadPageAsync(uri);
+
+            if (addToHistory)
+            {
+                if (_historyIndex < _history.Count - 1)
+                {
+                    _history.RemoveRange(_historyIndex + 1, _history.Count - _historyIndex - 1);
+                }
+
+                _history.Add(page.Uri);
+                _historyIndex = _history.Count - 1;
+            }
+
+            UrlTextBoxControl.Text = page.Uri.AbsoluteUri;
+            PageTitleBlockControl.Text = page.Title;
+            PageContentBlockControl.Text = page.Content;
+            PopulateLinks(page.Links);
+            SetLoadingState(false, string.Empty);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Documentation browser failed to load {uri}");
+            Logger.Error(ex);
+
+            UrlTextBoxControl.Text = uri.AbsoluteUri;
+            PageTitleBlockControl.Text = CoreTools.Translate("Help");
+            PageContentBlockControl.Text = CoreTools.Translate("Please try again later") + "\n\n" + ex.Message;
+            PopulateLinks([]);
+            SetLoadingState(false, CoreTools.Translate("Please try again later"));
+        }
+        finally
+        {
+            _isLoading = false;
+            UpdateNavigationButtons();
+        }
+    }
+
+    private static async Task<DocumentationPage> LoadPageAsync(Uri uri)
+    {
+        if (TryConvertGitHubBlobToRaw(uri, out Uri? rawUri) && rawUri is not null)
+        {
+            return await LoadMarkdownPageAsync(uri, rawUri);
+        }
+
+        using HttpClient client = new(CoreTools.GenericHttpClientParameters);
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("UniGetUI.Avalonia", CoreData.VersionName));
+        string html = await client.GetStringAsync(uri);
+        return ParseHtmlPage(uri, html);
+    }
+
+    private static async Task<DocumentationPage> LoadMarkdownPageAsync(Uri originalUri, Uri rawUri)
+    {
+        using HttpClient client = new(CoreTools.GenericHttpClientParameters);
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("UniGetUI.Avalonia", CoreData.VersionName));
+        string markdown = await client.GetStringAsync(rawUri);
+
+        var links = new List<DocumentationLink>();
+        foreach (Match match in _markdownLinkRegex.Matches(markdown))
+        {
+            string href = match.Groups["href"].Value.Trim();
+            string text = HtmlDecodeAndNormalize(match.Groups["text"].Value);
+
+            if (string.IsNullOrWhiteSpace(href) || string.IsNullOrWhiteSpace(text))
+                continue;
+
+            if (Uri.TryCreate(originalUri, href, out Uri? linkUri))
+            {
+                links.Add(new DocumentationLink(text, linkUri));
+            }
+        }
+
+        string title = Path.GetFileNameWithoutExtension(originalUri.AbsolutePath);
+        if (string.IsNullOrWhiteSpace(title))
+            title = CoreTools.Translate("Help");
+
+        return new DocumentationPage(CoreTools.FormatAsName(title), markdown.Trim(), DistinctLinks(links), originalUri);
+    }
+
+    private static DocumentationPage ParseHtmlPage(Uri pageUri, string html)
+    {
+        string fragment = NormalizeDocumentationContent(ExtractMainContent(html));
+        string title = ExtractTitle(html, fragment);
+        string text = HtmlToReadableText(fragment);
+        var links = ExtractLinks(pageUri, fragment);
+        return new DocumentationPage(title, text, links, pageUri);
+    }
+
+    private static string ExtractTitle(string html, string fragment)
+    {
+        Match headingMatch = _h1Regex.Match(fragment);
+        if (headingMatch.Success)
+        {
+            string heading = HtmlDecodeAndNormalize(_tagRegex.Replace(headingMatch.Groups["value"].Value, string.Empty));
+            if (!string.IsNullOrWhiteSpace(heading))
+                return heading;
+        }
+
+        Match titleMatch = _titleRegex.Match(html);
+        if (!titleMatch.Success)
+            return CoreTools.Translate("Help");
+
+        string title = HtmlDecodeAndNormalize(titleMatch.Groups["value"].Value);
+        return string.IsNullOrWhiteSpace(title) ? CoreTools.Translate("Help") : title;
+    }
+
+    private static string ExtractMainContent(string html)
+    {
+        string mainContent = ExtractSection(html, ["id='mainContent'", "id=\"mainContent\""], ["</body>"]);
+        if (string.IsNullOrWhiteSpace(mainContent))
+            return html;
+
+        string contentIsland = ExtractSection(mainContent, ["class='contentIsland'", "class=\"contentIsland\""], ["<p class=\"footer\"", "<p class='footer'", "<script defer src="]);
+        return string.IsNullOrWhiteSpace(contentIsland) ? mainContent : contentIsland;
+    }
+
+    private static string NormalizeDocumentationContent(string html)
+    {
+        string normalized = _migrationNoticeRegex.Replace(html, string.Empty);
+        return normalized.Trim();
+    }
+
+    private static string HtmlToReadableText(string html)
+    {
+        string sanitized = _scriptRegex.Replace(html, string.Empty);
+        sanitized = _breakRegex.Replace(sanitized, "\n");
+        sanitized = _blockEndRegex.Replace(sanitized, "\n\n");
+        sanitized = _tagRegex.Replace(sanitized, string.Empty);
+        sanitized = WebUtility.HtmlDecode(sanitized).Replace("\r", string.Empty);
+
+        var lines = sanitized.Split('\n')
+            .Select(line => Regex.Replace(line, "\\s+", " ").Trim())
+            .ToArray();
+
+        string normalized = string.Join("\n", lines);
+        normalized = _lineCollapseRegex.Replace(normalized, "\n\n");
+        return normalized.Trim();
+    }
+
+    private static IReadOnlyList<DocumentationLink> ExtractLinks(Uri currentUri, string html)
+    {
+        var links = new List<DocumentationLink>();
+
+        foreach (Match match in _articleLinkRegex.Matches(html))
+        {
+            string href = match.Groups["href"].Value.Trim();
+            string text = HtmlDecodeAndNormalize(match.Groups["text"].Value);
+
+            if (Uri.TryCreate(currentUri, href, out Uri? linkUri) && ShouldKeepLink(currentUri, linkUri, text))
+            {
+                links.Add(new DocumentationLink(text, linkUri));
+            }
+        }
+
+        if (links.Count > 0)
+        {
+            return DistinctLinks(links);
+        }
+
+        foreach (Match match in _anchorRegex.Matches(html))
+        {
+            string href = match.Groups["href"].Value.Trim();
+            string text = HtmlDecodeAndNormalize(_tagRegex.Replace(match.Groups["text"].Value, string.Empty));
+
+            if (Uri.TryCreate(currentUri, href, out Uri? linkUri) && ShouldKeepLink(currentUri, linkUri, text))
+            {
+                links.Add(new DocumentationLink(text, linkUri));
+            }
+        }
+
+        return DistinctLinks(links);
+    }
+
+    private static IReadOnlyList<DocumentationLink> DistinctLinks(IEnumerable<DocumentationLink> links)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var distinct = new List<DocumentationLink>();
+
+        foreach (DocumentationLink link in links)
+        {
+            if (seen.Add(link.Uri.AbsoluteUri))
+            {
+                distinct.Add(link);
+            }
+        }
+
+        return distinct;
+    }
+
+    private static bool ShouldKeepLink(Uri currentUri, Uri linkUri, string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        if (linkUri.Scheme is not ("http" or "https"))
+            return false;
+
+        if (!IsDocumentationLink(linkUri))
+            return false;
+
+        if (string.Equals(currentUri.GetLeftPart(UriPartial.Path), linkUri.GetLeftPart(UriPartial.Path), StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(linkUri.Fragment))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsDocumentationLink(Uri uri)
+    {
+        if (uri.Host.EndsWith("marticliment.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return uri.AbsolutePath.StartsWith("/unigetui/help", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return uri.AbsolutePath.StartsWith("/devolutions/UniGetUI/blob/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (uri.Host.Equals("raw.githubusercontent.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return uri.AbsolutePath.StartsWith("/devolutions/UniGetUI/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static string ExtractSection(string html, IReadOnlyList<string> startMarkers, IReadOnlyList<string> endMarkers)
+    {
+        int markerIndex = FindFirstIndex(html, startMarkers);
+        if (markerIndex < 0)
+            return string.Empty;
+
+        int start = html.IndexOf('>', markerIndex);
+        if (start < 0 || start >= html.Length - 1)
+            return string.Empty;
+
+        start++;
+
+        int end = FindFirstIndex(html, endMarkers, start);
+        if (end < 0 || end <= start)
+            end = html.Length;
+
+        return html[start..end];
+    }
+
+    private static int FindFirstIndex(string value, IReadOnlyList<string> candidates, int startIndex = 0)
+    {
+        int matchIndex = -1;
+
+        foreach (string candidate in candidates)
+        {
+            int index = value.IndexOf(candidate, startIndex, StringComparison.OrdinalIgnoreCase);
+            if (index >= 0 && (matchIndex < 0 || index < matchIndex))
+            {
+                matchIndex = index;
+            }
+        }
+
+        return matchIndex;
+    }
+
+    private static string HtmlDecodeAndNormalize(string value)
+    {
+        return Regex.Replace(WebUtility.HtmlDecode(value), "\\s+", " ").Trim();
+    }
+
+    private static bool TryConvertGitHubBlobToRaw(Uri uri, out Uri? rawUri)
+    {
+        rawUri = null;
+
+        if (!uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        string[] segments = uri.AbsolutePath.Trim('/').Split('/');
+        if (segments.Length < 5 || !segments[2].Equals("blob", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        string owner = segments[0];
+        string repo = segments[1];
+        string branch = segments[3];
+        string path = string.Join('/', segments.Skip(4));
+
+        rawUri = new Uri($"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}");
+        return true;
+    }
+
+    private void PopulateLinks(IReadOnlyList<DocumentationLink> links)
+    {
+        LinksPanelControl.Children.Clear();
+        LinksSectionBorderControl.IsVisible = links.Count > 0;
+
+        foreach (DocumentationLink link in links)
+        {
+            Uri targetUri = link.Uri;
+            bool isInternal = CanLoadInApp(targetUri);
+            var button = new Button
+            {
+                Content = isInternal ? link.Text : link.Text + " ↗",
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Classes = { "toolbar-secondary" },
+            };
+
+            button.Click += async (_, _) =>
+            {
+                if (CanLoadInApp(targetUri))
+                {
+                    await NavigateToAsync(targetUri);
+                }
+                else
+                {
+                    OpenInBrowser(targetUri.AbsoluteUri);
+                }
+            };
+
+            LinksPanelControl.Children.Add(button);
+        }
+    }
+
+    private static bool CanLoadInApp(Uri uri)
+    {
+        if (uri.Scheme is not ("http" or "https"))
+            return false;
+
+        return IsDocumentationLink(uri);
+    }
+
+    private void SetLoadingState(bool isLoading, string statusText)
+    {
+        LoadingProgressBarControl.IsVisible = isLoading;
+        StatusBlockControl.Text = statusText;
+        StatusBlockControl.IsVisible = isLoading || !string.IsNullOrWhiteSpace(statusText);
+        BackButtonControl.IsEnabled = !isLoading && _historyIndex > 0;
+        ForwardButtonControl.IsEnabled = !isLoading && _historyIndex >= 0 && _historyIndex < _history.Count - 1;
+        HomeButtonControl.IsEnabled = !isLoading;
+        ReloadButtonControl.IsEnabled = !isLoading && _historyIndex >= 0;
+        BrowserButtonControl.IsEnabled = !isLoading && !string.IsNullOrWhiteSpace(UrlTextBoxControl.Text);
+    }
+
+    private void UpdateNavigationButtons()
+    {
+        BackButtonControl.IsEnabled = _historyIndex > 0;
+        ForwardButtonControl.IsEnabled = _historyIndex >= 0 && _historyIndex < _history.Count - 1;
+        HomeButtonControl.IsEnabled = !_isLoading;
+        ReloadButtonControl.IsEnabled = !_isLoading && _historyIndex >= 0;
+        BrowserButtonControl.IsEnabled = !_isLoading && !string.IsNullOrWhiteSpace(UrlTextBoxControl.Text);
+    }
+
+    private async void BackButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_historyIndex <= 0)
+            return;
+
+        _historyIndex--;
+        await NavigateToAsync(_history[_historyIndex], addToHistory: false);
+    }
+
+    private async void ForwardButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_historyIndex < 0 || _historyIndex >= _history.Count - 1)
+            return;
+
+        _historyIndex++;
+        await NavigateToAsync(_history[_historyIndex], addToHistory: false);
+    }
+
+    private async void HomeButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        await NavigateToAsync(_homeUri);
+    }
+
+    private async void ReloadButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_historyIndex < 0)
+            return;
+
+        await NavigateToAsync(_history[_historyIndex], addToHistory: false);
+    }
+
+    private void BrowserButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(UrlTextBoxControl.Text))
+            return;
+
+        OpenInBrowser(UrlTextBoxControl.Text);
+    }
+
+    private static void OpenInBrowser(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
+        }
+        catch
+        {
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+
+    private sealed record DocumentationLink(string Text, Uri Uri);
+
+    private sealed record DocumentationPage(string Title, string Content, IReadOnlyList<DocumentationLink> Links, Uri Uri);
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPageView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPageView.axaml
@@ -1,0 +1,99 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.HelpPageView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+
+      <!-- Lead card -->
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Documentation links -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="DocumentationTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="DocumentationDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+
+          <Button x:Name="OpenDocumentationButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  Click="OpenDocumentationButton_OnClick" />
+
+          <Button x:Name="OpenChangelogButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  Click="OpenChangelogButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Community & support links -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="CommunityTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="CommunityDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+
+          <Button x:Name="OpenIssuesButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  Click="OpenIssuesButton_OnClick" />
+
+          <Button x:Name="OpenDiscussionsButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  Click="OpenDiscussionsButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- About UniGetUI -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="AboutTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <Border Padding="14"
+                  Classes="surface-card subtle-panel"
+                  CornerRadius="14">
+            <StackPanel Spacing="6">
+              <TextBlock x:Name="AboutVersionBlock"
+                         TextWrapping="Wrap" />
+              <TextBlock x:Name="AboutLicenseBlock"
+                         Opacity="0.72"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+          <Button x:Name="OpenLicenseButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  Click="OpenLicenseButton_OnClick" />
+          <Button x:Name="OpenContributorsButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  Click="OpenContributorsButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPageView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPageView.axaml.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class HelpPageView : UserControl, IShellPage
+{
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+    private TextBlock DocumentationTitleText => GetControl<TextBlock>("DocumentationTitleBlock");
+    private TextBlock DocumentationDescriptionText => GetControl<TextBlock>("DocumentationDescriptionBlock");
+    private TextBlock CommunityTitleText => GetControl<TextBlock>("CommunityTitleBlock");
+    private TextBlock CommunityDescriptionText => GetControl<TextBlock>("CommunityDescriptionBlock");
+    private TextBlock AboutTitleText => GetControl<TextBlock>("AboutTitleBlock");
+    private TextBlock AboutVersionText => GetControl<TextBlock>("AboutVersionBlock");
+    private TextBlock AboutLicenseText => GetControl<TextBlock>("AboutLicenseBlock");
+    private Button OpenDocumentationButtonControl => GetControl<Button>("OpenDocumentationButton");
+    private Button OpenChangelogButtonControl => GetControl<Button>("OpenChangelogButton");
+    private Button OpenIssuesButtonControl => GetControl<Button>("OpenIssuesButton");
+    private Button OpenDiscussionsButtonControl => GetControl<Button>("OpenDiscussionsButton");
+    private Button OpenLicenseButtonControl => GetControl<Button>("OpenLicenseButton");
+    private Button OpenContributorsButtonControl => GetControl<Button>("OpenContributorsButton");
+
+    public string Title { get; } = CoreTools.Translate("Help");
+    public string Subtitle { get; } = CoreTools.Translate("Help and documentation");
+    public bool SupportsSearch => false;
+    public string SearchPlaceholder => string.Empty;
+
+    public HelpPageView()
+    {
+        InitializeComponent();
+        ApplyLocalizedText();
+    }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Help and documentation");
+        LeadDescriptionText.Text = CoreTools.Translate(
+            "But here are other things you can do to learn about WingetUI even more:"
+        );
+
+        DocumentationTitleText.Text = CoreTools.Translate("Help and documentation");
+        DocumentationDescriptionText.Text = CoreTools.Translate(
+            "But here are other things you can do to learn about WingetUI even more:"
+        );
+        OpenDocumentationButtonControl.Content = CoreTools.Translate("View page on browser");
+        OpenChangelogButtonControl.Content = CoreTools.Translate("Release notes");
+
+        CommunityTitleText.Text = CoreTools.Translate("Support the developer");
+        CommunityDescriptionText.Text = CoreTools.Translate(
+            "View WingetUI on GitHub"
+        );
+        OpenIssuesButtonControl.Content = CoreTools.Translate("Open GitHub");
+        OpenDiscussionsButtonControl.Content = CoreTools.Translate("View WingetUI on GitHub");
+
+        AboutTitleText.Text = CoreTools.Translate("About WingetUI");
+        AboutVersionText.Text = CoreTools.Translate("About WingetUI version {0}", CoreData.VersionName);
+        AboutLicenseText.Text = CoreTools.Translate("Using WingetUI implies the acceptation of the MIT License");
+        OpenLicenseButtonControl.Content = CoreTools.Translate("WingetUI License");
+        OpenContributorsButtonControl.Content = CoreTools.Translate("Contributors");
+    }
+
+    public void UpdateSearchQuery(string query) { }
+
+    private void OpenDocumentationButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenDocumentationWindow();
+
+    private async void OpenChangelogButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var win = new ReleaseNotesWindow();
+        if (VisualRoot is Window owner)
+            await win.ShowDialog(owner);
+        else
+            win.Show();
+    }
+
+    private void OpenIssuesButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenUrl("https://github.com/marticliment/UniGetUI/issues");
+
+    private void OpenDiscussionsButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenUrl("https://github.com/marticliment/UniGetUI/discussions");
+
+    private void OpenLicenseButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenUrl("https://github.com/marticliment/UniGetUI/blob/main/LICENSE");
+
+    private void OpenContributorsButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var win = new AboutPageWindow();
+        if (VisualRoot is Window owner)
+            win.ShowDialog(owner);
+        else
+            win.Show();
+    }
+
+    private async void OpenDocumentationWindow()
+    {
+        var win = new DocumentationBrowserWindow();
+        if (VisualRoot is Window owner)
+            await win.ShowDialog(owner);
+        else
+            win.Show();
+    }
+
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
+        }
+        catch
+        {
+            // ignore — best effort
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/IgnoredUpdatesWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/IgnoredUpdatesWindow.axaml
@@ -1,0 +1,155 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.IgnoredUpdatesWindow"
+        Width="680"
+        Height="500"
+        MinWidth="480"
+        MinHeight="320"
+        Title="Manage ignored updates"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+
+    <Window.Styles>
+        <StyleInclude Source="/Styles/AppStyles.axaml" />
+    </Window.Styles>
+
+    <Grid RowDefinitions="Auto,*,Auto"
+          Margin="16"
+          RowSpacing="12">
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Spacing="4">
+            <TextBlock x:Name="HeaderTitleBlock"
+                       Text="Manage ignored updates"
+                       FontSize="20"
+                       FontWeight="SemiBold" />
+            <TextBlock x:Name="HeaderSubtitleBlock"
+                       Text="Packages listed below will not show update notifications."
+                       Opacity="0.7"
+                       TextWrapping="Wrap" />
+        </StackPanel>
+
+        <!-- Column headers + list -->
+        <Border Grid.Row="1"
+                Classes="surface-card"
+                Padding="0">
+            <Grid RowDefinitions="Auto,*">
+
+                <!-- Column headings -->
+                <Border Grid.Row="0"
+                        Padding="12,8"
+                        BorderThickness="0,0,0,1">
+                    <Border.BorderBrush>
+                        <SolidColorBrush Color="{DynamicResource SystemBaseMediumLowColor}" />
+                    </Border.BorderBrush>
+                    <Grid ColumnDefinitions="2.5*,1.2*,1.5*,Auto"
+                          ColumnSpacing="8">
+                        <TextBlock x:Name="ColPackageBlock"
+                                   Grid.Column="0"
+                                   Text="Package"
+                                   FontWeight="SemiBold"
+                                   Opacity="0.8" />
+                        <TextBlock x:Name="ColManagerBlock"
+                                   Grid.Column="1"
+                                   Text="Manager"
+                                   FontWeight="SemiBold"
+                                   Opacity="0.8" />
+                        <TextBlock x:Name="ColVersionBlock"
+                                   Grid.Column="2"
+                                   Text="Ignored version"
+                                   FontWeight="SemiBold"
+                                   Opacity="0.8" />
+                        <TextBlock Grid.Column="3"
+                                   Width="80"
+                                   Text=""
+                                   FontWeight="SemiBold"
+                                   Opacity="0.8" />
+                    </Grid>
+                </Border>
+
+                <!-- Rows -->
+                <ScrollViewer Grid.Row="1">
+                    <ItemsControl x:Name="EntriesList"
+                                  Padding="0,4">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Padding="12,6"
+                                        Background="Transparent">
+                                    <Grid ColumnDefinitions="2.5*,1.2*,1.5*,Auto"
+                                          ColumnSpacing="8">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding DisplayName}"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding ManagerName}"
+                                                   VerticalAlignment="Center"
+                                                   Opacity="0.72"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding DisplayVersion}"
+                                                   VerticalAlignment="Center"
+                                                   Opacity="0.72"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <Button Grid.Column="3"
+                                                Width="80"
+                                                Classes="toolbar-secondary"
+                                                Content="Remove"
+                                                Tag="{Binding}"
+                                                Click="RemoveButton_OnClick" />
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+            </Grid>
+        </Border>
+
+        <!-- Footer -->
+        <Grid Grid.Row="2"
+              ColumnDefinitions="*,Auto,Auto"
+              ColumnSpacing="8">
+
+            <!-- Confirm reset panel (hidden by default) -->
+            <Border x:Name="ConfirmResetPanel"
+                    Grid.Column="0"
+                    Classes="surface-card"
+                    Padding="10,6"
+                    IsVisible="False">
+                <Grid ColumnDefinitions="*,Auto,Auto"
+                      ColumnSpacing="8">
+                    <TextBlock x:Name="ConfirmResetTextBlock"
+                               Grid.Column="0"
+                               Text="Remove all ignored entries?"
+                               VerticalAlignment="Center"
+                               TextWrapping="Wrap" />
+                    <Button x:Name="ConfirmYesButton"
+                            Grid.Column="1"
+                            Classes="toolbar-primary accent"
+                            Content="Yes"
+                            Click="ConfirmResetYes_OnClick" />
+                    <Button x:Name="ConfirmCancelButton"
+                            Grid.Column="2"
+                            Classes="toolbar-secondary"
+                            Content="Cancel"
+                            Click="ConfirmResetCancel_OnClick" />
+                </Grid>
+            </Border>
+
+            <Button x:Name="ResetAllButtonControl"
+                    Grid.Column="1"
+                    Classes="toolbar-secondary"
+                    Content="Reset all"
+                    Click="ResetAllButton_OnClick" />
+
+            <Button x:Name="CloseWindowButton"
+                    Grid.Column="2"
+                    Classes="toolbar-primary accent"
+                    Content="Close"
+                    Click="CloseButton_OnClick" />
+        </Grid>
+
+    </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/IgnoredUpdatesWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/IgnoredUpdatesWindow.axaml.cs
@@ -1,0 +1,131 @@
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine;
+using UniGetUI.PackageEngine.Classes.Packages.Classes;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>
+/// Represents a single entry in the ignored-updates list.
+/// </summary>
+public sealed class IgnoredEntryModel
+{
+    public string IgnoredId { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string ManagerName { get; init; } = string.Empty;
+    public string DisplayVersion { get; init; } = string.Empty;
+}
+
+public partial class IgnoredUpdatesWindow : Window
+{
+    private readonly ObservableCollection<IgnoredEntryModel> _entries = [];
+
+    public IgnoredUpdatesWindow()
+    {
+        InitializeComponent();
+        ApplyTranslations();
+        EntriesList.ItemsSource = _entries;
+        LoadEntries();
+    }
+
+    private void ApplyTranslations()
+    {
+        Title = CoreTools.Translate("Manage ignored updates");
+        HeaderTitleBlock.Text = CoreTools.Translate("Manage ignored updates");
+        HeaderSubtitleBlock.Text = CoreTools.Translate("The packages listed here won't be taken in account when checking for updates. Double-click them or click the button on their right to stop ignoring their updates.");
+        ColPackageBlock.Text = CoreTools.Translate("Package");
+        ColManagerBlock.Text = CoreTools.Translate("Package manager");
+        ColVersionBlock.Text = CoreTools.Translate("Ignored version");
+        ConfirmResetTextBlock.Text = CoreTools.Translate("Reset list");
+        ConfirmYesButton.Content = CoreTools.Translate("Yes");
+        ConfirmCancelButton.Content = CoreTools.Translate("Cancel");
+        ResetAllButtonControl.Content = CoreTools.Translate("Reset");
+        CloseWindowButton.Content = CoreTools.Translate("Close");
+    }
+
+    private void LoadEntries()
+    {
+        _entries.Clear();
+
+        var db = IgnoredUpdatesDatabase.GetDatabase();
+        foreach (var (key, version) in db)
+        {
+            // key format: "managername\packageId"
+            var separatorIdx = key.IndexOf('\\');
+            string managerPrefix = separatorIdx >= 0 ? key[..separatorIdx] : string.Empty;
+            string packageId = separatorIdx >= 0 ? key[(separatorIdx + 1)..] : key;
+
+            // Try to match to a known manager by name prefix
+            string managerName = managerPrefix;
+            bool isWinGet = false;
+            foreach (var mgr in PEInterface.Managers)
+            {
+                if (string.Equals(mgr.Name, managerPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    managerName = mgr.Name;
+                    isWinGet = string.Equals(mgr.Name, "WinGet", StringComparison.OrdinalIgnoreCase);
+                    break;
+                }
+            }
+
+            // Derive display name using the same logic as WinUI
+            string displayName;
+            if (isWinGet && packageId.Contains('.'))
+                displayName = string.Join(' ', packageId.Split('.')[1..]);
+            else
+                displayName = CoreTools.FormatAsName(packageId);
+
+            // Display version: "*" → "All versions"
+            string displayVersion = version == "*"
+                ? CoreTools.Translate("All versions")
+                : version;
+
+            _entries.Add(new IgnoredEntryModel
+            {
+                IgnoredId = key,
+                DisplayName = displayName,
+                ManagerName = managerName,
+                DisplayVersion = displayVersion,
+            });
+        }
+    }
+
+    private void RemoveButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: IgnoredEntryModel entry })
+            return;
+
+        IgnoredUpdatesDatabase.Remove(entry.IgnoredId);
+        _entries.Remove(entry);
+    }
+
+    private void ResetAllButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        ConfirmResetPanel.IsVisible = true;
+    }
+
+    private void ConfirmResetYes_OnClick(object? sender, RoutedEventArgs e)
+    {
+        ConfirmResetPanel.IsVisible = false;
+
+        var toRemove = new List<IgnoredEntryModel>(_entries);
+        foreach (var entry in toRemove)
+        {
+            IgnoredUpdatesDatabase.Remove(entry.IgnoredId);
+            _entries.Remove(entry);
+        }
+    }
+
+    private void ConfirmResetCancel_OnClick(object? sender, RoutedEventArgs e)
+    {
+        ConfirmResetPanel.IsVisible = false;
+    }
+
+    private void CloseButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}
+

--- a/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsEditorView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsEditorView.axaml
@@ -1,0 +1,235 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.InstallOptionsEditorView">
+  <UserControl.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </UserControl.Styles>
+
+  <StackPanel Spacing="10">
+
+    <Border Padding="18"
+            Classes="surface-card subtle-panel">
+      <StackPanel Spacing="4">
+        <TextBlock x:Name="PackageTitleBlock"
+                   FontSize="20"
+                   FontWeight="Bold" />
+        <Grid ColumnDefinitions="Auto,8,*,16,Auto,8,*">
+          <TextBlock Text="ID:"
+                     Opacity="0.60"
+                     VerticalAlignment="Center" />
+          <TextBlock x:Name="PackageIdBlock"
+                     Grid.Column="2"
+                     FontWeight="SemiBold"
+                     VerticalAlignment="Center"
+                     TextTrimming="CharacterEllipsis" />
+          <TextBlock Text="Version:"
+                     Grid.Column="4"
+                     Opacity="0.60"
+                     VerticalAlignment="Center" />
+          <TextBlock x:Name="PackageVersionBlock"
+                     Grid.Column="6"
+                     FontWeight="SemiBold"
+                     VerticalAlignment="Center"
+                     TextTrimming="CharacterEllipsis" />
+        </Grid>
+        <TextBlock x:Name="PackageManagerBlock"
+                   Opacity="0.60"
+                   FontSize="12" />
+      </StackPanel>
+    </Border>
+
+    <Border Padding="18"
+            Classes="surface-card">
+      <StackPanel Spacing="10">
+        <TextBlock x:Name="GeneralOptionsTitleBlock"
+                   FontWeight="SemiBold"
+                   FontSize="14"
+                   Opacity="0.80" />
+        <CheckBox x:Name="RunAsAdminCheckBox" />
+        <CheckBox x:Name="InteractiveCheckBox" />
+        <CheckBox x:Name="HashCheckBox" />
+        <CheckBox x:Name="AutoUpdateCheckBox" />
+        <CheckBox x:Name="SkipMinorUpdatesCheckBox" />
+        <CheckBox x:Name="IgnoreUpdatesCheckBox" />
+        <CheckBox x:Name="UninstallPreviousCheckBox"
+                  IsVisible="False" />
+      </StackPanel>
+    </Border>
+
+    <Border Padding="18"
+            Classes="surface-card">
+      <StackPanel Spacing="12">
+        <TextBlock x:Name="VersionSectionTitleBlock"
+                   FontWeight="SemiBold"
+                   FontSize="14"
+                   Opacity="0.80" />
+
+        <Grid ColumnDefinitions="120,*,Auto">
+          <TextBlock x:Name="VersionLabelBlock"
+                     VerticalAlignment="Center"
+                     Opacity="0.70" />
+          <ComboBox x:Name="VersionComboBox"
+                    Grid.Column="1"
+                    HorizontalAlignment="Stretch" />
+          <ProgressBar x:Name="VersionLoadingBar"
+                       Grid.Column="2"
+                       Width="18"
+                       Height="18"
+                       Margin="8,0,0,0"
+                       IsIndeterminate="True"
+                       IsVisible="False" />
+        </Grid>
+
+        <Grid ColumnDefinitions="120,*">
+          <TextBlock x:Name="ArchitectureLabelBlock"
+                     VerticalAlignment="Center"
+                     Opacity="0.70" />
+          <ComboBox x:Name="ArchitectureComboBox"
+                    Grid.Column="1"
+                    HorizontalAlignment="Stretch" />
+        </Grid>
+
+        <Grid ColumnDefinitions="120,*">
+          <TextBlock x:Name="ScopeLabelBlock"
+                     VerticalAlignment="Center"
+                     Opacity="0.70" />
+          <ComboBox x:Name="ScopeComboBox"
+                    Grid.Column="1"
+                    HorizontalAlignment="Stretch" />
+        </Grid>
+      </StackPanel>
+    </Border>
+
+    <Border x:Name="CustomLocationCard"
+            Padding="18"
+            Classes="surface-card"
+            IsVisible="False">
+      <StackPanel Spacing="10">
+        <TextBlock x:Name="LocationTitleBlock"
+                   FontWeight="SemiBold"
+                   FontSize="14"
+                   Opacity="0.80" />
+        <Grid ColumnDefinitions="*,Auto,Auto"
+              ColumnSpacing="6">
+          <TextBox x:Name="CustomLocationTextBox" />
+          <Button x:Name="BrowseLocationButton"
+                  Grid.Column="1"
+                  Classes="toolbar-secondary" />
+          <Button x:Name="ResetLocationButton"
+                  Grid.Column="2"
+                  Classes="toolbar-secondary" />
+        </Grid>
+      </StackPanel>
+    </Border>
+
+    <Border x:Name="CustomParametersCard"
+            Padding="18"
+            Classes="surface-card"
+            IsVisible="False">
+      <StackPanel Spacing="10">
+        <TextBlock x:Name="ParametersTitleBlock"
+                   FontWeight="SemiBold"
+                   FontSize="14"
+                   Opacity="0.80" />
+        <TextBlock x:Name="CustomParamsDescBlock"
+                   Opacity="0.60"
+                   FontSize="12"
+                   TextWrapping="Wrap" />
+        <TextBlock x:Name="InstallParamsLabelBlock"
+                   Opacity="0.70" />
+        <TextBox x:Name="CustomParams1TextBox"
+                 FontFamily="Consolas,Menlo,monospace" />
+        <TextBlock x:Name="UpdateParamsLabelBlock"
+                   Opacity="0.70" />
+        <TextBox x:Name="CustomParams2TextBox"
+                 FontFamily="Consolas,Menlo,monospace" />
+        <TextBlock x:Name="UninstallParamsLabelBlock"
+                   Opacity="0.70" />
+        <TextBox x:Name="CustomParams3TextBox"
+                 FontFamily="Consolas,Menlo,monospace" />
+      </StackPanel>
+    </Border>
+
+    <Border x:Name="KillProcessesCard"
+            Padding="18"
+            Classes="surface-card">
+      <StackPanel Spacing="10">
+        <TextBlock x:Name="KillProcessesTitleBlock"
+                   FontWeight="SemiBold"
+                   FontSize="14"
+                   Opacity="0.80" />
+        <TextBlock x:Name="KillProcessesDescBlock"
+                   Opacity="0.60"
+                   FontSize="12"
+                   TextWrapping="Wrap" />
+        <TextBox x:Name="KillProcessesTextBox"
+                 FontFamily="Consolas,Menlo,monospace" />
+        <CheckBox x:Name="KillProcessesThatWontDieCheckBox" />
+      </StackPanel>
+    </Border>
+
+    <Border x:Name="PrePostCommandsCard"
+            Padding="18"
+            Classes="surface-card"
+            IsVisible="False">
+      <StackPanel Spacing="10">
+        <TextBlock x:Name="PrePostTitleBlock"
+                   FontWeight="SemiBold"
+                   FontSize="14"
+                   Opacity="0.80" />
+        <TextBlock x:Name="PrePostCommandsDescBlock"
+                   Opacity="0.60"
+                   FontSize="12"
+                   TextWrapping="Wrap" />
+
+        <TextBlock x:Name="PreInstallLabelBlock"
+                   Opacity="0.70" />
+        <Grid ColumnDefinitions="*,12,Auto">
+          <TextBox x:Name="PreInstallCommandBox"
+                   FontFamily="Consolas,Menlo,monospace" />
+          <CheckBox x:Name="AbortInstallCheckBox"
+                    Grid.Column="2"
+                    VerticalAlignment="Center" />
+        </Grid>
+
+        <TextBlock x:Name="PostInstallLabelBlock"
+                   Opacity="0.70" />
+        <TextBox x:Name="PostInstallCommandBox"
+                 FontFamily="Consolas,Menlo,monospace" />
+
+        <TextBlock x:Name="PreUpdateLabelBlock"
+                   Opacity="0.70" />
+        <Grid ColumnDefinitions="*,12,Auto">
+          <TextBox x:Name="PreUpdateCommandBox"
+                   FontFamily="Consolas,Menlo,monospace" />
+          <CheckBox x:Name="AbortUpdateCheckBox"
+                    Grid.Column="2"
+                    VerticalAlignment="Center" />
+        </Grid>
+
+        <TextBlock x:Name="PostUpdateLabelBlock"
+                   Opacity="0.70" />
+        <TextBox x:Name="PostUpdateCommandBox"
+                 FontFamily="Consolas,Menlo,monospace" />
+
+        <TextBlock x:Name="PreUninstallLabelBlock"
+                   Opacity="0.70" />
+        <Grid ColumnDefinitions="*,12,Auto">
+          <TextBox x:Name="PreUninstallCommandBox"
+                   FontFamily="Consolas,Menlo,monospace" />
+          <CheckBox x:Name="AbortUninstallCheckBox"
+                    Grid.Column="2"
+                    VerticalAlignment="Center" />
+        </Grid>
+
+        <TextBlock x:Name="PostUninstallLabelBlock"
+                   Opacity="0.70" />
+        <TextBox x:Name="PostUninstallCommandBox"
+                 FontFamily="Consolas,Menlo,monospace" />
+      </StackPanel>
+    </Border>
+
+    <Border Height="8" />
+
+  </StackPanel>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsEditorView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsEditorView.axaml.cs
@@ -1,0 +1,444 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.Serializable;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class InstallOptionsEditorView : UserControl
+{
+    private readonly IPackage _package;
+    private InstallOptions _options = new();
+
+    public InstallOptionsEditorView()
+    {
+        _package = null!;
+        InitializeComponent();
+        IsEnabled = false;
+    }
+
+    private TextBlock PackageTitleText => GetControl<TextBlock>("PackageTitleBlock");
+    private TextBlock PackageIdText => GetControl<TextBlock>("PackageIdBlock");
+    private TextBlock PackageVersionText => GetControl<TextBlock>("PackageVersionBlock");
+    private TextBlock PackageManagerText => GetControl<TextBlock>("PackageManagerBlock");
+    private TextBlock GeneralOptionsTitleText => GetControl<TextBlock>("GeneralOptionsTitleBlock");
+    private CheckBox RunAsAdminCheckBoxControl => GetControl<CheckBox>("RunAsAdminCheckBox");
+    private CheckBox InteractiveCheckBoxControl => GetControl<CheckBox>("InteractiveCheckBox");
+    private CheckBox HashCheckBoxControl => GetControl<CheckBox>("HashCheckBox");
+    private CheckBox AutoUpdateCheckBoxControl => GetControl<CheckBox>("AutoUpdateCheckBox");
+    private CheckBox SkipMinorUpdatesCheckBoxControl => GetControl<CheckBox>("SkipMinorUpdatesCheckBox");
+    private CheckBox IgnoreUpdatesCheckBoxControl => GetControl<CheckBox>("IgnoreUpdatesCheckBox");
+    private CheckBox UninstallPreviousCheckBoxControl => GetControl<CheckBox>("UninstallPreviousCheckBox");
+    private TextBlock VersionSectionTitleText => GetControl<TextBlock>("VersionSectionTitleBlock");
+    private TextBlock VersionLabelText => GetControl<TextBlock>("VersionLabelBlock");
+    private ComboBox VersionComboBoxControl => GetControl<ComboBox>("VersionComboBox");
+    private ProgressBar VersionLoadingBarControl => GetControl<ProgressBar>("VersionLoadingBar");
+    private TextBlock ArchitectureLabelText => GetControl<TextBlock>("ArchitectureLabelBlock");
+    private ComboBox ArchitectureComboBoxControl => GetControl<ComboBox>("ArchitectureComboBox");
+    private TextBlock ScopeLabelText => GetControl<TextBlock>("ScopeLabelBlock");
+    private ComboBox ScopeComboBoxControl => GetControl<ComboBox>("ScopeComboBox");
+    private Border CustomLocationCardControl => GetControl<Border>("CustomLocationCard");
+    private TextBlock LocationTitleText => GetControl<TextBlock>("LocationTitleBlock");
+    private TextBox CustomLocationTextBoxControl => GetControl<TextBox>("CustomLocationTextBox");
+    private Button BrowseLocationButtonControl => GetControl<Button>("BrowseLocationButton");
+    private Button ResetLocationButtonControl => GetControl<Button>("ResetLocationButton");
+    private Border CustomParametersCardControl => GetControl<Border>("CustomParametersCard");
+    private TextBlock ParametersTitleText => GetControl<TextBlock>("ParametersTitleBlock");
+    private TextBlock CustomParamsDescText => GetControl<TextBlock>("CustomParamsDescBlock");
+    private TextBlock InstallParamsLabelText => GetControl<TextBlock>("InstallParamsLabelBlock");
+    private TextBox CustomParams1TextBoxControl => GetControl<TextBox>("CustomParams1TextBox");
+    private TextBlock UpdateParamsLabelText => GetControl<TextBlock>("UpdateParamsLabelBlock");
+    private TextBox CustomParams2TextBoxControl => GetControl<TextBox>("CustomParams2TextBox");
+    private TextBlock UninstallParamsLabelText => GetControl<TextBlock>("UninstallParamsLabelBlock");
+    private TextBox CustomParams3TextBoxControl => GetControl<TextBox>("CustomParams3TextBox");
+    private TextBlock KillProcessesTitleText => GetControl<TextBlock>("KillProcessesTitleBlock");
+    private TextBlock KillProcessesDescText => GetControl<TextBlock>("KillProcessesDescBlock");
+    private TextBox KillProcessesTextBoxControl => GetControl<TextBox>("KillProcessesTextBox");
+    private CheckBox KillProcessesThatWontDieCheckBoxControl => GetControl<CheckBox>("KillProcessesThatWontDieCheckBox");
+    private Border PrePostCommandsCardControl => GetControl<Border>("PrePostCommandsCard");
+    private TextBlock PrePostTitleText => GetControl<TextBlock>("PrePostTitleBlock");
+    private TextBlock PrePostCommandsDescText => GetControl<TextBlock>("PrePostCommandsDescBlock");
+    private TextBlock PreInstallLabelText => GetControl<TextBlock>("PreInstallLabelBlock");
+    private TextBox PreInstallCommandBoxControl => GetControl<TextBox>("PreInstallCommandBox");
+    private CheckBox AbortInstallCheckBoxControl => GetControl<CheckBox>("AbortInstallCheckBox");
+    private TextBlock PostInstallLabelText => GetControl<TextBlock>("PostInstallLabelBlock");
+    private TextBox PostInstallCommandBoxControl => GetControl<TextBox>("PostInstallCommandBox");
+    private TextBlock PreUpdateLabelText => GetControl<TextBlock>("PreUpdateLabelBlock");
+    private TextBox PreUpdateCommandBoxControl => GetControl<TextBox>("PreUpdateCommandBox");
+    private CheckBox AbortUpdateCheckBoxControl => GetControl<CheckBox>("AbortUpdateCheckBox");
+    private TextBlock PostUpdateLabelText => GetControl<TextBlock>("PostUpdateLabelBlock");
+    private TextBox PostUpdateCommandBoxControl => GetControl<TextBox>("PostUpdateCommandBox");
+    private TextBlock PreUninstallLabelText => GetControl<TextBlock>("PreUninstallLabelBlock");
+    private TextBox PreUninstallCommandBoxControl => GetControl<TextBox>("PreUninstallCommandBox");
+    private CheckBox AbortUninstallCheckBoxControl => GetControl<CheckBox>("AbortUninstallCheckBox");
+    private TextBlock PostUninstallLabelText => GetControl<TextBlock>("PostUninstallLabelBlock");
+    private TextBox PostUninstallCommandBoxControl => GetControl<TextBox>("PostUninstallCommandBox");
+
+    public InstallOptionsEditorView(IPackage package)
+    {
+        _package = package;
+        InitializeComponent();
+        ApplyTranslations();
+        PopulateStaticControls();
+        _ = LoadOptionsAsync();
+    }
+
+    public async Task SaveAsync()
+    {
+        var options = ReadOptionsFromUi();
+        await InstallOptionsFactory.SaveForPackageAsync(options, _package);
+
+        Settings.Set(
+            Settings.K.KillProcessesThatRefuseToDie,
+            KillProcessesThatWontDieCheckBoxControl.IsChecked ?? false);
+
+        if (IgnoreUpdatesCheckBoxControl.IsChecked ?? false)
+        {
+            await _package.AddToIgnoredUpdatesAsync(version: "*");
+        }
+        else if (await _package.GetIgnoredUpdatesVersionAsync() == "*")
+        {
+            await _package.RemoveFromIgnoredUpdatesAsync();
+        }
+    }
+
+    private void ApplyTranslations()
+    {
+        PackageTitleText.Text = CoreTools.Translate("{0} installation options", _package.Name);
+        PackageIdText.Text = _package.Id;
+        PackageVersionText.Text = string.IsNullOrWhiteSpace(_package.VersionString)
+            ? CoreTools.Translate("Unknown")
+            : _package.VersionString;
+        PackageManagerText.Text = _package.Source.AsString_DisplayName;
+
+        GeneralOptionsTitleText.Text = CoreTools.Translate("Installation options");
+        RunAsAdminCheckBoxControl.Content = CoreTools.Translate("Install as administrator");
+        InteractiveCheckBoxControl.Content = CoreTools.Translate("Interactive installation");
+        HashCheckBoxControl.Content = CoreTools.Translate("Skip hash checks");
+        AutoUpdateCheckBoxControl.Content = CoreTools.Translate("Automatically update this package");
+        SkipMinorUpdatesCheckBoxControl.Content = CoreTools.Translate("Skip minor updates for this package");
+        IgnoreUpdatesCheckBoxControl.Content = CoreTools.Translate("Ignore updates for this package");
+        UninstallPreviousCheckBoxControl.Content = CoreTools.Translate("Uninstall previous versions when updated");
+
+        KillProcessesTitleText.Text = CoreTools.Translate("Custom arguments:");
+        KillProcessesDescText.Text = CoreTools.Translate("Custom command-line arguments:");
+        KillProcessesTextBoxControl.Watermark = CoreTools.Translate("Custom arguments:");
+        KillProcessesThatWontDieCheckBoxControl.Content = CoreTools.Translate("Abort install if pre-install command fails");
+
+        VersionSectionTitleText.Text = CoreTools.Translate("Installation options");
+        VersionLabelText.Text = CoreTools.Translate("Version");
+        ArchitectureLabelText.Text = CoreTools.Translate("Architecture to install:");
+        ScopeLabelText.Text = CoreTools.Translate("Installation scope:");
+
+        LocationTitleText.Text = CoreTools.Translate("Install location:");
+        CustomLocationTextBoxControl.Watermark = CoreTools.Translate("Change install location");
+        BrowseLocationButtonControl.Content = CoreTools.Translate("Select");
+        ResetLocationButtonControl.Content = CoreTools.Translate("Reset");
+        BrowseLocationButtonControl.Click += BrowseLocationButton_OnClick;
+        ResetLocationButtonControl.Click += (_, _) => CustomLocationTextBoxControl.Text = string.Empty;
+
+        ParametersTitleText.Text = CoreTools.Translate("Custom command-line arguments:");
+        CustomParamsDescText.Text = CoreTools.Translate("Custom command-line arguments can change the way in which programs are installed, upgraded or uninstalled, in a way UniGetUI cannot control. Using custom command-lines can break packages. Proceed with caution.");
+        CustomParams1TextBoxControl.Watermark = CoreTools.Translate("Custom arguments:");
+        CustomParams2TextBoxControl.Watermark = CoreTools.Translate("Custom arguments:");
+        CustomParams3TextBoxControl.Watermark = CoreTools.Translate("Custom arguments:");
+        InstallParamsLabelText.Text = CoreTools.Translate("Custom install arguments:");
+        UpdateParamsLabelText.Text = CoreTools.Translate("Custom update arguments:");
+        UninstallParamsLabelText.Text = CoreTools.Translate("Custom uninstall arguments:");
+
+        PrePostTitleText.Text = CoreTools.Translate("Pre-install command:");
+        PrePostCommandsDescText.Text = CoreTools.Translate("Pre and post install commands will be run before and after a package gets installed, upgraded or uninstalled. Be aware that they may break things unless used carefully");
+        PreInstallCommandBoxControl.Watermark = CoreTools.Translate("Pre-install command:");
+        PostInstallCommandBoxControl.Watermark = CoreTools.Translate("Post-install command:");
+        PreUpdateCommandBoxControl.Watermark = CoreTools.Translate("Pre-update command:");
+        PostUpdateCommandBoxControl.Watermark = CoreTools.Translate("Post-update command:");
+        PreUninstallCommandBoxControl.Watermark = CoreTools.Translate("Pre-uninstall command:");
+        PostUninstallCommandBoxControl.Watermark = CoreTools.Translate("Post-uninstall command:");
+        ToolTip.SetTip(AbortInstallCheckBoxControl, CoreTools.Translate("Abort install if pre-install command fails"));
+        ToolTip.SetTip(AbortUpdateCheckBoxControl, CoreTools.Translate("Abort update if pre-update command fails"));
+        ToolTip.SetTip(AbortUninstallCheckBoxControl, CoreTools.Translate("Abort uninstall if pre-uninstall command fails"));
+        PreInstallLabelText.Text = CoreTools.Translate("Pre-install command:");
+        PostInstallLabelText.Text = CoreTools.Translate("Post-install command:");
+        PreUpdateLabelText.Text = CoreTools.Translate("Pre-update command:");
+        PostUpdateLabelText.Text = CoreTools.Translate("Post-update command:");
+        PreUninstallLabelText.Text = CoreTools.Translate("Pre-uninstall command:");
+        PostUninstallLabelText.Text = CoreTools.Translate("Post-uninstall command:");
+        AbortInstallCheckBoxControl.Content = CoreTools.Translate("Abort install if pre-install command fails");
+        AbortUpdateCheckBoxControl.Content = CoreTools.Translate("Abort update if pre-update command fails");
+        AbortUninstallCheckBoxControl.Content = CoreTools.Translate("Abort uninstall if pre-uninstall command fails");
+    }
+
+    private void PopulateStaticControls()
+    {
+        var caps = _package.Manager.Capabilities;
+
+        RunAsAdminCheckBoxControl.IsEnabled = caps.CanRunAsAdmin;
+        InteractiveCheckBoxControl.IsEnabled = caps.CanRunInteractively;
+        HashCheckBoxControl.IsEnabled = caps.CanSkipIntegrityChecks;
+        UninstallPreviousCheckBoxControl.IsVisible = caps.CanUninstallPreviousVersionsAfterUpdate;
+
+        VersionComboBoxControl.Items.Add(CoreTools.Translate("Latest"));
+        VersionComboBoxControl.SelectedIndex = 0;
+        if (caps.SupportsPreRelease)
+        {
+            VersionComboBoxControl.Items.Add(CoreTools.Translate("PreRelease"));
+        }
+        VersionComboBoxControl.IsEnabled = caps.SupportsCustomVersions || caps.SupportsPreRelease;
+
+        ArchitectureComboBoxControl.Items.Add(CoreTools.Translate("Default"));
+        ArchitectureComboBoxControl.SelectedIndex = 0;
+        if (caps.SupportsCustomArchitectures)
+        {
+            foreach (var arch in caps.SupportedCustomArchitectures)
+            {
+                ArchitectureComboBoxControl.Items.Add(arch);
+            }
+        }
+        ArchitectureComboBoxControl.IsEnabled = caps.SupportsCustomArchitectures;
+
+        ScopeComboBoxControl.Items.Add(CoreTools.Translate("Default"));
+        ScopeComboBoxControl.SelectedIndex = 0;
+        if (caps.SupportsCustomScopes)
+        {
+            ScopeComboBoxControl.Items.Add(CoreTools.Translate("User | Local"));
+            ScopeComboBoxControl.Items.Add(CoreTools.Translate("Machine | Global"));
+        }
+        ScopeComboBoxControl.IsEnabled = caps.SupportsCustomScopes;
+
+        CustomLocationCardControl.IsVisible = caps.SupportsCustomLocations;
+        CustomParametersCardControl.IsVisible = SecureSettings.Get(SecureSettings.K.AllowCLIArguments);
+        PrePostCommandsCardControl.IsVisible = SecureSettings.Get(SecureSettings.K.AllowPrePostOpCommand);
+        KillProcessesThatWontDieCheckBoxControl.IsChecked = Settings.Get(Settings.K.KillProcessesThatRefuseToDie);
+    }
+
+    private async Task LoadOptionsAsync()
+    {
+        _options = await InstallOptionsFactory.LoadForPackageAsync(_package);
+        ApplyOptionsToUi(_options);
+        IgnoreUpdatesCheckBoxControl.IsChecked = await _package.HasUpdatesIgnoredAsync();
+
+        if (_package.Manager.Capabilities.SupportsCustomVersions)
+        {
+            VersionLoadingBarControl.IsVisible = true;
+            VersionComboBoxControl.IsEnabled = false;
+            var versions = await Task.Run(() => _package.Manager.DetailsHelper.GetVersions(_package));
+            foreach (var version in versions)
+            {
+                VersionComboBoxControl.Items.Add(version);
+            }
+            VersionLoadingBarControl.IsVisible = false;
+            VersionComboBoxControl.IsEnabled = true;
+        }
+    }
+
+    private void ApplyOptionsToUi(InstallOptions options)
+    {
+        RunAsAdminCheckBoxControl.IsChecked = options.RunAsAdministrator;
+        InteractiveCheckBoxControl.IsChecked = options.InteractiveInstallation;
+        HashCheckBoxControl.IsChecked = options.SkipHashCheck;
+        AutoUpdateCheckBoxControl.IsChecked = options.AutoUpdatePackage;
+        SkipMinorUpdatesCheckBoxControl.IsChecked = options.SkipMinorUpdates;
+        UninstallPreviousCheckBoxControl.IsChecked = options.UninstallPreviousVersionsOnUpdate;
+        KillProcessesTextBoxControl.Text = string.Join(", ", options.KillBeforeOperation);
+
+        if (options.PreRelease && _package.Manager.Capabilities.SupportsPreRelease)
+        {
+            VersionComboBoxControl.SelectedItem = CoreTools.Translate("PreRelease");
+        }
+        else if (!string.IsNullOrWhiteSpace(options.Version))
+        {
+            var versionMatch = VersionComboBoxControl.Items.Cast<object?>()
+                .FirstOrDefault(item => item?.ToString() == options.Version);
+            if (versionMatch is not null)
+            {
+                VersionComboBoxControl.SelectedItem = versionMatch;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Architecture))
+        {
+            var architectureMatch = ArchitectureComboBoxControl.Items.Cast<object?>()
+                .FirstOrDefault(item => item?.ToString() == options.Architecture);
+            if (architectureMatch is not null)
+            {
+                ArchitectureComboBoxControl.SelectedItem = architectureMatch;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.InstallationScope))
+        {
+            string? displayScope = options.InstallationScope == PackageScope.User
+                ? CoreTools.Translate("User | Local")
+                : options.InstallationScope == PackageScope.Machine
+                    ? CoreTools.Translate("Machine | Global")
+                    : null;
+            if (displayScope is not null)
+            {
+                var scopeMatch = ScopeComboBoxControl.Items.Cast<object?>()
+                    .FirstOrDefault(item => item?.ToString() == displayScope);
+                if (scopeMatch is not null)
+                {
+                    ScopeComboBoxControl.SelectedItem = scopeMatch;
+                }
+            }
+        }
+
+        CustomLocationTextBoxControl.Text = options.CustomInstallLocation;
+        CustomParams1TextBoxControl.Text = string.Join(' ', options.CustomParameters_Install);
+        CustomParams2TextBoxControl.Text = string.Join(' ', options.CustomParameters_Update);
+        CustomParams3TextBoxControl.Text = string.Join(' ', options.CustomParameters_Uninstall);
+        PreInstallCommandBoxControl.Text = options.PreInstallCommand;
+        PostInstallCommandBoxControl.Text = options.PostInstallCommand;
+        AbortInstallCheckBoxControl.IsChecked = options.AbortOnPreInstallFail;
+        PreUpdateCommandBoxControl.Text = options.PreUpdateCommand;
+        PostUpdateCommandBoxControl.Text = options.PostUpdateCommand;
+        AbortUpdateCheckBoxControl.IsChecked = options.AbortOnPreUpdateFail;
+        PreUninstallCommandBoxControl.Text = options.PreUninstallCommand;
+        PostUninstallCommandBoxControl.Text = options.PostUninstallCommand;
+        AbortUninstallCheckBoxControl.IsChecked = options.AbortOnPreUninstallFail;
+    }
+
+    private InstallOptions ReadOptionsFromUi()
+    {
+        var options = new InstallOptions
+        {
+            RunAsAdministrator = RunAsAdminCheckBoxControl.IsChecked ?? false,
+            InteractiveInstallation = InteractiveCheckBoxControl.IsChecked ?? false,
+            SkipHashCheck = HashCheckBoxControl.IsChecked ?? false,
+            AutoUpdatePackage = AutoUpdateCheckBoxControl.IsChecked ?? false,
+            UninstallPreviousVersionsOnUpdate = UninstallPreviousCheckBoxControl.IsChecked ?? false,
+            CustomInstallLocation = CustomLocationTextBoxControl.Text?.Trim() ?? string.Empty,
+            PreInstallCommand = PreInstallCommandBoxControl.Text?.Trim() ?? string.Empty,
+            PostInstallCommand = PostInstallCommandBoxControl.Text?.Trim() ?? string.Empty,
+            AbortOnPreInstallFail = AbortInstallCheckBoxControl.IsChecked ?? true,
+            PreUpdateCommand = PreUpdateCommandBoxControl.Text?.Trim() ?? string.Empty,
+            PostUpdateCommand = PostUpdateCommandBoxControl.Text?.Trim() ?? string.Empty,
+            AbortOnPreUpdateFail = AbortUpdateCheckBoxControl.IsChecked ?? true,
+            PreUninstallCommand = PreUninstallCommandBoxControl.Text?.Trim() ?? string.Empty,
+            PostUninstallCommand = PostUninstallCommandBoxControl.Text?.Trim() ?? string.Empty,
+            AbortOnPreUninstallFail = AbortUninstallCheckBoxControl.IsChecked ?? true,
+            SkipMinorUpdates = SkipMinorUpdatesCheckBoxControl.IsChecked ?? false,
+            OverridesNextLevelOpts = true,
+        };
+
+        string versionSelection = VersionComboBoxControl.SelectedItem?.ToString() ?? string.Empty;
+        if (versionSelection == CoreTools.Translate("PreRelease"))
+        {
+            options.PreRelease = true;
+            options.Version = string.Empty;
+        }
+        else if (versionSelection == CoreTools.Translate("Latest") || string.IsNullOrWhiteSpace(versionSelection))
+        {
+            options.PreRelease = false;
+            options.Version = string.Empty;
+        }
+        else
+        {
+            options.PreRelease = false;
+            options.Version = versionSelection;
+        }
+
+        string architectureSelection = ArchitectureComboBoxControl.SelectedItem?.ToString() ?? string.Empty;
+        options.Architecture = Architecture.ValidValues.Contains(architectureSelection)
+            ? architectureSelection
+            : string.Empty;
+
+        string scopeSelection = ScopeComboBoxControl.SelectedItem?.ToString() ?? string.Empty;
+        if (scopeSelection == CoreTools.Translate("User | Local"))
+        {
+            options.InstallationScope = PackageScope.User;
+        }
+        else if (scopeSelection == CoreTools.Translate("Machine | Global"))
+        {
+            options.InstallationScope = PackageScope.Machine;
+        }
+        else
+        {
+            options.InstallationScope = string.Empty;
+        }
+
+        options.CustomParameters_Install = SplitParams(CustomParams1TextBoxControl.Text);
+        options.CustomParameters_Update = SplitParams(CustomParams2TextBoxControl.Text);
+        options.CustomParameters_Uninstall = SplitParams(CustomParams3TextBoxControl.Text);
+
+        options.KillBeforeOperation.Clear();
+        var killNames = (KillProcessesTextBoxControl.Text ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var name in killNames)
+        {
+            if (!string.IsNullOrEmpty(name))
+            {
+                options.KillBeforeOperation.Add(name);
+            }
+        }
+
+        return options;
+    }
+
+    private static List<string> SplitParams(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return [];
+        }
+
+        return [.. text.Split(' ', StringSplitOptions.RemoveEmptyEntries)];
+    }
+
+    private async void BrowseLocationButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel?.StorageProvider is null)
+        {
+            return;
+        }
+
+        var options = new FolderPickerOpenOptions
+        {
+            Title = CoreTools.Translate("Select a folder"),
+            AllowMultiple = false,
+        };
+
+        if (!string.IsNullOrWhiteSpace(CustomLocationTextBoxControl.Text))
+        {
+            try
+            {
+                var current = await topLevel.StorageProvider.TryGetFolderFromPathAsync(
+                    new Uri(CustomLocationTextBoxControl.Text.Trim()));
+                if (current is not null)
+                {
+                    options.SuggestedStartLocation = current;
+                }
+            }
+            catch
+            {
+                // ignore invalid path
+            }
+        }
+
+        var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(options);
+        if (folders.Count > 0)
+        {
+            CustomLocationTextBoxControl.Text = folders[0].TryGetLocalPath() ?? string.Empty;
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsWindow.axaml
@@ -1,0 +1,39 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.InstallOptionsWindow"
+        Width="660"
+        Height="700"
+        MinWidth="480"
+        MinHeight="460"
+        Title="Install Options"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+  <Grid RowDefinitions="*,Auto">
+
+    <ScrollViewer Grid.Row="0"
+                  Margin="18,18,18,0">
+      <ContentControl x:Name="EditorHost" />
+    </ScrollViewer>
+
+    <!-- Footer buttons (sticky) -->
+    <Border Grid.Row="1"
+            Padding="18,12"
+            Classes="surface-card flat-shell-panel"
+            BorderThickness="0,1,0,0">
+      <StackPanel Orientation="Horizontal"
+                  Spacing="10"
+                  HorizontalAlignment="Right">
+        <Button x:Name="CancelBtn"
+                Classes="toolbar-secondary"
+                MinWidth="90">Cancel</Button>
+        <Button x:Name="SaveBtn"
+                Classes="toolbar-primary"
+                MinWidth="90">Save</Button>
+      </StackPanel>
+    </Border>
+
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/InstallOptionsWindow.axaml.cs
@@ -1,0 +1,56 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class InstallOptionsWindow : Window
+{
+    private readonly InstallOptionsEditorView? _editorView;
+
+    public InstallOptionsWindow()
+    {
+        InitializeComponent();
+        ApplyTranslations();
+        SaveBtn.IsEnabled = false;
+    }
+
+    public InstallOptionsWindow(IPackage package, PackagePageMode pageMode)
+    {
+        _editorView = new InstallOptionsEditorView(package);
+        InitializeComponent();
+        ApplyTranslations();
+        EditorHost.Content = _editorView;
+    }
+
+    private void ApplyTranslations()
+    {
+        SaveBtn.Content = CoreTools.Translate("Save");
+        CancelBtn.Content = CoreTools.Translate("Cancel");
+        Title = CoreTools.Translate("Install options");
+
+        SaveBtn.Click += SaveBtn_OnClick;
+        CancelBtn.Click += CancelBtn_OnClick;
+    }
+
+    private async void SaveBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_editorView is null)
+        {
+            Close();
+            return;
+        }
+
+        await _editorView.SaveAsync();
+        Close();
+    }
+
+    private void CancelBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/LogsPageView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogsPageView.axaml
@@ -1,0 +1,95 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.LogsPageView">
+
+    <Grid RowDefinitions="Auto,*"
+          RowSpacing="12">
+
+        <!-- Header / toolbar -->
+        <Border Grid.Row="0"
+                Padding="12,8"
+                Classes="surface-card">
+            <Grid ColumnDefinitions="*,Auto"
+                  ColumnSpacing="8">
+
+                <!-- Tab buttons -->
+                <StackPanel Orientation="Horizontal"
+                            Spacing="6">
+                    <Button x:Name="TabUniGetUILogButton"
+                            Classes="toolbar-primary accent"
+                            Tag="0"
+                            Click="TabButton_OnClick"
+                            Content="UniGetUI Log" />
+                    <Button x:Name="TabOperationHistoryButton"
+                            Classes="toolbar-secondary"
+                            Tag="1"
+                            Click="TabButton_OnClick"
+                            Content="Operation History" />
+                    <Button x:Name="TabManagerLogsButton"
+                            Classes="toolbar-secondary"
+                            Tag="2"
+                            Click="TabButton_OnClick"
+                            Content="Manager Logs" />
+                </StackPanel>
+
+                <!-- Optional selectors + action buttons -->
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            Spacing="6">
+                    <ComboBox x:Name="LogLevelCombo"
+                              MinWidth="180"
+                              IsVisible="True"
+                              SelectionChanged="LogLevelCombo_SelectionChanged" />
+                    <ComboBox x:Name="ManagerCombo"
+                              MinWidth="200"
+                              IsVisible="False"
+                              SelectionChanged="ManagerCombo_SelectionChanged" />
+                    <Button x:Name="CopyButton"
+                            Classes="toolbar-secondary"
+                            Click="CopyButton_OnClick"
+                            Content="Copy" />
+                    <Button x:Name="ExportButton"
+                            Classes="toolbar-secondary"
+                            Click="ExportButton_OnClick"
+                            Content="Export" />
+                    <Button x:Name="ReloadButton"
+                            Classes="toolbar-secondary"
+                            Click="ReloadButton_OnClick"
+                            Content="Reload" />
+                </StackPanel>
+
+            </Grid>
+        </Border>
+
+        <!-- Log content area -->
+        <Border Grid.Row="1"
+                Classes="surface-card"
+                Padding="4">
+            <ScrollViewer x:Name="LogScrollViewer"
+                          Padding="8">
+                <StackPanel Spacing="0">
+                    <!-- Colored line list (UniGetUI Log + Manager Logs) -->
+                    <ItemsControl x:Name="LogLinesItems">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Text}"
+                                           Foreground="{Binding Foreground}"
+                                           FontFamily="Cascadia Mono,Cascadia Code,Consolas,Courier New,monospace"
+                                           FontSize="12"
+                                           TextWrapping="Wrap" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Plain text (Operation History) -->
+                    <SelectableTextBlock x:Name="PlainTextBlock"
+                                         IsVisible="False"
+                                         FontFamily="Cascadia Mono,Cascadia Code,Consolas,Courier New,monospace"
+                                         FontSize="12"
+                                         TextWrapping="Wrap" />
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+    </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogsPageView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogsPageView.axaml.cs
@@ -1,0 +1,344 @@
+using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using Avalonia.Styling;
+using UniGetUI.Avalonia.Views;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>
+/// A single line in the colored log display.
+/// </summary>
+public sealed class LogLineModel
+{
+    public string Text { get; init; } = string.Empty;
+    public IBrush Foreground { get; init; } = Brushes.White;
+}
+
+/// <summary>
+/// Shell page hosting three log sub-views:
+/// UniGetUI Application Log, Operation History, Manager Logs.
+/// </summary>
+public partial class LogsPageView : global::Avalonia.Controls.UserControl, IShellPage
+{
+    // IShellPage ──────────────────────────────────────────────────────────────
+    public string Title { get; } = CoreTools.Translate("Package Manager logs");
+    public string Subtitle { get; } = CoreTools.Translate("Package Manager logs");
+    public bool SupportsSearch => false;
+    public string SearchPlaceholder => string.Empty;
+    public void UpdateSearchQuery(string query) { }
+
+    // State ───────────────────────────────────────────────────────────────────
+    private int _activeTab;     // 0 = UniGetUI, 1 = History, 2 = Managers
+    private int _logLevel = 4;  // for UniGetUI log
+
+    private readonly ObservableCollection<LogLineModel> _lines = [];
+
+    // ── Color palettes ────────────────────────────────────────────────────────
+    // Dark-theme colours
+    private static IBrush DarkGrey => new SolidColorBrush(Color.FromRgb(130, 130, 130));
+    private static IBrush DarkLightGrey => new SolidColorBrush(Color.FromRgb(190, 190, 190));
+    private static IBrush DarkWhite => new SolidColorBrush(Color.FromRgb(250, 250, 250));
+    private static IBrush DarkYellow => new SolidColorBrush(Color.FromRgb(255, 255, 90));
+    private static IBrush DarkRed => new SolidColorBrush(Color.FromRgb(255, 80, 80));
+    private static IBrush DarkGreen => new SolidColorBrush(Color.FromRgb(80, 255, 80));
+    private static IBrush DarkBlue => new SolidColorBrush(Color.FromRgb(120, 120, 255));
+
+    // Light-theme colours
+    private static IBrush LightGrey => new SolidColorBrush(Color.FromRgb(125, 125, 225));
+    private static IBrush LightLightGrey => new SolidColorBrush(Color.FromRgb(50, 50, 150));
+    private static IBrush LightWhite => new SolidColorBrush(Color.FromRgb(0, 0, 0));
+    private static IBrush LightYellow => new SolidColorBrush(Color.FromRgb(150, 150, 0));
+    private static IBrush LightRed => new SolidColorBrush(Color.FromRgb(205, 0, 0));
+    private static IBrush LightGreen => new SolidColorBrush(Color.FromRgb(0, 205, 0));
+    private static IBrush LightBlue => new SolidColorBrush(Color.FromRgb(0, 0, 205));
+
+    private bool IsDark => ActualThemeVariant == ThemeVariant.Dark;
+
+    // ── Constructor ───────────────────────────────────────────────────────────
+
+    public LogsPageView()
+    {
+        InitializeComponent();
+        LogLinesItems.ItemsSource = _lines;
+        PopulateLogLevelCombo();
+        PopulateManagerCombo();
+        // first load happens when the page is first shown (tab selection below)
+        ApplyTranslations();
+        SwitchTab(0);
+    }
+
+    private void ApplyTranslations()
+    {
+        TabUniGetUILogButton.Content = CoreTools.Translate("WingetUI log");
+        TabOperationHistoryButton.Content = CoreTools.Translate("Operation history");
+        TabManagerLogsButton.Content = CoreTools.Translate("Package Manager logs");
+        CopyButton.Content = CoreTools.Translate("Copy");
+        ExportButton.Content = CoreTools.Translate("Export");
+        ReloadButton.Content = CoreTools.Translate("Reload");
+    }
+
+    // ── Combo population ──────────────────────────────────────────────────────
+
+    private void PopulateLogLevelCombo()
+    {
+        LogLevelCombo.Items.Clear();
+        LogLevelCombo.Items.Add(CoreTools.Translate("1 - Errors"));
+        LogLevelCombo.Items.Add(CoreTools.Translate("2 - Warnings"));
+        LogLevelCombo.Items.Add(CoreTools.Translate("3 - Information (less)"));
+        LogLevelCombo.Items.Add(CoreTools.Translate("4 - Information (more)"));
+        LogLevelCombo.Items.Add(CoreTools.Translate("5 - information (debug)"));
+#if DEBUG
+        LogLevelCombo.SelectedIndex = 4;
+#else
+        LogLevelCombo.SelectedIndex = 3;
+#endif
+        _logLevel = LogLevelCombo.SelectedIndex + 1;
+    }
+
+    private void PopulateManagerCombo()
+    {
+        ManagerCombo.Items.Clear();
+        foreach (var mgr in PEInterface.Managers)
+        {
+            ManagerCombo.Items.Add(mgr.DisplayName);
+            ManagerCombo.Items.Add($"{mgr.DisplayName} ({CoreTools.Translate("Verbose")})");
+        }
+        if (ManagerCombo.ItemCount > 0)
+            ManagerCombo.SelectedIndex = 0;
+    }
+
+    // ── Tab switching ─────────────────────────────────────────────────────────
+
+    private void SwitchTab(int tab)
+    {
+        _activeTab = tab;
+
+        // Update tab button styles
+        TabUniGetUILogButton.Classes.Set("accent", tab == 0);
+        TabUniGetUILogButton.Classes.Set("toolbar-primary", tab == 0);
+        TabUniGetUILogButton.Classes.Set("toolbar-secondary", tab != 0);
+        TabOperationHistoryButton.Classes.Set("accent", tab == 1);
+        TabOperationHistoryButton.Classes.Set("toolbar-primary", tab == 1);
+        TabOperationHistoryButton.Classes.Set("toolbar-secondary", tab != 1);
+        TabManagerLogsButton.Classes.Set("accent", tab == 2);
+        TabManagerLogsButton.Classes.Set("toolbar-primary", tab == 2);
+        TabManagerLogsButton.Classes.Set("toolbar-secondary", tab != 2);
+
+        // Show / hide toolbar controls
+        LogLevelCombo.IsVisible = tab == 0;
+        ManagerCombo.IsVisible = tab == 2;
+
+        // Show / hide content controls
+        LogLinesItems.IsVisible = tab != 1;
+        PlainTextBlock.IsVisible = tab == 1;
+
+        Reload();
+    }
+
+    private void Reload()
+    {
+        switch (_activeTab)
+        {
+            case 0: LoadUniGetUILog(); break;
+            case 1: LoadOperationHistory(); break;
+            case 2: LoadManagerLogs(); break;
+        }
+    }
+
+    internal void ShowManagerLogs(IPackageManager manager, bool verbose = false)
+    {
+        string targetLabel = verbose
+            ? $"{manager.DisplayName} ({CoreTools.Translate("Verbose")})"
+            : manager.DisplayName;
+
+        for (int index = 0; index < ManagerCombo.ItemCount; index++)
+        {
+            if (string.Equals(ManagerCombo.Items[index]?.ToString(), targetLabel, StringComparison.Ordinal))
+            {
+                ManagerCombo.SelectedIndex = index;
+                break;
+            }
+        }
+
+        SwitchTab(2);
+    }
+
+    // ── Log loaders ───────────────────────────────────────────────────────────
+
+    private void LoadUniGetUILog()
+    {
+        _lines.Clear();
+        bool dark = IsDark;
+
+        foreach (var entry in Logger.GetLogs())
+        {
+            if (string.IsNullOrEmpty(entry.Content)) continue;
+
+            // Level filtering
+            if (_logLevel <= 4 && entry.Severity == LogEntry.SeverityLevel.Debug) continue;
+            if (_logLevel <= 3 && entry.Severity == LogEntry.SeverityLevel.Info) continue;
+            if (_logLevel <= 2 && entry.Severity == LogEntry.SeverityLevel.Success) continue;
+            if (_logLevel <= 1 && entry.Severity == LogEntry.SeverityLevel.Warning) continue;
+
+            IBrush brush = entry.Severity switch
+            {
+                LogEntry.SeverityLevel.Debug => dark ? DarkGrey : LightGrey,
+                LogEntry.SeverityLevel.Info => dark ? DarkLightGrey : LightLightGrey,
+                LogEntry.SeverityLevel.Success => dark ? DarkWhite : LightWhite,
+                LogEntry.SeverityLevel.Warning => dark ? DarkYellow : LightYellow,
+                LogEntry.SeverityLevel.Error => dark ? DarkRed : LightRed,
+                _ => dark ? DarkGrey : LightGrey,
+            };
+
+            string prefix = $"[{entry.Time:HH:mm:ss}] ";
+            string[] parts = entry.Content.Split('\n');
+            for (int i = 0; i < parts.Length; i++)
+            {
+                string line = i == 0 ? prefix + parts[i] : new string(' ', prefix.Length) + parts[i];
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                _lines.Add(new LogLineModel { Text = line, Foreground = brush });
+            }
+        }
+    }
+
+    private void LoadOperationHistory()
+    {
+        var raw = Settings.GetValue(Settings.K.OperationHistory);
+        var sb = new System.Text.StringBuilder();
+        foreach (var line in raw.Split('\n'))
+        {
+            var trimmed = line.Replace("\r", "").Trim();
+            if (trimmed.Length > 0)
+                sb.AppendLine(trimmed);
+        }
+        PlainTextBlock.Text = sb.ToString().TrimEnd();
+    }
+
+    private void LoadManagerLogs()
+    {
+        _lines.Clear();
+        bool dark = IsDark;
+
+        if (ManagerCombo.SelectedIndex < 0) return;
+
+        var selectedText = ManagerCombo.SelectedItem?.ToString() ?? string.Empty;
+        bool verbose = selectedText.Contains(CoreTools.Translate("Verbose"));
+
+        // Find matching manager
+        IPackageManager? manager = null;
+        foreach (var mgr in PEInterface.Managers)
+        {
+            if (selectedText.Contains(mgr.DisplayName))
+            {
+                manager = mgr;
+                break;
+            }
+        }
+        if (manager is null) return;
+
+        // Version header
+        _lines.Add(new LogLineModel
+        {
+            Text = $"Manager {manager.DisplayName}  —  {manager.Status.Version}",
+            Foreground = dark ? DarkYellow : LightYellow,
+        });
+        _lines.Add(new LogLineModel { Text = new string('─', 60), Foreground = dark ? DarkGrey : LightGrey });
+
+        foreach (var operation in manager.TaskLogger.Operations)
+        {
+            foreach (var line in operation.AsColoredString(verbose))
+            {
+                if (line.Length < 2) continue;
+
+                IBrush brush = line[0] switch
+                {
+                    '0' => dark ? DarkWhite : LightWhite,
+                    '1' => dark ? DarkLightGrey : LightLightGrey,
+                    '2' => dark ? DarkRed : LightRed,
+                    '3' => dark ? DarkBlue : LightBlue,
+                    '4' => dark ? DarkGreen : LightGreen,
+                    '5' => dark ? DarkYellow : LightYellow,
+                    _ => dark ? DarkYellow : LightYellow,
+                };
+                _lines.Add(new LogLineModel { Text = line[1..], Foreground = brush });
+            }
+            // Separator between operations
+            _lines.Add(new LogLineModel { Text = string.Empty, Foreground = dark ? DarkGrey : LightGrey });
+        }
+    }
+
+    // ── Build clipboard / export text ─────────────────────────────────────────
+
+    private string BuildAllText()
+    {
+        if (_activeTab == 1)
+            return PlainTextBlock.Text ?? string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var line in _lines)
+            sb.AppendLine(line.Text);
+        return sb.ToString();
+    }
+
+    // ── Event handlers ────────────────────────────────────────────────────────
+
+    private void TabButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: string tag } && int.TryParse(tag, out int tab))
+            SwitchTab(tab);
+    }
+
+    private void LogLevelCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        _logLevel = LogLevelCombo.SelectedIndex + 1;
+        if (_activeTab == 0)
+            LoadUniGetUILog();
+    }
+
+    private void ManagerCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_activeTab == 2)
+            LoadManagerLogs();
+    }
+
+    private void ReloadButton_OnClick(object? sender, RoutedEventArgs e) => Reload();
+
+    private async void CopyButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is not null)
+            await clipboard.SetTextAsync(BuildAllText());
+    }
+
+    private async void ExportButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel is null) return;
+
+        var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = CoreTools.Translate("Export log as a file"),
+            SuggestedFileName = CoreTools.Translate("WingetUI log"),
+            FileTypeChoices =
+            [
+                new FilePickerFileType(CoreTools.Translate("Text file")) { Patterns = ["*.txt"] },
+            ],
+        });
+
+        if (file is not null)
+        {
+            await using var stream = await file.OpenWriteAsync();
+            await using var writer = new System.IO.StreamWriter(stream, System.Text.Encoding.UTF8);
+            await writer.WriteAsync(BuildAllText());
+        }
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/IManagerSectionView.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/IManagerSectionView.cs
@@ -1,0 +1,10 @@
+namespace UniGetUI.Avalonia.Views.Pages.ManagersPages;
+
+internal interface IManagerSectionView
+{
+    string SectionTitle { get; }
+
+    string SectionSubtitle { get; }
+
+    string SectionStatus { get; }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerDetailView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerDetailView.axaml
@@ -1,0 +1,101 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.ManagersPages.ManagerDetailView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+
+      <!-- Header: name + description -->
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Status -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="StatusHeadingBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <Border x:Name="StatusBadgeBorder"
+                  Padding="8,4"
+                  HorizontalAlignment="Left"
+                  Classes="surface-card badge-panel manager-status">
+            <TextBlock x:Name="StatusTextBlock"
+                       FontSize="12"
+                       FontWeight="SemiBold" />
+          </Border>
+          <TextBlock x:Name="VersionBlock"
+                     Classes="data-secondary"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="ExecutablePathBlock"
+                     Classes="data-secondary"
+                     TextWrapping="Wrap" />
+            <Button x:Name="CopyExecutablePathButton"
+              HorizontalAlignment="Left"
+              Classes="toolbar-secondary" />
+        </StackPanel>
+      </Border>
+
+      <!-- Enable / disable -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="EnableSectionTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="EnableSectionDescBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnabledCheckBox"
+                    Click="EnabledCheckBox_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Executable path selection -->
+      <Border x:Name="ExePathCardBorder"
+              Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="ExeSectionTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ExeSectionDescBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <ComboBox x:Name="ExecutableComboBox"
+                    MinWidth="400"
+                    HorizontalAlignment="Left"
+                    SelectionChanged="ExecutableComboBox_OnSelectionChanged" />
+          <Border x:Name="ExeWarningBorder"
+                  Padding="10,8"
+                  CornerRadius="6"
+                  Classes="subtle-panel">
+            <StackPanel Spacing="8">
+              <TextBlock x:Name="ExeWarningBlock"
+                         Opacity="0.82"
+                         TextWrapping="Wrap" />
+              <Button x:Name="OpenAdminSettingsButton"
+                      HorizontalAlignment="Left"
+                      Classes="toolbar-secondary" />
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <!-- Manager-specific extra settings (populated in code) -->
+      <StackPanel x:Name="ExtraSettingsHost"
+                  Spacing="12" />
+
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerDetailView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerDetailView.axaml.cs
@@ -1,0 +1,999 @@
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using Avalonia.VisualTree;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Avalonia.Views;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Classes.Manager;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Operations;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.PackageLoader;
+using UniGetUI.PackageEngine.Serializable;
+
+namespace UniGetUI.Avalonia.Views.Pages.ManagersPages;
+
+public partial class ManagerDetailView : UserControl, IManagerSectionView
+{
+    private bool _isLoading;
+    private IPackageManager? _manager;
+    private string _currentExecutablePath = string.Empty;
+
+    // Header card
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+
+    // Status card
+    private TextBlock StatusHeadingText => GetControl<TextBlock>("StatusHeadingBlock");
+    private Border StatusBadge => GetControl<Border>("StatusBadgeBorder");
+    private TextBlock StatusText => GetControl<TextBlock>("StatusTextBlock");
+    private TextBlock VersionText => GetControl<TextBlock>("VersionBlock");
+    private TextBlock ExecutablePathText => GetControl<TextBlock>("ExecutablePathBlock");
+    private Button CopyExecutablePathButtonControl => GetControl<Button>("CopyExecutablePathButton");
+
+    // Enable/disable card
+    private TextBlock EnableSectionTitleText => GetControl<TextBlock>("EnableSectionTitleBlock");
+    private TextBlock EnableSectionDescText => GetControl<TextBlock>("EnableSectionDescBlock");
+    private CheckBox EnabledCheckBoxControl => GetControl<CheckBox>("EnabledCheckBox");
+
+    // Executable card
+    private TextBlock ExeSectionTitleText => GetControl<TextBlock>("ExeSectionTitleBlock");
+    private TextBlock ExeSectionDescText => GetControl<TextBlock>("ExeSectionDescBlock");
+    private ComboBox ExecutableComboBoxControl => GetControl<ComboBox>("ExecutableComboBox");
+    private Border ExeWarningCard => GetControl<Border>("ExeWarningBorder");
+    private TextBlock ExeWarningText => GetControl<TextBlock>("ExeWarningBlock");
+    private Button OpenAdminSettingsButtonControl => GetControl<Button>("OpenAdminSettingsButton");
+
+    // Extra-settings host
+    private StackPanel ExtraSettingsPanel => GetControl<StackPanel>("ExtraSettingsHost");
+
+    public ManagerDetailView()
+    {
+        InitializeComponent();
+        SectionTitle = CoreTools.Translate("Package manager");
+        SectionSubtitle = CoreTools.Translate("Package manager preferences");
+        SectionStatus = CoreTools.Translate("Package manager preferences");
+        OpenAdminSettingsButtonControl.Click += OpenAdminSettingsButton_OnClick;
+        CopyExecutablePathButtonControl.Click += CopyExecutablePathButton_OnClick;
+    }
+
+    public string SectionTitle { get; private set; }
+    public string SectionSubtitle { get; private set; }
+    public string SectionStatus { get; private set; }
+
+    public void LoadManager(IPackageManager manager)
+    {
+        _manager = manager;
+        var description = manager.Properties.Description.Replace("<br>", Environment.NewLine);
+
+        SectionTitle = CoreTools.Translate("{0} settings", manager.DisplayName);
+        SectionSubtitle = CoreTools.Translate("Enable and disable package managers, change default install options, etc.");
+        SectionStatus = BuildStatus(manager);
+
+        // Header
+        LeadTitleText.Text = manager.DisplayName;
+        LeadDescriptionText.Text = description;
+
+        // Status card
+        StatusHeadingText.Text = CoreTools.Translate("Status");
+        StatusText.Text = SectionStatus;
+        VersionText.Text = string.IsNullOrWhiteSpace(manager.Status.Version)
+            ? CoreTools.Translate("Version")
+            : CoreTools.Translate("version {0}", manager.Status.Version);
+        _currentExecutablePath = manager.Status.ExecutablePath ?? string.Empty;
+        ExecutablePathText.Text = string.IsNullOrWhiteSpace(manager.Status.ExecutablePath)
+            ? CoreTools.Translate("The executable file for {0} was not found", manager.DisplayName)
+            : CoreTools.Translate("Current executable file:") + " " + manager.Status.ExecutablePath;
+        CopyExecutablePathButtonControl.Content = CoreTools.Translate("Copy");
+        CopyExecutablePathButtonControl.IsEnabled = !string.IsNullOrWhiteSpace(_currentExecutablePath);
+
+        ApplyStatusBadgeClasses(manager);
+
+        // Enable/disable card
+        EnableSectionTitleText.Text = CoreTools.Translate("Package manager");
+        EnableSectionDescText.Text = CoreTools.Translate("By toggling a package manager off, you will no longer be able to see or update its packages.");
+        _isLoading = true;
+        EnabledCheckBoxControl.Content = CoreTools.Translate("Package manager") + ": " + manager.DisplayName;
+        EnabledCheckBoxControl.IsChecked = !Settings.GetDictionaryItem<string, bool>(Settings.K.DisabledManagers, manager.Name);
+        _isLoading = false;
+
+        // Executable path card
+        ExeSectionTitleText.Text = CoreTools.Translate("Current executable file:");
+        ExeSectionDescText.Text = CoreTools.Translate("Select the executable to be used. The following list shows the executables found by UniGetUI");
+
+        bool customPathsAllowed = SecureSettings.Get(SecureSettings.K.AllowCustomManagerPaths);
+        ExeWarningCard.IsVisible = !customPathsAllowed;
+        ExeWarningText.Text = CoreTools.Translate("For security reasons, changing the executable file is disabled by default");
+        OpenAdminSettingsButtonControl.Content = CoreTools.Translate("Open UniGetUI security settings");
+        ExecutableComboBoxControl.IsEnabled = customPathsAllowed;
+
+        _isLoading = true;
+        ExecutableComboBoxControl.SelectionChanged -= ExecutableComboBox_OnSelectionChanged;
+        ExecutableComboBoxControl.Items.Clear();
+        foreach (var path in manager.FindCandidateExecutableFiles())
+        {
+            ExecutableComboBoxControl.Items.Add(path);
+        }
+        string currentPath = Settings.GetDictionaryItem<string, string>(Settings.K.ManagerPaths, manager.Name) ?? "";
+        if (string.IsNullOrEmpty(currentPath))
+        {
+            var exe = manager.GetExecutableFile();
+            currentPath = exe.Item1 ? exe.Item2 : "";
+        }
+        ExecutableComboBoxControl.SelectedItem = currentPath;
+        ExecutableComboBoxControl.SelectionChanged += ExecutableComboBox_OnSelectionChanged;
+        _isLoading = false;
+
+        // Extra manager-specific settings
+        BuildExtraSettings(manager);
+    }
+
+    private void BuildExtraSettings(IPackageManager manager)
+    {
+        ExtraSettingsPanel.Children.Clear();
+
+        // Disable notifications toggle (all managers)
+        var disableNotifSection = MakeSettingsCard();
+        var disableNotifTitle = MakeSectionTitle(CoreTools.Translate("Enable WingetUI notifications"));
+        var disableNotifDesc = MakeSectionDesc(CoreTools.Translate("Show notifications on different events"));
+        var disableNotifCheck = new CheckBox
+        {
+            Content = CoreTools.Translate("Ignore packages from {pm} when showing a notification about updates", manager.DisplayName),
+        };
+        bool notifDisabled = Settings.GetDictionaryItem<string, bool>(Settings.K.DisabledPackageManagerNotifications, manager.Name);
+        disableNotifCheck.IsChecked = notifDisabled;
+        disableNotifCheck.Click += (_, _) =>
+        {
+            if (_isLoading) return;
+            Settings.SetDictionaryItem(Settings.K.DisabledPackageManagerNotifications, manager.Name, disableNotifCheck.IsChecked == true);
+        };
+        var openLogsBtn = new Button
+        {
+            Content = CoreTools.Translate("View {0} logs", manager.DisplayName),
+            Margin = new Thickness(0, 4, 0, 0),
+        };
+        openLogsBtn.Click += (_, _) =>
+        {
+            var shell = this.FindAncestorOfType<MainShellView>();
+            shell?.OpenManagerLogs(manager);
+        };
+        ((StackPanel)disableNotifSection.Child!).Children.Add(disableNotifTitle);
+        ((StackPanel)disableNotifSection.Child!).Children.Add(disableNotifDesc);
+        ((StackPanel)disableNotifSection.Child!).Children.Add(disableNotifCheck);
+        ((StackPanel)disableNotifSection.Child!).Children.Add(openLogsBtn);
+        ExtraSettingsPanel.Children.Add(disableNotifSection);
+
+        // WinGet-specific
+        if (manager.Name == "WinGet")
+        {
+            var wingetSection = MakeSettingsCard();
+            var wingetTitle = MakeSectionTitle(CoreTools.Translate("Package manager preferences"));
+
+            var forceLocationCheck = new CheckBox
+            {
+                Content = CoreTools.Translate("Force install location parameter when updating packages with custom locations"),
+                IsChecked = Settings.Get(Settings.K.WinGetForceLocationOnUpdate),
+                Margin = new Thickness(0, 4, 0, 0),
+            };
+            forceLocationCheck.Click += (_, _) =>
+            {
+                if (_isLoading) return;
+                Settings.Set(Settings.K.WinGetForceLocationOnUpdate, forceLocationCheck.IsChecked == true);
+            };
+
+            var useBundledCheck = new CheckBox
+            {
+                Content = CoreTools.Translate("Use bundled WinGet instead of system WinGet") + $" ({CoreTools.Translate("This may help if WinGet packages are not shown")})",
+                IsChecked = Settings.Get(Settings.K.ForceLegacyBundledWinGet),
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            useBundledCheck.Click += (_, _) =>
+            {
+                if (_isLoading) return;
+                Settings.Set(Settings.K.ForceLegacyBundledWinGet, useBundledCheck.IsChecked == true);
+                _ = ReloadManagerAsync();
+            };
+
+            var resetWinGetBtn = new Button
+            {
+                Content = CoreTools.Translate("Reset WinGet") + $" ({CoreTools.Translate("This may help if WinGet packages are not shown")})",
+                Margin = new Thickness(0, 4, 0, 0),
+            };
+            resetWinGetBtn.Click += async (_, _) =>
+            {
+                resetWinGetBtn.IsEnabled = false;
+                try
+                {
+                    using var p = new Process
+                    {
+                        StartInfo = new()
+                        {
+                            FileName = CoreData.PowerShell5,
+                            Arguments =
+                                "-ExecutionPolicy Bypass -NoLogo -NoProfile -Command \"& {"
+                                + "cmd.exe /C \"rmdir /Q /S `\"%temp%\\WinGet`\"\"; "
+                                + "cmd.exe /C \"`\"%localappdata%\\Microsoft\\WindowsApps\\winget.exe`\" source reset --force\"; "
+                                + "taskkill /im winget.exe /f; "
+                                + "taskkill /im WindowsPackageManagerServer.exe /f; "
+                                + "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; "
+                                + "Install-Module Microsoft.WinGet.Client -Force -AllowClobber; "
+                                + "Import-Module Microsoft.WinGet.Client; "
+                                + "Repair-WinGetPackageManager -Force -Latest; "
+                                + "Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' | Reset-AppxPackage; "
+                                + "}\"",
+                            UseShellExecute = true,
+                            Verb = "runas",
+                        },
+                    };
+                    p.Start();
+                    await p.WaitForExitAsync();
+                    _ = UpgradablePackagesLoader.Instance.ReloadPackages();
+                    _ = InstalledPackagesLoader.Instance.ReloadPackages();
+                }
+                finally { resetWinGetBtn.IsEnabled = true; }
+            };
+
+            ((StackPanel)wingetSection.Child!).Children.Add(wingetTitle);
+            ((StackPanel)wingetSection.Child!).Children.Add(forceLocationCheck);
+            ((StackPanel)wingetSection.Child!).Children.Add(useBundledCheck);
+            ((StackPanel)wingetSection.Child!).Children.Add(resetWinGetBtn);
+            ExtraSettingsPanel.Children.Add(wingetSection);
+        }
+        // Scoop-specific
+        else if (manager.Name == "Scoop")
+        {
+            var scoopSection = MakeSettingsCard();
+            var scoopTitle = MakeSectionTitle(CoreTools.Translate("Package manager preferences"));
+
+            var installBtn = new Button
+            {
+                Content = CoreTools.Translate("Install Scoop"),
+                Margin = new Thickness(0, 4, 0, 0),
+            };
+            installBtn.Click += (_, _) =>
+                _ = CoreTools.LaunchBatchFile(
+                    Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "install_scoop.cmd"),
+                    CoreTools.Translate("Scoop Installer - WingetUI"));
+
+            var uninstallBtn = new Button
+            {
+                Content = CoreTools.Translate("Uninstall Scoop (and its packages)"),
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            uninstallBtn.Click += (_, _) =>
+                _ = CoreTools.LaunchBatchFile(
+                    Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "uninstall_scoop.cmd"),
+                    CoreTools.Translate("Scoop Uninstaller - WingetUI"));
+
+            var cleanupBtn = new Button
+            {
+                Content = CoreTools.Translate("Run cleanup and clear cache"),
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            cleanupBtn.Click += (_, _) =>
+                _ = CoreTools.LaunchBatchFile(
+                    Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "scoop_cleanup.cmd"),
+                    CoreTools.Translate("Clearing Scoop cache - WingetUI"),
+                    RunAsAdmin: true);
+
+            var cleanupOnStartCheck = new CheckBox
+            {
+                Content = CoreTools.Translate("Enable Scoop cleanup on launch"),
+                IsChecked = Settings.Get(Settings.K.EnableScoopCleanup),
+                Margin = new Thickness(0, 4, 0, 0),
+            };
+            cleanupOnStartCheck.Click += (_, _) =>
+            {
+                if (_isLoading) return;
+                Settings.Set(Settings.K.EnableScoopCleanup, cleanupOnStartCheck.IsChecked == true);
+            };
+
+            ((StackPanel)scoopSection.Child!).Children.Add(scoopTitle);
+            ((StackPanel)scoopSection.Child!).Children.Add(installBtn);
+            ((StackPanel)scoopSection.Child!).Children.Add(uninstallBtn);
+            ((StackPanel)scoopSection.Child!).Children.Add(cleanupBtn);
+            ((StackPanel)scoopSection.Child!).Children.Add(cleanupOnStartCheck);
+            ExtraSettingsPanel.Children.Add(scoopSection);
+        }
+        // Chocolatey-specific
+        else if (manager.Name == "Chocolatey")
+        {
+            var chocoSection = MakeSettingsCard();
+            var chocoTitle = MakeSectionTitle(CoreTools.Translate("Package manager preferences"));
+
+            var systemChocoCheck = new CheckBox
+            {
+                Content = CoreTools.Translate("Use system Chocolatey"),
+                IsChecked = Settings.Get(Settings.K.UseSystemChocolatey),
+                Margin = new Thickness(0, 4, 0, 0),
+            };
+            systemChocoCheck.Click += (_, _) =>
+            {
+                if (_isLoading) return;
+                Settings.Set(Settings.K.UseSystemChocolatey, systemChocoCheck.IsChecked == true);
+                _ = ReloadManagerAsync();
+            };
+
+            ((StackPanel)chocoSection.Child!).Children.Add(chocoTitle);
+            ((StackPanel)chocoSection.Child!).Children.Add(systemChocoCheck);
+            ExtraSettingsPanel.Children.Add(chocoSection);
+        }
+        // Vcpkg-specific
+        else if (manager.Name == "Vcpkg")
+        {
+            var vcpkgSection = MakeSettingsCard();
+            var vcpkgTitle = MakeSectionTitle(CoreTools.Translate("Package manager preferences"));
+
+            // Default triplet
+            var tripletLabel = MakeSectionDesc(CoreTools.Translate("Default vcpkg triplet"));
+            var tripletCombo = new ComboBox
+            {
+                MinWidth = 220,
+                HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Left,
+                Margin = new Thickness(0, 4, 0, 0),
+            };
+
+            string currentTriplet = Settings.GetValue(Settings.K.DefaultVcpkgTriplet);
+            tripletCombo.Items.Add(CoreTools.Translate("Default"));
+
+            // We can't directly call Vcpkg.GetSystemTriplets() since that project is not referenced.
+            // Populate with common triplets instead.
+            foreach (var t in new[] { "x64-windows", "x86-windows", "arm64-windows", "x64-osx", "x64-linux", "arm64-osx" })
+            {
+                tripletCombo.Items.Add(t);
+            }
+
+            tripletCombo.SelectedItem = string.IsNullOrEmpty(currentTriplet)
+                ? CoreTools.Translate("Default")
+                : currentTriplet;
+
+            tripletCombo.SelectionChanged += (_, _) =>
+            {
+                if (_isLoading) return;
+                var selected = tripletCombo.SelectedItem?.ToString() ?? "";
+                if (selected == CoreTools.Translate("Default"))
+                    Settings.SetValue(Settings.K.DefaultVcpkgTriplet, "");
+                else
+                    Settings.SetValue(Settings.K.DefaultVcpkgTriplet, selected);
+            };
+
+            // Custom vcpkg root
+            var vcpkgRootTitle = MakeSectionDesc(CoreTools.Translate("Vcpkg root was not found. Please define the %VCPKG_ROOT% environment variable or define it from UniGetUI Settings"));
+            var vcpkgRootLabel = new TextBlock
+            {
+                Opacity = 0.82,
+                Margin = new Thickness(0, 4, 0, 2),
+                Text = Settings.Get(Settings.K.CustomVcpkgRoot)
+                    ? Settings.GetValue(Settings.K.CustomVcpkgRoot)
+                    : "%VCPKG_ROOT%",
+            };
+            var vcpkgRootRow = new StackPanel { Orientation = global::Avalonia.Layout.Orientation.Horizontal, Spacing = 6, Margin = new Thickness(0, 2, 0, 0) };
+            var selectRootBtn = new Button { Content = CoreTools.Translate("Select") };
+            var resetRootBtn = new Button
+            {
+                Content = CoreTools.Translate("Reset"),
+                IsEnabled = Settings.Get(Settings.K.CustomVcpkgRoot),
+            };
+            var openRootBtn = new Button
+            {
+                Content = CoreTools.Translate("Open"),
+                IsEnabled = Settings.Get(Settings.K.CustomVcpkgRoot),
+            };
+
+            selectRootBtn.Click += async (_, _) =>
+            {
+                var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+                if (storageProvider is null) return;
+                var result = await storageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = CoreTools.Translate("Select a folder"),
+                    AllowMultiple = false,
+                });
+                if (result.Count > 0)
+                {
+                    string? path = result[0].TryGetLocalPath();
+                    if (!string.IsNullOrWhiteSpace(path))
+                    {
+                        Settings.SetValue(Settings.K.CustomVcpkgRoot, path);
+                        Settings.Set(Settings.K.CustomVcpkgRoot, true);
+                        vcpkgRootLabel.Text = path;
+                        resetRootBtn.IsEnabled = true;
+                        openRootBtn.IsEnabled = true;
+                    }
+                }
+            };
+            resetRootBtn.Click += (_, _) =>
+            {
+                Settings.Set(Settings.K.CustomVcpkgRoot, false);
+                vcpkgRootLabel.Text = "%VCPKG_ROOT%";
+                resetRootBtn.IsEnabled = false;
+                openRootBtn.IsEnabled = false;
+            };
+            openRootBtn.Click += (_, _) =>
+            {
+                string dir = Settings.GetValue(Settings.K.CustomVcpkgRoot).Replace("/", "\\");
+                if (!string.IsNullOrEmpty(dir))
+                    Process.Start(new ProcessStartInfo { FileName = dir, UseShellExecute = true });
+            };
+
+            vcpkgRootRow.Children.Add(selectRootBtn);
+            vcpkgRootRow.Children.Add(resetRootBtn);
+            vcpkgRootRow.Children.Add(openRootBtn);
+
+            ((StackPanel)vcpkgSection.Child!).Children.Add(vcpkgTitle);
+            ((StackPanel)vcpkgSection.Child!).Children.Add(tripletLabel);
+            ((StackPanel)vcpkgSection.Child!).Children.Add(tripletCombo);
+            ((StackPanel)vcpkgSection.Child!).Children.Add(vcpkgRootTitle);
+            ((StackPanel)vcpkgSection.Child!).Children.Add(vcpkgRootLabel);
+            ((StackPanel)vcpkgSection.Child!).Children.Add(vcpkgRootRow);
+            ExtraSettingsPanel.Children.Add(vcpkgSection);
+        }
+        // Pip-specific warning
+        else if (manager.Name == "Pip")
+        {
+            var pipSection = MakeSettingsCard();
+            var pipTitle = MakeSectionTitle(CoreTools.Translate("Package manager"));
+            var pipNote = MakeSectionDesc(
+                CoreTools.Translate("Please note that not all package managers may fully support this feature"));
+            ((StackPanel)pipSection.Child!).Children.Add(pipTitle);
+            ((StackPanel)pipSection.Child!).Children.Add(pipNote);
+            ExtraSettingsPanel.Children.Add(pipSection);
+        }
+
+        // Source management (for managers that support custom sources, except Vcpkg)
+        if (manager.Capabilities.SupportsCustomSources && manager.Name != "Vcpkg")
+        {
+            var sourcesSection = MakeSettingsCard();
+            var sourcesTitle = MakeSectionTitle(CoreTools.Translate("Manage {0} sources", manager.DisplayName));
+            var sourcesDesc = MakeSectionDesc(CoreTools.Translate(
+                "Add or remove package sources for {0}.", manager.DisplayName));
+
+            var sourcesListPanel = new StackPanel { Spacing = 4, Margin = new Thickness(0, 6, 0, 2) };
+
+            // Known-sources combo pre-fills name/URL fields when there are predefined sources
+            var nameBox = new TextBox
+            {
+                Watermark = CoreTools.Translate("Source name:"),
+                MinWidth = 140,
+            };
+            var urlBox = new TextBox
+            {
+                Watermark = CoreTools.Translate("Source URL:"),
+                MinWidth = 220,
+            };
+
+            var addInputRow = new StackPanel
+            {
+                Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+                Spacing = 6,
+                Margin = new Thickness(0, 8, 0, 0),
+            };
+
+            if (manager.Properties.KnownSources.Length > 0)
+            {
+                var knownCombo = new ComboBox
+                {
+                    PlaceholderText = CoreTools.Translate("Sources"),
+                    MinWidth = 160,
+                };
+                var nameSourceRef = new Dictionary<string, IManagerSource>();
+                knownCombo.Items.Add(CoreTools.Translate("Another source"));
+                foreach (var ks in manager.Properties.KnownSources)
+                {
+                    knownCombo.Items.Add(ks.Name);
+                    nameSourceRef[ks.Name] = ks;
+                }
+                knownCombo.SelectedIndex = 0;
+                knownCombo.SelectionChanged += (_, _) =>
+                {
+                    var sel = knownCombo.SelectedItem?.ToString();
+                    if (sel is null || sel == CoreTools.Translate("Another source"))
+                    {
+                        nameBox.Text = "";
+                        urlBox.Text = "";
+                        nameBox.IsEnabled = true;
+                        urlBox.IsEnabled = true;
+                    }
+                    else if (nameSourceRef.TryGetValue(sel, out var src))
+                    {
+                        nameBox.Text = src.Name;
+                        urlBox.Text = src.Url.ToString();
+                        nameBox.IsEnabled = false;
+                        urlBox.IsEnabled = false;
+                    }
+                };
+                addInputRow.Children.Add(knownCombo);
+            }
+
+            var addBtn = new Button { Content = CoreTools.Translate("Add source") };
+            addBtn.Click += (_, _) =>
+            {
+                var name = nameBox.Text?.Trim() ?? "";
+                var url = urlBox.Text?.Trim() ?? "";
+                if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(url)) return;
+                Uri? uri;
+                try { uri = new Uri(url); }
+                catch { return; }
+                var newSource = new ManagerSource(manager, name, uri);
+                var op = new AddSourceOperation(newSource);
+                AvaloniaOperationRegistry.Add(op);
+                op.OperationSucceeded += (_, _) => _ = LoadSourcesAsync(manager, sourcesListPanel);
+                nameBox.Text = "";
+                urlBox.Text = "";
+            };
+
+            addInputRow.Children.Add(nameBox);
+            addInputRow.Children.Add(urlBox);
+            addInputRow.Children.Add(addBtn);
+
+            var reloadBtn = new Button
+            {
+                Content = CoreTools.Translate("Reload"),
+                Margin = new Thickness(0, 4, 0, 0),
+            };
+            reloadBtn.Click += (_, _) => _ = LoadSourcesAsync(manager, sourcesListPanel);
+
+            ((StackPanel)sourcesSection.Child!).Children.Add(sourcesTitle);
+            ((StackPanel)sourcesSection.Child!).Children.Add(sourcesDesc);
+            ((StackPanel)sourcesSection.Child!).Children.Add(sourcesListPanel);
+            ((StackPanel)sourcesSection.Child!).Children.Add(addInputRow);
+            ((StackPanel)sourcesSection.Child!).Children.Add(reloadBtn);
+            ExtraSettingsPanel.Children.Add(sourcesSection);
+
+            _ = LoadSourcesAsync(manager, sourcesListPanel);
+        }
+
+        // Default install options (all managers)
+        _ = AddDefaultInstallOptionsSectionAsync(manager);
+    }
+
+    // ── Default install options ───────────────────────────────────────────
+
+    private async Task AddDefaultInstallOptionsSectionAsync(IPackageManager manager)
+    {
+        var card = MakeSettingsCard();
+        var panel = (StackPanel)card.Child!;
+
+        panel.Children.Add(MakeSectionTitle(CoreTools.Translate("Default installation options for {0} packages", manager.DisplayName)));
+        panel.Children.Add(MakeSectionDesc(CoreTools.Translate(
+            "These options are applied by default to all {0} operations unless overridden per-package.", manager.DisplayName)));
+
+        var loadingBlock = new TextBlock { Text = CoreTools.Translate("Loading..."), Opacity = 0.60 };
+        panel.Children.Add(loadingBlock);
+        ExtraSettingsPanel.Children.Add(card);
+
+        InstallOptions options;
+        try
+        {
+            options = await InstallOptionsFactory.LoadForManagerAsync(manager);
+        }
+        catch (Exception)
+        {
+            loadingBlock.Text = CoreTools.Translate("An interal error occurred. Please view the log for further details.");
+            return;
+        }
+
+        panel.Children.Remove(loadingBlock);
+        var caps = manager.Capabilities;
+
+        var adminCheck = new CheckBox
+        {
+            Content = CoreTools.Translate("Install as administrator"),
+            IsChecked = options.RunAsAdministrator,
+        };
+        panel.Children.Add(adminCheck);
+
+        CheckBox? interactiveCheck = null;
+        if (caps.CanRunInteractively)
+        {
+            interactiveCheck = new CheckBox
+            {
+                Content = CoreTools.Translate("Interactive installation"),
+                IsChecked = options.InteractiveInstallation,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            panel.Children.Add(interactiveCheck);
+        }
+
+        CheckBox? skipHashCheck = null;
+        if (caps.CanSkipIntegrityChecks)
+        {
+            skipHashCheck = new CheckBox
+            {
+                Content = CoreTools.Translate("Skip integrity checks"),
+                IsChecked = options.SkipHashCheck,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            panel.Children.Add(skipHashCheck);
+        }
+
+        CheckBox? preReleaseCheck = null;
+        if (caps.SupportsPreRelease)
+        {
+            preReleaseCheck = new CheckBox
+            {
+                Content = CoreTools.Translate("Allow pre-release versions"),
+                IsChecked = options.PreRelease,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            panel.Children.Add(preReleaseCheck);
+        }
+
+        ComboBox? archCombo = null;
+        if (caps.SupportsCustomArchitectures)
+        {
+            panel.Children.Add(MakeSectionDesc(CoreTools.Translate("Default")));
+            archCombo = new ComboBox
+            {
+                MinWidth = 160,
+                HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Left,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            archCombo.Items.Add(CoreTools.Translate("Default"));
+            archCombo.SelectedIndex = 0;
+            foreach (var arch in caps.SupportedCustomArchitectures)
+            {
+                archCombo.Items.Add(arch);
+                if (options.Architecture == arch)
+                    archCombo.SelectedItem = arch;
+            }
+            panel.Children.Add(archCombo);
+        }
+
+        ComboBox? scopeCombo = null;
+        if (caps.SupportsCustomScopes)
+        {
+            panel.Children.Add(MakeSectionDesc(CoreTools.Translate("Installation scope:")));
+            scopeCombo = new ComboBox
+            {
+                MinWidth = 160,
+                HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Left,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            scopeCombo.Items.Add(CoreTools.Translate("Default"));
+            scopeCombo.SelectedIndex = 0;
+            scopeCombo.Items.Add(CoreTools.Translate("User | Local"));
+            scopeCombo.Items.Add(CoreTools.Translate("Machine | Global"));
+            if (options.InstallationScope == PackageScope.User)
+                scopeCombo.SelectedItem = CoreTools.Translate("User | Local");
+            else if (options.InstallationScope == PackageScope.Machine)
+                scopeCombo.SelectedItem = CoreTools.Translate("Machine | Global");
+            panel.Children.Add(scopeCombo);
+        }
+
+        TextBox? locationBox = null;
+        if (caps.SupportsCustomLocations)
+        {
+            panel.Children.Add(MakeSectionDesc(CoreTools.Translate("Install location:")));
+            var locationRow = new StackPanel
+            {
+                Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+                Spacing = 6,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            locationBox = new TextBox
+            {
+                Watermark = CoreTools.Translate("Change install location"),
+                MinWidth = 220,
+                Text = options.CustomInstallLocation,
+            };
+            var browseBtn = new Button { Content = CoreTools.Translate("Select") };
+            browseBtn.Click += async (_, _) =>
+            {
+                var sp = TopLevel.GetTopLevel(this)?.StorageProvider;
+                if (sp is null) return;
+                var result = await sp.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = CoreTools.Translate("Select a folder"),
+                    AllowMultiple = false,
+                });
+                if (result.Count > 0)
+                {
+                    var path = result[0].TryGetLocalPath();
+                    if (!string.IsNullOrWhiteSpace(path)) locationBox.Text = path;
+                }
+            };
+            var resetLocationBtn = new Button { Content = CoreTools.Translate("Reset") };
+            resetLocationBtn.Click += (_, _) => locationBox.Text = string.Empty;
+            locationRow.Children.Add(locationBox);
+            locationRow.Children.Add(browseBtn);
+            locationRow.Children.Add(resetLocationBtn);
+            panel.Children.Add(locationRow);
+        }
+
+        // Save / Reset buttons
+        var buttonRow = new StackPanel
+        {
+            Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+            Spacing = 8,
+            Margin = new Thickness(0, 10, 0, 0),
+        };
+
+        var saveBtn = new Button { Content = CoreTools.Translate("Save as") };
+        saveBtn.Click += async (_, _) =>
+        {
+            saveBtn.IsEnabled = false;
+            try
+            {
+                var newOpts = new InstallOptions();
+                newOpts.RunAsAdministrator = adminCheck.IsChecked ?? false;
+                if (interactiveCheck is not null) newOpts.InteractiveInstallation = interactiveCheck.IsChecked ?? false;
+                if (skipHashCheck is not null) newOpts.SkipHashCheck = skipHashCheck.IsChecked ?? false;
+                if (preReleaseCheck is not null) newOpts.PreRelease = preReleaseCheck.IsChecked ?? false;
+                if (archCombo is not null)
+                {
+                    string sel = archCombo.SelectedItem?.ToString() ?? "";
+                    newOpts.Architecture = Architecture.ValidValues.Contains(sel) ? sel : string.Empty;
+                }
+                if (scopeCombo is not null)
+                {
+                    string sel = scopeCombo.SelectedItem?.ToString() ?? "";
+                    if (sel == CoreTools.Translate("User | Local")) newOpts.InstallationScope = PackageScope.User;
+                    else if (sel == CoreTools.Translate("Machine | Global")) newOpts.InstallationScope = PackageScope.Machine;
+                }
+                if (locationBox is not null) newOpts.CustomInstallLocation = locationBox.Text?.Trim() ?? string.Empty;
+                await InstallOptionsFactory.SaveForManagerAsync(newOpts, manager);
+            }
+            finally { saveBtn.IsEnabled = true; }
+        };
+
+        var resetBtn = new Button { Content = CoreTools.Translate("Reset") };
+        resetBtn.Click += async (_, _) =>
+        {
+            resetBtn.IsEnabled = false;
+            try
+            {
+                await InstallOptionsFactory.SaveForManagerAsync(new InstallOptions(), manager);
+                adminCheck.IsChecked = false;
+                interactiveCheck?.IsChecked = false;
+                skipHashCheck?.IsChecked = false;
+                preReleaseCheck?.IsChecked = false;
+                archCombo?.SelectedIndex = 0;
+                scopeCombo?.SelectedIndex = 0;
+                locationBox?.Text = string.Empty;
+            }
+            finally { resetBtn.IsEnabled = true; }
+        };
+
+        buttonRow.Children.Add(saveBtn);
+        buttonRow.Children.Add(resetBtn);
+        panel.Children.Add(buttonRow);
+    }
+
+    // ── Event handlers ────────────────────────────────────────────────────
+
+    private async void EnabledCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_manager is null || _isLoading) return;
+        _isLoading = true;
+        EnabledCheckBoxControl.IsEnabled = false;
+        try
+        {
+            bool disabled = EnabledCheckBoxControl.IsChecked != true;
+            Settings.SetDictionaryItem(Settings.K.DisabledManagers, _manager.Name, disabled);
+            await Task.Run(_manager.Initialize);
+        }
+        finally
+        {
+            EnabledCheckBoxControl.IsEnabled = true;
+            _isLoading = false;
+            ApplyStatusBadgeClasses(_manager);
+            StatusText.Text = BuildStatus(_manager);
+        }
+    }
+
+    private void ExecutableComboBox_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_manager is null || _isLoading) return;
+        string? selected = ExecutableComboBoxControl.SelectedItem?.ToString();
+        if (string.IsNullOrEmpty(selected)) return;
+        Settings.SetDictionaryItem(Settings.K.ManagerPaths, _manager.Name, selected);
+        _ = ReloadManagerAsync();
+    }
+
+    private async Task ReloadManagerAsync()
+    {
+        if (_manager is null) return;
+        _isLoading = true;
+        EnabledCheckBoxControl.IsEnabled = false;
+        ExecutableComboBoxControl.IsEnabled = false;
+        try
+        {
+            await Task.Run(_manager.Initialize);
+        }
+        finally
+        {
+            _isLoading = false;
+            EnabledCheckBoxControl.IsEnabled = true;
+            ExecutableComboBoxControl.IsEnabled = SecureSettings.Get(SecureSettings.K.AllowCustomManagerPaths);
+            ApplyStatusBadgeClasses(_manager);
+            StatusText.Text = BuildStatus(_manager);
+            VersionText.Text = string.IsNullOrWhiteSpace(_manager.Status.Version)
+                ? CoreTools.Translate("Version")
+                : CoreTools.Translate("version {0}", _manager.Status.Version);
+            _currentExecutablePath = _manager.Status.ExecutablePath ?? string.Empty;
+            ExecutablePathText.Text = string.IsNullOrWhiteSpace(_manager.Status.ExecutablePath)
+                ? CoreTools.Translate("The executable file for {0} was not found", _manager.DisplayName)
+                : CoreTools.Translate("Current executable file:") + " " + _manager.Status.ExecutablePath;
+            CopyExecutablePathButtonControl.IsEnabled = !string.IsNullOrWhiteSpace(_currentExecutablePath);
+        }
+    }
+
+    private void OpenAdminSettingsButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var shell = this.FindAncestorOfType<MainShellView>();
+        shell?.OpenSettingsSection(SettingsPages.SettingsSectionRoute.Administrator);
+    }
+
+    private async void CopyExecutablePathButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(_currentExecutablePath))
+            return;
+
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is null)
+            return;
+
+        await clipboard.SetTextAsync(_currentExecutablePath);
+        CopyExecutablePathButtonControl.Content = CoreTools.Translate("Copy to clipboard");
+        await Task.Delay(1000);
+        CopyExecutablePathButtonControl.Content = CoreTools.Translate("Copy");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private void ApplyStatusBadgeClasses(IPackageManager manager)
+    {
+        StatusBadge.Classes.Set("ready", false);
+        StatusBadge.Classes.Set("disabled", false);
+        StatusBadge.Classes.Set("missing", false);
+
+        if (!manager.IsEnabled())
+            StatusBadge.Classes.Set("disabled", true);
+        else if (manager.Status.Found)
+            StatusBadge.Classes.Set("ready", true);
+        else
+            StatusBadge.Classes.Set("missing", true);
+    }
+
+    private static string BuildStatus(IPackageManager manager)
+    {
+        if (!manager.IsEnabled())
+            return CoreTools.Translate("Disabled");
+        return manager.Status.Found
+            ? CoreTools.Translate("Ready")
+            : CoreTools.Translate("Not found");
+    }
+
+    private static async Task LoadSourcesAsync(IPackageManager manager, StackPanel panel)
+    {
+        panel.Children.Clear();
+        if (!manager.IsReady())
+        {
+            panel.Children.Add(new TextBlock
+            {
+                Text = CoreTools.Translate("No sources were found"),
+                Opacity = 0.60,
+            });
+            return;
+        }
+
+        panel.Children.Add(new TextBlock { Text = CoreTools.Translate("Loading..."), Opacity = 0.60 });
+
+        IReadOnlyList<IManagerSource> sources;
+        try
+        {
+            sources = await Task.Run(manager.SourcesHelper.GetSources);
+        }
+        catch (Exception)
+        {
+            panel.Children.Clear();
+            panel.Children.Add(new TextBlock
+            {
+                Text = CoreTools.Translate("An interal error occurred. Please view the log for further details."),
+                Opacity = 0.60,
+                TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+            });
+            return;
+        }
+
+        panel.Children.Clear();
+
+        if (sources.Count == 0)
+        {
+            panel.Children.Add(new TextBlock
+            {
+                Text = CoreTools.Translate("No sources found"),
+                Opacity = 0.60,
+            });
+            return;
+        }
+
+        foreach (var source in sources)
+        {
+            var row = new StackPanel
+            {
+                Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+                Spacing = 10,
+                Margin = new Thickness(0, 2, 0, 2),
+            };
+            var nameText = new TextBlock
+            {
+                Text = source.Name,
+                VerticalAlignment = global::Avalonia.Layout.VerticalAlignment.Center,
+                MinWidth = 130,
+            };
+            var urlText = new TextBlock
+            {
+                Text = source.Url.ToString(),
+                Opacity = 0.70,
+                VerticalAlignment = global::Avalonia.Layout.VerticalAlignment.Center,
+                MinWidth = 160,
+            };
+            var removeBtn = new Button { Content = CoreTools.Translate("Remove from list") };
+            var capturedSource = source;
+            removeBtn.Click += (_, _) =>
+            {
+                var op = new RemoveSourceOperation(capturedSource);
+                AvaloniaOperationRegistry.Add(op);
+                op.OperationSucceeded += (_, _) => _ = LoadSourcesAsync(manager, panel);
+            };
+            row.Children.Add(nameText);
+            row.Children.Add(urlText);
+            row.Children.Add(removeBtn);
+            panel.Children.Add(row);
+        }
+    }
+
+    private static Border MakeSettingsCard()
+    {
+        return new Border
+        {
+            Padding = new Thickness(18),
+            Classes = { "surface-card" },
+            Child = new StackPanel { Spacing = 8 },
+        };
+    }
+
+    private static TextBlock MakeSectionTitle(string text)
+    {
+        return new TextBlock
+        {
+            Text = text,
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+    }
+
+    private static TextBlock MakeSectionDesc(string text)
+    {
+        return new TextBlock
+        {
+            Text = text,
+            Opacity = 0.78,
+            TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+        };
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerRowView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerRowView.axaml
@@ -1,0 +1,63 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.ManagersPages.ManagerRowView">
+  <Border Padding="18"
+          Classes="surface-card">
+    <Grid ColumnDefinitions="Auto,*,Auto"
+          ColumnSpacing="14">
+      <Border x:Name="AvatarBorder"
+              Width="42"
+              Height="42"
+              VerticalAlignment="Top"
+              Classes="surface-card subtle-panel manager-avatar">
+        <TextBlock x:Name="AvatarTextBlock"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   FontSize="18"
+                   FontWeight="Bold" />
+      </Border>
+
+      <Button x:Name="OpenManagerButton"
+              Grid.Column="1"
+              HorizontalContentAlignment="Stretch"
+              Classes="manager-row-button"
+              Click="OpenManagerButton_OnClick">
+        <StackPanel Spacing="6">
+          <TextBlock x:Name="ManagerTitleBlock"
+                     FontSize="16"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="ManagerDescriptionBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <StackPanel Orientation="Horizontal"
+                      Spacing="8">
+            <Border x:Name="StatusBadgeBorder"
+                    Padding="8,4"
+                    Classes="surface-card badge-panel manager-status">
+              <TextBlock x:Name="StatusTextBlock"
+                         FontSize="12"
+                         FontWeight="SemiBold" />
+            </Border>
+            <TextBlock x:Name="ExecutablePathBlock"
+                       VerticalAlignment="Center"
+                       Classes="data-secondary manager-path"
+                       TextWrapping="Wrap"
+                       TextTrimming="CharacterEllipsis" />
+          </StackPanel>
+        </StackPanel>
+      </Button>
+
+      <StackPanel Grid.Column="2"
+                  HorizontalAlignment="Right"
+                  Spacing="6">
+        <CheckBox x:Name="EnabledCheckBox"
+                  HorizontalAlignment="Right"
+                  Click="EnabledCheckBox_OnClick" />
+        <TextBlock x:Name="ToggleCaptionBlock"
+                   HorizontalAlignment="Right"
+                   Classes="data-secondary" />
+      </StackPanel>
+    </Grid>
+  </Border>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerRowView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagerRowView.axaml.cs
@@ -1,0 +1,154 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Views.Pages.ManagersPages;
+
+public partial class ManagerRowView : UserControl
+{
+    private bool _isLoading;
+    private IPackageManager? _manager;
+
+    private TextBlock AvatarText => GetControl<TextBlock>("AvatarTextBlock");
+
+    private TextBlock TitleText => GetControl<TextBlock>("ManagerTitleBlock");
+
+    private TextBlock DescriptionText => GetControl<TextBlock>("ManagerDescriptionBlock");
+
+    private Border StatusBadge => GetControl<Border>("StatusBadgeBorder");
+
+    private TextBlock StatusText => GetControl<TextBlock>("StatusTextBlock");
+
+    private TextBlock ExecutablePathText => GetControl<TextBlock>("ExecutablePathBlock");
+
+    private CheckBox EnabledToggle => GetControl<CheckBox>("EnabledCheckBox");
+
+    private TextBlock ToggleCaptionText => GetControl<TextBlock>("ToggleCaptionBlock");
+
+    private Button OpenManagerAction => GetControl<Button>("OpenManagerButton");
+
+    public ManagerRowView()
+    {
+        InitializeComponent();
+        EnabledToggle.Content = CoreTools.Translate("Enabled");
+        ToggleCaptionText.Text = CoreTools.Translate("Enabled");
+    }
+
+    internal event EventHandler<IPackageManager>? NavigationRequested;
+
+    public void LoadManager(IPackageManager manager)
+    {
+        _manager = manager;
+
+        var displayName = string.IsNullOrWhiteSpace(manager.DisplayName) ? manager.Name : manager.DisplayName;
+
+        var description = manager.Properties.Description.Split("<br>", StringSplitOptions.TrimEntries)[0];
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            description = string.IsNullOrWhiteSpace(manager.Properties.Description)
+                ? CoreTools.Translate("Package manager preferences")
+                : manager.Properties.Description;
+        }
+
+        AvatarText.Text = displayName[..1].ToUpperInvariant();
+        TitleText.Text = displayName;
+        DescriptionText.Text = description;
+
+        _isLoading = true;
+        EnabledToggle.IsChecked = !Settings.GetDictionaryItem<string, bool>(Settings.K.DisabledManagers, manager.Name);
+        _isLoading = false;
+
+        RefreshStatus();
+    }
+
+    private void RefreshStatus(string? overrideStatus = null)
+    {
+        if (_manager is null)
+        {
+            return;
+        }
+
+        StatusBadge.Classes.Set("ready", false);
+        StatusBadge.Classes.Set("disabled", false);
+        StatusBadge.Classes.Set("missing", false);
+        StatusBadge.Classes.Set("loading", false);
+
+        if (overrideStatus is not null)
+        {
+            StatusText.Text = overrideStatus;
+            StatusBadge.Classes.Set("loading", true);
+            ExecutablePathText.Text = CoreTools.Translate("Loading packages, please wait...");
+            return;
+        }
+
+        if (!_manager.IsEnabled())
+        {
+            StatusText.Text = CoreTools.Translate("Disabled");
+            StatusBadge.Classes.Set("disabled", true);
+        }
+        else if (_manager.Status.Found)
+        {
+            StatusText.Text = CoreTools.Translate("Ready");
+            StatusBadge.Classes.Set("ready", true);
+        }
+        else
+        {
+            StatusText.Text = CoreTools.Translate("Not found");
+            StatusBadge.Classes.Set("missing", true);
+        }
+
+        ExecutablePathText.Text = string.IsNullOrWhiteSpace(_manager.Status.ExecutablePath)
+            ? CoreTools.Translate("Not found")
+            : _manager.Status.ExecutablePath;
+    }
+
+    private void OpenManagerButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_manager is not null && !_isLoading)
+        {
+            NavigationRequested?.Invoke(this, _manager);
+        }
+    }
+
+    private async void EnabledCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_manager is null || _isLoading)
+        {
+            return;
+        }
+
+        _isLoading = true;
+        EnabledToggle.IsEnabled = false;
+        OpenManagerAction.IsEnabled = false;
+        RefreshStatus(CoreTools.Translate("Please wait..."));
+
+        try
+        {
+            var disabled = EnabledToggle.IsChecked != true;
+            Settings.SetDictionaryItem(Settings.K.DisabledManagers, _manager.Name, disabled);
+            await Task.Run(_manager.Initialize);
+        }
+        finally
+        {
+            EnabledToggle.IsEnabled = true;
+            OpenManagerAction.IsEnabled = true;
+            _isLoading = false;
+            RefreshStatus();
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersHomeView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersHomeView.axaml
@@ -1,0 +1,24 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.ManagersPages.ManagersHomeView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="IntroTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="IntroDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <StackPanel x:Name="RowsHostPanel"
+                  Spacing="10" />
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersHomeView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersHomeView.axaml.cs
@@ -1,0 +1,95 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Views.Pages.ManagersPages;
+
+public partial class ManagersHomeView : UserControl, IManagerSectionView
+{
+    private TextBlock IntroTitleText => GetControl<TextBlock>("IntroTitleBlock");
+
+    private TextBlock IntroDescriptionText => GetControl<TextBlock>("IntroDescriptionBlock");
+
+    private StackPanel RowsHost => GetControl<StackPanel>("RowsHostPanel");
+
+    public ManagersHomeView()
+    {
+        InitializeComponent();
+
+        IntroTitleText.Text = CoreTools.Translate("Package manager preferences");
+        IntroDescriptionText.Text = CoreTools.Translate("Enable and disable package managers, change default install options, etc.");
+
+        foreach (var manager in PEInterface.Managers)
+        {
+            try
+            {
+                var row = new ManagerRowView();
+                row.LoadManager(manager);
+                row.NavigationRequested += Row_NavigationRequested;
+                RowsHost.Children.Add(row);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to build manager overview row for {manager.Name}");
+                Logger.Error(ex);
+                RowsHost.Children.Add(CreateFallbackRow(manager));
+            }
+        }
+    }
+
+    internal event EventHandler<IPackageManager>? NavigationRequested;
+
+    public string SectionTitle => CoreTools.Translate("Package manager preferences");
+
+    public string SectionSubtitle => CoreTools.Translate("Enable and disable package managers, change default install options, etc.");
+
+    public string SectionStatus => CoreTools.Translate("{0} settings", PEInterface.Managers.Length);
+
+    private void Row_NavigationRequested(object? sender, IPackageManager manager)
+    {
+        NavigationRequested?.Invoke(this, manager);
+    }
+
+    private static Border CreateFallbackRow(IPackageManager manager)
+    {
+        return new Border
+        {
+            Classes = { "surface-card", "subtle-panel" },
+            Padding = new global::Avalonia.Thickness(18),
+            Child = new StackPanel
+            {
+                Spacing = 6,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        FontSize = 16,
+                        FontWeight = global::Avalonia.Media.FontWeight.SemiBold,
+                        Text = manager.DisplayName,
+                    },
+                    new TextBlock
+                    {
+                        Opacity = 0.78,
+                        TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                        Text = CoreTools.Translate("Something went wrong"),
+                    },
+                },
+            },
+        };
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersPageView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersPageView.axaml
@@ -1,0 +1,47 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.ManagersPages.ManagersPageView">
+  <Grid RowDefinitions="Auto,*"
+        RowSpacing="12">
+    <Border Padding="18"
+            Classes="surface-card">
+      <Grid ColumnDefinitions="Auto,*,Auto"
+            ColumnSpacing="14">
+        <Button x:Name="SectionBackButton"
+                Width="36"
+                Height="36"
+                Padding="0"
+                IsVisible="False"
+                Classes="icon-shell"
+                Click="SectionBackButton_OnClick"
+                Content="←" />
+
+        <StackPanel Grid.Column="1"
+                    Spacing="2">
+          <TextBlock x:Name="SectionKickerBlock"
+                     Classes="data-header" />
+          <TextBlock x:Name="SectionTitleBlock"
+                     FontSize="28"
+                     FontWeight="Black"
+                     Classes="hero-title" />
+          <TextBlock x:Name="SectionSubtitleBlock"
+                     MaxWidth="860"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Border Grid.Column="2"
+                Padding="10,4"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Classes="surface-card badge-panel">
+          <TextBlock x:Name="SectionStatusBlock"
+                     Opacity="0.82" />
+        </Border>
+      </Grid>
+    </Border>
+
+    <ContentControl x:Name="SectionContentHost"
+                    Grid.Row="1" />
+  </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersPageView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Managers/ManagersPageView.axaml.cs
@@ -1,0 +1,111 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Views.Pages.ManagersPages;
+
+public partial class ManagersPageView : UserControl, IShellPage
+{
+    private readonly Dictionary<string, ManagerDetailView> _detailCache = [];
+
+    private ManagersHomeView? _homeView;
+    private IPackageManager? _selectedManager;
+
+    private Button BackNavigationButton => GetControl<Button>("SectionBackButton");
+
+    private TextBlock SectionKickerText => GetControl<TextBlock>("SectionKickerBlock");
+
+    private TextBlock SectionTitleText => GetControl<TextBlock>("SectionTitleBlock");
+
+    private TextBlock SectionSubtitleText => GetControl<TextBlock>("SectionSubtitleBlock");
+
+    private TextBlock SectionStatusText => GetControl<TextBlock>("SectionStatusBlock");
+
+    private ContentControl SectionContentPresenter => GetControl<ContentControl>("SectionContentHost");
+
+    public ManagersPageView()
+    {
+        Title = CoreTools.Translate("Package Managers");
+        Subtitle = CoreTools.Translate("Enable and disable package managers, change default install options, etc.");
+        SupportsSearch = false;
+        SearchPlaceholder = string.Empty;
+
+        InitializeComponent();
+        SectionKickerText.Text = CoreTools.Translate("Package Managers");
+        NavigateHome();
+    }
+
+    public string Title { get; }
+
+    public string Subtitle { get; }
+
+    public bool SupportsSearch { get; }
+
+    public string SearchPlaceholder { get; }
+
+    public void UpdateSearchQuery(string query)
+    {
+    }
+
+    private void NavigateHome()
+    {
+        _selectedManager = null;
+
+        if (_homeView is null)
+        {
+            _homeView = new ManagersHomeView();
+            _homeView.NavigationRequested += HomeView_NavigationRequested;
+        }
+
+        SectionContentPresenter.Content = _homeView;
+        ApplySectionChrome(_homeView);
+        BackNavigationButton.IsVisible = false;
+    }
+
+    private void NavigateToManager(IPackageManager manager)
+    {
+        _selectedManager = manager;
+
+        if (!_detailCache.TryGetValue(manager.Name, out var detailView))
+        {
+            detailView = new ManagerDetailView();
+            _detailCache[manager.Name] = detailView;
+        }
+
+        detailView.LoadManager(manager);
+        SectionContentPresenter.Content = detailView;
+        ApplySectionChrome(detailView);
+        BackNavigationButton.IsVisible = true;
+    }
+
+    private void ApplySectionChrome(IManagerSectionView sectionView)
+    {
+        SectionTitleText.Text = sectionView.SectionTitle;
+        SectionSubtitleText.Text = sectionView.SectionSubtitle;
+        SectionStatusText.Text = sectionView.SectionStatus;
+    }
+
+    private void HomeView_NavigationRequested(object? sender, IPackageManager manager)
+    {
+        NavigateToManager(manager);
+    }
+
+    private void SectionBackButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        NavigateHome();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/MissingDependencyDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/MissingDependencyDialog.axaml
@@ -1,0 +1,63 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.MissingDependencyDialog"
+        Width="540"
+        MinWidth="400"
+        MinHeight="220"
+        Title="Missing dependency"
+        SizeToContent="Height"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <StackPanel Margin="24" Spacing="14">
+
+    <!-- Description -->
+    <TextBlock x:Name="DescriptionBlock"
+               TextWrapping="Wrap" />
+
+    <!-- Sub-description -->
+    <TextBlock x:Name="SubDescriptionBlock"
+               TextWrapping="Wrap"
+               Opacity="0.70"
+               FontStyle="Italic" />
+
+    <!-- Manual install command -->
+    <TextBlock x:Name="CommandLabelBlock"
+               TextWrapping="Wrap"
+               Opacity="0.70" />
+
+    <Border Padding="10,8"
+            Classes="surface-card subtle-panel">
+      <TextBlock x:Name="CommandBlock"
+                 TextWrapping="Wrap"
+                 FontFamily="Cascadia Mono,Cascadia Code,Consolas,monospace"
+                 FontSize="12"
+                 IsVisible="False" />
+    </Border>
+
+    <!-- "Don't show again" checkbox -->
+    <CheckBox x:Name="DoNotShowAgainCheckBox"
+              IsVisible="False"
+              Click="DoNotShowAgainCheckBox_OnClick" />
+
+    <!-- Buttons -->
+    <Grid ColumnDefinitions="*,Auto,Auto"
+          ColumnSpacing="8"
+          Margin="0,4,0,0">
+      <Button x:Name="InstallButton"
+              Grid.Column="1"
+              Classes="toolbar-primary accent"
+              MinWidth="130"
+              Click="InstallButton_OnClick" />
+      <Button x:Name="SkipButton"
+              Grid.Column="2"
+              Classes="toolbar-secondary"
+              MinWidth="110"
+              Click="SkipButton_OnClick" />
+    </Grid>
+
+  </StackPanel>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/MissingDependencyDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/MissingDependencyDialog.axaml.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Classes.Manager.Classes;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>
+/// Modal dialog shown once per missing <see cref="ManagerDependency"/>.
+/// Offers an automated install, a "not right now" dismiss, and a persistent
+/// "do not show again" checkbox once the user has already been prompted once.
+/// </summary>
+public partial class MissingDependencyDialog : Window
+{
+    private readonly ManagerDependency _dep;
+    private bool _installing;
+
+    public MissingDependencyDialog()
+    {
+        _dep = default;
+        InitializeComponent();
+        IsEnabled = false;
+    }
+
+    public MissingDependencyDialog(ManagerDependency dep, int current, int total)
+    {
+        _dep = dep;
+        InitializeComponent();
+
+        Title = CoreTools.Translate("Missing dependency")
+            + (total > 1 ? $" ({current}/{total})" : "");
+
+        DescriptionBlock.Text = CoreTools.Translate(
+            "UniGetUI requires {0} to operate, but it was not found on your system.",
+            dep.Name);
+
+        SubDescriptionBlock.Text = CoreTools.Translate(
+            "Click on Install to begin the installation process. If you skip the installation, UniGetUI may not work as expected.");
+
+        if (!string.IsNullOrWhiteSpace(dep.FancyInstallCommand))
+        {
+            CommandLabelBlock.Text = CoreTools.Translate(
+                "Alternatively, you can install {0} by running the following command in a PowerShell prompt:",
+                dep.Name);
+            CommandBlock.Text = dep.FancyInstallCommand;
+            CommandBlock.IsVisible = true;
+        }
+        else
+        {
+            CommandLabelBlock.IsVisible = false;
+        }
+
+        bool notFirstTime =
+            Settings.GetDictionaryItem<string, string>(Settings.K.DependencyManagement, dep.Name)
+            == "attempted";
+        Settings.SetDictionaryItem(Settings.K.DependencyManagement, dep.Name, "attempted");
+
+        if (notFirstTime)
+        {
+            DoNotShowAgainCheckBox.IsVisible = true;
+            DoNotShowAgainCheckBox.Content =
+                CoreTools.Translate("Do not show this dialog again for {0}", dep.Name);
+        }
+
+        InstallButton.Content = CoreTools.Translate("Install {0}", dep.Name);
+        SkipButton.Content = CoreTools.Translate("Not right now");
+    }
+
+    private async void InstallButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_installing) return;
+        _installing = true;
+
+        InstallButton.IsEnabled = false;
+        SkipButton.IsEnabled = false;
+        InstallButton.Content = CoreTools.Translate("Please wait");
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = _dep.InstallFileName,
+                Arguments = _dep.InstallArguments,
+                UseShellExecute = true,
+            };
+            using var proc = Process.Start(psi);
+            if (proc is not null)
+                await proc.WaitForExitAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to start dependency installer for {_dep.Name}: {ex.Message}");
+        }
+
+        Close();
+    }
+
+    private void SkipButton_OnClick(object? sender, RoutedEventArgs e) => Close();
+
+    private void DoNotShowAgainCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Settings.SetDictionaryItem(
+            Settings.K.DependencyManagement,
+            _dep.Name,
+            DoNotShowAgainCheckBox.IsChecked == true ? "skipped" : "attempted");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/OperationFailedWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/OperationFailedWindow.axaml
@@ -1,0 +1,64 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.OperationFailedWindow"
+        Width="680"
+        Height="500"
+        MinWidth="420"
+        MinHeight="300"
+        Title="Operation failed"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <Grid RowDefinitions="Auto,*,Auto"
+        Margin="16"
+        RowSpacing="0">
+
+    <!-- Failure message header -->
+    <TextBlock x:Name="FailureHeaderBlock"
+               Grid.Row="0"
+               TextWrapping="Wrap"
+               Margin="0,0,0,12"
+               FontSize="13" />
+
+    <!-- Color-coded log output -->
+    <Border Grid.Row="1"
+            Classes="surface-card"
+            Padding="0">
+      <ScrollViewer x:Name="LogScrollViewer"
+                    HorizontalScrollBarVisibility="Auto"
+                    VerticalScrollBarVisibility="Auto">
+        <StackPanel x:Name="LogLinesPanel"
+                    Margin="12,10"
+                    Spacing="1" />
+      </ScrollViewer>
+    </Border>
+
+    <!-- Footer: hint text + Close + Retry -->
+    <Grid Grid.Row="2"
+          Margin="0,10,0,0"
+          ColumnDefinitions="*,Auto,Auto"
+          ColumnSpacing="8">
+      <TextBlock x:Name="StatusHintBlock"
+                 Grid.Column="0"
+                 VerticalAlignment="Center"
+                 Opacity="0.65"
+                 FontSize="12"
+                 TextTrimming="CharacterEllipsis" />
+      <Button x:Name="CloseBtn"
+              Grid.Column="1"
+              MinWidth="90"
+              Content="Close"
+              Click="CloseBtn_OnClick" />
+      <Button x:Name="RetryBtn"
+              Grid.Column="2"
+              MinWidth="90"
+              Content="Retry"
+              Classes="accent"
+              Click="RetryBtn_OnClick" />
+    </Grid>
+
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/OperationFailedWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/OperationFailedWindow.axaml.cs
@@ -1,0 +1,193 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Classes.Packages.Classes;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Operations;
+using UniGetUI.PackageEngine.Serializable;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>
+/// Dialog shown when an operation finishes with <see cref="OperationStatus.Failed"/> or
+/// <see cref="OperationStatus.Canceled"/>.  Replays color-coded output and offers
+/// basic retry options derived from the operation's manager capabilities.
+/// </summary>
+public partial class OperationFailedWindow : Window
+{
+    private readonly AbstractOperation _operation;
+
+    private static readonly FontFamily MonoFont =
+        new("Cascadia Mono,Cascadia Code,Consolas,Courier New,monospace");
+
+    public OperationFailedWindow()
+    {
+        _operation = null!;
+        InitializeComponent();
+        IsEnabled = false;
+    }
+
+    public OperationFailedWindow(AbstractOperation operation)
+    {
+        _operation = operation;
+        Title = CoreTools.Translate("{0} failed", operation.Metadata.Title);
+
+        InitializeComponent();
+
+        var failureMsg = operation.Metadata.FailureMessage.Length > 0
+            ? operation.Metadata.FailureMessage
+            : CoreTools.Translate("Failed");
+
+        FailureHeaderBlock.Text = failureMsg + ".\n"
+            + CoreTools.Translate(
+                "Please see the Command-line Output or refer to the Operation History for further information about the issue.");
+
+        StatusHintBlock.Text = CoreTools.Translate("Show the live output");
+
+        foreach (var (text, type) in operation.GetOutput())
+            AddLine(text, type);
+
+        BuildRetryFlyout();
+
+        CloseBtn.Content = CoreTools.Translate("Close");
+        RetryBtn.Content = CoreTools.Translate("Retry");
+    }
+
+    // ── Log rendering ────────────────────────────────────────────────────────
+
+    private void AddLine(string text, AbstractOperation.LineType type)
+    {
+        var tb = new TextBlock
+        {
+            Text = text,
+            TextWrapping = TextWrapping.Wrap,
+            FontFamily = MonoFont,
+            FontSize = 12,
+        };
+
+        switch (type)
+        {
+            case AbstractOperation.LineType.Error:
+                tb.Foreground = new SolidColorBrush(Color.FromRgb(220, 60, 60));
+                break;
+            case AbstractOperation.LineType.VerboseDetails:
+                tb.Opacity = 0.52;
+                break;
+        }
+
+        LogLinesPanel.Children.Add(tb);
+    }
+
+    // ── Retry flyout ─────────────────────────────────────────────────────────
+
+    private void BuildRetryFlyout()
+    {
+        var flyout = new MenuFlyout();
+
+        // Plain retry is always the first option
+        var plainRetry = new MenuItem { Header = CoreTools.Translate("Retry") };
+        plainRetry.Click += (_, _) => { _operation.Retry(AbstractOperation.RetryMode.Retry); Close(); };
+        flyout.Items.Add(plainRetry);
+
+        // --- Basic retry-mode options ---
+        if (_operation is PackageOperation pkgOp)
+        {
+            var caps = pkgOp.Package.Manager.Capabilities;
+
+            if (!pkgOp.Options.RunAsAdministrator && caps.CanRunAsAdmin)
+                AddRetryItem(flyout, CoreTools.Translate("Retry as administrator"), AbstractOperation.RetryMode.Retry_AsAdmin);
+
+            if (!pkgOp.Options.InteractiveInstallation && caps.CanRunInteractively)
+                AddRetryItem(flyout, CoreTools.Translate("Retry interactively"), AbstractOperation.RetryMode.Retry_Interactive);
+
+            if (!pkgOp.Options.SkipHashCheck && caps.CanSkipIntegrityChecks)
+                AddRetryItem(flyout, CoreTools.Translate("Retry skipping integrity checks"), AbstractOperation.RetryMode.Retry_SkipIntegrity);
+        }
+        else if (_operation is SourceOperation srcOp && !srcOp.ForceAsAdministrator)
+        {
+            AddRetryItem(flyout, CoreTools.Translate("Retry as administrator"), AbstractOperation.RetryMode.Retry_AsAdmin);
+        }
+
+        // --- Update-failure-specific actions ---
+        if (_operation is UpdatePackageOperation updateOp)
+        {
+            flyout.Items.Add(new Separator());
+
+            var reinstallItem = new MenuItem { Header = CoreTools.Translate("Reinstall package") };
+            reinstallItem.Click += (_, _) =>
+            {
+                var opts = updateOp.Options.Copy();
+                var op = new InstallPackageOperation(updateOp.Package, opts);
+                AvaloniaOperationRegistry.Add(op);
+                _ = op.MainThread();
+                Close();
+            };
+            flyout.Items.Add(reinstallItem);
+
+            var uninstallReinstallItem = new MenuItem
+            {
+                Header = CoreTools.Translate("Uninstall package, then reinstall it")
+            };
+            uninstallReinstallItem.Click += (_, _) =>
+            {
+                var opts = updateOp.Options.Copy();
+                var reinstallOp = new InstallPackageOperation(updateOp.Package, opts);
+                var uninstallOp = new UninstallPackageOperation(updateOp.Package, new InstallOptions(), req: reinstallOp);
+                AvaloniaOperationRegistry.Add(reinstallOp);
+                AvaloniaOperationRegistry.Add(uninstallOp);
+                _ = uninstallOp.MainThread();
+                Close();
+            };
+            flyout.Items.Add(uninstallReinstallItem);
+
+            flyout.Items.Add(new Separator());
+
+            var skipVersionItem = new MenuItem { Header = CoreTools.Translate("Skip this version") };
+            skipVersionItem.Click += async (_, _) =>
+            {
+                await updateOp.Package.AddToIgnoredUpdatesAsync(updateOp.Package.NewVersionString);
+                Close();
+            };
+            flyout.Items.Add(skipVersionItem);
+
+            var ignoreItem = new MenuItem { Header = CoreTools.Translate("Ignore updates for this package") };
+            ignoreItem.Click += async (_, _) =>
+            {
+                await updateOp.Package.AddToIgnoredUpdatesAsync();
+                Close();
+            };
+            flyout.Items.Add(ignoreItem);
+        }
+
+        // Only attach the flyout (showing "Retry ▾") when there are extra options beyond plain retry
+        if (flyout.Items.Count > 1)
+        {
+            RetryBtn.Flyout = flyout;
+            RetryBtn.Content = CoreTools.Translate("Retry failed operations");
+        }
+    }
+
+    private void AddRetryItem(MenuFlyout flyout, string label, string mode)
+    {
+        if (flyout.Items.Count == 1) // first extra option — add separator after "Retry"
+            flyout.Items.Add(new Separator());
+
+        var item = new MenuItem { Header = label };
+        item.Click += (_, _) => { _operation.Retry(mode); Close(); };
+        flyout.Items.Add(item);
+    }
+
+    // ── Button handlers ──────────────────────────────────────────────────────
+
+    private void CloseBtn_OnClick(object? sender, RoutedEventArgs e) => Close();
+
+    private void RetryBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        // Only invoked when there is no flyout (no extra options).
+        _operation.Retry(AbstractOperation.RetryMode.Retry);
+        Close();
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/OperationLogWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/OperationLogWindow.axaml
@@ -1,0 +1,46 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.OperationLogWindow"
+        Width="680"
+        Height="500"
+        MinWidth="400"
+        MinHeight="260"
+        Title="Operation output"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <Grid RowDefinitions="*,Auto"
+        Margin="12">
+
+    <!-- Log area -->
+    <Border Classes="surface-card"
+            Padding="0">
+      <ScrollViewer x:Name="LogScrollViewer"
+                    HorizontalScrollBarVisibility="Auto"
+                    VerticalScrollBarVisibility="Auto">
+        <StackPanel x:Name="LogLinesPanel"
+                    Margin="12,10"
+                    Spacing="1" />
+      </ScrollViewer>
+    </Border>
+
+    <!-- Footer -->
+    <Grid Grid.Row="1"
+          Margin="0,8,0,0"
+          ColumnDefinitions="*,Auto">
+      <TextBlock x:Name="StatusFooterBlock"
+                 VerticalAlignment="Center"
+                 Opacity="0.65"
+                 FontSize="12"
+                 TextTrimming="CharacterEllipsis" />
+      <Button Grid.Column="1"
+              x:Name="CloseButton"
+              Content="Close"
+              Click="CloseButton_OnClick" />
+    </Grid>
+
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/OperationLogWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/OperationLogWindow.axaml.cs
@@ -1,0 +1,133 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>
+/// Scrollable live-log window for a running or finished <see cref="AbstractOperation"/>.
+/// Replays already-captured output on open and subscribes to <see cref="AbstractOperation.LogLineAdded"/>
+/// for live updates while the window is visible.
+/// </summary>
+public partial class OperationLogWindow : Window
+{
+    private readonly AbstractOperation _operation;
+    private bool _lastLineWasProgress;
+
+    private ScrollViewer LogScroll => GetControl<ScrollViewer>("LogScrollViewer");
+    private StackPanel LogPanel => GetControl<StackPanel>("LogLinesPanel");
+    private TextBlock StatusFooter => GetControl<TextBlock>("StatusFooterBlock");
+
+    // Mono-space font stack used for log output
+    private static readonly FontFamily MonoFont =
+        new("Cascadia Mono,Cascadia Code,Consolas,Courier New,monospace");
+
+    public OperationLogWindow()
+    {
+        _operation = null!;
+        InitializeComponent();
+        IsEnabled = false;
+    }
+
+    public OperationLogWindow(AbstractOperation operation)
+    {
+        _operation = operation;
+        Title = CoreTools.Translate("View {0} logs", operation.Metadata.Title);
+
+        InitializeComponent();
+
+        // Replay lines captured before the window was opened
+        foreach (var (text, type) in operation.GetOutput())
+        {
+            AddLine(text, type);
+        }
+
+        UpdateFooter(operation.Status);
+
+        // Subscribe for live output and status changes
+        operation.LogLineAdded += OnLogLineAdded;
+        operation.StatusChanged += OnStatusChanged;
+
+        GetControl<Button>("CloseButton").Content = CoreTools.Translate("Close");
+
+        Closed += (_, _) =>
+        {
+            operation.LogLineAdded -= OnLogLineAdded;
+            operation.StatusChanged -= OnStatusChanged;
+        };
+    }
+
+    // ── Event handlers ────────────────────────────────────────────────────────
+
+    private void OnLogLineAdded(object? sender, (string, AbstractOperation.LineType) line) =>
+        Dispatcher.UIThread.Post(() => AddLine(line.Item1, line.Item2));
+
+    private void OnStatusChanged(object? sender, OperationStatus status) =>
+        Dispatcher.UIThread.Post(() => UpdateFooter(status));
+
+    private void CloseButton_OnClick(object? sender, RoutedEventArgs e) => Close();
+
+    // ── Log rendering ─────────────────────────────────────────────────────────
+
+    private void AddLine(string text, AbstractOperation.LineType type)
+    {
+        // ProgressIndicator lines replace the previous progress line (spinner-style)
+        if (type == AbstractOperation.LineType.ProgressIndicator)
+        {
+            if (_lastLineWasProgress && LogPanel.Children.Count > 0)
+                LogPanel.Children.RemoveAt(LogPanel.Children.Count - 1);
+            _lastLineWasProgress = true;
+        }
+        else
+        {
+            _lastLineWasProgress = false;
+        }
+
+        var tb = new TextBlock
+        {
+            Text = text,
+            TextWrapping = TextWrapping.Wrap,
+            FontFamily = MonoFont,
+            FontSize = 12,
+        };
+
+        switch (type)
+        {
+            case AbstractOperation.LineType.Error:
+                tb.Foreground = new SolidColorBrush(Color.FromRgb(220, 60, 60));
+                break;
+            case AbstractOperation.LineType.VerboseDetails:
+                tb.Opacity = 0.52;
+                break;
+        }
+
+        LogPanel.Children.Add(tb);
+        LogScroll.ScrollToEnd();
+    }
+
+    private void UpdateFooter(OperationStatus status)
+    {
+        StatusFooter.Text = status switch
+        {
+            OperationStatus.InQueue => CoreTools.Translate("This package is on the queue"),
+            OperationStatus.Running => CoreTools.Translate("Operation in progress"),
+            OperationStatus.Succeeded => CoreTools.Translate("Success!"),
+            OperationStatus.Failed => CoreTools.Translate("Failed"),
+            OperationStatus.Canceled => CoreTools.Translate("Operation cancelled"),
+            _ => string.Empty,
+        };
+    }
+
+    // ── Boilerplate ───────────────────────────────────────────────────────────
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private T GetControl<T>(string name)
+        where T : Control
+        => this.FindControl<T>(name) ?? throw new InvalidOperationException($"Control '{name}' not found");
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/OperationWidgetView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/OperationWidgetView.axaml
@@ -1,0 +1,50 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.OperationWidgetView">
+
+  <Border Margin="0,2"
+          Padding="12,8"
+          CornerRadius="8"
+          Classes="surface-card"
+          ContextRequested="Card_ContextRequested">
+    <Grid ColumnDefinitions="*,Auto,Auto"
+          ColumnSpacing="8">
+
+      <!-- Left: title + status + progress -->
+      <StackPanel Spacing="4">
+        <TextBlock x:Name="TitleBlock"
+                   FontWeight="SemiBold"
+                   TextTrimming="CharacterEllipsis"
+                   Text="Operation" />
+        <TextBlock x:Name="LiveLineBlock"
+                   FontSize="12"
+                   Opacity="0.7"
+                   TextTrimming="CharacterEllipsis"
+                   Text="Please wait…" />
+        <ProgressBar x:Name="ProgressBar"
+                     Height="4"
+                     Minimum="0"
+                     Maximum="100"
+                     Value="0"
+                     IsIndeterminate="False" />
+      </StackPanel>
+
+      <!-- Retry / view-output button (content and click handler change by state) -->
+      <Button x:Name="ViewOutputBtn"
+              Grid.Column="1"
+              Classes="toolbar-secondary"
+              VerticalAlignment="Center"
+              Click="ViewOutputButton_OnClick"
+              Content="View output" />
+
+      <!-- Cancel / Close button -->
+      <Button x:Name="ActionBtn"
+              Grid.Column="2"
+              Classes="toolbar-secondary"
+              VerticalAlignment="Center"
+              Click="ActionButton_OnClick"
+              Content="Cancel" />
+
+    </Grid>
+  </Border>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/OperationWidgetView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/OperationWidgetView.axaml.cs
@@ -1,0 +1,234 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+/// <summary>
+/// Compact card that tracks a single <see cref="AbstractOperation"/> and shows live progress.
+/// The DataContext is set to the AbstractOperation by the ItemsControl DataTemplate.
+/// </summary>
+public partial class OperationWidgetView : UserControl
+{
+    private AbstractOperation? _operation;
+
+    private static readonly IBrush _runningBrush = Brushes.DodgerBlue;
+    private static readonly IBrush _successBrush = Brushes.ForestGreen;
+    private static readonly IBrush _failedBrush = Brushes.Crimson;
+    private static readonly IBrush _cancelBrush = Brushes.DarkGoldenrod;
+    private static readonly IBrush _neutralBrush = Brushes.DimGray;
+
+    public OperationWidgetView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (DataContext is not AbstractOperation op) return;
+
+        if (_operation is not null)
+        {
+            _operation.LogLineAdded -= OnLogLineAdded;
+            _operation.StatusChanged -= OnStatusChanged;
+        }
+
+        _operation = op;
+
+        TitleBlock.Text = op.Metadata.Title.Length > 0
+            ? op.Metadata.Title
+            : CoreTools.Translate("Operation in progress");
+
+        var outputLines = op.GetOutput();
+        LiveLineBlock.Text = outputLines.Count > 0
+            ? outputLines[^1].Item1
+            : CoreTools.Translate("Please wait...");
+
+        ApplyStatus(op.Status);
+
+        op.LogLineAdded += OnLogLineAdded;
+        op.StatusChanged += OnStatusChanged;
+    }
+
+    private void OnLogLineAdded(object? sender, (string text, AbstractOperation.LineType type) line)
+    {
+        if (line.type == AbstractOperation.LineType.ProgressIndicator) return;
+        Dispatcher.UIThread.Post(() => LiveLineBlock.Text = line.text);
+    }
+
+    private void OnStatusChanged(object? sender, OperationStatus status) =>
+        Dispatcher.UIThread.Post(() => ApplyStatus(status));
+
+    private void ApplyStatus(OperationStatus status)
+    {
+        switch (status)
+        {
+            case OperationStatus.InQueue:
+                ProgressBar.IsIndeterminate = false;
+                ProgressBar.Value = 0;
+                SetProgressForeground(_neutralBrush);
+                ActionBtn.Content = CoreTools.Translate("Cancel");
+                ViewOutputBtn.Content = CoreTools.Translate("Show the live output");
+                break;
+
+            case OperationStatus.Running:
+                ProgressBar.IsIndeterminate = true;
+                SetProgressForeground(_runningBrush);
+                ActionBtn.Content = CoreTools.Translate("Cancel");
+                ViewOutputBtn.Content = CoreTools.Translate("Show the live output");
+                break;
+
+            case OperationStatus.Succeeded:
+                ProgressBar.IsIndeterminate = false;
+                ProgressBar.Value = 100;
+                SetProgressForeground(_successBrush);
+                LiveLineBlock.Text = _operation?.Metadata.SuccessMessage.Length > 0
+                    ? _operation.Metadata.SuccessMessage
+                    : CoreTools.Translate("Success!");
+                ActionBtn.Content = CoreTools.Translate("Close");
+                ViewOutputBtn.Content = CoreTools.Translate("Show the live output");
+                if (!Settings.Get(Settings.K.MaintainSuccessfulInstalls))
+                    ScheduleAutoDismiss();
+                break;
+
+            case OperationStatus.Failed:
+                ProgressBar.IsIndeterminate = false;
+                ProgressBar.Value = 100;
+                SetProgressForeground(_failedBrush);
+                LiveLineBlock.Text = _operation?.Metadata.FailureMessage.Length > 0
+                    ? _operation.Metadata.FailureMessage
+                    : CoreTools.Translate("Failed");
+                ActionBtn.Content = CoreTools.Translate("Close");
+                ViewOutputBtn.Content = CoreTools.Translate("Retry failed operations");
+                break;
+
+            case OperationStatus.Canceled:
+                ProgressBar.IsIndeterminate = false;
+                ProgressBar.Value = 100;
+                SetProgressForeground(_cancelBrush);
+                LiveLineBlock.Text = CoreTools.Translate("Operation cancelled");
+                ActionBtn.Content = CoreTools.Translate("Close");
+                ViewOutputBtn.Content = CoreTools.Translate("Retry failed operations");
+                break;
+        }
+    }
+
+    private void SetProgressForeground(IBrush brush) =>
+        ProgressBar.Foreground = brush;
+
+    private void ScheduleAutoDismiss()
+    {
+        var captured = _operation;
+        _ = Task.Delay(TimeSpan.FromSeconds(10)).ContinueWith(_ =>
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (captured?.Status is OperationStatus.Succeeded)
+                    AvaloniaOperationRegistry.Operations.Remove(captured);
+            }),
+            TaskScheduler.Default);
+    }
+
+    private void ActionButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_operation is null) return;
+
+        if (_operation.Status is OperationStatus.InQueue or OperationStatus.Running)
+            _operation.Cancel();
+        else
+            AvaloniaOperationRegistry.Operations.Remove(_operation);
+    }
+
+    private async void ViewOutputButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_operation is null) return;
+
+        if (_operation.Status is OperationStatus.Failed or OperationStatus.Canceled)
+        {
+            // Build a retry flyout context menu
+            var menu = new ContextMenu();
+
+            var retryItem = new MenuItem { Header = CoreTools.Translate("Retry") };
+            retryItem.Click += (_, _) => _operation.Retry(AbstractOperation.RetryMode.Retry);
+            menu.Items.Add(retryItem);
+
+            var adminItem = new MenuItem { Header = CoreTools.Translate("Retry as administrator") };
+            adminItem.Click += (_, _) => _operation.Retry(AbstractOperation.RetryMode.Retry_AsAdmin);
+            menu.Items.Add(adminItem);
+
+            var interactiveItem = new MenuItem { Header = CoreTools.Translate("Interactive operation") };
+            interactiveItem.Click += (_, _) => _operation.Retry(AbstractOperation.RetryMode.Retry_Interactive);
+            menu.Items.Add(interactiveItem);
+
+            var skipHashItem = new MenuItem { Header = CoreTools.Translate("Retry skipping integrity checks") };
+            skipHashItem.Click += (_, _) => _operation.Retry(AbstractOperation.RetryMode.Retry_SkipIntegrity);
+            menu.Items.Add(skipHashItem);
+
+            menu.Items.Add(new Separator());
+
+            var viewOutputItem = new MenuItem { Header = CoreTools.Translate("Show the live output") };
+            viewOutputItem.Click += async (_, _) =>
+            {
+                var win = new OperationLogWindow(_operation);
+                if (VisualRoot is Window p) await win.ShowDialog(p); else win.Show();
+            };
+            menu.Items.Add(viewOutputItem);
+
+            if (sender is Control anchor)
+            {
+                menu.PlacementTarget = anchor;
+                menu.Placement = PlacementMode.Bottom;
+                menu.Open(anchor);
+            }
+            return;
+        }
+
+        Window window = new OperationLogWindow(_operation);
+
+        if (VisualRoot is Window parent)
+            await window.ShowDialog(parent);
+        else
+            window.Show();
+    }
+
+    private void Card_ContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        if (_operation is null || _operation.Status != OperationStatus.InQueue) return;
+
+        var menu = new ContextMenu();
+
+        var runNowItem = new MenuItem { Header = CoreTools.Translate("Run now") };
+        runNowItem.Click += (_, _) => _operation.SkipQueue();
+        menu.Items.Add(runNowItem);
+
+        var runNextItem = new MenuItem { Header = CoreTools.Translate("Run next") };
+        runNextItem.Click += (_, _) => _operation.RunNext();
+        menu.Items.Add(runNextItem);
+
+        var runLastItem = new MenuItem { Header = CoreTools.Translate("Run last") };
+        runLastItem.Click += (_, _) => _operation.BackOfTheQueue();
+        menu.Items.Add(runLastItem);
+
+        menu.Items.Add(new Separator());
+
+        var cancelItem = new MenuItem { Header = CoreTools.Translate("Cancel") };
+        cancelItem.Click += (_, _) => _operation.Cancel();
+        menu.Items.Add(cancelItem);
+
+        if (sender is Control ctrl)
+        {
+            menu.PlacementTarget = ctrl;
+            menu.Placement = PlacementMode.Pointer;
+            menu.Open(ctrl);
+        }
+        e.Handled = true;
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/PackageDetailsWindow.axaml
@@ -1,0 +1,421 @@
+<Window xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:pages="clr-namespace:UniGetUI.Avalonia.Views.Pages"
+        x:Class="UniGetUI.Avalonia.Views.Pages.PackageDetailsWindow"
+        Width="680"
+        Height="720"
+        MinWidth="480"
+        MinHeight="400"
+        Title="Package Details"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <!-- Two-column responsive root: column 1 is the screenshots side panel (shown at ≥950 px) -->
+  <Grid x:Name="RootLayoutGrid"
+        ColumnDefinitions="*,0"
+        ColumnSpacing="0"
+        Margin="18">
+
+    <!-- LEFT / primary column -->
+    <ScrollViewer>
+      <StackPanel x:Name="PrimaryContent" Spacing="12">
+
+        <!-- Header -->
+        <Border Padding="18"
+                Classes="surface-card subtle-panel">
+          <StackPanel Spacing="6">
+            <StackPanel Orientation="Horizontal"
+                        Spacing="12">
+              <Border Width="42"
+                      Height="42"
+                      Classes="surface-card"
+                      CornerRadius="12">
+                <Panel>
+                  <TextBlock x:Name="PackageIconGlyphBlock"
+                             HorizontalAlignment="Center"
+                             VerticalAlignment="Center"
+                             FontSize="18"
+                             Text="📦" />
+                  <Image x:Name="PackageIconImage"
+                         Width="30"
+                         Height="30"
+                         IsVisible="False"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         Stretch="Uniform" />
+                </Panel>
+              </Border>
+              <StackPanel Spacing="2">
+                <TextBlock x:Name="PackageNameBlock"
+                           FontSize="22"
+                           FontWeight="Bold" />
+                <TextBlock x:Name="PackageIdBlock"
+                           Opacity="0.70" />
+              </StackPanel>
+            </StackPanel>
+            <Grid ColumnDefinitions="Auto,*,Auto,*"
+                  ColumnSpacing="6"
+                  Margin="0,6,0,0">
+              <TextBlock x:Name="PackageVersionLabelBlock"
+                         Text="Version:"
+                         Opacity="0.60"
+                         VerticalAlignment="Center" />
+              <TextBlock x:Name="PackageVersionBlock"
+                         Grid.Column="1"
+                         FontWeight="SemiBold"
+                         VerticalAlignment="Center" />
+              <TextBlock x:Name="PackageManagerLabelBlock"
+                         Text="Manager:"
+                         Grid.Column="2"
+                         Opacity="0.60"
+                         VerticalAlignment="Center" />
+              <TextBlock x:Name="PackageManagerBlock"
+                         Grid.Column="3"
+                         FontWeight="SemiBold"
+                         VerticalAlignment="Center" />
+            </Grid>
+          </StackPanel>
+        </Border>
+
+      <!-- Loading indicator -->
+      <Border x:Name="LoadingCard"
+              Padding="16"
+              Classes="surface-card">
+        <StackPanel Spacing="8">
+          <ProgressBar IsIndeterminate="True" />
+          <TextBlock x:Name="LoadingStateBlock"
+                     HorizontalAlignment="Center"
+                     Opacity="0.70" />
+        </StackPanel>
+      </Border>
+
+      <Border x:Name="ScreenshotsCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <StackPanel Spacing="10">
+          <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                ColumnSpacing="8">
+            <TextBlock x:Name="ScreenshotsTitleBlock"
+                       VerticalAlignment="Center"
+                       FontSize="16"
+                       FontWeight="SemiBold" />
+            <TextBlock x:Name="ScreenshotsPipsBlock"
+                       Grid.Column="2"
+                       VerticalAlignment="Center"
+                       Opacity="0.68" />
+            <ProgressBar x:Name="ScreenshotsLoadingBar"
+                         Grid.Column="3"
+                         Width="18"
+                         Height="18"
+                         IsIndeterminate="True"
+                         IsVisible="False" />
+          </Grid>
+
+          <Border x:Name="ScreenshotsImageCard"
+                  Padding="12"
+                  Classes="surface-card subtle-panel"
+                  IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto"
+                  ColumnSpacing="12">
+              <Button x:Name="PreviousScreenshotButton"
+                      VerticalAlignment="Center"
+                      Classes="toolbar-secondary"
+                      Content="◀"
+                      Click="PreviousScreenshotButton_OnClick" />
+              <Image x:Name="ScreenshotImage"
+                     Grid.Column="1"
+                     Height="240"
+                     Stretch="Uniform" />
+              <Button x:Name="NextScreenshotButton"
+                      Grid.Column="2"
+                      VerticalAlignment="Center"
+                      Classes="toolbar-secondary"
+                      Content="▶"
+                      Click="NextScreenshotButton_OnClick" />
+            </Grid>
+          </Border>
+
+          <Border x:Name="ScreenshotsBannerCard"
+                  Padding="12"
+                  Classes="surface-card subtle-panel">
+            <Grid ColumnDefinitions="*,Auto"
+                  ColumnSpacing="12">
+              <TextBlock x:Name="ScreenshotsBannerTextBlock"
+                         VerticalAlignment="Center"
+                         TextWrapping="Wrap" />
+              <Button x:Name="ContributeScreenshotsButton"
+                      Grid.Column="1"
+                      Classes="toolbar-secondary"
+                      VerticalAlignment="Center"
+                      Click="ContributeScreenshotsButton_OnClick" />
+            </Grid>
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <!-- Description -->
+      <Border x:Name="TagsCard"
+          Padding="18"
+          Classes="surface-card subtle-panel"
+          IsVisible="False">
+        <WrapPanel x:Name="TagsPanel" />
+      </Border>
+
+      <Border x:Name="DescriptionCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="DescriptionTitleBlock"
+                     FontSize="16"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="DescriptionBlock"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Package info -->
+      <Border x:Name="InfoCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="InfoTitleBlock"
+                     FontSize="16"
+                     FontWeight="SemiBold" />
+
+          <Grid x:Name="AuthorRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="AuthorLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="AuthorValueBlock"
+                       Grid.Column="1"
+                       TextWrapping="Wrap" />
+          </Grid>
+
+          <Grid x:Name="PublisherRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="PublisherLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="PublisherValueBlock"
+                       Grid.Column="1"
+                       TextWrapping="Wrap" />
+          </Grid>
+
+          <Grid x:Name="LicenseRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="LicenseLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="LicenseValueBlock"
+                       Grid.Column="1"
+                       TextWrapping="Wrap" />
+          </Grid>
+
+          <Grid x:Name="UpdateDateRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="UpdateDateLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="UpdateDateValueBlock"
+                       Grid.Column="1"
+                       TextWrapping="Wrap" />
+          </Grid>
+
+          <Grid x:Name="InstallerTypeRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="InstallerTypeLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="InstallerTypeValueBlock"
+                       Grid.Column="1"
+                       TextWrapping="Wrap" />
+          </Grid>
+        </StackPanel>
+      </Border>
+
+      <!-- Installer details (hash, URL, size, download) -->
+      <Border x:Name="InstallerCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="InstallerTitleBlock"
+                     FontSize="16"
+                     FontWeight="SemiBold" />
+          <Grid x:Name="InstallerHashRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="InstallerHashLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="InstallerHashValueBlock"
+                       Grid.Column="1"
+                       TextWrapping="Wrap"
+                       FontFamily="Cascadia Mono,Cascadia Code,Consolas,monospace"
+                       FontSize="11" />
+          </Grid>
+          <Grid x:Name="InstallerUrlRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="InstallerUrlLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="InstallerUrlValueBlock"
+                       Grid.Column="1"
+                       TextWrapping="Wrap"
+                       TextTrimming="CharacterEllipsis" />
+          </Grid>
+          <Grid x:Name="InstallerSizeRow"
+                ColumnDefinitions="160,*"
+                IsVisible="False">
+            <TextBlock x:Name="InstallerSizeLabelBlock"
+                       Opacity="0.68" />
+            <TextBlock x:Name="InstallerSizeValueBlock"
+                       Grid.Column="1" />
+          </Grid>
+          <Button x:Name="DownloadInstallerButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  IsVisible="False"
+                  Click="DownloadInstallerButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Dependencies -->
+      <Border x:Name="DependenciesCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="DependenciesTitleBlock"
+                     FontSize="16"
+                     FontWeight="SemiBold" />
+          <StackPanel x:Name="DependenciesPanel"
+                      Spacing="4" />
+        </StackPanel>
+      </Border>
+
+      <!-- Homepage & release notes links -->
+      <Border x:Name="LinksCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="LinksTitleBlock"
+                     FontSize="16"
+                     FontWeight="SemiBold" />
+
+          <Button x:Name="HomepageButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  IsVisible="False"
+                  Click="HomepageButton_OnClick" />
+
+          <Button x:Name="ReleaseNotesUrlButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  IsVisible="False"
+                  Click="ReleaseNotesUrlButton_OnClick" />
+
+          <Button x:Name="ManifestUrlButton"
+                  Classes="toolbar-secondary"
+                  HorizontalAlignment="Left"
+                  IsVisible="False"
+                  Click="ManifestUrlButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Release notes text -->
+      <Border x:Name="ReleaseNotesCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="ReleaseNotesTitleBlock"
+                     FontSize="16"
+                     FontWeight="SemiBold" />
+          <Border Padding="12"
+                  Classes="surface-card subtle-panel"
+                  CornerRadius="10">
+            <TextBlock x:Name="ReleaseNotesBlock"
+                       Opacity="0.82"
+                       TextWrapping="Wrap" />
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <Border x:Name="InstallOptionsCard"
+              Padding="18"
+              Classes="surface-card"
+              IsVisible="False">
+        <Expander x:Name="InstallOptionsExpander"
+                  HorizontalAlignment="Stretch"
+                  HorizontalContentAlignment="Stretch">
+          <Expander.Header>
+            <Grid ColumnDefinitions="*,Auto"
+                  ColumnSpacing="12">
+              <TextBlock x:Name="InstallOptionsTitleBlock"
+                         VerticalAlignment="Center"
+                         FontSize="16"
+                         FontWeight="SemiBold" />
+              <Button x:Name="SaveInstallOptionsButton"
+                      Grid.Column="1"
+                      MinWidth="60"
+                      Height="34"
+                      Classes="toolbar-primary accent"
+                      Click="SaveInstallOptionsButton_OnClick" />
+            </Grid>
+          </Expander.Header>
+          <Border Padding="0,12,0,0">
+            <ContentControl x:Name="InstallOptionsHost" />
+          </Border>
+        </Expander>
+      </Border>
+
+      <!-- Bottom actions -->
+            <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto"
+            ColumnSpacing="4">
+        <Button x:Name="ShareButton"
+          Grid.Column="0"
+          Classes="toolbar-secondary"
+          Click="ShareButton_OnClick" />
+        <Button x:Name="ActionButton"
+          Grid.Column="2"
+                Classes="toolbar-primary accent"
+                IsVisible="False"
+                Click="ActionButton_OnClick" />
+        <Button x:Name="ActionDropdownButton"
+          Grid.Column="3"
+                Classes="toolbar-primary accent"
+                Content="▾"
+                Padding="6,4"
+                IsVisible="False" />
+        <Button x:Name="CloseButton"
+          Grid.Column="4"
+                Margin="8,0,0,0"
+                HorizontalAlignment="Right"
+                Classes="toolbar-secondary"
+                Click="CloseButton_OnClick" />
+      </Grid>
+
+    </StackPanel>
+  </ScrollViewer>
+
+  <!-- RIGHT column: side screenshots panel (activated at ≥950 px) -->
+  <ScrollViewer x:Name="SidePanelScrollViewer"
+                Grid.Column="1"
+                HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto">
+    <StackPanel x:Name="SidePanelContent"
+                Spacing="12"
+                Margin="0,0,0,18" />
+  </ScrollViewer>
+
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/PackageDetailsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/PackageDetailsWindow.axaml.cs
@@ -1,0 +1,1069 @@
+using System.Diagnostics;
+using System.Net.Http;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Operations;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class PackageDetailsWindow : Window
+{
+    private const string ScreenshotsInfoUrl = "https://marticliment.com/unigetui/help/icons-and-screenshots/#about-icons";
+
+    private readonly IPackage _package;
+    private readonly PackagePageMode _pageMode;
+    private readonly InstallOptionsEditorView? _installOptionsEditorView;
+    private Uri? _homepageUrl;
+    private Uri? _releaseNotesUrl;
+    private Uri? _manifestUrl;
+    private IReadOnlyList<Uri> _screenshotUris = [];
+    private int _selectedScreenshotIndex;
+    private bool _isTwoColumnLayout;
+
+    private TextBlock PackageVersionLabelText => GetControl<TextBlock>("PackageVersionLabelBlock");
+    private TextBlock PackageManagerLabelText => GetControl<TextBlock>("PackageManagerLabelBlock");
+    private TextBlock PackageNameText => GetControl<TextBlock>("PackageNameBlock");
+    private TextBlock PackageIdText => GetControl<TextBlock>("PackageIdBlock");
+    private TextBlock PackageVersionText => GetControl<TextBlock>("PackageVersionBlock");
+    private TextBlock PackageManagerText => GetControl<TextBlock>("PackageManagerBlock");
+    private Border LoadingCardControl => GetControl<Border>("LoadingCard");
+    private TextBlock LoadingStateText => GetControl<TextBlock>("LoadingStateBlock");
+    private Border ScreenshotsCardControl => GetControl<Border>("ScreenshotsCard");
+    private TextBlock ScreenshotsTitleText => GetControl<TextBlock>("ScreenshotsTitleBlock");
+    private TextBlock ScreenshotsPipsText => GetControl<TextBlock>("ScreenshotsPipsBlock");
+    private ProgressBar ScreenshotsLoadingBarControl => GetControl<ProgressBar>("ScreenshotsLoadingBar");
+    private Border ScreenshotsImageCardControl => GetControl<Border>("ScreenshotsImageCard");
+    private Image ScreenshotImageControl => GetControl<Image>("ScreenshotImage");
+    private Button PreviousScreenshotButtonControl => GetControl<Button>("PreviousScreenshotButton");
+    private Button NextScreenshotButtonControl => GetControl<Button>("NextScreenshotButton");
+    private Border ScreenshotsBannerCardControl => GetControl<Border>("ScreenshotsBannerCard");
+    private TextBlock ScreenshotsBannerText => GetControl<TextBlock>("ScreenshotsBannerTextBlock");
+    private Button ContributeScreenshotsButtonControl => GetControl<Button>("ContributeScreenshotsButton");
+    private Border TagsCardControl => GetControl<Border>("TagsCard");
+    private WrapPanel TagsPanelControl => GetControl<WrapPanel>("TagsPanel");
+    private Border DescriptionCardControl => GetControl<Border>("DescriptionCard");
+    private TextBlock DescriptionTitleText => GetControl<TextBlock>("DescriptionTitleBlock");
+    private TextBlock DescriptionText => GetControl<TextBlock>("DescriptionBlock");
+    private Border InfoCardControl => GetControl<Border>("InfoCard");
+    private TextBlock InfoTitleText => GetControl<TextBlock>("InfoTitleBlock");
+    private Grid AuthorRowControl => GetControl<Grid>("AuthorRow");
+    private TextBlock AuthorLabelText => GetControl<TextBlock>("AuthorLabelBlock");
+    private TextBlock AuthorValueText => GetControl<TextBlock>("AuthorValueBlock");
+    private Grid PublisherRowControl => GetControl<Grid>("PublisherRow");
+    private TextBlock PublisherLabelText => GetControl<TextBlock>("PublisherLabelBlock");
+    private TextBlock PublisherValueText => GetControl<TextBlock>("PublisherValueBlock");
+    private Grid LicenseRowControl => GetControl<Grid>("LicenseRow");
+    private TextBlock LicenseLabelText => GetControl<TextBlock>("LicenseLabelBlock");
+    private TextBlock LicenseValueText => GetControl<TextBlock>("LicenseValueBlock");
+    private Grid UpdateDateRowControl => GetControl<Grid>("UpdateDateRow");
+    private TextBlock UpdateDateLabelText => GetControl<TextBlock>("UpdateDateLabelBlock");
+    private TextBlock UpdateDateValueText => GetControl<TextBlock>("UpdateDateValueBlock");
+    private Grid InstallerTypeRowControl => GetControl<Grid>("InstallerTypeRow");
+    private TextBlock InstallerTypeLabelText => GetControl<TextBlock>("InstallerTypeLabelBlock");
+    private TextBlock InstallerTypeValueText => GetControl<TextBlock>("InstallerTypeValueBlock");
+    private Border LinksCardControl => GetControl<Border>("LinksCard");
+    private TextBlock LinksTitleText => GetControl<TextBlock>("LinksTitleBlock");
+    private Button HomepageButtonControl => GetControl<Button>("HomepageButton");
+    private Button ReleaseNotesUrlButtonControl => GetControl<Button>("ReleaseNotesUrlButton");
+    private Button ManifestUrlButtonControl => GetControl<Button>("ManifestUrlButton");
+    private Border ReleaseNotesCardControl => GetControl<Border>("ReleaseNotesCard");
+    private TextBlock ReleaseNotesTitleText => GetControl<TextBlock>("ReleaseNotesTitleBlock");
+    private TextBlock ReleaseNotesText => GetControl<TextBlock>("ReleaseNotesBlock");
+    private Border InstallOptionsCardControl => GetControl<Border>("InstallOptionsCard");
+    private Expander InstallOptionsExpanderControl => GetControl<Expander>("InstallOptionsExpander");
+    private TextBlock InstallOptionsTitleText => GetControl<TextBlock>("InstallOptionsTitleBlock");
+    private ContentControl InstallOptionsHostControl => GetControl<ContentControl>("InstallOptionsHost");
+    private Button SaveInstallOptionsButtonControl => GetControl<Button>("SaveInstallOptionsButton");
+    private Button ShareButtonControl => GetControl<Button>("ShareButton");
+    private Button CloseButtonControl => GetControl<Button>("CloseButton");
+    private Button ActionButtonControl => GetControl<Button>("ActionButton");
+    private Button ActionDropdownButtonControl => GetControl<Button>("ActionDropdownButton");
+    private Image PackageIconImageControl => GetControl<Image>("PackageIconImage");
+    private TextBlock PackageIconGlyphControl => GetControl<TextBlock>("PackageIconGlyphBlock");
+    private Border InstallerCardControl => GetControl<Border>("InstallerCard");
+    private TextBlock InstallerTitleText => GetControl<TextBlock>("InstallerTitleBlock");
+    private Grid InstallerHashRowControl => GetControl<Grid>("InstallerHashRow");
+    private TextBlock InstallerHashLabelText => GetControl<TextBlock>("InstallerHashLabelBlock");
+    private TextBlock InstallerHashValueText => GetControl<TextBlock>("InstallerHashValueBlock");
+    private Grid InstallerUrlRowControl => GetControl<Grid>("InstallerUrlRow");
+    private TextBlock InstallerUrlLabelText => GetControl<TextBlock>("InstallerUrlLabelBlock");
+    private TextBlock InstallerUrlValueText => GetControl<TextBlock>("InstallerUrlValueBlock");
+    private Grid InstallerSizeRowControl => GetControl<Grid>("InstallerSizeRow");
+    private TextBlock InstallerSizeLabelText => GetControl<TextBlock>("InstallerSizeLabelBlock");
+    private TextBlock InstallerSizeValueText => GetControl<TextBlock>("InstallerSizeValueBlock");
+    private Button DownloadInstallerButtonControl => GetControl<Button>("DownloadInstallerButton");
+    private Border DependenciesCardControl => GetControl<Border>("DependenciesCard");
+    private TextBlock DependenciesTitleText => GetControl<TextBlock>("DependenciesTitleBlock");
+    private StackPanel DependenciesPanelControl => GetControl<StackPanel>("DependenciesPanel");
+    private Grid RootLayoutGridControl => GetControl<Grid>("RootLayoutGrid");
+    private StackPanel PrimaryContentControl => GetControl<StackPanel>("PrimaryContent");
+    private StackPanel SidePanelContentControl => GetControl<StackPanel>("SidePanelContent");
+
+    public PackageDetailsWindow()
+    {
+        _package = null!;
+        _pageMode = PackagePageMode.None;
+        InitializeComponent();
+        IsEnabled = false;
+    }
+
+    public PackageDetailsWindow(IPackage package, PackagePageMode pageMode)
+    {
+        _package = package;
+        _pageMode = pageMode;
+        if (pageMode != PackagePageMode.None)
+        {
+            _installOptionsEditorView = new InstallOptionsEditorView(package);
+        }
+        InitializeComponent();
+        Opened += (_, _) => UpdateColumnsLayout(Bounds.Width);
+        ApplyStaticContent(package);
+        _ = LoadDetailsAsync();
+    }
+
+    protected override void OnSizeChanged(SizeChangedEventArgs e)
+    {
+        base.OnSizeChanged(e);
+        UpdateColumnsLayout(e.NewSize.Width);
+    }
+
+    private void UpdateColumnsLayout(double width)
+    {
+        bool wantTwoColumn = width >= 950;
+        if (wantTwoColumn == _isTwoColumnLayout) return;
+        _isTwoColumnLayout = wantTwoColumn;
+
+        var rootGrid = RootLayoutGridControl;
+        var primaryContent = PrimaryContentControl;
+        var sideContent = SidePanelContentControl;
+        var screenshotsCard = ScreenshotsCardControl;
+
+        if (wantTwoColumn)
+        {
+            rootGrid.ColumnDefinitions[1].Width = new GridLength(380, GridUnitType.Pixel);
+            rootGrid.ColumnSpacing = 12;
+            if (primaryContent.Children.Contains(screenshotsCard))
+            {
+                primaryContent.Children.Remove(screenshotsCard);
+                sideContent.Children.Insert(0, screenshotsCard);
+            }
+        }
+        else
+        {
+            rootGrid.ColumnDefinitions[1].Width = new GridLength(0, GridUnitType.Pixel);
+            rootGrid.ColumnSpacing = 0;
+            if (sideContent.Children.Contains(screenshotsCard))
+            {
+                sideContent.Children.Remove(screenshotsCard);
+                // Insert after header (index 0) — LoadingCard moves to index 1
+                primaryContent.Children.Insert(Math.Min(1, primaryContent.Children.Count), screenshotsCard);
+            }
+        }
+    }
+
+    private void ApplyStaticContent(IPackage package)
+    {
+        Title = package.Name + " — " + CoreTools.Translate("Package details");
+
+        PackageNameText.Text = package.Name;
+        PackageIdText.Text = package.Id;
+        PackageVersionText.Text = string.IsNullOrWhiteSpace(package.VersionString)
+            ? CoreTools.Translate("Unknown")
+            : package.VersionString;
+        PackageManagerText.Text = package.Source.AsString_DisplayName;
+
+        PackageVersionLabelText.Text = CoreTools.Translate("Version:");
+        PackageManagerLabelText.Text = CoreTools.Translate("Package manager");
+
+        if (_pageMode != PackagePageMode.None)
+        {
+            ActionButtonControl.Content = _pageMode switch
+            {
+                PackagePageMode.Discover => CoreTools.Translate("Install"),
+                PackagePageMode.Updates => CoreTools.Translate("Update"),
+                PackagePageMode.Installed => CoreTools.Translate("Uninstall"),
+                _ => string.Empty,
+            };
+            ActionButtonControl.IsVisible = true;
+            // ActionDropdownButton visibility is set by BuildActionFlyout() after capability check
+        }
+
+        LoadingStateText.Text = CoreTools.Translate("Loading...");
+        ShareButtonControl.Content = CoreTools.Translate("Share this package");
+        CloseButtonControl.Content = CoreTools.Translate("Close");
+
+        DescriptionTitleText.Text = CoreTools.Translate("Description:");
+        ScreenshotsTitleText.Text = CoreTools.Translate("Package details");
+        ScreenshotsBannerText.Text = CoreTools.Translate("The icons and screenshots are maintained by users like you!");
+        ContributeScreenshotsButtonControl.Content = CoreTools.Translate("Become a contributor");
+        InfoTitleText.Text = CoreTools.Translate("Package details");
+        LinksTitleText.Text = CoreTools.Translate("Useful links");
+        ReleaseNotesTitleText.Text = CoreTools.Translate("Release notes");
+        InstallOptionsTitleText.Text = CoreTools.Translate("Installation options");
+        SaveInstallOptionsButtonControl.Content = CoreTools.Translate("Save");
+        SaveInstallOptionsButtonControl.IsEnabled = false;
+
+        AuthorLabelText.Text = CoreTools.Translate("Author");
+        PublisherLabelText.Text = CoreTools.Translate("Publisher");
+        LicenseLabelText.Text = CoreTools.Translate("License");
+        UpdateDateLabelText.Text = CoreTools.Translate("Last updated:");
+        InstallerTypeLabelText.Text = CoreTools.Translate("Installer Type");
+
+        HomepageButtonControl.Content = CoreTools.Translate("Homepage");
+        ReleaseNotesUrlButtonControl.Content = CoreTools.Translate("Release notes URL");
+        ManifestUrlButtonControl.Content = CoreTools.Translate("Manifest");
+
+        // Installer card
+        InstallerTitleText.Text = CoreTools.Translate("Installer Type");
+        InstallerHashLabelText.Text = CoreTools.Translate("Skip hash check");
+        InstallerUrlLabelText.Text = CoreTools.Translate("Installer URL");
+        InstallerSizeLabelText.Text = CoreTools.Translate("Size");
+        DownloadInstallerButtonControl.Content = CoreTools.Translate("Download installer");
+        if (_package.Manager.Capabilities.CanDownloadInstaller)
+            DownloadInstallerButtonControl.IsVisible = true;
+
+        // Dependencies card
+        DependenciesTitleText.Text = CoreTools.Translate("Dependencies:");
+
+        if (_installOptionsEditorView is not null)
+        {
+            InstallOptionsHostControl.Content = _installOptionsEditorView;
+            InstallOptionsCardControl.IsVisible = true;
+            InstallOptionsExpanderControl.IsExpanded = false;
+            InstallOptionsExpanderControl.Expanded += InstallOptionsExpander_OnExpandedChanged;
+            InstallOptionsExpanderControl.Collapsed += InstallOptionsExpander_OnExpandedChanged;
+        }
+
+        // Action dropdown flyout
+        BuildActionFlyout();
+    }
+
+    private async Task LoadDetailsAsync()
+    {
+        try
+        {
+            var details = _package.Details;
+            if (!details.IsPopulated)
+            {
+                await details.Load();
+            }
+
+            Dispatcher.UIThread.Post(() => PopulateDetails(details));
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+            Dispatcher.UIThread.Post(() =>
+            {
+                LoadingCardControl.IsVisible = true;
+                LoadingStateText.Text = CoreTools.Translate("An interal error occurred. Please view the log for further details.");
+            });
+        }
+
+        _ = LoadIconAsync();
+        _ = LoadScreenshotsAsync();
+    }
+
+    private void PopulateDetails(IPackageDetails details)
+    {
+        LoadingCardControl.IsVisible = false;
+
+        var visibleTags = details.Tags
+            .Where(static tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(static tag => tag.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (visibleTags.Length > 0)
+        {
+            TagsPanelControl.Children.Clear();
+            foreach (var tag in visibleTags)
+            {
+                TagsPanelControl.Children.Add(new Border
+                {
+                    Background = new SolidColorBrush(Color.Parse("#1F6A92B8")),
+                    BorderBrush = new SolidColorBrush(Color.Parse("#4F6A92B8")),
+                    BorderThickness = new Thickness(1),
+                    CornerRadius = new CornerRadius(999),
+                    Margin = new Thickness(0, 0, 8, 8),
+                    Padding = new Thickness(10, 4),
+                    Child = new TextBlock
+                    {
+                        Text = tag,
+                        FontSize = 12,
+                        FontWeight = FontWeight.SemiBold,
+                    },
+                });
+            }
+
+            TagsCardControl.IsVisible = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(details.Description))
+        {
+            DescriptionText.Text = details.Description;
+            DescriptionCardControl.IsVisible = true;
+        }
+
+        bool anyInfoRow = false;
+
+        if (!string.IsNullOrWhiteSpace(details.Author))
+        {
+            AuthorValueText.Text = details.Author;
+            AuthorRowControl.IsVisible = true;
+            anyInfoRow = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(details.Publisher))
+        {
+            PublisherValueText.Text = details.Publisher;
+            PublisherRowControl.IsVisible = true;
+            anyInfoRow = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(details.License))
+        {
+            LicenseValueText.Text = details.LicenseUrl is not null
+                ? $"{details.License} ({details.LicenseUrl})"
+                : details.License;
+            LicenseRowControl.IsVisible = true;
+            anyInfoRow = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(details.UpdateDate))
+        {
+            UpdateDateValueText.Text = details.UpdateDate;
+            UpdateDateRowControl.IsVisible = true;
+            anyInfoRow = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(details.InstallerType))
+        {
+            InstallerTypeValueText.Text = details.InstallerType;
+            InstallerTypeRowControl.IsVisible = true;
+            anyInfoRow = true;
+        }
+
+        if (anyInfoRow)
+        {
+            InfoCardControl.IsVisible = true;
+        }
+
+        bool anyLink = false;
+
+        if (details.HomepageUrl is not null)
+        {
+            _homepageUrl = details.HomepageUrl;
+            HomepageButtonControl.IsVisible = true;
+            anyLink = true;
+        }
+
+        if (details.ReleaseNotesUrl is not null)
+        {
+            _releaseNotesUrl = details.ReleaseNotesUrl;
+            ReleaseNotesUrlButtonControl.IsVisible = true;
+            anyLink = true;
+        }
+
+        if (details.ManifestUrl is not null)
+        {
+            _manifestUrl = details.ManifestUrl;
+            ManifestUrlButtonControl.IsVisible = true;
+            anyLink = true;
+        }
+
+        if (anyLink)
+        {
+            LinksCardControl.IsVisible = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(details.ReleaseNotes))
+        {
+            ReleaseNotesText.Text = details.ReleaseNotes;
+            ReleaseNotesCardControl.IsVisible = true;
+        }
+
+        // Installer card
+        bool anyInstallerRow = false;
+
+        if (!string.IsNullOrWhiteSpace(details.InstallerHash))
+        {
+            InstallerHashValueText.Text = details.InstallerHash;
+            InstallerHashRowControl.IsVisible = true;
+            anyInstallerRow = true;
+        }
+
+        if (details.InstallerUrl is not null)
+        {
+            InstallerUrlValueText.Text = details.InstallerUrl.ToString();
+            InstallerUrlRowControl.IsVisible = true;
+            anyInstallerRow = true;
+        }
+
+        if (details.InstallerSize > 0)
+        {
+            InstallerSizeValueText.Text = CoreTools.FormatAsSize(details.InstallerSize);
+            InstallerSizeRowControl.IsVisible = true;
+            anyInstallerRow = true;
+        }
+
+        if (anyInstallerRow || _package.Manager.Capabilities.CanDownloadInstaller)
+            InstallerCardControl.IsVisible = true;
+
+        // Dependencies
+        if (details.Dependencies.Count > 0)
+        {
+            foreach (var dep in details.Dependencies)
+            {
+                string label = dep.Name;
+                if (!string.IsNullOrWhiteSpace(dep.Version))
+                    label += " " + dep.Version;
+
+                DependenciesPanelControl.Children.Add(new TextBlock
+                {
+                    Text = label,
+                    Opacity = 0.82,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                });
+            }
+            DependenciesCardControl.IsVisible = true;
+        }
+    }
+
+    private void HomepageButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenUrl(_homepageUrl?.ToString());
+
+    private void ReleaseNotesUrlButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenUrl(_releaseNotesUrl?.ToString());
+
+    private void ManifestUrlButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenUrl(_manifestUrl?.ToString());
+
+    private void CloseButton_OnClick(object? sender, RoutedEventArgs e)
+        => Close();
+
+    private void ContributeScreenshotsButton_OnClick(object? sender, RoutedEventArgs e)
+        => OpenUrl(ScreenshotsInfoUrl);
+
+    private async void PreviousScreenshotButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_screenshotUris.Count <= 1)
+        {
+            return;
+        }
+
+        _selectedScreenshotIndex = (_selectedScreenshotIndex - 1 + _screenshotUris.Count) % _screenshotUris.Count;
+        await ShowSelectedScreenshotAsync();
+    }
+
+    private async void NextScreenshotButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_screenshotUris.Count <= 1)
+        {
+            return;
+        }
+
+        _selectedScreenshotIndex = (_selectedScreenshotIndex + 1) % _screenshotUris.Count;
+        await ShowSelectedScreenshotAsync();
+    }
+
+    private void InstallOptionsExpander_OnExpandedChanged(object? sender, RoutedEventArgs e)
+    {
+        SaveInstallOptionsButtonControl.IsEnabled = InstallOptionsExpanderControl.IsExpanded;
+    }
+
+    private async void SaveInstallOptionsButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_installOptionsEditorView is null)
+        {
+            return;
+        }
+
+        try
+        {
+            SaveInstallOptionsButtonControl.IsEnabled = false;
+            SaveInstallOptionsButtonControl.Content = CoreTools.Translate("Loading...");
+            await _installOptionsEditorView.SaveAsync();
+            SaveInstallOptionsButtonControl.Content = CoreTools.Translate("Save");
+            global::UniGetUI.Avalonia.MainWindow.Instance?.ShowRuntimeNotification(
+                CoreTools.Translate("Installation options"),
+                CoreTools.Translate("Update succeeded"),
+                global::UniGetUI.Avalonia.MainWindow.RuntimeNotificationLevel.Success);
+            await Task.Delay(1200);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while saving install options");
+            Logger.Error(ex);
+            global::UniGetUI.Avalonia.MainWindow.Instance?.ShowRuntimeNotification(
+                CoreTools.Translate("Installation options"),
+                CoreTools.Translate("Update failed"),
+                global::UniGetUI.Avalonia.MainWindow.RuntimeNotificationLevel.Error);
+        }
+        finally
+        {
+            SaveInstallOptionsButtonControl.Content = CoreTools.Translate("Save");
+            SaveInstallOptionsButtonControl.IsEnabled = InstallOptionsExpanderControl.IsExpanded;
+        }
+    }
+
+    private async void ShareButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_package.Source.IsVirtualManager || _package is InvalidImportedPackage)
+        {
+            global::UniGetUI.Avalonia.MainWindow.Instance?.ShowRuntimeNotification(
+                CoreTools.Translate("Something went wrong"),
+                CoreTools.Translate("Share this package"),
+                global::UniGetUI.Avalonia.MainWindow.RuntimeNotificationLevel.Error);
+            return;
+        }
+
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is null)
+        {
+            return;
+        }
+
+        await clipboard.SetTextAsync(BuildShareUrl(_package));
+        global::UniGetUI.Avalonia.MainWindow.Instance?.ShowRuntimeNotification(
+            CoreTools.Translate("Share this package"),
+            CoreTools.Translate("Copy to clipboard"),
+            global::UniGetUI.Avalonia.MainWindow.RuntimeNotificationLevel.Success);
+    }
+
+    private async void ActionButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        ActionButtonControl.IsEnabled = false;
+        try
+        {
+            if (_pageMode == PackagePageMode.Installed
+                && !await ConfirmUninstallAsync(_package))
+            {
+                ActionButtonControl.IsEnabled = true;
+                return;
+            }
+
+            var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+            AbstractOperation? operation = _pageMode switch
+            {
+                PackagePageMode.Discover => new InstallPackageOperation(_package, options),
+                PackagePageMode.Updates => new UpdatePackageOperation(_package, options),
+                PackagePageMode.Installed => new UninstallPackageOperation(_package, options),
+                _ => null,
+            };
+            if (operation is null) return;
+            AvaloniaOperationRegistry.Add(operation);
+            _ = operation.MainThread();
+            Close();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+            ActionButtonControl.IsEnabled = true;
+        }
+    }
+
+    private async void DownloadInstallerButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (!_package.Manager.Capabilities.CanDownloadInstaller) return;
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel is null) return;
+
+        var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = CoreTools.Translate("Download installer"),
+            SuggestedFileName = _package.Id,
+            DefaultExtension = "exe",
+            FileTypeChoices =
+            [
+                new FilePickerFileType("Executable") { Patterns = ["*.exe"] },
+                new FilePickerFileType("MSI") { Patterns = ["*.msi"] },
+                new FilePickerFileType("Compressed file") { Patterns = ["*.zip"] },
+                new FilePickerFileType("MSIX") { Patterns = ["*.msix"] },
+                new FilePickerFileType("NuGet package") { Patterns = ["*.nupkg"] },
+            ],
+        });
+        if (file is null) return;
+
+        var op = new DownloadOperation(_package, file.Path.LocalPath);
+        AvaloniaOperationRegistry.Add(op);
+        _ = op.MainThread();
+        Close();
+    }
+
+    private Task<bool> ConfirmUninstallAsync(IPackage package)
+    {
+        return UninstallConfirmationDialog.ConfirmAsync(this, package);
+    }
+
+    private async Task LoadIconAsync()
+    {
+        try
+        {
+            var iconUri = _package.GetIconUrlIfAny();
+            if (iconUri is null || iconUri.Scheme == "ms-appx") return;
+
+            using var client = new HttpClient(CoreTools.GenericHttpClientParameters);
+            client.Timeout = TimeSpan.FromSeconds(10);
+            var bytes = await client.GetByteArrayAsync(iconUri);
+            using var ms = new MemoryStream(bytes);
+            var bitmap = new Bitmap(ms);
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                PackageIconImageControl.Source = bitmap;
+                PackageIconImageControl.IsVisible = true;
+                PackageIconGlyphControl.IsVisible = false;
+            });
+        }
+        catch
+        {
+            // ignore — glyph fallback stays visible
+        }
+    }
+
+    private async Task LoadScreenshotsAsync()
+    {
+        try
+        {
+            var screenshots = await Task.Run(_package.GetScreenshots);
+            Dispatcher.UIThread.Post(() =>
+            {
+                _screenshotUris = screenshots;
+                _selectedScreenshotIndex = 0;
+                ScreenshotsCardControl.IsVisible = true;
+                ApplyScreenshotChrome();
+            });
+
+            if (screenshots.Count > 0)
+            {
+                await ShowSelectedScreenshotAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+            Dispatcher.UIThread.Post(() =>
+            {
+                _screenshotUris = [];
+                ScreenshotsCardControl.IsVisible = true;
+                ApplyScreenshotChrome();
+            });
+        }
+    }
+
+    private async Task ShowSelectedScreenshotAsync()
+    {
+        if (_screenshotUris.Count == 0)
+        {
+            Dispatcher.UIThread.Post(ApplyScreenshotChrome);
+            return;
+        }
+
+        Uri screenshotUri = _screenshotUris[_selectedScreenshotIndex];
+        Dispatcher.UIThread.Post(() =>
+        {
+            ScreenshotsLoadingBarControl.IsVisible = true;
+            PreviousScreenshotButtonControl.IsEnabled = false;
+            NextScreenshotButtonControl.IsEnabled = false;
+        });
+
+        try
+        {
+            using var client = new HttpClient(CoreTools.GenericHttpClientParameters);
+            client.Timeout = TimeSpan.FromSeconds(15);
+            var bytes = await client.GetByteArrayAsync(screenshotUri);
+            using var stream = new MemoryStream(bytes);
+            var bitmap = new Bitmap(stream);
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                ScreenshotImageControl.Source = bitmap;
+                ApplyScreenshotChrome();
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+            Dispatcher.UIThread.Post(() =>
+            {
+                ScreenshotImageControl.Source = null;
+                ApplyScreenshotChrome();
+            });
+        }
+    }
+
+    private void ApplyScreenshotChrome()
+    {
+        bool hasScreenshots = _screenshotUris.Count > 0;
+
+        ScreenshotsCardControl.IsVisible = true;
+        ScreenshotsImageCardControl.IsVisible = hasScreenshots;
+        ScreenshotsBannerCardControl.IsVisible = true;
+        ScreenshotsLoadingBarControl.IsVisible = false;
+
+        if (!hasScreenshots)
+        {
+            ScreenshotsPipsText.Text = string.Empty;
+            PreviousScreenshotButtonControl.IsVisible = false;
+            NextScreenshotButtonControl.IsVisible = false;
+            return;
+        }
+
+        PreviousScreenshotButtonControl.IsVisible = _screenshotUris.Count > 1;
+        NextScreenshotButtonControl.IsVisible = _screenshotUris.Count > 1;
+        PreviousScreenshotButtonControl.IsEnabled = _screenshotUris.Count > 1;
+        NextScreenshotButtonControl.IsEnabled = _screenshotUris.Count > 1;
+        ScreenshotsPipsText.Text = $"{_selectedScreenshotIndex + 1} / {_screenshotUris.Count}";
+    }
+
+    private void BuildActionFlyout()
+    {
+        if (_pageMode == PackagePageMode.None) return;
+
+        var flyout = new MenuFlyout();
+        var caps = _package.Manager.Capabilities;
+
+        // Admin variant
+        string adminLabel = _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("Install as administrator"),
+            PackagePageMode.Updates => CoreTools.Translate("Update as administrator"),
+            PackagePageMode.Installed => CoreTools.Translate("Uninstall as administrator"),
+            _ => CoreTools.Translate("Install as administrator"),
+        };
+        var adminItem = new MenuItem { Header = adminLabel, IsEnabled = caps.CanRunAsAdmin };
+        adminItem.Click += async (_, _) =>
+        {
+            ActionButtonControl.IsEnabled = false;
+            ActionDropdownButtonControl.IsEnabled = false;
+            try
+            {
+                if (_pageMode == PackagePageMode.Installed
+                    && !await ConfirmUninstallAsync(_package))
+                {
+                    ActionButtonControl.IsEnabled = true;
+                    ActionDropdownButtonControl.IsEnabled = true;
+                    return;
+                }
+
+                var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+                options.RunAsAdministrator = true;
+                AbstractOperation? op = _pageMode switch
+                {
+                    PackagePageMode.Discover => new InstallPackageOperation(_package, options),
+                    PackagePageMode.Updates => new UpdatePackageOperation(_package, options),
+                    PackagePageMode.Installed => new UninstallPackageOperation(_package, options),
+                    _ => null,
+                };
+                if (op is null) return;
+                AvaloniaOperationRegistry.Add(op);
+                _ = op.MainThread();
+                Close();
+            }
+            catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; ActionDropdownButtonControl.IsEnabled = true; }
+        };
+        flyout.Items.Add(adminItem);
+
+        // Interactive variant
+        string interactiveLabel = _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("Interactive installation"),
+            PackagePageMode.Updates => CoreTools.Translate("Interactive update"),
+            PackagePageMode.Installed => CoreTools.Translate("Interactive uninstall"),
+            _ => CoreTools.Translate("Interactive installation"),
+        };
+        var interactiveItem = new MenuItem { Header = interactiveLabel, IsEnabled = caps.CanRunInteractively };
+        interactiveItem.Click += async (_, _) =>
+        {
+            ActionButtonControl.IsEnabled = false;
+            ActionDropdownButtonControl.IsEnabled = false;
+            try
+            {
+                if (_pageMode == PackagePageMode.Installed
+                    && !await ConfirmUninstallAsync(_package))
+                {
+                    ActionButtonControl.IsEnabled = true;
+                    ActionDropdownButtonControl.IsEnabled = true;
+                    return;
+                }
+
+                var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+                options.InteractiveInstallation = true;
+                AbstractOperation? op = _pageMode switch
+                {
+                    PackagePageMode.Discover => new InstallPackageOperation(_package, options),
+                    PackagePageMode.Updates => new UpdatePackageOperation(_package, options),
+                    PackagePageMode.Installed => new UninstallPackageOperation(_package, options),
+                    _ => null,
+                };
+                if (op is null) return;
+                AvaloniaOperationRegistry.Add(op);
+                _ = op.MainThread();
+                Close();
+            }
+            catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; ActionDropdownButtonControl.IsEnabled = true; }
+        };
+        flyout.Items.Add(interactiveItem);
+
+        // Skip hash check (non-Installed pages)
+        if (_pageMode != PackagePageMode.Installed)
+        {
+            var item = new MenuItem
+            {
+                Header = CoreTools.Translate("Skip hash check"),
+                IsEnabled = caps.CanSkipIntegrityChecks,
+            };
+            item.Click += async (_, _) =>
+            {
+                ActionButtonControl.IsEnabled = false;
+                ActionDropdownButtonControl.IsEnabled = false;
+                try
+                {
+                    var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+                    options.SkipHashCheck = true;
+                    AbstractOperation? op = _pageMode switch
+                    {
+                        PackagePageMode.Discover => new InstallPackageOperation(_package, options),
+                        PackagePageMode.Updates => new UpdatePackageOperation(_package, options),
+                        _ => null,
+                    };
+                    if (op is null) return;
+                    AvaloniaOperationRegistry.Add(op);
+                    _ = op.MainThread();
+                    Close();
+                }
+                catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; ActionDropdownButtonControl.IsEnabled = true; }
+            };
+            flyout.Items.Add(item);
+        }
+
+        // Cross-op actions
+        if (_pageMode == PackagePageMode.Discover)
+        {
+            var upgradable = _package.GetUpgradablePackage();
+            if (upgradable is not null)
+            {
+                if (flyout.Items.Count > 0) flyout.Items.Add(new Separator());
+                var updateItem = new MenuItem
+                {
+                    Header = CoreTools.Translate("Update to version {0}", upgradable.NewVersionString)
+                };
+                updateItem.Click += async (_, _) =>
+                {
+                    ActionButtonControl.IsEnabled = false;
+                    try
+                    {
+                        var options = await InstallOptionsFactory.LoadApplicableAsync(upgradable);
+                        var op = new UpdatePackageOperation(upgradable, options);
+                        AvaloniaOperationRegistry.Add(op);
+                        _ = op.MainThread();
+                        Close();
+                    }
+                    catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; }
+                };
+                flyout.Items.Add(updateItem);
+            }
+
+            if (_package.GetInstalledPackages().Count > 0)
+            {
+                if (flyout.Items.Count > 0) flyout.Items.Add(new Separator());
+                var item = new MenuItem { Header = CoreTools.Translate("Uninstall") };
+                item.Click += async (_, _) =>
+                {
+                    ActionButtonControl.IsEnabled = false;
+                    try
+                    {
+                        var installed = _package.GetInstalledPackages()[0];
+                        if (!await ConfirmUninstallAsync(installed))
+                        {
+                            ActionButtonControl.IsEnabled = true;
+                            return;
+                        }
+
+                        var options = await InstallOptionsFactory.LoadApplicableAsync(installed);
+                        var op = new UninstallPackageOperation(installed, options);
+                        AvaloniaOperationRegistry.Add(op);
+                        _ = op.MainThread();
+                        Close();
+                    }
+                    catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; }
+                };
+                flyout.Items.Add(item);
+            }
+        }
+        else if (_pageMode == PackagePageMode.Updates)
+        {
+            if (flyout.Items.Count > 0) flyout.Items.Add(new Separator());
+
+            var uninstallItem = new MenuItem { Header = CoreTools.Translate("Uninstall package") };
+            uninstallItem.Click += async (_, _) =>
+            {
+                ActionButtonControl.IsEnabled = false;
+                try
+                {
+                    if (!await ConfirmUninstallAsync(_package))
+                    {
+                        ActionButtonControl.IsEnabled = true;
+                        return;
+                    }
+
+                    var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+                    var op = new UninstallPackageOperation(_package, options);
+                    AvaloniaOperationRegistry.Add(op);
+                    _ = op.MainThread();
+                    Close();
+                }
+                catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; }
+            };
+            flyout.Items.Add(uninstallItem);
+
+            if (!_package.Source.IsVirtualManager)
+            {
+                var reinstallItem = new MenuItem { Header = CoreTools.Translate("Reinstall package") };
+                reinstallItem.Click += async (_, _) =>
+                {
+                    ActionButtonControl.IsEnabled = false;
+                    try
+                    {
+                        var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+                        var op = new InstallPackageOperation(_package, options);
+                        AvaloniaOperationRegistry.Add(op);
+                        _ = op.MainThread();
+                        Close();
+                    }
+                    catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; }
+                };
+                flyout.Items.Add(reinstallItem);
+            }
+        }
+        else if (_pageMode == PackagePageMode.Installed)
+        {
+            var removeDataItem = new MenuItem
+            {
+                Header = CoreTools.Translate("Uninstall and remove data"),
+                IsEnabled = caps.CanRemoveDataOnUninstall,
+            };
+            removeDataItem.Click += async (_, _) =>
+            {
+                ActionButtonControl.IsEnabled = false;
+                ActionDropdownButtonControl.IsEnabled = false;
+                try
+                {
+                    if (!await ConfirmUninstallAsync(_package))
+                    {
+                        ActionButtonControl.IsEnabled = true;
+                        ActionDropdownButtonControl.IsEnabled = true;
+                        return;
+                    }
+
+                    var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+                    options.RemoveDataOnUninstall = true;
+                    var op = new UninstallPackageOperation(_package, options);
+                    AvaloniaOperationRegistry.Add(op);
+                    _ = op.MainThread();
+                    Close();
+                }
+                catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; ActionDropdownButtonControl.IsEnabled = true; }
+            };
+            flyout.Items.Add(removeDataItem);
+
+            var upgradable = _package.GetUpgradablePackage();
+            if (upgradable is not null)
+            {
+                if (flyout.Items.Count > 0) flyout.Items.Add(new Separator());
+                var updateItem = new MenuItem
+                {
+                    Header = CoreTools.Translate("Update to version {0}", upgradable.NewVersionString)
+                };
+                updateItem.Click += async (_, _) =>
+                {
+                    ActionButtonControl.IsEnabled = false;
+                    try
+                    {
+                        var options = await InstallOptionsFactory.LoadApplicableAsync(upgradable);
+                        var op = new UpdatePackageOperation(upgradable, options);
+                        AvaloniaOperationRegistry.Add(op);
+                        _ = op.MainThread();
+                        Close();
+                    }
+                    catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; }
+                };
+                flyout.Items.Add(updateItem);
+            }
+
+            if (!_package.Source.IsVirtualManager)
+            {
+                if (flyout.Items.Count > 0 && upgradable is null) flyout.Items.Add(new Separator());
+                var reinstallItem = new MenuItem { Header = CoreTools.Translate("Reinstall package") };
+                reinstallItem.Click += async (_, _) =>
+                {
+                    ActionButtonControl.IsEnabled = false;
+                    try
+                    {
+                        var options = await InstallOptionsFactory.LoadApplicableAsync(_package);
+                        var op = new InstallPackageOperation(_package, options);
+                        AvaloniaOperationRegistry.Add(op);
+                        _ = op.MainThread();
+                        Close();
+                    }
+                    catch (Exception ex) { Logger.Error(ex); ActionButtonControl.IsEnabled = true; }
+                };
+                flyout.Items.Add(reinstallItem);
+            }
+        }
+
+        if (flyout.Items.Count > 0)
+        {
+            ActionDropdownButtonControl.Flyout = flyout;
+            ActionDropdownButtonControl.IsVisible = true;
+        }
+    }
+
+    private static void OpenUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return;
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
+        }
+        catch
+        {
+            // ignore — best effort
+        }
+    }
+
+    private static string BuildShareUrl(IPackage package)
+    {
+        return "https://marticliment.com/unigetui/share?"
+            + "name=" + Uri.EscapeDataString(package.Name)
+            + "&id=" + Uri.EscapeDataString(package.Id)
+            + "&sourceName=" + Uri.EscapeDataString(package.Source.Name)
+            + "&managerName=" + Uri.EscapeDataString(package.Manager.DisplayName);
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/PackagePageView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/PackagePageView.axaml
@@ -1,0 +1,481 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+                                                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                                 xmlns:models="using:UniGetUI.Avalonia.Models"
+                                                 x:CompileBindings="False"
+                                                 x:Class="UniGetUI.Avalonia.Views.Pages.PackagePageView">
+        <Grid RowDefinitions="Auto,Auto,Auto,*"
+                                RowSpacing="12">
+                <Border Padding="18"
+                                                Classes="surface-card">
+                        <Grid ColumnDefinitions="Auto,*,Auto"
+                                                ColumnSpacing="14">
+                                <Border Width="48"
+                                                                Height="48"
+                                                                Classes="surface-card subtle-panel"
+                                                                CornerRadius="14">
+                                        <TextBlock x:Name="GlyphBlock"
+                                                                                 HorizontalAlignment="Center"
+                                                                                 VerticalAlignment="Center"
+                                                                                 FontSize="20"
+                                                                                 FontWeight="SemiBold"
+                                                                                 Text="◎" />
+                                </Border>
+
+                                <StackPanel Grid.Column="1"
+                                                                                Spacing="2">
+                                        <TextBlock x:Name="PageTitleBlock"
+                                                                                 FontSize="28"
+                                                                                 FontWeight="Black"
+                                                                                 Classes="hero-title" />
+                                        <TextBlock x:Name="PageSubtitleBlock"
+                                                                                 Opacity="0.72" />
+                                </StackPanel>
+
+                                <Border Grid.Column="2"
+                                                                Padding="10,4"
+                                                                HorizontalAlignment="Right"
+                                                                VerticalAlignment="Top"
+                                                                Classes="surface-card badge-panel">
+                                        <TextBlock x:Name="SearchStateBlock"
+                                                                                 Opacity="0.8"
+                                                                                 Text="Waiting for package engine" />
+                                </Border>
+                        </Grid>
+                </Border>
+
+                <Border x:Name="WinGetWarningCard"
+                                                Grid.Row="1"
+                                                IsVisible="False"
+                                                Padding="14"
+                                                Classes="surface-card warning-panel">
+                        <Grid ColumnDefinitions="*,Auto"
+                                                ColumnSpacing="12">
+                                <StackPanel Spacing="4">
+                                        <TextBlock x:Name="WinGetWarningTitleBlock"
+                                                                                 FontSize="16"
+                                                                                 FontWeight="SemiBold"
+                                                                                 Text="WinGet malfunction detected" />
+                                        <TextBlock x:Name="WinGetWarningDescriptionBlock"
+                                                                                 Opacity="0.8"
+                                                                                 TextWrapping="Wrap"
+                                                                                 Text="It looks like WinGet is not working properly. Do you want to attempt to repair WinGet?" />
+                                </StackPanel>
+                                <Button x:Name="RepairWinGetButton"
+                                                                Grid.Column="1"
+                                                                Classes="toolbar-primary accent"
+                                                                VerticalAlignment="Center"
+                                                                Content="Repair WinGet"
+                                                                Click="RepairWinGetButton_OnClick" />
+                        </Grid>
+                </Border>
+
+                <Border Grid.Row="2"
+                                                Padding="12"
+                                                Classes="surface-card">
+                        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                                                ColumnSpacing="6">
+                                <Button x:Name="PrimaryActionButton"
+                                                                Classes="toolbar-primary accent"
+                                                                IsEnabled="False" />
+                                <Button x:Name="PrimaryActionDropdownButton"
+                                                                Grid.Column="1"
+                                                                Classes="toolbar-primary accent"
+                                                                IsEnabled="False"
+                                                                Content="▾"
+                                                                Padding="8,0" />
+                                <Button x:Name="InstallOptionsButton"
+                                                                Grid.Column="2"
+                                                                Classes="toolbar-secondary"
+                                                                IsEnabled="False"
+                                                                Content="Install options" />
+                                <Button x:Name="DetailsButton"
+                                                                Grid.Column="3"
+                                                                Classes="toolbar-secondary"
+                                                                IsEnabled="False"
+                                                                Content="Details" />
+                                <Button x:Name="ShareButton"
+                                                                Grid.Column="4"
+                                                                Classes="toolbar-secondary"
+                                                                IsEnabled="False"
+                                                                Content="Share" />
+
+                                <TextBlock x:Name="OperationStateBlock"
+                                                               Grid.Column="5"
+                                                               VerticalAlignment="Center"
+                                                               Opacity="0.76"
+                                                               TextTrimming="CharacterEllipsis" />
+
+                                <Button x:Name="ViewOutputButton"
+                                                                Grid.Column="6"
+                                                                Classes="toolbar-secondary"
+                                                                IsVisible="False"
+                                                                Click="ViewOutputButton_OnClick"
+                                                                Content="View output" />
+
+                                <Button x:Name="ManageIgnoredButton"
+                                                                Grid.Column="8"
+                                                                Classes="toolbar-secondary"
+                                                                IsVisible="False"
+                                                                Click="ManageIgnoredButton_OnClick"
+                                                                Content="Manage ignored" />
+
+                                <Button x:Name="IgnoreSelectedButton"
+                                                                Grid.Column="7"
+                                                                Classes="toolbar-secondary"
+                                                                IsVisible="False"
+                                                                Click="IgnoreSelectedButton_OnClick"
+                                                                Content="Ignore selected" />
+
+                                <Button x:Name="ExportSelectionButton"
+                                                                Grid.Column="9"
+                                                                Classes="toolbar-secondary"
+                                                                IsVisible="False"
+                                                                Click="ExportSelectionButton_OnClick"
+                                                                Content="Add to bundle" />
+
+                                <TextBlock x:Name="ViewModeLabelBlock"
+                                                               Grid.Column="10"
+                                                               VerticalAlignment="Center"
+                                                               Opacity="0.76"
+                                                               Text="View" />
+
+                                <ComboBox x:Name="ViewModeSelector"
+                                                                  Grid.Column="11"
+                                                                  Width="132"
+                                                                  SelectedIndex="0">
+                                        <ComboBoxItem Content="List" />
+                                        <ComboBoxItem Content="Grid" />
+                                        <ComboBoxItem Content="Icons" />
+                                </ComboBox>
+
+                                <Button x:Name="ReloadButton"
+                                                                Grid.Column="12"
+                                                                Classes="toolbar-secondary"
+                                                                Content="Reload"
+                                                                Click="ReloadButton_OnClick" />
+                                <ToggleButton x:Name="ToggleFiltersButton"
+                                                                  Grid.Column="13"
+                                                                  Classes="toolbar-secondary"
+                                                                  IsChecked="True"
+                                                                  Content="☰ Filters"
+                                                                  Click="ToggleFiltersButton_OnClick" />
+                        </Grid>
+                </Border>
+
+                <Grid Grid.Row="3"
+                                        x:Name="FilterContentGrid"
+                                        ColumnDefinitions="264,*"
+                                        ColumnSpacing="12">
+                        <StackPanel x:Name="FilterPanelContainer" Spacing="12">
+                                <Border Padding="16"
+                                                                Classes="surface-card">
+                                        <StackPanel Spacing="12">
+                                                <StackPanel Orientation="Horizontal"
+                                                                                        Spacing="8">
+                                                        <TextBlock x:Name="SourcesTitleBlock"
+                                                                                                 FontSize="18"
+                                                                                                 FontWeight="SemiBold"
+                                                                                                 VerticalAlignment="Center"
+                                                                                                 Text="Sources" />
+                                                        <Button x:Name="ClearSourceFilterButton"
+                                                                                        Classes="toolbar-secondary"
+                                                                                        Padding="6,2"
+                                                                                        FontSize="11"
+                                                                                        IsVisible="False"
+                                                                                        Click="ClearSourceFilterButton_OnClick" />
+                                                </StackPanel>
+                                                <TextBlock x:Name="SourcesDescriptionBlock"
+                                                                                         Opacity="0.72"
+                                                                                         TextWrapping="Wrap"
+                                                                                         IsVisible="False"
+                                                                                         Text="Click a source to filter." />
+                                                <TextBlock x:Name="SourcesEmptyStateBlock"
+                                                                                         Opacity="0.62"
+                                                                                         TextWrapping="Wrap"
+                                                                                         IsVisible="False"
+                                                                                         FontSize="12"
+                                                                                         Text="No packages were found" />
+                                                <ItemsControl x:Name="SourceTogglesItemsControl">
+                                                        <ItemsControl.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                        <StackPanel Spacing="6" />
+                                                                </ItemsPanelTemplate>
+                                                        </ItemsControl.ItemsPanel>
+                                                </ItemsControl>
+                                        </StackPanel>
+                                </Border>
+
+                                <Border Padding="16"
+                                                                Classes="surface-card">
+                                        <StackPanel Spacing="10">
+                                                <TextBlock x:Name="FiltersTitleBlock"
+                                                                                         FontSize="18"
+                                                                                         FontWeight="SemiBold" />
+                                                <RadioButton x:Name="PackageNameFilterRadio"
+                                                                                                 Content="Package Name" />
+                                                <RadioButton x:Name="PackageIdFilterRadio"
+                                                                                                 Content="Package ID" />
+                                                <RadioButton x:Name="BothFilterRadio"
+                                                                                                 IsChecked="True"
+                                                                                                 Content="Both" />
+                                                <RadioButton x:Name="ExactMatchFilterRadio"
+                                                                                                 Content="Exact match" />
+                                                <RadioButton x:Name="ShowSimilarResultsRadio"
+                                                                                                 Content="Show all packages" />
+
+                                                <Separator Margin="0,4" />
+
+                                                <CheckBox x:Name="InstantSearchCheckBox"
+                                                                          IsChecked="True"
+                                                                          Content="Instant search" />
+                                                <CheckBox x:Name="UpperLowerCaseCheckBox"
+                                                                          IsChecked="False"
+                                                                          Content="Distinguish uppercase and lowercase" />
+                                                <CheckBox x:Name="IgnoreSpecialCharsCheckBox"
+                                                                          IsChecked="True"
+                                                                          Content="Ignore special characters" />
+                                        </StackPanel>
+                                </Border>
+                        </StackPanel>
+
+                        <Border Grid.Column="1"
+                                                        Padding="0"
+                                                        Classes="surface-card">
+                                <Grid RowDefinitions="Auto,Auto,*">
+                                        <Grid x:Name="PackageColumnsHeaderGrid"
+                                                                Margin="16,16,16,8"
+                                                                ColumnDefinitions="36,2.5*,2.2*,1.1*,1.2*,1.4*,Auto"
+                                                                ColumnSpacing="14">
+                                                <CheckBox x:Name="SelectAllCheckBox"
+                                                                          HorizontalAlignment="Center"
+                                                                          VerticalAlignment="Center"
+                                                                          IsThreeState="True"
+                                                                          Click="SelectAllCheckBox_OnClick" />
+                                                <Button x:Name="PackageNameSortBtn"
+                                                                Grid.Column="1"
+                                                                Classes="sort-header"
+                                                                Click="NameHeader_OnClick" />
+                                                <Button x:Name="PackageIdSortBtn"
+                                                                Grid.Column="2"
+                                                                Classes="sort-header"
+                                                                Click="IdHeader_OnClick" />
+                                                <Button x:Name="VersionSortBtn"
+                                                                Grid.Column="3"
+                                                                Classes="sort-header"
+                                                                Click="VersionHeader_OnClick" />
+                                                <Button x:Name="UpgradeColumnSortBtn"
+                                                                Grid.Column="4"
+                                                                Classes="sort-header"
+                                                                Click="StatusHeader_OnClick" />
+                                                <Button x:Name="SourceSortBtn"
+                                                                Grid.Column="5"
+                                                                Classes="sort-header"
+                                                                Click="SourceHeader_OnClick" />
+                                                <TextBlock x:Name="ActionHeaderBlock"
+                                                                                         Grid.Column="6"
+                                                                                         Classes="data-header" />
+                                        </Grid>
+
+                                        <ProgressBar x:Name="LoadingProgressBar"
+                                                                     Grid.Row="1"
+                                                                     Height="2"
+                                                                     IsIndeterminate="True"
+                                                                     IsVisible="False"
+                                                                     Margin="0" />
+
+                                        <Grid Grid.Row="2"
+                                                                Margin="16,0,16,16">
+                                                <ScrollViewer x:Name="PackageRowsScrollViewer"
+                                                                IsVisible="False"
+                                                                Focusable="True"
+                                                                KeyDown="PackageRowsScrollViewer_KeyDown">
+                                                        <Grid>
+                                                                <ItemsControl x:Name="PackageRowsListItemsControl">
+                                                                        <ItemsControl.ItemTemplate>
+                                                                                <DataTemplate x:DataType="models:PackageRowModel">
+                                                                                        <Border Classes="data-row"
+                                                                                                Classes.selected="{Binding IsSelected}"
+                                                                                                ContextRequested="PackageRow_ContextRequested">
+                                                                                                <Grid ColumnDefinitions="36,28,2.5*,2.2*,1.1*,1.2*,1.4*,Auto"
+                                                                                                                        ColumnSpacing="14">
+                                                                                                        <CheckBox HorizontalAlignment="Center"
+                                                                                                                          VerticalAlignment="Center"
+                                                                                                                          IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                                                                                                          Click="RowCheckBox_OnClick" />
+                                                                                                        <Image Grid.Column="1"
+                                                                                                               Width="20"
+                                                                                                               Height="20"
+                                                                                                               Source="{Binding IconBitmap}"
+                                                                                                               Stretch="Uniform"
+                                                                                                               VerticalAlignment="Center" />
+                                                                                                        <TextBlock Grid.Column="2"
+                                                                                                                                                 Text="{Binding Name}"
+                                                                                                                                                 Classes="data-primary" />
+                                                                                                        <TextBlock Grid.Column="3"
+                                                                                                                                                 Text="{Binding Id}"
+                                                                                                                                                 Classes="data-secondary" />
+                                                                                                        <TextBlock Grid.Column="4"
+                                                                                                                                                 Text="{Binding Version}"
+                                                                                                                                                 Classes="data-secondary" />
+                                                                                                        <TextBlock Grid.Column="5"
+                                                                                                                                                 Text="{Binding Status}"
+                                                                                                                                                 Classes="data-secondary" />
+                                                                                                        <TextBlock Grid.Column="6"
+                                                                                                                                                 Text="{Binding Source}"
+                                                                                                                                                 Classes="data-secondary" />
+                                                                                                        <Button Grid.Column="7"
+                                                                                                                        Classes="toolbar-secondary inline-row-action"
+                                                                                                                        Content="{Binding PrimaryActionLabel}"
+                                                                                                                        Command="{Binding PrimaryActionCommand}"
+                                                                                                                        IsEnabled="{Binding CanExecutePrimaryAction}" />
+                                                                                                </Grid>
+                                                                                        </Border>
+                                                                                </DataTemplate>
+                                                                        </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+
+                                                                <ItemsControl x:Name="PackageRowsGridItemsControl"
+                                                                              IsVisible="False">
+                                                                        <ItemsControl.ItemsPanel>
+                                                                                <ItemsPanelTemplate>
+                                                                                        <WrapPanel ItemWidth="340"
+                                                                                                   ItemHeight="190" />
+                                                                                </ItemsPanelTemplate>
+                                                                        </ItemsControl.ItemsPanel>
+                                                                        <ItemsControl.ItemTemplate>
+                                                                                <DataTemplate x:DataType="models:PackageRowModel">
+                                                                                        <Border Margin="0,0,12,12"
+                                                                                                Padding="12"
+                                                                                                Classes="surface-card subtle-panel data-row"
+                                                                                                Classes.selected="{Binding IsSelected}"
+                                                                                                ContextRequested="PackageRow_ContextRequested">
+                                                                                                <Grid RowDefinitions="Auto,Auto,Auto,Auto,*,Auto"
+                                                                                                      ColumnDefinitions="Auto,*"
+                                                                                                      RowSpacing="6"
+                                                                                                      ColumnSpacing="8">
+                                                                                                        <CheckBox Grid.Row="0"
+                                                                                                                  Grid.Column="0"
+                                                                                                                  VerticalAlignment="Center"
+                                                                                                                  IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                                                                                                  Click="RowCheckBox_OnClick" />
+                                                                                                        <Image Grid.Row="0"
+                                                                                                               Grid.Column="1"
+                                                                                                               Width="26"
+                                                                                                               Height="26"
+                                                                                                               Source="{Binding IconBitmap}"
+                                                                                                               Stretch="Uniform"
+                                                                                                               VerticalAlignment="Center" />
+
+                                                                                                        <TextBlock Grid.Row="1"
+                                                                                                                   Grid.ColumnSpan="2"
+                                                                                                                   Text="{Binding Name}"
+                                                                                                                   TextTrimming="CharacterEllipsis"
+                                                                                                                   Classes="data-primary" />
+                                                                                                        <TextBlock Grid.Row="2"
+                                                                                                                   Grid.ColumnSpan="2"
+                                                                                                                   Text="{Binding Id}"
+                                                                                                                   TextTrimming="CharacterEllipsis"
+                                                                                                                   Classes="data-secondary" />
+                                                                                                        <TextBlock Grid.Row="3"
+                                                                                                                   Grid.ColumnSpan="2"
+                                                                                                                   Text="{Binding Version}"
+                                                                                                                   Classes="data-secondary" />
+                                                                                                                                                                                                                <StackPanel Grid.Row="4"
+                                                                                                                                                                                                                                        Grid.ColumnSpan="2"
+                                                                                                                                                                                                                                        Orientation="Horizontal"
+                                                                                                                                                                                                                                        Spacing="4">
+                                                                                                                                                                                                                                <TextBlock Text="{Binding Status}"
+                                                                                                                                                                                                                                                   Classes="data-secondary" />
+                                                                                                                                                                                                                                <TextBlock Text="-"
+                                                                                                                                                                                                                                                   Classes="data-secondary" />
+                                                                                                                                                                                                                                <TextBlock Text="{Binding Source}"
+                                                                                                                                                                                                                                                   TextTrimming="CharacterEllipsis"
+                                                                                                                                                                                                                                                   Classes="data-secondary" />
+                                                                                                                                                                                                                </StackPanel>
+
+                                                                                                        <Button Grid.Row="5"
+                                                                                                                Grid.ColumnSpan="2"
+                                                                                                                HorizontalAlignment="Stretch"
+                                                                                                                Classes="toolbar-secondary"
+                                                                                                                Content="{Binding PrimaryActionLabel}"
+                                                                                                                Command="{Binding PrimaryActionCommand}"
+                                                                                                                IsEnabled="{Binding CanExecutePrimaryAction}" />
+                                                                                                </Grid>
+                                                                                        </Border>
+                                                                                </DataTemplate>
+                                                                        </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+
+                                                                <ItemsControl x:Name="PackageRowsIconsItemsControl"
+                                                                              IsVisible="False">
+                                                                        <ItemsControl.ItemsPanel>
+                                                                                <ItemsPanelTemplate>
+                                                                                        <WrapPanel ItemWidth="180"
+                                                                                                   ItemHeight="170" />
+                                                                                </ItemsPanelTemplate>
+                                                                        </ItemsControl.ItemsPanel>
+                                                                        <ItemsControl.ItemTemplate>
+                                                                                <DataTemplate x:DataType="models:PackageRowModel">
+                                                                                        <Border Margin="0,0,12,12"
+                                                                                                Padding="10"
+                                                                                                Classes="surface-card subtle-panel data-row"
+                                                                                                Classes.selected="{Binding IsSelected}"
+                                                                                                ContextRequested="PackageRow_ContextRequested">
+                                                                                                <Grid RowDefinitions="Auto,Auto,Auto,Auto"
+                                                                                                      RowSpacing="8">
+                                                                                                        <CheckBox HorizontalAlignment="Right"
+                                                                                                                  IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                                                                                                  Click="RowCheckBox_OnClick" />
+                                                                                                        <Image Grid.Row="1"
+                                                                                                               Width="36"
+                                                                                                               Height="36"
+                                                                                                               HorizontalAlignment="Center"
+                                                                                                               Source="{Binding IconBitmap}"
+                                                                                                               Stretch="Uniform" />
+                                                                                                        <TextBlock Grid.Row="2"
+                                                                                                                   Text="{Binding Name}"
+                                                                                                                   HorizontalAlignment="Center"
+                                                                                                                   TextAlignment="Center"
+                                                                                                                   TextTrimming="CharacterEllipsis"
+                                                                                                                   MaxWidth="150"
+                                                                                                                   Classes="data-primary" />
+                                                                                                        <Button Grid.Row="3"
+                                                                                                                HorizontalAlignment="Stretch"
+                                                                                                                Classes="toolbar-secondary"
+                                                                                                                Content="{Binding PrimaryActionLabel}"
+                                                                                                                Command="{Binding PrimaryActionCommand}"
+                                                                                                                IsEnabled="{Binding CanExecutePrimaryAction}" />
+                                                                                                </Grid>
+                                                                                        </Border>
+                                                                                </DataTemplate>
+                                                                        </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+                                                        </Grid>
+                                                </ScrollViewer>
+
+                                                <Border x:Name="EmptyStateCard"
+                                                                                Padding="24"
+                                                                                Classes="surface-card subtle-panel"
+                                                                                CornerRadius="18">
+                                                        <StackPanel HorizontalAlignment="Center"
+                                                                                                        VerticalAlignment="Center"
+                                                                                                        Spacing="10">
+                                                                <TextBlock x:Name="EmptyStateTitleBlock"
+                                                                                                         HorizontalAlignment="Center"
+                                                                                                         FontSize="22"
+                                                                                                         FontWeight="Bold"
+                                                                                                         TextAlignment="Center" />
+                                                                <TextBlock x:Name="EmptyStateDescriptionBlock"
+                                                                                                         MaxWidth="520"
+                                                                                                         HorizontalAlignment="Center"
+                                                                                                         Opacity="0.74"
+                                                                                                         TextAlignment="Center"
+                                                                                                         TextWrapping="Wrap" />
+                                                        </StackPanel>
+                                                </Border>
+                                        </Grid>
+                                </Grid>
+                        </Border>
+                </Grid>
+        </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/PackagePageView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/PackagePageView.axaml.cs
@@ -1,0 +1,2435 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Models;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
+using UniGetUI.Interface.Telemetry;
+using UniGetUI.PackageEngine.Classes.Packages.Classes;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Operations;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.PackageLoader;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class PackagePageView : UserControl, IShellPage
+{
+    private readonly string _defaultEmptyStateTitle;
+    private readonly string _defaultEmptyStateDescription;
+    private readonly bool _showNewVersionColumn;
+    private readonly PackagePageMode _pageMode;
+    private readonly ObservableCollection<PackageRowModel> _visibleRows = [];
+
+    private enum SortColumn { Name, Id, Version, Status, Source }
+    private enum PackageListViewMode { List = 0, Grid = 1, Icons = 2 }
+
+    private readonly AbstractPackageLoader? _loader;
+    private CancellationTokenSource? _discoverSearchCancellationSource;
+    private string _searchQuery = string.Empty;
+    private PackageRowModel? _selectedRow;
+    private HashSet<string>? _sourceFilter; // null = all sources visible
+    private AbstractOperation? _lastOperation;
+    private SortColumn _sortColumn = SortColumn.Name;
+    private bool _sortDescending;
+    private string _typeQuery = string.Empty;
+    private int _lastTypeKeyDown;
+    private const int TypeQuerySeparationTimeMs = 1000;
+    private PackageListViewMode _viewMode = PackageListViewMode.List;
+    private bool _isUpdatingViewModeSelector;
+    private DateTime? _lastPackageLoadTime;
+
+    private sealed class SourceFilterEntry
+    {
+        public required string ManagerName { get; init; }
+        public required string ManagerDisplayName { get; init; }
+        public required string SourceDisplayName { get; init; }
+        public required string FilterKey { get; init; }
+    }
+
+    // Tracks whether the one-time backup-on-load has run for the Installed page
+    private static bool _hasBackedUp;
+
+    private TextBlock PageTitleText => GetControl<TextBlock>("PageTitleBlock");
+
+    private TextBlock PageSubtitleText => GetControl<TextBlock>("PageSubtitleBlock");
+
+    private Button PrimaryAction => GetControl<Button>("PrimaryActionButton");
+    private Button PrimaryActionDropdown => GetControl<Button>("PrimaryActionDropdownButton");
+
+    private Button InstallOptionsAction => GetControl<Button>("InstallOptionsButton");
+
+    private Button DetailsAction => GetControl<Button>("DetailsButton");
+
+    private Button ShareAction => GetControl<Button>("ShareButton");
+
+    private TextBlock GlyphText => GetControl<TextBlock>("GlyphBlock");
+
+    private TextBlock SourcesTitleText => GetControl<TextBlock>("SourcesTitleBlock");
+
+    private TextBlock SourcesDescriptionText => GetControl<TextBlock>("SourcesDescriptionBlock");
+
+    private TextBlock SourcesEmptyStateText => GetControl<TextBlock>("SourcesEmptyStateBlock");
+
+    private Button ClearFilterBtn => GetControl<Button>("ClearSourceFilterButton");
+
+    private ItemsControl SourceToggles => GetControl<ItemsControl>("SourceTogglesItemsControl");
+
+    private TextBlock FiltersTitleText => GetControl<TextBlock>("FiltersTitleBlock");
+
+    private RadioButton PackageNameFilterOption => GetControl<RadioButton>("PackageNameFilterRadio");
+
+    private RadioButton PackageIdFilterOption => GetControl<RadioButton>("PackageIdFilterRadio");
+
+    private RadioButton BothFilterOption => GetControl<RadioButton>("BothFilterRadio");
+
+    private RadioButton ExactMatchFilterOption => GetControl<RadioButton>("ExactMatchFilterRadio");
+
+    private RadioButton ShowSimilarResultsOption => GetControl<RadioButton>("ShowSimilarResultsRadio");
+
+    private CheckBox InstantSearchOption => GetControl<CheckBox>("InstantSearchCheckBox");
+    private CheckBox UpperLowerCaseOption => GetControl<CheckBox>("UpperLowerCaseCheckBox");
+    private CheckBox IgnoreSpecialCharsOption => GetControl<CheckBox>("IgnoreSpecialCharsCheckBox");
+    private Button ReloadBtn => GetControl<Button>("ReloadButton");
+
+    private Border WinGetWarningCardControl => GetControl<Border>("WinGetWarningCard");
+    private TextBlock WinGetWarningTitleText => GetControl<TextBlock>("WinGetWarningTitleBlock");
+    private TextBlock WinGetWarningDescriptionText => GetControl<TextBlock>("WinGetWarningDescriptionBlock");
+    private Button RepairWinGetButtonControl => GetControl<Button>("RepairWinGetButton");
+
+    private Button PackageNameSortButton => GetControl<Button>("PackageNameSortBtn");
+
+    private Button PackageIdSortButton => GetControl<Button>("PackageIdSortBtn");
+
+    private Button VersionSortButton => GetControl<Button>("VersionSortBtn");
+
+    private Button StatusSortButton => GetControl<Button>("UpgradeColumnSortBtn");
+
+    private Button SourceSortButton => GetControl<Button>("SourceSortBtn");
+
+    private TextBlock ActionHeaderText => GetControl<TextBlock>("ActionHeaderBlock");
+
+    private Grid PackageColumnsHeader => GetControl<Grid>("PackageColumnsHeaderGrid");
+
+    private TextBlock EmptyStateTitleText => GetControl<TextBlock>("EmptyStateTitleBlock");
+
+    private TextBlock EmptyStateDescriptionText => GetControl<TextBlock>("EmptyStateDescriptionBlock");
+
+    private TextBlock SearchStateText => GetControl<TextBlock>("SearchStateBlock");
+
+    private TextBlock OperationStateText => GetControl<TextBlock>("OperationStateBlock");
+
+    private Button ViewOutputBtn => GetControl<Button>("ViewOutputButton");
+    private Button IgnoreSelectedBtn => GetControl<Button>("IgnoreSelectedButton");
+    private Button ExportSelectionBtn => GetControl<Button>("ExportSelectionButton");
+    private Button ManageIgnoredBtn => GetControl<Button>("ManageIgnoredButton");
+
+    private CheckBox SelectAllCheckBoxControl => GetControl<CheckBox>("SelectAllCheckBox");
+
+    private TextBlock ViewModeLabelText => GetControl<TextBlock>("ViewModeLabelBlock");
+
+    private ComboBox ViewModeSelectorControl => GetControl<ComboBox>("ViewModeSelector");
+
+    private ItemsControl PackageRowsListItems => GetControl<ItemsControl>("PackageRowsListItemsControl");
+
+    private ItemsControl PackageRowsGridItems => GetControl<ItemsControl>("PackageRowsGridItemsControl");
+
+    private ItemsControl PackageRowsIconsItems => GetControl<ItemsControl>("PackageRowsIconsItemsControl");
+
+    private ScrollViewer PackageRowsScrollHost => GetControl<ScrollViewer>("PackageRowsScrollViewer");
+
+    private Border EmptyStateHost => GetControl<Border>("EmptyStateCard");
+
+    private ProgressBar LoadingProgressBarControl => GetControl<ProgressBar>("LoadingProgressBar");
+
+    public PackagePageView()
+        : this(
+            title: string.Empty,
+            subtitle: string.Empty,
+            searchPlaceholder: string.Empty,
+            primaryActionLabel: string.Empty,
+            pageGlyph: "◎",
+            emptyStateTitle: string.Empty,
+            emptyStateDescription: string.Empty,
+            showUpgradeColumn: false,
+            filtersTitle: string.Empty,
+            pageMode: PackagePageMode.None
+        )
+    {
+    }
+
+    public PackagePageView(
+        string title,
+        string subtitle,
+        string searchPlaceholder,
+        string primaryActionLabel,
+        string pageGlyph,
+        string emptyStateTitle,
+        string emptyStateDescription,
+        bool showUpgradeColumn,
+        string filtersTitle,
+        PackagePageMode pageMode
+    )
+    {
+        Title = title;
+        Subtitle = subtitle;
+        SearchPlaceholder = searchPlaceholder;
+        SupportsSearch = pageMode != PackagePageMode.None;
+        _defaultEmptyStateTitle = emptyStateTitle;
+        _defaultEmptyStateDescription = emptyStateDescription;
+        _showNewVersionColumn = showUpgradeColumn;
+        _pageMode = pageMode;
+
+        InitializeComponent();
+        ApplyStaticTranslations();
+        ViewModeSelectorControl.SelectionChanged += ViewModeSelector_OnSelectionChanged;
+        PackageRowsListItems.ItemsSource = _visibleRows;
+        PackageRowsGridItems.ItemsSource = _visibleRows;
+        PackageRowsIconsItems.ItemsSource = _visibleRows;
+        AttachFilterEvents();
+
+        if (Design.IsDesignMode)
+        {
+            ViewModeSelectorControl.SelectedIndex = (int)PackageListViewMode.List;
+            ApplyViewMode(PackageListViewMode.List, persist: false);
+        }
+        else
+        {
+            InitializeViewModeSelector();
+        }
+
+        PageTitleText.Text = title;
+        PageSubtitleText.Text = subtitle;
+        PrimaryAction.Content = pageMode == PackagePageMode.Updates
+            ? CoreTools.Translate("Update all")
+            : primaryActionLabel;
+        GlyphText.Text = pageGlyph;
+        FiltersTitleText.Text = filtersTitle;
+        EmptyStateTitleText.Text = emptyStateTitle;
+        EmptyStateDescriptionText.Text = emptyStateDescription;
+        ActionHeaderText.Text = CoreTools.Translate("Operation in progress");
+
+        PrimaryAction.Click += PrimaryAction_OnClick;
+        PrimaryActionDropdown.Click += PrimaryActionDropdown_OnClick;
+        DetailsAction.Click += DetailsAction_OnClick;
+        InstallOptionsAction.Click += InstallOptionsAction_OnClick;
+        ShareAction.Click += ShareAction_OnClick;
+        PackageRowsListItems.AddHandler(
+            InputElement.PointerPressedEvent,
+            OnPackageRowsPointerPressed,
+            RoutingStrategies.Bubble
+        );
+        PackageRowsGridItems.AddHandler(
+            InputElement.PointerPressedEvent,
+            OnPackageRowsPointerPressed,
+            RoutingStrategies.Bubble
+        );
+        PackageRowsIconsItems.AddHandler(
+            InputElement.PointerPressedEvent,
+            OnPackageRowsPointerPressed,
+            RoutingStrategies.Bubble
+        );
+
+        if (pageMode == PackagePageMode.Updates)
+            ManageIgnoredBtn.IsVisible = true;
+
+        if (pageMode is PackagePageMode.Updates or PackagePageMode.Installed)
+            IgnoreSelectedBtn.IsVisible = true;
+
+        if (pageMode is not PackagePageMode.None)
+            ExportSelectionBtn.IsVisible = true;
+
+        if (Design.IsDesignMode)
+        {
+            SearchStateText.Text = CoreTools.Translate("Search mode");
+            EmptyStateTitleText.Text = CoreTools.Translate("Search for packages");
+            EmptyStateDescriptionText.Text = CoreTools.Translate("Search for packages to start");
+            PackageRowsScrollHost.IsVisible = false;
+            EmptyStateHost.IsVisible = true;
+            return;
+        }
+
+        _loader = ResolveLoader(pageMode);
+        UpdateSortIndicators();
+
+        if (_loader is not null)
+        {
+            AttachLoaderEvents(_loader);
+            _ = LoadPackagesAsync();
+        }
+        else
+        {
+            SearchStateText.Text = CoreTools.Translate("Loading packages");
+            RefreshRows();
+        }
+    }
+
+    private void ApplyStaticTranslations()
+    {
+        InstallOptionsAction.Content = GetInstallOptionsLabel();
+        DetailsAction.Content = CoreTools.Translate("Package details");
+        ShareAction.Content = CoreTools.Translate("Share");
+        IgnoreSelectedBtn.Content = CoreTools.Translate("Ignore updates for the selected packages");
+        ExportSelectionBtn.Content = CoreTools.Translate("Add selection to bundle");
+        SourcesTitleText.Text = CoreTools.Translate("Sources");
+        ClearFilterBtn.Content = CoreTools.Translate("Reset");
+        SourcesDescriptionText.Text = CoreTools.Translate("Toggle search filters pane");
+        SourcesEmptyStateText.Text = CoreTools.Translate("No packages were found");
+        PackageNameFilterOption.Content = CoreTools.Translate("Package Name");
+        PackageIdFilterOption.Content = CoreTools.Translate("Package ID");
+        BothFilterOption.Content = CoreTools.Translate("Both");
+        ExactMatchFilterOption.Content = CoreTools.Translate("Exact match");
+        ShowSimilarResultsOption.Content = CoreTools.Translate("Show similar packages");
+        InstantSearchOption.Content = CoreTools.Translate("Instant search");
+        UpperLowerCaseOption.Content = CoreTools.Translate("Distinguish between uppercase and lowercase");
+        IgnoreSpecialCharsOption.Content = CoreTools.Translate("Ignore special characters");
+        ReloadBtn.Content = CoreTools.Translate("Reload");
+        ViewModeLabelText.Text = CoreTools.Translate("View mode:");
+        ToggleFiltersButtonControl.Content = CoreTools.Translate("Filters");
+
+        if (ViewModeSelectorControl.Items is IList<object> items && items.Count >= 3)
+        {
+            if (items[0] is ComboBoxItem listItem)
+                listItem.Content = CoreTools.Translate("List");
+            if (items[1] is ComboBoxItem gridItem)
+                gridItem.Content = CoreTools.Translate("Grid");
+            if (items[2] is ComboBoxItem iconsItem)
+                iconsItem.Content = CoreTools.Translate("Icons");
+        }
+
+        WinGetWarningTitleText.Text = CoreTools.Translate("WinGet malfunction detected");
+        WinGetWarningDescriptionText.Text = CoreTools.Translate(
+            "It looks like WinGet is not working properly. Do you want to attempt to repair WinGet?"
+        );
+        RepairWinGetButtonControl.Content = CoreTools.Translate("Repair WinGet");
+    }
+
+    private void InitializeViewModeSelector()
+    {
+        int savedMode = Settings.GetDictionaryItem<string, int>(
+            Settings.K.PackageListViewMode,
+            GetPageSettingsKey()
+        );
+
+        var parsedMode = ParseViewMode(savedMode);
+
+        _isUpdatingViewModeSelector = true;
+        ViewModeSelectorControl.SelectedIndex = (int)parsedMode;
+        _isUpdatingViewModeSelector = false;
+
+        ApplyViewMode(parsedMode, persist: false);
+    }
+
+    private string GetPageSettingsKey()
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => "Discover",
+            PackagePageMode.Updates => "Updates",
+            PackagePageMode.Installed => "Installed",
+            _ => "Discover",
+        };
+    }
+
+    private static PackageListViewMode ParseViewMode(int mode)
+    {
+        return Enum.IsDefined(typeof(PackageListViewMode), mode)
+            ? (PackageListViewMode)mode
+            : PackageListViewMode.List;
+    }
+
+    private ItemsControl ActivePackageRowsItems => _viewMode switch
+    {
+        PackageListViewMode.Grid => PackageRowsGridItems,
+        PackageListViewMode.Icons => PackageRowsIconsItems,
+        _ => PackageRowsListItems,
+    };
+
+    private void ApplyViewMode(PackageListViewMode mode, bool persist)
+    {
+        _viewMode = mode;
+
+        bool isList = mode == PackageListViewMode.List;
+        PackageRowsListItems.IsVisible = isList;
+        PackageRowsGridItems.IsVisible = mode == PackageListViewMode.Grid;
+        PackageRowsIconsItems.IsVisible = mode == PackageListViewMode.Icons;
+        PackageColumnsHeader.IsVisible = isList;
+
+        if (!_isUpdatingViewModeSelector && ViewModeSelectorControl.SelectedIndex != (int)mode)
+        {
+            _isUpdatingViewModeSelector = true;
+            ViewModeSelectorControl.SelectedIndex = (int)mode;
+            _isUpdatingViewModeSelector = false;
+        }
+
+        if (persist)
+        {
+            Settings.SetDictionaryItem(
+                Settings.K.PackageListViewMode,
+                GetPageSettingsKey(),
+                (int)mode
+            );
+        }
+    }
+
+    private void ViewModeSelector_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_isUpdatingViewModeSelector)
+            return;
+
+        var mode = ParseViewMode(ViewModeSelectorControl.SelectedIndex);
+        ApplyViewMode(mode, persist: true);
+    }
+
+    public string Title { get; }
+
+    public string Subtitle { get; }
+
+    public bool SupportsSearch { get; }
+
+    public string SearchPlaceholder { get; }
+
+    public void UpdateSearchQuery(string query)
+    {
+        _searchQuery = query.Trim();
+
+        if (_pageMode == PackagePageMode.Discover)
+        {
+            // When instant search is disabled, only trigger on empty query (to reset the list)
+            if (string.IsNullOrWhiteSpace(_searchQuery) || InstantSearchOption.IsChecked != false)
+                ScheduleDiscoverSearch();
+            return;
+        }
+
+        RefreshRows();
+    }
+
+    private static AbstractPackageLoader? ResolveLoader(PackagePageMode pageMode)
+    {
+        return pageMode switch
+        {
+            PackagePageMode.Discover => DiscoverablePackagesLoader.Instance,
+            PackagePageMode.Updates => UpgradablePackagesLoader.Instance,
+            PackagePageMode.Installed => InstalledPackagesLoader.Instance,
+            _ => null,
+        };
+    }
+
+    private void AttachLoaderEvents(AbstractPackageLoader loader)
+    {
+        loader.StartedLoading += OnLoaderStartedLoading;
+        loader.PackagesChanged += OnLoaderPackagesChanged;
+        loader.FinishedLoading += OnLoaderFinishedLoading;
+    }
+
+    private void AttachFilterEvents()
+    {
+        PackageNameFilterOption.IsCheckedChanged += FilterOption_OnChecked;
+        PackageIdFilterOption.IsCheckedChanged += FilterOption_OnChecked;
+        BothFilterOption.IsCheckedChanged += FilterOption_OnChecked;
+        ExactMatchFilterOption.IsCheckedChanged += FilterOption_OnChecked;
+        ShowSimilarResultsOption.IsCheckedChanged += FilterOption_OnChecked;
+        InstantSearchOption.IsCheckedChanged += FilterOption_OnChecked;
+        UpperLowerCaseOption.IsCheckedChanged += FilterOption_OnChecked;
+        IgnoreSpecialCharsOption.IsCheckedChanged += FilterOption_OnChecked;
+    }
+
+    private void FilterOption_OnChecked(object? sender, RoutedEventArgs e)
+    {
+        RefreshRows();
+    }
+
+    private async void PrimaryAction_OnClick(object? sender, RoutedEventArgs e)
+    {
+        // Operate on checked rows, or fall back to all visible eligible packages when none are checked
+        var checkedRows = _visibleRows.Where(r => r.IsChecked).ToArray();
+        var packages = (checkedRows.Length > 0
+                ? checkedRows.Select(r => r.Package)
+                : GetPackageSnapshot())
+            .Where(CanRunPrimaryAction)
+            .OrderBy(package => package.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (packages.Length == 0)
+        {
+            return;
+        }
+
+        int queuedCount = 0;
+        foreach (var package in packages)
+        {
+            if (await QueuePrimaryActionAsync(package, updateSummaryAfterQueue: false))
+            {
+                queuedCount++;
+            }
+        }
+
+        if (queuedCount > 0)
+        {
+            OperationStateText.Text = _pageMode switch
+            {
+                PackagePageMode.Discover => CoreTools.Translate("(Number {0} in the queue)", queuedCount),
+                PackagePageMode.Installed => CoreTools.Translate("(Number {0} in the queue)", queuedCount),
+                _ => CoreTools.Translate("(Number {0} in the queue)", queuedCount),
+            };
+            RefreshRows();
+        }
+    }
+
+    private void PrimaryActionDropdown_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var menu = new ContextMenu();
+
+        string adminLabel = _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("Install as administrator"),
+            PackagePageMode.Updates => CoreTools.Translate("Update as administrator"),
+            PackagePageMode.Installed => CoreTools.Translate("Uninstall as administrator"),
+            _ => CoreTools.Translate("Install as administrator"),
+        };
+        var adminItem = new MenuItem { Header = adminLabel };
+        adminItem.Click += async (_, _) => await QueueAllCheckedWithFlagsAsync(elevated: true);
+        menu.Items.Add(adminItem);
+
+        string interactiveLabel = _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("Interactive installation"),
+            PackagePageMode.Updates => CoreTools.Translate("Interactive update"),
+            PackagePageMode.Installed => CoreTools.Translate("Interactive uninstall"),
+            _ => CoreTools.Translate("Interactive installation"),
+        };
+        var interactiveItem = new MenuItem { Header = interactiveLabel };
+        interactiveItem.Click += async (_, _) => await QueueAllCheckedWithFlagsAsync(interactive: true);
+        menu.Items.Add(interactiveItem);
+
+        if (_pageMode != PackagePageMode.Installed)
+        {
+            var skipHashItem = new MenuItem { Header = CoreTools.Translate("Skip integrity checks") };
+            skipHashItem.Click += async (_, _) => await QueueAllCheckedWithFlagsAsync(skipHash: true);
+            menu.Items.Add(skipHashItem);
+        }
+
+        // Download selected installers (Discover / Updates only, for capable managers)
+        if (_pageMode != PackagePageMode.Installed)
+        {
+            var checkedDownloadable = _visibleRows
+                .Where(r => r.IsChecked && r.Package.Manager.Capabilities.CanDownloadInstaller)
+                .ToArray();
+            if (checkedDownloadable.Length > 0)
+            {
+                menu.Items.Add(new Separator());
+                var downloadSelectedItem = new MenuItem { Header = CoreTools.Translate("Download selected installers") };
+                downloadSelectedItem.Click += async (_, _) =>
+                {
+                    foreach (var row in checkedDownloadable)
+                        await DownloadPackageInstallerAsync(row.Package);
+                };
+                menu.Items.Add(downloadSelectedItem);
+            }
+        }
+
+        if (sender is Control anchor)
+        {
+            menu.PlacementTarget = anchor;
+            menu.Placement = PlacementMode.Bottom;
+            menu.Open(anchor);
+        }
+    }
+
+    private async Task QueueAllCheckedWithFlagsAsync(
+        bool elevated = false,
+        bool interactive = false,
+        bool skipHash = false)
+    {
+        var checkedRows = _visibleRows.Where(r => r.IsChecked).ToArray();
+        var packages = (checkedRows.Length > 0
+                ? checkedRows.Select(r => r.Package)
+                : GetPackageSnapshot())
+            .Where(CanRunPrimaryAction)
+            .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (packages.Length == 0) return;
+
+        if (_pageMode == PackagePageMode.Installed
+            && !await ConfirmUninstallAsync(packages))
+        {
+            return;
+        }
+
+        int queuedCount = 0;
+        foreach (var package in packages)
+        {
+            var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+            if (elevated) opts.RunAsAdministrator = true;
+            if (interactive) opts.InteractiveInstallation = true;
+            if (skipHash) opts.SkipHashCheck = true;
+            AbstractOperation? op = _pageMode switch
+            {
+                PackagePageMode.Discover => new InstallPackageOperation(package, opts),
+                PackagePageMode.Updates => new UpdatePackageOperation(package, opts),
+                PackagePageMode.Installed => new UninstallPackageOperation(package, opts),
+                _ => null,
+            };
+            if (op is null) continue;
+            AttachOperationEvents(op, package);
+            AvaloniaOperationRegistry.Add(op);
+            _ = op.MainThread();
+            queuedCount++;
+        }
+
+        if (queuedCount > 0)
+        {
+            OperationStateText.Text = _pageMode switch
+            {
+                PackagePageMode.Discover => CoreTools.Translate("(Number {0} in the queue)", queuedCount),
+                PackagePageMode.Installed => CoreTools.Translate("(Number {0} in the queue)", queuedCount),
+                _ => CoreTools.Translate("(Number {0} in the queue)", queuedCount),
+            };
+            RefreshRows();
+        }
+    }
+
+    private void SelectAllCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        // Cycle: indeterminate/false → check all; true → uncheck all
+        bool checkAll = SelectAllCheckBoxControl.IsChecked == true;
+        foreach (var row in _visibleRows)
+        {
+            row.IsChecked = checkAll;
+        }
+    }
+
+    /// <summary>Keyboard-triggered select-all: check all when nothing or some are checked; uncheck all when all are checked.</summary>
+    internal void TriggerSelectAll()
+    {
+        bool allChecked = _visibleRows.Count > 0 && _visibleRows.All(r => r.IsChecked);
+        bool target = !allChecked;
+        foreach (var row in _visibleRows)
+            row.IsChecked = target;
+        UpdateSelectAllState();
+    }
+
+    private void RowCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        UpdateSelectAllState();
+    }
+
+    private void UpdateSelectAllState()
+    {
+        int checkedCount = _visibleRows.Count(r => r.IsChecked);
+        SelectAllCheckBoxControl.IsChecked = checkedCount == 0
+            ? false
+            : checkedCount == _visibleRows.Count
+                ? true
+                : null; // indeterminate
+    }
+
+    private void OnLoaderStartedLoading(object? sender, EventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            LoadingProgressBarControl.IsVisible = true;
+            SearchStateText.Text = GetLoadingStateText();
+            RefreshRows();
+        });
+    }
+
+    private void OnLoaderPackagesChanged(object? sender, PackagesChangedEvent e)
+    {
+        Dispatcher.UIThread.Post(RefreshRows);
+    }
+
+    private void OnLoaderFinishedLoading(object? sender, EventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            LoadingProgressBarControl.IsVisible = false;
+            _lastPackageLoadTime = DateTime.Now;
+            RefreshRows();
+
+            if (_pageMode == PackagePageMode.Installed)
+            {
+                WinGetWarningCardControl.IsVisible = IsWinGetMalfunctionDetected();
+            }
+            else
+            {
+                WinGetWarningCardControl.IsVisible = false;
+            }
+        });
+
+        if (_pageMode == PackagePageMode.Installed && !_hasBackedUp)
+        {
+            _hasBackedUp = true;
+            _ = Task.Run(TriggerInstalledPageBackupAsync);
+        }
+
+        if (_pageMode == PackagePageMode.Updates)
+        {
+            _ = Task.Run(TriggerAutoUpdateCheckAsync);
+        }
+    }
+
+    // ── Auto-update trigger (D3: battery / battery-saver gate) ──────────────
+
+    // P/Invoke for battery status — compiles on all platforms; only called on Windows.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SYSTEM_POWER_STATUS
+    {
+        public byte ACLineStatus;       // 0 = offline (on battery), 1 = online
+        public byte BatteryFlag;
+        public byte BatteryLifePercent;
+        public byte SystemStatusFlag;   // bit 0 = Battery Saver active
+        public uint BatteryLifeTime;
+        public uint BatteryFullLifeTime;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetSystemPowerStatus(out SYSTEM_POWER_STATUS status);
+
+    private static bool IsOnBattery()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return false;
+        try { return GetSystemPowerStatus(out var s) && s.ACLineStatus == 0; }
+        catch { return false; }
+    }
+
+    private static bool IsMeteredConnection()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return false;
+
+        try
+        {
+            // Avoid a compile-time WinRT dependency in this cross-platform target.
+            var networkInfoType = Type.GetType(
+                "Windows.Networking.Connectivity.NetworkInformation, Windows, ContentType=WindowsRuntime");
+            var profile = networkInfoType?
+                .GetMethod("GetInternetConnectionProfile", BindingFlags.Public | BindingFlags.Static)?
+                .Invoke(null, null);
+            if (profile is null) return false;
+
+            var cost = profile.GetType().GetMethod("GetConnectionCost")?.Invoke(profile, null);
+            var networkCostType = cost?.GetType().GetProperty("NetworkCostType")?.GetValue(cost)?.ToString();
+            return networkCostType is "Fixed" or "Variable";
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsBatterySaverActive()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return false;
+        try { return GetSystemPowerStatus(out var s) && (s.SystemStatusFlag & 0x1) != 0; }
+        catch { return false; }
+    }
+
+    private static async Task TriggerAutoUpdateCheckAsync()
+    {
+        try
+        {
+            var upgradable = UpgradablePackagesLoader.Instance.Packages
+                .Where(p => p.Tag is not PackageTag.OnQueue and not PackageTag.BeingProcessed)
+                .ToList();
+
+            if (upgradable.Count == 0) return;
+
+            if (Settings.Get(Settings.K.DisableAUPOnMeteredConnections) && IsMeteredConnection())
+            {
+                Logger.Warn("Auto-updates skipped: current internet connection is metered.");
+                WindowsAppNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
+                return;
+            }
+
+            if (Settings.Get(Settings.K.DisableAUPOnBattery) && IsOnBattery())
+            {
+                Logger.Warn("Auto-updates skipped: device is running on battery.");
+                WindowsAppNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
+                return;
+            }
+
+            if (Settings.Get(Settings.K.DisableAUPOnBatterySaver) && IsBatterySaverActive())
+            {
+                Logger.Warn("Auto-updates skipped: Battery Saver is enabled.");
+                WindowsAppNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
+                return;
+            }
+
+            // ── B2: show update available notification ─────────────────────
+            WindowsAppNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
+
+            if (Settings.Get(Settings.K.AutomaticallyUpdatePackages)
+                || Environment.GetCommandLineArgs().Contains("--updateapps"))
+            {
+                Logger.Info("Triggering automatic update of all upgradable packages.");
+                await AvaloniaPackageOperationHelper.UpdateAllAsync();
+                return;
+            }
+
+            // Per-package AutoUpdatePackage flag
+            foreach (var pkg in upgradable)
+            {
+                var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+                if (!opts.AutoUpdatePackage) continue;
+                var op = new UpdatePackageOperation(pkg, opts);
+                AvaloniaOperationRegistry.Add(op);
+                _ = op.MainThread();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Auto-update trigger failed:");
+            Logger.Error(ex);
+        }
+    }
+
+    // ── Filter panel toggle (B1) ────────────────────────────────────────────
+
+    private bool _filterPanelVisible = true;
+
+    private Grid FilterContentGridControl => GetControl<Grid>("FilterContentGrid");
+    private StackPanel FilterPanelContainerControl => GetControl<StackPanel>("FilterPanelContainer");
+    private ToggleButton ToggleFiltersButtonControl => GetControl<ToggleButton>("ToggleFiltersButton");
+
+    private void ToggleFiltersButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _filterPanelVisible = ToggleFiltersButtonControl.IsChecked == true;
+        ApplyFilterPanelVisibility();
+    }
+
+    private void ApplyFilterPanelVisibility()
+    {
+        FilterPanelContainerControl.IsVisible = _filterPanelVisible;
+        var col = FilterContentGridControl.ColumnDefinitions[0];
+        col.Width = _filterPanelVisible
+            ? new GridLength(264, GridUnitType.Pixel)
+            : new GridLength(0, GridUnitType.Pixel);
+    }
+
+    private static bool IsWinGetMalfunctionDetected()
+    {
+        try
+        {
+            var type = Type.GetType(
+                "UniGetUI.PackageEngine.Managers.WingetManager.WinGet, UniGetUI.PackageEngine.Managers.WinGet"
+            );
+            var property = type?.GetProperty(
+                "NO_PACKAGES_HAVE_BEEN_LOADED",
+                BindingFlags.Public | BindingFlags.Static
+            );
+            return property?.GetValue(null) as bool? == true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async void RepairWinGetButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        RepairWinGetButtonControl.IsEnabled = false;
+        try
+        {
+            using var p = new Process
+            {
+                StartInfo = new()
+                {
+                    FileName = CoreData.PowerShell5,
+                    Arguments =
+                        "-ExecutionPolicy Bypass -NoLogo -NoProfile -Command \"& {"
+                        + "cmd.exe /C \"rmdir /Q /S `\"%temp%\\WinGet`\"\"; "
+                        + "cmd.exe /C \"`\"%localappdata%\\Microsoft\\WindowsApps\\winget.exe`\" source reset --force\"; "
+                        + "taskkill /im winget.exe /f; "
+                        + "taskkill /im WindowsPackageManagerServer.exe /f; "
+                        + "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; "
+                        + "Install-Module Microsoft.WinGet.Client -Force -AllowClobber; "
+                        + "Import-Module Microsoft.WinGet.Client; "
+                        + "Repair-WinGetPackageManager -Force -Latest; "
+                        + "Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' | Reset-AppxPackage; "
+                        + "}\"",
+                    UseShellExecute = true,
+                    Verb = "runas",
+                },
+            };
+            p.Start();
+            await p.WaitForExitAsync();
+
+            _ = UpgradablePackagesLoader.Instance.ReloadPackages();
+            _ = InstalledPackagesLoader.Instance.ReloadPackages();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while trying to repair WinGet");
+            Logger.Error(ex);
+        }
+        finally
+        {
+            RepairWinGetButtonControl.IsEnabled = true;
+        }
+    }
+
+    private static async Task TriggerInstalledPageBackupAsync()
+    {
+        bool shouldBackupLocal = Settings.Get(Settings.K.EnablePackageBackup_LOCAL);
+        bool shouldBackupCloud = Settings.Get(Settings.K.EnablePackageBackup_CLOUD);
+
+        if (!shouldBackupLocal && !shouldBackupCloud)
+            return;
+
+        string backupContents;
+
+        try
+        {
+            var packages = InstalledPackagesLoader.Instance.Packages.ToArray();
+            backupContents = await BundlesPageView.CreateBundleStringAsync(packages);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while generating installed-page backup contents");
+            Logger.Error(ex);
+            return;
+        }
+
+        if (shouldBackupLocal)
+            await SaveInstalledPageBackupLocallyAsync(backupContents);
+
+        if (shouldBackupCloud)
+            await SaveInstalledPageBackupToCloudAsync(backupContents);
+    }
+
+    private static async Task SaveInstalledPageBackupLocallyAsync(string backupContents)
+    {
+        try
+        {
+            string dirName = Settings.GetValue(Settings.K.ChangeBackupOutputDirectory);
+            if (string.IsNullOrEmpty(dirName))
+                dirName = CoreData.UniGetUI_DefaultBackupDirectory;
+
+            if (!Directory.Exists(dirName))
+                Directory.CreateDirectory(dirName);
+
+            string fileName = Settings.GetValue(Settings.K.ChangeBackupFileName);
+            if (string.IsNullOrEmpty(fileName))
+                fileName = CoreTools.Translate("{pcName} installed packages",
+                    new Dictionary<string, object?> { { "pcName", Environment.MachineName } });
+
+            if (Settings.Get(Settings.K.EnableBackupTimestamping))
+                fileName += " " + DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss");
+
+            fileName += ".ubundle";
+
+            string filePath = Path.Combine(dirName, fileName);
+            await File.WriteAllTextAsync(filePath, backupContents);
+            Logger.ImportantInfo("Backup saved to " + filePath);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while performing a LOCAL backup");
+            Logger.Error(ex);
+        }
+    }
+
+    private static async Task SaveInstalledPageBackupToCloudAsync(string backupContents)
+    {
+        try
+        {
+            await CoreTools.WaitForInternetConnection();
+            await GitHubCloudBackupService.UploadPackageBundleAsync(backupContents);
+            Logger.ImportantInfo("Cloud backup succeeded");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while performing a CLOUD backup");
+            Logger.Error(ex);
+        }
+    }
+
+    private void ScheduleDiscoverSearch()
+    {
+        _discoverSearchCancellationSource?.Cancel();
+
+        if (string.IsNullOrWhiteSpace(_searchQuery))
+        {
+            RefreshRows();
+            return;
+        }
+
+        SearchStateText.Text = CoreTools.Translate("Searching for packages...");
+        var cancellationSource = new CancellationTokenSource();
+        _discoverSearchCancellationSource = cancellationSource;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(350, cancellationSource.Token);
+                if (cancellationSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                await LoadPackagesAsync();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+        });
+    }
+
+    private async Task LoadPackagesAsync()
+    {
+        try
+        {
+            if (_loader is null)
+            {
+                return;
+            }
+
+            switch (_pageMode)
+            {
+                case PackagePageMode.Discover:
+                    if (!string.IsNullOrWhiteSpace(_searchQuery))
+                    {
+                        await DiscoverablePackagesLoader.Instance.ReloadPackages(_searchQuery);
+                    }
+                    break;
+                case PackagePageMode.Updates:
+                case PackagePageMode.Installed:
+                    if (!_loader.IsLoading)
+                    {
+                        await _loader.ReloadPackages();
+                    }
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+            Dispatcher.UIThread.Post(() =>
+            {
+                SearchStateText.Text = CoreTools.Translate("Error");
+                EmptyStateTitleText.Text = CoreTools.Translate("An error occurred");
+                EmptyStateDescriptionText.Text = ex.Message;
+                PackageRowsScrollHost.IsVisible = false;
+                EmptyStateHost.IsVisible = true;
+            });
+        }
+    }
+
+    private void ReloadButton_OnClick(object? sender, RoutedEventArgs e) => _ = LoadPackagesAsync();
+
+    private void NameHeader_OnClick(object? sender, RoutedEventArgs e) => SetSort(SortColumn.Name);
+
+    private void IdHeader_OnClick(object? sender, RoutedEventArgs e) => SetSort(SortColumn.Id);
+
+    private void VersionHeader_OnClick(object? sender, RoutedEventArgs e) => SetSort(SortColumn.Version);
+
+    private void StatusHeader_OnClick(object? sender, RoutedEventArgs e) => SetSort(SortColumn.Status);
+
+    private void SourceHeader_OnClick(object? sender, RoutedEventArgs e) => SetSort(SortColumn.Source);
+
+    private void SetSort(SortColumn col)
+    {
+        if (_sortColumn == col)
+            _sortDescending = !_sortDescending;
+        else
+        {
+            _sortColumn = col;
+            _sortDescending = false;
+        }
+
+        RefreshRows();
+    }
+
+    private void UpdateSortIndicators()
+    {
+        string indicator = _sortDescending ? " ↓" : " ↑";
+        string statusLabel = _showNewVersionColumn
+            ? CoreTools.Translate("New version")
+            : CoreTools.Translate("Package Manager");
+
+        PackageNameSortButton.Content = CoreTools.Translate("Package Name")
+            + (_sortColumn == SortColumn.Name ? indicator : "");
+        PackageIdSortButton.Content = CoreTools.Translate("Package ID")
+            + (_sortColumn == SortColumn.Id ? indicator : "");
+        VersionSortButton.Content = CoreTools.Translate("Version")
+            + (_sortColumn == SortColumn.Version ? indicator : "");
+        StatusSortButton.Content = statusLabel
+            + (_sortColumn == SortColumn.Status ? indicator : "");
+        SourceSortButton.Content = CoreTools.Translate("Source")
+            + (_sortColumn == SortColumn.Source ? indicator : "");
+
+        PackageNameSortButton.Classes.Set("active", _sortColumn == SortColumn.Name);
+        PackageIdSortButton.Classes.Set("active", _sortColumn == SortColumn.Id);
+        VersionSortButton.Classes.Set("active", _sortColumn == SortColumn.Version);
+        StatusSortButton.Classes.Set("active", _sortColumn == SortColumn.Status);
+        SourceSortButton.Classes.Set("active", _sortColumn == SortColumn.Source);
+    }
+
+    private string GetSortKey(IPackage p) => _sortColumn switch
+    {
+        SortColumn.Name => p.Name,
+        SortColumn.Id => p.Id,
+        SortColumn.Version => p.VersionString,
+        SortColumn.Status => _showNewVersionColumn ? p.NewVersionString : p.Manager.DisplayName,
+        SortColumn.Source => p.Source.AsString_DisplayName,
+        _ => p.Name,
+    };
+
+    private void RefreshRows()
+    {
+        var packagesSnapshot = GetPackageSnapshot();
+
+        IEnumerable<IPackage> sorted = _sortDescending
+            ? packagesSnapshot
+                .OrderByDescending(GetSortKey, StringComparer.OrdinalIgnoreCase)
+                .ThenByDescending(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            : packagesSnapshot
+                .OrderBy(GetSortKey, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+        var filteredPackages = sorted.ToArray();
+
+        ClearVisibleRows();
+        _visibleRows.Clear();
+        foreach (var package in filteredPackages)
+        {
+            _visibleRows.Add(
+                new PackageRowModel(
+                    package,
+                    _showNewVersionColumn,
+                    _pageMode,
+                    QueuePrimaryActionAsync
+                )
+            );
+        }
+
+        PackageRowsScrollHost.IsVisible = _visibleRows.Count > 0;
+        EmptyStateHost.IsVisible = _visibleRows.Count == 0;
+
+        UpdateToolbarActions(filteredPackages);
+        UpdateSourceSummary(filteredPackages);
+        UpdateEmptyState(filteredPackages.Length);
+        UpdateStatusSummary(packagesSnapshot.Count, filteredPackages.Length);
+        UpdateSelectAllState();
+        UpdateSortIndicators();
+    }
+
+    private async Task QueuePrimaryActionAsync(IPackage package)
+    {
+        await QueuePrimaryActionAsync(package, updateSummaryAfterQueue: true);
+    }
+
+    private async Task<bool> QueuePrimaryActionAsync(
+        IPackage package,
+        bool updateSummaryAfterQueue = true
+    )
+    {
+        if (!CanRunPrimaryAction(package))
+        {
+            return false;
+        }
+
+        if (_pageMode == PackagePageMode.Installed
+            && !await ConfirmUninstallAsync(package))
+        {
+            return false;
+        }
+
+        try
+        {
+            var operation = await CreatePrimaryActionOperationAsync(package);
+            if (operation is null)
+            {
+                return false;
+            }
+
+            AttachOperationEvents(operation, package);
+            AvaloniaOperationRegistry.Add(operation);
+            _ = operation.MainThread();
+
+            if (updateSummaryAfterQueue)
+            {
+                OperationStateText.Text = GetQueuedStateText(package);
+                RefreshRows();
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+            OperationStateText.Text = ex.Message;
+            return false;
+        }
+    }
+
+    private async Task<AbstractOperation?> CreatePrimaryActionOperationAsync(IPackage package)
+    {
+        var options = await InstallOptionsFactory.LoadApplicableAsync(package);
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => new InstallPackageOperation(package, options),
+            PackagePageMode.Updates => new UpdatePackageOperation(package, options),
+            PackagePageMode.Installed => new UninstallPackageOperation(package, options),
+            _ => null,
+        };
+    }
+
+    private async Task QueuePrimaryActionWithFlagsAsync(
+        IPackage package,
+        bool elevated = false,
+        bool interactive = false,
+        bool skipHash = false)
+    {
+        if (!CanRunPrimaryAction(package)) return;
+        if (_pageMode == PackagePageMode.Installed
+            && !await ConfirmUninstallAsync(package))
+        {
+            return;
+        }
+
+        var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+        if (elevated) opts.RunAsAdministrator = true;
+        if (interactive) opts.InteractiveInstallation = true;
+        if (skipHash) opts.SkipHashCheck = true;
+        AbstractOperation? operation = _pageMode switch
+        {
+            PackagePageMode.Discover => new InstallPackageOperation(package, opts),
+            PackagePageMode.Updates => new UpdatePackageOperation(package, opts),
+            PackagePageMode.Installed => new UninstallPackageOperation(package, opts),
+            _ => null,
+        };
+        if (operation is null) return;
+        AttachOperationEvents(operation, package);
+        AvaloniaOperationRegistry.Add(operation);
+        _ = operation.MainThread();
+        OperationStateText.Text = GetQueuedStateText(package);
+        RefreshRows();
+    }
+
+    private async Task DownloadPackageInstallerAsync(IPackage package)
+    {
+        if (!package.Manager.Capabilities.CanDownloadInstaller) return;
+        var topLevel = global::Avalonia.Controls.TopLevel.GetTopLevel(this);
+        if (topLevel is null) return;
+
+        var file = await topLevel.StorageProvider.SaveFilePickerAsync(new global::Avalonia.Platform.Storage.FilePickerSaveOptions
+        {
+            Title = CoreTools.Translate("Download installer"),
+            SuggestedFileName = package.Id,
+            DefaultExtension = "exe",
+            FileTypeChoices =
+            [
+                new global::Avalonia.Platform.Storage.FilePickerFileType("Executable") { Patterns = ["*.exe"] },
+                new global::Avalonia.Platform.Storage.FilePickerFileType("MSI") { Patterns = ["*.msi"] },
+                new global::Avalonia.Platform.Storage.FilePickerFileType("Compressed file") { Patterns = ["*.zip"] },
+                new global::Avalonia.Platform.Storage.FilePickerFileType("MSIX") { Patterns = ["*.msix"] },
+                new global::Avalonia.Platform.Storage.FilePickerFileType("NuGet package") { Patterns = ["*.nupkg"] },
+            ],
+        });
+        if (file is null) return;
+
+        var op = new DownloadOperation(package, file.Path.LocalPath);
+        AvaloniaOperationRegistry.Add(op);
+        _ = op.MainThread();
+        OperationStateText.Text = CoreTools.Translate("{0} installer is being downloaded", package.Name);
+    }
+
+    private async Task<bool> ConfirmUninstallAsync(IPackage package)
+    {
+        if (VisualRoot is not Window owner)
+        {
+            return true;
+        }
+
+        return await UninstallConfirmationDialog.ConfirmAsync(owner, package);
+    }
+
+    private async Task<bool> ConfirmUninstallAsync(IReadOnlyList<IPackage> packages)
+    {
+        if (packages.Count == 0 || VisualRoot is not Window owner)
+        {
+            return packages.Count > 0;
+        }
+
+        return await UninstallConfirmationDialog.ConfirmAsync(owner, packages);
+    }
+
+    private void AttachOperationEvents(AbstractOperation operation, IPackage package)
+    {
+        _lastOperation = operation;
+        Dispatcher.UIThread.Post(() => ViewOutputBtn.IsVisible = true);
+
+        operation.Enqueued += (_, _) => Dispatcher.UIThread.Post(() =>
+        {
+            OperationStateText.Text = GetQueuedStateText(package);
+            RefreshRows();
+        });
+
+        operation.OperationStarting += (_, _) => Dispatcher.UIThread.Post(() =>
+        {
+            OperationStateText.Text = GetRunningStateText(package);
+            RefreshRows();
+        });
+
+        operation.OperationSucceeded += (_, _) => Dispatcher.UIThread.Post(() =>
+        {
+            OperationStateText.Text = GetSuccessStateText(package);
+            RefreshRows();
+            if (operation is InstallPackageOperation)
+                TelemetryHandler.InstallPackage(package, TEL_OP_RESULT.SUCCESS, TEL_InstallReferral.DIRECT_SEARCH);
+            else if (operation is UpdatePackageOperation)
+                TelemetryHandler.UpdatePackage(package, TEL_OP_RESULT.SUCCESS);
+            else if (operation is UninstallPackageOperation)
+                TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.SUCCESS);
+            else if (operation is DownloadOperation)
+                TelemetryHandler.DownloadPackage(package, TEL_OP_RESULT.SUCCESS, TEL_InstallReferral.DIRECT_SEARCH);
+        });
+
+        operation.OperationFailed += (_, _) => Dispatcher.UIThread.Post(() =>
+        {
+            OperationStateText.Text = GetFailureStateText(package);
+            RefreshRows();
+            if (operation is InstallPackageOperation)
+                TelemetryHandler.InstallPackage(package, TEL_OP_RESULT.FAILED, TEL_InstallReferral.DIRECT_SEARCH);
+            else if (operation is UpdatePackageOperation)
+                TelemetryHandler.UpdatePackage(package, TEL_OP_RESULT.FAILED);
+            else if (operation is UninstallPackageOperation)
+                TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.FAILED);
+            else if (operation is DownloadOperation)
+                TelemetryHandler.DownloadPackage(package, TEL_OP_RESULT.FAILED, TEL_InstallReferral.DIRECT_SEARCH);
+        });
+    }
+
+    private async void ViewOutputButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_lastOperation is null) return;
+        var window = new OperationLogWindow(_lastOperation);
+        if (VisualRoot is Window parentWindow)
+            await window.ShowDialog(parentWindow);
+        else
+            window.Show();
+    }
+
+    private async void ManageIgnoredButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var window = new IgnoredUpdatesWindow();
+        if (VisualRoot is Window parentWindow)
+            await window.ShowDialog(parentWindow);
+        else
+            window.Show();
+    }
+
+    private async void IgnoreSelectedButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var checkedRows = _visibleRows.Where(r => r.IsChecked).ToArray();
+        var packages = (checkedRows.Length > 0
+                ? checkedRows.Select(r => r.Package)
+                : (IEnumerable<IPackage>)GetPackageSnapshot())
+            .Where(p => !p.Source.IsVirtualManager)
+            .ToArray();
+
+        foreach (var package in packages)
+            await package.AddToIgnoredUpdatesAsync();
+
+        OperationStateText.Text = CoreTools.Translate("Ignore updates for the selected packages");
+        RefreshRows();
+    }
+
+    private async void ExportSelectionButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var checkedRows = _visibleRows.Where(r => r.IsChecked).ToArray();
+        var packages = (checkedRows.Length > 0
+                ? checkedRows.Select(r => r.Package)
+                : (IEnumerable<IPackage>)GetPackageSnapshot())
+            .ToArray();
+
+        await PackageBundlesLoader.Instance.AddPackagesAsync(packages);
+
+        // Navigate shell to Bundles page
+        var shell = this.FindAncestorOfType<UniGetUI.Avalonia.Views.MainShellView>();
+        shell?.OpenPage(ShellPageType.Bundles);
+    }
+
+    private void ClearVisibleRows()
+    {
+        foreach (var row in _visibleRows)
+        {
+            row.Dispose();
+        }
+    }
+
+    private void UpdateToolbarActions(IReadOnlyList<IPackage> filteredPackages)
+    {
+        PrimaryAction.IsEnabled = _pageMode != PackagePageMode.None
+            && filteredPackages.Any(CanRunPrimaryAction);
+        PrimaryActionDropdown.IsEnabled = PrimaryAction.IsEnabled;
+        bool rowSelected = _selectedRow is not null && filteredPackages.Contains(_selectedRow.Package);
+        DetailsAction.IsEnabled = rowSelected;
+        InstallOptionsAction.IsEnabled = rowSelected;
+        ShareAction.IsEnabled = rowSelected;
+    }
+
+    private void OnPackageRowsPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Walk up the visual tree from the event source to find a control with a PackageRowModel DataContext
+        var visual = e.Source as global::Avalonia.Visual;
+        while (visual is not null)
+        {
+            if (visual is Control ctrl && ctrl.DataContext is PackageRowModel row)
+            {
+                OnRowSelected(row);
+                return;
+            }
+            visual = visual.GetVisualParent();
+        }
+    }
+
+    private void OnRowSelected(PackageRowModel row)
+    {
+        if (_selectedRow == row)
+        {
+            return;
+        }
+
+        _selectedRow?.IsSelected = false;
+
+        _selectedRow = row;
+        _selectedRow.IsSelected = true;
+
+        var filteredPackages = GetPackageSnapshot();
+        bool rowVisible = filteredPackages.Contains(row.Package);
+        DetailsAction.IsEnabled = rowVisible;
+        InstallOptionsAction.IsEnabled = rowVisible;
+        ShareAction.IsEnabled = rowVisible;
+    }
+
+    private async void PackageRowsScrollViewer_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (_visibleRows.Count == 0)
+            return;
+
+        int current = _selectedRow is not null ? _visibleRows.IndexOf(_selectedRow) : -1;
+
+        switch (e.Key)
+        {
+            case Key.Up:
+                {
+                    int next = current <= 0 ? 0 : current - 1;
+                    OnRowSelected(_visibleRows[next]);
+                    ScrollRowIntoView(next);
+                    e.Handled = true;
+                    break;
+                }
+            case Key.Down:
+                {
+                    int next = current < 0 ? 0 : Math.Min(current + 1, _visibleRows.Count - 1);
+                    OnRowSelected(_visibleRows[next]);
+                    ScrollRowIntoView(next);
+                    e.Handled = true;
+                    break;
+                }
+            case Key.Home:
+                {
+                    OnRowSelected(_visibleRows[0]);
+                    ScrollRowIntoView(0);
+                    e.Handled = true;
+                    break;
+                }
+            case Key.End:
+                {
+                    int last = _visibleRows.Count - 1;
+                    OnRowSelected(_visibleRows[last]);
+                    ScrollRowIntoView(last);
+                    e.Handled = true;
+                    break;
+                }
+            case Key.Space when current >= 0:
+                {
+                    _visibleRows[current].IsChecked = !_visibleRows[current].IsChecked;
+                    UpdateSelectAllState();
+                    UpdateStatusSummary(
+                        _loader?.Packages.Count ?? _visibleRows.Count,
+                        _visibleRows.Count);
+                    e.Handled = true;
+                    break;
+                }
+            case Key.Enter when current >= 0:
+                {
+                    var mods = e.KeyModifiers;
+                    if (mods.HasFlag(KeyModifiers.Control))
+                    {
+                        // Ctrl+Enter → run primary action
+                        await QueuePrimaryActionAsync(_visibleRows[current].Package);
+                    }
+                    else if (mods.HasFlag(KeyModifiers.Alt))
+                    {
+                        // Alt+Enter → install options
+                        var window = new InstallOptionsWindow(_visibleRows[current].Package, _pageMode);
+                        if (VisualRoot is Window parentWindow)
+                            await window.ShowDialog(parentWindow);
+                        else
+                            window.Show();
+                    }
+                    else
+                    {
+                        // Enter → package details
+                        var window = new PackageDetailsWindow(_visibleRows[current].Package, _pageMode);
+                        if (VisualRoot is Window parentWindow)
+                            await window.ShowDialog(parentWindow);
+                        else
+                            window.Show();
+                    }
+                    e.Handled = true;
+                    break;
+                }
+        }
+
+        if (e.Handled)
+            return;
+
+        if (TryHandleTypeToSelect(e))
+            e.Handled = true;
+    }
+
+    private bool TryHandleTypeToSelect(KeyEventArgs e)
+    {
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || e.KeyModifiers.HasFlag(KeyModifiers.Alt)
+            || e.KeyModifiers.HasFlag(KeyModifiers.Meta))
+        {
+            return false;
+        }
+
+        if (!TryMapKeyToAlphaNumericChar(e.Key, out char typedChar))
+            return false;
+
+        typedChar = char.ToLowerInvariant(typedChar);
+
+        if (Environment.TickCount - _lastTypeKeyDown > TypeQuerySeparationTimeMs)
+            _typeQuery = typedChar.ToString();
+        else
+            _typeQuery += typedChar;
+
+        _lastTypeKeyDown = Environment.TickCount;
+
+        if (TrySelectByTypeQuery(_typeQuery))
+            return true;
+
+        return TrySelectByRepeatedCharacter(_typeQuery);
+    }
+
+    private bool TrySelectByTypeQuery(string query)
+    {
+        int idStartsWithIndex = -1;
+        int nameContainsIndex = -1;
+        int idContainsIndex = -1;
+
+        for (int i = 0; i < _visibleRows.Count; i++)
+        {
+            string name = _visibleRows[i].Name.ToLowerInvariant();
+            string id = _visibleRows[i].Id.ToLowerInvariant();
+
+            if (name.StartsWith(query, StringComparison.Ordinal))
+            {
+                OnRowSelected(_visibleRows[i]);
+                ScrollRowIntoView(i);
+                return true;
+            }
+
+            if (idStartsWithIndex == -1 && id.StartsWith(query, StringComparison.Ordinal))
+                idStartsWithIndex = i;
+
+            if (nameContainsIndex == -1 && name.Contains(query, StringComparison.Ordinal))
+                nameContainsIndex = i;
+
+            if (idContainsIndex == -1 && id.Contains(query, StringComparison.Ordinal))
+                idContainsIndex = i;
+        }
+
+        int fallbackIndex = idStartsWithIndex > -1
+            ? idStartsWithIndex
+            : (nameContainsIndex > -1 ? nameContainsIndex : idContainsIndex);
+
+        if (fallbackIndex > -1)
+        {
+            OnRowSelected(_visibleRows[fallbackIndex]);
+            ScrollRowIntoView(fallbackIndex);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TrySelectByRepeatedCharacter(string query)
+    {
+        if (query.Length <= 1)
+            return false;
+
+        char first = query[0];
+        for (int i = 1; i < query.Length; i++)
+        {
+            if (query[i] != first)
+                return false;
+        }
+
+        int firstIndex = -1;
+        int lastIndex = -1;
+        for (int i = 0; i < _visibleRows.Count; i++)
+        {
+            if (_visibleRows[i].Name.Length > 0
+                && char.ToLowerInvariant(_visibleRows[i].Name[0]) == first)
+            {
+                if (firstIndex == -1)
+                    firstIndex = i;
+                lastIndex = i;
+            }
+            else if (firstIndex > -1)
+            {
+                break;
+            }
+        }
+
+        if (firstIndex == -1 || lastIndex == -1)
+            return false;
+
+        int range = lastIndex - firstIndex + 1;
+        int offset = (query.Length - 1) % range;
+        int target = firstIndex + offset;
+
+        OnRowSelected(_visibleRows[target]);
+        ScrollRowIntoView(target);
+        return true;
+    }
+
+    private static bool TryMapKeyToAlphaNumericChar(Key key, out char value)
+    {
+        if (key >= Key.A && key <= Key.Z)
+        {
+            value = (char)('a' + (key - Key.A));
+            return true;
+        }
+
+        if (key >= Key.D0 && key <= Key.D9)
+        {
+            value = (char)('0' + (key - Key.D0));
+            return true;
+        }
+
+        if (key >= Key.NumPad0 && key <= Key.NumPad9)
+        {
+            value = (char)('0' + (key - Key.NumPad0));
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private void ScrollRowIntoView(int index)
+    {
+        if (ActivePackageRowsItems.ContainerFromIndex(index) is Control container)
+            container.BringIntoView();
+    }
+
+    private async void DetailsAction_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_selectedRow is null)
+        {
+            return;
+        }
+
+        var window = new PackageDetailsWindow(_selectedRow.Package, _pageMode);
+        if (VisualRoot is Window parentWindow)
+        {
+            await window.ShowDialog(parentWindow);
+        }
+        else
+        {
+            window.Show();
+        }
+    }
+
+    private async void InstallOptionsAction_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_selectedRow is null)
+        {
+            return;
+        }
+
+        var window = new InstallOptionsWindow(_selectedRow.Package, _pageMode);
+        if (VisualRoot is Window parentWindow)
+        {
+            await window.ShowDialog(parentWindow);
+        }
+        else
+        {
+            window.Show();
+        }
+    }
+
+    private async void ShareAction_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_selectedRow is null)
+        {
+            return;
+        }
+
+        await DoShareAsync(_selectedRow.Package);
+    }
+
+    private async Task DoShareAsync(IPackage package)
+    {
+        if (package.Source.IsVirtualManager)
+        {
+            OperationStateText.Text = CoreTools.Translate("\"{0}\" is a local package and can't be shared", package.Name);
+            return;
+        }
+
+        var url = "https://marticliment.com/unigetui/share?"
+            + "name=" + Uri.EscapeDataString(package.Name)
+            + "&id=" + Uri.EscapeDataString(package.Id)
+            + "&sourceName=" + Uri.EscapeDataString(package.Source.Name)
+            + "&managerName=" + Uri.EscapeDataString(package.Manager.DisplayName);
+
+        var clipboard = global::Avalonia.Controls.TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is not null)
+        {
+            await clipboard.SetTextAsync(url);
+            OperationStateText.Text = CoreTools.Translate("Success!");
+        }
+    }
+
+    private async void PackageRow_ContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        if (sender is not Control ctrl || ctrl.DataContext is not PackageRowModel row)
+        {
+            return;
+        }
+
+        e.Handled = true;
+        OnRowSelected(row);
+        var menu = await BuildContextMenuAsync(row);
+        ctrl.ContextMenu = menu;
+        menu.Open(ctrl);
+    }
+
+    private string GetInstallOptionsLabel()
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Updates => CoreTools.Translate("Update options"),
+            PackagePageMode.Installed => CoreTools.Translate("Uninstall options"),
+            _ => CoreTools.Translate("Install options"),
+        };
+    }
+
+    private static object CreateMenuHeader(string label, string? accelerator = null)
+    {
+        if (string.IsNullOrWhiteSpace(accelerator))
+        {
+            return label;
+        }
+
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            ColumnSpacing = 16,
+            MinWidth = 220,
+        };
+
+        grid.Children.Add(new TextBlock { Text = label });
+
+        var acceleratorText = new TextBlock
+        {
+            Text = accelerator,
+            HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right,
+            Opacity = 0.72,
+        };
+        Grid.SetColumn(acceleratorText, 1);
+        grid.Children.Add(acceleratorText);
+
+        return grid;
+    }
+
+    private async Task<ContextMenu> BuildContextMenuAsync(PackageRowModel row)
+    {
+        var menu = new ContextMenu();
+        var package = row.Package;
+
+        // Primary action
+        if (CanRunPrimaryAction(package))
+        {
+            string primaryLabel = _pageMode switch
+            {
+                PackagePageMode.Discover => CoreTools.Translate("Install"),
+                PackagePageMode.Updates => CoreTools.Translate("Update"),
+                PackagePageMode.Installed => CoreTools.Translate("Uninstall"),
+                _ => CoreTools.Translate("Open"),
+            };
+            var primaryItem = new MenuItem { Header = CreateMenuHeader(primaryLabel, "Ctrl+Enter") };
+            primaryItem.Click += async (_, _) => await QueuePrimaryActionAsync(package);
+            menu.Items.Add(primaryItem);
+
+            // Run as administrator
+            if (package.Manager.Capabilities.CanRunAsAdmin)
+            {
+                string adminLabel = _pageMode switch
+                {
+                    PackagePageMode.Discover => CoreTools.Translate("Install as administrator"),
+                    PackagePageMode.Updates => CoreTools.Translate("Update as administrator"),
+                    PackagePageMode.Installed => CoreTools.Translate("Uninstall as administrator"),
+                    _ => CoreTools.Translate("Install as administrator"),
+                };
+                var adminItem = new MenuItem { Header = adminLabel };
+                adminItem.Click += async (_, _) => await QueuePrimaryActionWithFlagsAsync(package, elevated: true);
+                menu.Items.Add(adminItem);
+            }
+
+            // Interactive
+            if (package.Manager.Capabilities.CanRunInteractively)
+            {
+                string interactiveLabel = _pageMode switch
+                {
+                    PackagePageMode.Discover => CoreTools.Translate("Interactive installation"),
+                    PackagePageMode.Updates => CoreTools.Translate("Interactive update"),
+                    PackagePageMode.Installed => CoreTools.Translate("Interactive uninstall"),
+                    _ => CoreTools.Translate("Interactive installation"),
+                };
+                var interactiveItem = new MenuItem { Header = interactiveLabel };
+                interactiveItem.Click += async (_, _) => await QueuePrimaryActionWithFlagsAsync(package, interactive: true);
+                menu.Items.Add(interactiveItem);
+            }
+
+            // Uninstall and remove data (Installed page only)
+            if (package.Manager.Capabilities.CanRemoveDataOnUninstall && _pageMode == PackagePageMode.Installed)
+            {
+                var removeDataItem = new MenuItem { Header = CoreTools.Translate("Uninstall and remove data") };
+                removeDataItem.Click += async (_, _) =>
+                {
+                    if (!await ConfirmUninstallAsync(package))
+                    {
+                        return;
+                    }
+
+                    var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+                    opts.RemoveDataOnUninstall = true;
+                    var op = new UninstallPackageOperation(package, opts);
+                    AttachOperationEvents(op, package);
+                    AvaloniaOperationRegistry.Add(op);
+                    _ = op.MainThread();
+                    OperationStateText.Text = CoreTools.Translate("{0} Uninstallation", package.Name);
+                    RefreshRows();
+                };
+                menu.Items.Add(removeDataItem);
+            }
+
+            // Skip integrity checks
+            if (package.Manager.Capabilities.CanSkipIntegrityChecks && _pageMode != PackagePageMode.Installed)
+            {
+                var skipHashItem = new MenuItem { Header = CoreTools.Translate("Skip integrity checks") };
+                skipHashItem.Click += async (_, _) => await QueuePrimaryActionWithFlagsAsync(package, skipHash: true);
+                menu.Items.Add(skipHashItem);
+            }
+
+            // Download installer
+            if (package.Manager.Capabilities.CanDownloadInstaller)
+            {
+                var downloadItem = new MenuItem { Header = CoreTools.Translate("Download installer") };
+                downloadItem.Click += async (_, _) => await DownloadPackageInstallerAsync(package);
+                menu.Items.Add(downloadItem);
+            }
+
+            menu.Items.Add(new Separator());
+        }
+
+        // Open install location (Updates + Installed pages)
+        if (_pageMode is PackagePageMode.Updates or PackagePageMode.Installed)
+        {
+            string? installPath = null;
+            try { installPath = package.Manager.DetailsHelper.GetInstallLocation(package); }
+            catch (Exception ex) { Logger.Warn($"GetInstallLocation failed: {ex.Message}"); }
+
+            var openLocationItem = new MenuItem
+            {
+                Header = CoreTools.Translate("Open install location"),
+                IsEnabled = installPath is not null,
+            };
+            openLocationItem.Click += (_, _) => CoreTools.Launch(installPath);
+            menu.Items.Add(openLocationItem);
+            menu.Items.Add(new Separator());
+        }
+
+        // Details
+        var detailsItem = new MenuItem { Header = CreateMenuHeader(CoreTools.Translate("Package details"), "Enter") };
+        detailsItem.Click += async (_, _) =>
+        {
+            var window = new PackageDetailsWindow(package, _pageMode);
+            if (VisualRoot is Window w) await window.ShowDialog(w);
+            else window.Show();
+        };
+        menu.Items.Add(detailsItem);
+
+        // Install options
+        var optionsItem = new MenuItem { Header = CreateMenuHeader(GetInstallOptionsLabel(), "Alt+Enter") };
+        optionsItem.Click += async (_, _) =>
+        {
+            var window = new InstallOptionsWindow(package, _pageMode);
+            if (VisualRoot is Window w) await window.ShowDialog(w);
+            else window.Show();
+        };
+        menu.Items.Add(optionsItem);
+
+        // Share
+        if (!package.Source.IsVirtualManager)
+        {
+            var shareItem = new MenuItem { Header = CoreTools.Translate("Share") };
+            shareItem.Click += async (_, _) => await DoShareAsync(package);
+            menu.Items.Add(shareItem);
+        }
+
+        // Ignore updates (Updates and Installed pages)
+        if (_pageMode is PackagePageMode.Updates or PackagePageMode.Installed)
+        {
+            menu.Items.Add(new Separator());
+
+            bool alreadyIgnored = _pageMode == PackagePageMode.Installed
+                && await package.HasUpdatesIgnoredAsync();
+
+            var ignoreItem = new MenuItem
+            {
+                Header = alreadyIgnored
+                    ? CoreTools.Translate("Do not ignore updates for this package anymore")
+                    : CoreTools.Translate("Ignore updates for this package")
+            };
+            ignoreItem.Click += async (_, _) =>
+            {
+                if (alreadyIgnored)
+                {
+                    await package.RemoveFromIgnoredUpdatesAsync();
+                    OperationStateText.Text = CoreTools.Translate(
+                        "Updates for {0} will no longer be ignored", package.Name);
+                }
+                else
+                {
+                    await package.AddToIgnoredUpdatesAsync();
+                    OperationStateText.Text = CoreTools.Translate(
+                        "Updates for {0} will be ignored", package.Name);
+                }
+                RefreshRows();
+            };
+            menu.Items.Add(ignoreItem);
+
+            // Skip this version (Updates page only)
+            if (_pageMode == PackagePageMode.Updates)
+            {
+                var skipItem = new MenuItem { Header = CoreTools.Translate("Skip this version") };
+                skipItem.Click += async (_, _) =>
+                {
+                    await package.AddToIgnoredUpdatesAsync(package.NewVersionString);
+                    OperationStateText.Text = CoreTools.Translate(
+                        "Version {0} of {1} will be skipped", package.NewVersionString, package.Name);
+                    RefreshRows();
+                };
+                menu.Items.Add(skipItem);
+
+                // Pause updates for… submenu
+                var pauseParent = new MenuItem { Header = CoreTools.Translate("Pause updates for") };
+                foreach (var pauseTime in new[]
+                {
+                    new IgnoredUpdatesDatabase.PauseTime { Days = 1 },
+                    new IgnoredUpdatesDatabase.PauseTime { Days = 3 },
+                    new IgnoredUpdatesDatabase.PauseTime { Weeks = 1 },
+                    new IgnoredUpdatesDatabase.PauseTime { Weeks = 2 },
+                    new IgnoredUpdatesDatabase.PauseTime { Weeks = 4 },
+                    new IgnoredUpdatesDatabase.PauseTime { Months = 3 },
+                    new IgnoredUpdatesDatabase.PauseTime { Months = 6 },
+                    new IgnoredUpdatesDatabase.PauseTime { Months = 12 },
+                })
+                {
+                    var pt = pauseTime; // capture
+                    var pauseItem = new MenuItem { Header = pt.StringRepresentation() };
+                    pauseItem.Click += async (_, _) =>
+                    {
+                        await package.AddToIgnoredUpdatesAsync("<" + pt.GetDateFromNow());
+                        UpgradablePackagesLoader.Instance.IgnoredPackages[package.Id] = package;
+                        UpgradablePackagesLoader.Instance.Remove(package);
+                        OperationStateText.Text = CoreTools.Translate(
+                            "Updates for {0} are paused until {1}", package.Name, pt.GetDateFromNow());
+                        RefreshRows();
+                    };
+                    pauseParent.Items.Add(pauseItem);
+                }
+                menu.Items.Add(pauseParent);
+
+                // Updates-page uninstall actions
+                menu.Items.Add(new Separator());
+
+                var uninstallItem = new MenuItem { Header = CoreTools.Translate("Uninstall package") };
+                uninstallItem.Click += async (_, _) =>
+                {
+                    if (!await ConfirmUninstallAsync(package))
+                    {
+                        return;
+                    }
+
+                    var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+                    var op = new UninstallPackageOperation(package, opts);
+                    AttachOperationEvents(op, package);
+                    AvaloniaOperationRegistry.Add(op);
+                    _ = op.MainThread();
+                    OperationStateText.Text = CoreTools.Translate("{0} Uninstallation", package.Name);
+                    RefreshRows();
+                };
+                menu.Items.Add(uninstallItem);
+
+                var uninstallThenUpdateItem = new MenuItem
+                { Header = CoreTools.Translate("Uninstall package, then update it") };
+                uninstallThenUpdateItem.Click += async (_, _) =>
+                {
+                    var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+                    var uninstallOp = new UninstallPackageOperation(package, opts.Copy());
+                    opts.Version = package.NewVersionString;
+                    opts.OverridesNextLevelOpts = true;
+                    var installOp = new InstallPackageOperation(package, opts, req: uninstallOp);
+                    AttachOperationEvents(uninstallOp, package);
+                    AvaloniaOperationRegistry.Add(uninstallOp);
+                    AvaloniaOperationRegistry.Add(installOp);
+                    _ = uninstallOp.MainThread();
+                    OperationStateText.Text = CoreTools.Translate(
+                        "Queued reinstall/update for {0}", package.Name);
+                    RefreshRows();
+                };
+                menu.Items.Add(uninstallThenUpdateItem);
+            }
+
+            // Installed-page-specific actions
+            if (_pageMode == PackagePageMode.Installed && !package.Source.IsVirtualManager)
+            {
+                menu.Items.Add(new Separator());
+
+                var reinstallItem = new MenuItem { Header = CoreTools.Translate("Reinstall package") };
+                reinstallItem.Click += async (_, _) =>
+                {
+                    var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+                    var op = new InstallPackageOperation(package, opts);
+                    AttachOperationEvents(op, package);
+                    AvaloniaOperationRegistry.Add(op);
+                    _ = op.MainThread();
+                    OperationStateText.Text = CoreTools.Translate("{0} installation", package.Name);
+                    RefreshRows();
+                };
+                menu.Items.Add(reinstallItem);
+
+                var uninstallReinstallItem = new MenuItem
+                { Header = CoreTools.Translate("Uninstall package, then reinstall it") };
+                uninstallReinstallItem.Click += async (_, _) =>
+                {
+                    var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+                    var uninstallOp = new UninstallPackageOperation(package, opts.Copy());
+                    var installOp = new InstallPackageOperation(package, opts, req: uninstallOp);
+                    AttachOperationEvents(uninstallOp, package);
+                    AvaloniaOperationRegistry.Add(uninstallOp);
+                    AvaloniaOperationRegistry.Add(installOp);
+                    _ = uninstallOp.MainThread();
+                    OperationStateText.Text = CoreTools.Translate("{0} installation", package.Name);
+                    RefreshRows();
+                };
+                menu.Items.Add(uninstallReinstallItem);
+            }
+        }
+
+        return menu;
+    }
+
+    private bool CanRunPrimaryAction(IPackage package)
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => package.Tag is not PackageTag.AlreadyInstalled
+                and not PackageTag.OnQueue
+                and not PackageTag.BeingProcessed
+                and not PackageTag.Unavailable,
+            PackagePageMode.Updates => package.Tag is not PackageTag.OnQueue
+                and not PackageTag.BeingProcessed
+                and not PackageTag.Unavailable,
+            PackagePageMode.Installed => package.Tag is not PackageTag.OnQueue
+                and not PackageTag.BeingProcessed
+                and not PackageTag.Unavailable,
+            _ => false,
+        };
+    }
+
+    private string GetQueuedStateText(IPackage package)
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("{0} installation", package.Name),
+            PackagePageMode.Updates => CoreTools.Translate("{0} update", package.Name),
+            PackagePageMode.Installed => CoreTools.Translate("{0} Uninstallation", package.Name),
+            _ => CoreTools.Translate("This package is on the queue"),
+        };
+    }
+
+    private string GetRunningStateText(IPackage package)
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("{0} is being installed", package.Name),
+            PackagePageMode.Updates => CoreTools.Translate("{0} is being updated", package.Name),
+            PackagePageMode.Installed => CoreTools.Translate("{0} is being uninstalled", package.Name),
+            _ => CoreTools.Translate("Operation in progress"),
+        };
+    }
+
+    private string GetSuccessStateText(IPackage package)
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("{0} was {1} successfully!", package.Name, CoreTools.Translate("installed")),
+            PackagePageMode.Updates => CoreTools.Translate("{0} was {1} successfully!", package.Name, CoreTools.Translate("updated")),
+            PackagePageMode.Installed => CoreTools.Translate("{0} was {1} successfully!", package.Name, CoreTools.Translate("uninstalled")),
+            _ => CoreTools.Translate("{0} succeeded", package.Name),
+        };
+    }
+
+    private string GetFailureStateText(IPackage package)
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("{0} {1} failed", package.Name, CoreTools.Translate("installation")),
+            PackagePageMode.Updates => CoreTools.Translate("{0} {1} failed", package.Name, CoreTools.Translate("update(verb)")),
+            PackagePageMode.Installed => CoreTools.Translate("{0} {1} failed", package.Name, CoreTools.Translate("uninstallation")),
+            _ => CoreTools.Translate("{0} failed", package.Name),
+        };
+    }
+
+    private IReadOnlyList<IPackage> GetPackageSnapshot()
+    {
+        if (_loader is null)
+        {
+            return [];
+        }
+
+        var packages = _loader.Packages.ToArray();
+        if (_pageMode == PackagePageMode.Discover && string.IsNullOrWhiteSpace(_searchQuery))
+        {
+            return [];
+        }
+
+        IEnumerable<IPackage> filtered = packages;
+
+        if (!string.IsNullOrWhiteSpace(_searchQuery) && ShowSimilarResultsOption.IsChecked != true)
+        {
+            filtered = filtered.Where(package => MatchesSearch(package, _searchQuery));
+        }
+
+        if (_sourceFilter is not null)
+        {
+            filtered = filtered.Where(p => _sourceFilter.Contains(GetSourceFilterKey(p)));
+        }
+
+        return filtered.ToArray();
+    }
+
+    private static string GetSourceFilterKey(IPackage package)
+    {
+        return GetSourceFilterKey(package.Manager.Name, package.Source.AsString_DisplayName);
+    }
+
+    private static string GetSourceFilterKey(string managerName, string sourceDisplayName)
+    {
+        return managerName + "::" + sourceDisplayName;
+    }
+
+    private bool MatchesSearch(IPackage package, string query)
+    {
+        bool caseSensitive = UpperLowerCaseOption.IsChecked == true;
+        bool ignoreSpecial = IgnoreSpecialCharsOption.IsChecked == true;
+
+        string Treat(string s)
+        {
+            if (!caseSensitive) s = s.ToLowerInvariant();
+            if (ignoreSpecial) s = NormalizeSpecialChars(s);
+            return s;
+        }
+
+        string treatedQuery = Treat(query);
+
+        if (ExactMatchFilterOption.IsChecked == true)
+        {
+            return Treat(package.Name) == treatedQuery || Treat(package.Id) == treatedQuery;
+        }
+
+        if (PackageNameFilterOption.IsChecked == true)
+        {
+            return Treat(package.Name).Contains(treatedQuery);
+        }
+
+        if (PackageIdFilterOption.IsChecked == true)
+        {
+            return Treat(package.Id).Contains(treatedQuery);
+        }
+
+        return Treat(package.Name).Contains(treatedQuery) || Treat(package.Id).Contains(treatedQuery);
+    }
+
+    private static string NormalizeSpecialChars(string s) =>
+        s
+            .Replace("-", "").Replace("_", "").Replace(" ", "")
+            .Replace("@", "").Replace("\t", "").Replace(".", "")
+            .Replace(",", "").Replace(":", "")
+            .Replace("à", "a").Replace("á", "a").Replace("ä", "a").Replace("â", "a")
+            .Replace("è", "e").Replace("é", "e").Replace("ë", "e").Replace("ê", "e")
+            .Replace("ì", "i").Replace("í", "i").Replace("ï", "i").Replace("î", "i")
+            .Replace("ò", "o").Replace("ó", "o").Replace("ö", "o").Replace("ô", "o")
+            .Replace("ù", "u").Replace("ú", "u").Replace("ü", "u").Replace("û", "u")
+            .Replace("ý", "y").Replace("ÿ", "y").Replace("ç", "c").Replace("ñ", "n");
+
+    private void UpdateSourceSummary(IReadOnlyList<IPackage> _)
+    {
+        // Compute all sources from the unfiltered loader snapshot (not just visible)
+        IPackage[] allLoaderPackages = _loader?.Packages.ToArray() ?? [];
+        if (_pageMode == PackagePageMode.Discover && string.IsNullOrWhiteSpace(_searchQuery))
+        {
+            allLoaderPackages = [];
+        }
+
+        var allSourceEntries = allLoaderPackages
+            .Select(p => new SourceFilterEntry
+            {
+                ManagerName = p.Manager.Name,
+                ManagerDisplayName = p.Manager.DisplayName,
+                SourceDisplayName = p.Source.AsString_DisplayName,
+                FilterKey = GetSourceFilterKey(p),
+            })
+            .Where(e => !string.IsNullOrWhiteSpace(e.SourceDisplayName))
+            .GroupBy(e => e.FilterKey, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .OrderBy(e => e.ManagerDisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(e => e.SourceDisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        SourcesEmptyStateText.IsVisible = allSourceEntries.Length == 0;
+        SourcesDescriptionText.IsVisible = allSourceEntries.Length > 0;
+
+        if (allSourceEntries.Length == 0)
+        {
+            SourcesEmptyStateText.Text = _pageMode == PackagePageMode.Discover && string.IsNullOrWhiteSpace(_searchQuery)
+                ? CoreTools.Translate("Search for packages to start")
+                : CoreTools.Translate("No sources found");
+            SourceToggles.ItemsSource = null;
+            ClearFilterBtn.IsVisible = false;
+            return;
+        }
+
+        var controls = new List<Control>();
+
+        foreach (var managerGroup in allSourceEntries.GroupBy(e => e.ManagerDisplayName, StringComparer.OrdinalIgnoreCase))
+        {
+            controls.Add(new TextBlock
+            {
+                Text = managerGroup.Key,
+                FontSize = 12,
+                FontWeight = global::Avalonia.Media.FontWeight.SemiBold,
+                Opacity = 0.78,
+                Margin = new global::Avalonia.Thickness(0, controls.Count == 0 ? 0 : 10, 0, 2),
+            });
+
+            foreach (var entry in managerGroup)
+            {
+                bool isActive = _sourceFilter is null || _sourceFilter.Contains(entry.FilterKey);
+                var btn = new Button
+                {
+                    Content = entry.SourceDisplayName,
+                    HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Stretch,
+                    Tag = entry.FilterKey,
+                };
+                btn.Classes.Add(isActive ? "toolbar-primary" : "toolbar-secondary");
+                btn.Click += SourceToggleButton_OnClick;
+                controls.Add(btn);
+            }
+        }
+
+        SourceToggles.ItemsSource = controls;
+        ClearFilterBtn.IsVisible = _sourceFilter is not null;
+    }
+
+    private void SourceToggleButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn || btn.Tag is not string sourceKey)
+        {
+            return;
+        }
+
+        if (_sourceFilter is null)
+        {
+            // First exclusion: start a filter set with all sources except the clicked one
+            var allLoaderPackages = _loader?.Packages.ToArray() ?? [];
+            _sourceFilter = allLoaderPackages
+                .Select(GetSourceFilterKey)
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            _sourceFilter.Remove(sourceKey);
+        }
+        else if (_sourceFilter.Contains(sourceKey))
+        {
+            _sourceFilter.Remove(sourceKey);
+            if (_sourceFilter.Count == 0)
+            {
+                _sourceFilter = null; // back to "show all"
+            }
+        }
+        else
+        {
+            _sourceFilter.Add(sourceKey);
+        }
+
+        RefreshRows();
+    }
+
+    private void ClearSourceFilterButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _sourceFilter = null;
+        RefreshRows();
+    }
+
+    private void UpdateEmptyState(int visiblePackageCount)
+    {
+        if (visiblePackageCount > 0)
+        {
+            EmptyStateTitleText.Text = _defaultEmptyStateTitle;
+            EmptyStateDescriptionText.Text = _defaultEmptyStateDescription;
+            return;
+        }
+
+        if (_pageMode == PackagePageMode.Discover && string.IsNullOrWhiteSpace(_searchQuery))
+        {
+            EmptyStateTitleText.Text = CoreTools.Translate("Search for packages");
+            EmptyStateDescriptionText.Text = CoreTools.Translate("Search for packages to start");
+            return;
+        }
+
+        if (_loader?.IsLoading == true)
+        {
+            EmptyStateTitleText.Text = GetLoadingStateText();
+            EmptyStateDescriptionText.Text = CoreTools.Translate("We are checking for updates.");
+            return;
+        }
+
+        // Distinguish "loader has packages but filters hide them" from "loader found nothing"
+        bool loaderHasPackages = (_loader?.Packages.Count ?? 0) > 0;
+
+        if (_pageMode == PackagePageMode.Updates && !loaderHasPackages)
+        {
+            EmptyStateTitleText.Text = CoreTools.Translate("Hooray! No updates were found.");
+            EmptyStateDescriptionText.Text = CoreTools.Translate("No updates are available");
+            return;
+        }
+
+        if (loaderHasPackages)
+        {
+            EmptyStateTitleText.Text = CoreTools.Translate("No results were found matching the input criteria");
+            EmptyStateDescriptionText.Text = CoreTools.Translate("No packages were found");
+            return;
+        }
+
+        EmptyStateTitleText.Text = CoreTools.Translate("No results were found matching the input criteria");
+        EmptyStateDescriptionText.Text = CoreTools.Translate("No packages were found");
+    }
+
+    private void UpdateStatusSummary(int totalPackageCount, int visiblePackageCount)
+    {
+        if (_loader?.IsLoading == true)
+        {
+            SearchStateText.Text = visiblePackageCount > 0
+                ? CoreTools.Translate("{0} packages found", visiblePackageCount)
+                : GetLoadingStateText();
+            return;
+        }
+
+        if (_pageMode == PackagePageMode.Discover && string.IsNullOrWhiteSpace(_searchQuery))
+        {
+            SearchStateText.Text = CoreTools.Translate("Search for packages");
+            return;
+        }
+
+        if (_loader is null)
+        {
+            SearchStateText.Text = CoreTools.Translate("Loading packages");
+            return;
+        }
+
+        if (totalPackageCount == visiblePackageCount)
+        {
+            SearchStateText.Text = CoreTools.Translate("{0} packages found", visiblePackageCount);
+        }
+        else
+        {
+            SearchStateText.Text = CoreTools.Translate(
+                "{0} packages were found, {1} of which match the specified filters.",
+                totalPackageCount,
+                visiblePackageCount
+            );
+        }
+
+        int selectedCount = _visibleRows.Count(r => r.IsChecked);
+        if (selectedCount > 0)
+        {
+            SearchStateText.Text += " " + CoreTools.Translate("{0} selected", selectedCount);
+        }
+
+        if (_pageMode == PackagePageMode.Updates && _lastPackageLoadTime is DateTime lastChecked)
+        {
+            SearchStateText.Text += " " + CoreTools.Translate(
+                "(Last checked: {0})",
+                lastChecked.ToString(CultureInfo.CurrentCulture)
+            );
+        }
+    }
+
+    private string GetLoadingStateText()
+    {
+        return _pageMode switch
+        {
+            PackagePageMode.Discover => CoreTools.Translate("Searching for packages..."),
+            PackagePageMode.Updates => CoreTools.Translate("Checking for updates..."),
+            PackagePageMode.Installed => CoreTools.Translate("Searching for installed packages..."),
+            _ => CoreTools.Translate("Loading packages"),
+        };
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesWindow.axaml
@@ -1,0 +1,93 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.ReleaseNotesWindow"
+        Width="700"
+  Height="560"
+        MinWidth="560"
+  MinHeight="420"
+        Title="Release notes"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <Grid Margin="18"
+        RowDefinitions="Auto,Auto,*,Auto"
+        RowSpacing="10">
+    <TextBlock x:Name="TitleBlock"
+               FontSize="18"
+               FontWeight="SemiBold"
+               TextWrapping="Wrap"
+               Text="Release notes" />
+
+    <TextBlock x:Name="VersionBlock"
+               Grid.Row="1"
+               Opacity="0.75"
+               TextWrapping="Wrap" />
+
+    <Border Grid.Row="2"
+            Padding="12"
+            Classes="surface-card subtle-panel"
+            CornerRadius="12">
+      <Grid RowDefinitions="Auto,Auto,Auto,*,Auto,Auto"
+            RowSpacing="8">
+  <TextBlock x:Name="StatusBlock"
+       Opacity="0.72"
+       TextWrapping="Wrap"
+       Text="Loading..." />
+
+  <ProgressBar x:Name="LoadingProgressBar"
+         Grid.Row="1"
+         IsIndeterminate="True" />
+
+  <TextBlock x:Name="ReleaseNotesLabelBlock"
+       Grid.Row="2"
+                   FontWeight="SemiBold"
+       Text="Release notes:" />
+
+      <ScrollViewer Grid.Row="3"
+                  MinHeight="240"
+                  Padding="4,0"
+                  VerticalScrollBarVisibility="Auto">
+        <TextBlock x:Name="ReleaseNotesTextBlock"
+                 HorizontalAlignment="Stretch"
+                 TextWrapping="Wrap"
+                 VerticalAlignment="Top" />
+      </ScrollViewer>
+
+  <TextBlock x:Name="UrlLabelBlock"
+       Grid.Row="4"
+       FontWeight="SemiBold"
+       Text="Release notes URL:" />
+
+  <TextBox x:Name="UrlTextBox"
+     Grid.Row="5"
+     IsReadOnly="True"
+     TextWrapping="NoWrap" />
+      </Grid>
+    </Border>
+
+    <Grid Grid.Row="3"
+    ColumnDefinitions="*,Auto,Auto,Auto"
+          ColumnSpacing="8">
+      <Button x:Name="RetryButton"
+        Grid.Column="1"
+        MinWidth="96"
+        Content="Retry"
+        Click="RetryButton_OnClick" />
+
+      <Button x:Name="OpenButton"
+        Grid.Column="2"
+              MinWidth="160"
+              Classes="accent"
+              Content="Open release notes"
+              Click="OpenButton_OnClick" />
+
+      <Button x:Name="CloseButton"
+        Grid.Column="3"
+              MinWidth="96"
+              Content="Close"
+              Click="CloseButton_OnClick" />
+    </Grid>
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesWindow.axaml.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class ReleaseNotesWindow : Window
+{
+    private readonly string _releaseNotesUrl =
+        $"https://github.com/Devolutions/UniGetUI/releases/tag/{CoreData.VersionName}";
+    private readonly string _releaseNotesApiUrl =
+        $"https://api.github.com/repos/Devolutions/UniGetUI/releases/tags/{Uri.EscapeDataString(CoreData.VersionName)}";
+
+    private bool _hasLoadedReleaseNotes;
+
+    private TextBlock TitleBlockControl => GetControl<TextBlock>("TitleBlock");
+    private TextBlock VersionBlockControl => GetControl<TextBlock>("VersionBlock");
+    private TextBlock StatusBlockControl => GetControl<TextBlock>("StatusBlock");
+    private ProgressBar LoadingProgressBarControl => GetControl<ProgressBar>("LoadingProgressBar");
+    private TextBlock ReleaseNotesLabelBlockControl => GetControl<TextBlock>("ReleaseNotesLabelBlock");
+    private TextBlock ReleaseNotesTextBlockControl => GetControl<TextBlock>("ReleaseNotesTextBlock");
+    private TextBlock UrlLabelBlockControl => GetControl<TextBlock>("UrlLabelBlock");
+    private TextBox UrlTextBoxControl => GetControl<TextBox>("UrlTextBox");
+    private Button RetryButtonControl => GetControl<Button>("RetryButton");
+    private Button OpenButtonControl => GetControl<Button>("OpenButton");
+    private Button CloseButtonControl => GetControl<Button>("CloseButton");
+
+    public ReleaseNotesWindow()
+    {
+        InitializeComponent();
+        Opened += ReleaseNotesWindow_OnOpened;
+
+        Title = CoreTools.Translate("Release notes");
+        TitleBlockControl.Text = CoreTools.Translate("Release notes");
+        VersionBlockControl.Text = CoreTools.Translate("version {0}", CoreData.VersionName);
+        ReleaseNotesLabelBlockControl.Text = CoreTools.Translate("Release notes:");
+        UrlLabelBlockControl.Text = CoreTools.Translate("Release notes URL:");
+        UrlTextBoxControl.Text = _releaseNotesUrl;
+        StatusBlockControl.Text = CoreTools.Translate("Loading...");
+        ReleaseNotesTextBlockControl.Text = string.Empty;
+        RetryButtonControl.Content = CoreTools.Translate("Retry");
+        OpenButtonControl.Content = CoreTools.Translate("View page on browser");
+        CloseButtonControl.Content = CoreTools.Translate("Close");
+
+        SetLoadingState(isLoading: true);
+    }
+
+    private async void ReleaseNotesWindow_OnOpened(object? sender, EventArgs e)
+    {
+        if (_hasLoadedReleaseNotes)
+        {
+            return;
+        }
+
+        _hasLoadedReleaseNotes = true;
+        await LoadReleaseNotesAsync();
+    }
+
+    private async Task LoadReleaseNotesAsync()
+    {
+        SetLoadingState(isLoading: true);
+
+        try
+        {
+            using HttpClient client = new(CoreTools.GenericHttpClientParameters);
+            client.DefaultRequestHeaders.UserAgent.Add(
+                new ProductInfoHeaderValue("UniGetUI.Avalonia", CoreData.VersionName)
+            );
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+
+            using HttpResponseMessage response = await client.GetAsync(_releaseNotesApiUrl);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"GitHub API returned status code {(int)response.StatusCode} ({response.StatusCode})."
+                );
+            }
+
+            await using Stream responseStream = await response.Content.ReadAsStreamAsync();
+            GitHubReleaseResponse? release = await JsonSerializer.DeserializeAsync<GitHubReleaseResponse>(
+                responseStream,
+                SerializationHelpers.DefaultOptions
+            );
+
+            string releaseBody = string.IsNullOrWhiteSpace(release?.Body)
+                ? CoreTools.Translate("Please try again later")
+                : release.Body.Replace("\r\n", "\n").Trim();
+
+            if (!string.IsNullOrWhiteSpace(release?.HtmlUrl))
+            {
+                UrlTextBoxControl.Text = release.HtmlUrl;
+            }
+
+            ReleaseNotesTextBlockControl.Text = releaseBody;
+            StatusBlockControl.IsVisible = false;
+            RetryButtonControl.IsVisible = false;
+            LoadingProgressBarControl.IsVisible = false;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to load release notes from {_releaseNotesApiUrl}");
+            Logger.Error(ex);
+
+            ReleaseNotesTextBlockControl.Text = string.Empty;
+            StatusBlockControl.Text = CoreTools.Translate("Please try again later");
+            StatusBlockControl.IsVisible = true;
+            RetryButtonControl.IsVisible = true;
+            LoadingProgressBarControl.IsVisible = false;
+        }
+    }
+
+    private void SetLoadingState(bool isLoading)
+    {
+        LoadingProgressBarControl.IsVisible = isLoading;
+        StatusBlockControl.IsVisible = isLoading;
+        StatusBlockControl.Text = isLoading ? CoreTools.Translate("Loading...") : string.Empty;
+        RetryButtonControl.IsVisible = false;
+        if (isLoading)
+        {
+            ReleaseNotesTextBlockControl.Text = string.Empty;
+        }
+    }
+
+    private async void RetryButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        await LoadReleaseNotesAsync();
+    }
+
+    private void OpenButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Process.Start(
+                new ProcessStartInfo
+                {
+                    FileName = string.IsNullOrWhiteSpace(UrlTextBoxControl.Text)
+                        ? _releaseNotesUrl
+                        : UrlTextBoxControl.Text,
+                    UseShellExecute = true,
+                }
+            );
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+
+    private void CloseButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+
+    private sealed class GitHubReleaseResponse
+    {
+        [JsonPropertyName("body")]
+        public string Body { get; set; } = string.Empty;
+
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; set; } = string.Empty;
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/AdministratorSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/AdministratorSettingsView.axaml
@@ -1,0 +1,210 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.AdministratorSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+
+      <!-- Lead banner -->
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Security warning banner -->
+      <Border Padding="18"
+              Classes="surface-card warning-panel">
+        <StackPanel Spacing="6">
+          <TextBlock x:Name="WarningTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="WarningDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- UAC cache section -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ElevationTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ElevationDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="DoCacheAdminRightsForBatchesCheckBox"
+                    Content="Ask for administrator privileges once for each batch of operations" />
+          <CheckBox x:Name="DoCacheAdminRightsCheckBox"
+                    Content="Ask only once for administrator privileges" />
+          <TextBlock x:Name="ElevationHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Prohibit elevation — danger zone -->
+      <Border Padding="18"
+              Classes="surface-card danger-panel">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ProhibitTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ProhibitDescriptionBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="ProhibitElevationCheckBox"
+                    Content="Prohibit any kind of Elevation via UniGetUI Elevator or GSudo" />
+          <TextBlock x:Name="ProhibitHintBlock"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Secure settings — package operations -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="OperationsSecureTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="OperationsSecureDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <!-- Allow CLI arguments -->
+          <Border Padding="14"
+                  Classes="surface-card">
+            <StackPanel Spacing="8">
+              <CheckBox x:Name="AllowCLIArgumentsCheckBox"
+                        Content="Allow custom command-line arguments" />
+              <TextBlock x:Name="AllowCLIArgumentsHintBlock"
+                         Opacity="0.68"
+                         TextWrapping="Wrap" />
+              <Border x:Name="AllowCLIArgumentsPendingBadge"
+                      Padding="8,4"
+                      Classes="surface-card warning-panel"
+                      IsVisible="False">
+                <TextBlock x:Name="AllowCLIArgumentsPendingText"
+                           FontSize="12"
+                           TextWrapping="Wrap" />
+              </Border>
+            </StackPanel>
+          </Border>
+          <!-- Allow pre/post commands -->
+          <Border Padding="14"
+                  Classes="surface-card">
+            <StackPanel Spacing="8">
+              <CheckBox x:Name="AllowPrePostCommandsCheckBox"
+                        Content="Allow custom pre-install and post-install commands" />
+              <TextBlock x:Name="AllowPrePostCommandsHintBlock"
+                         Opacity="0.68"
+                         TextWrapping="Wrap" />
+              <Border x:Name="AllowPrePostCommandsPendingBadge"
+                      Padding="8,4"
+                      Classes="surface-card warning-panel"
+                      IsVisible="False">
+                <TextBlock x:Name="AllowPrePostCommandsPendingText"
+                           FontSize="12"
+                           TextWrapping="Wrap" />
+              </Border>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <!-- Secure settings — manager paths -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ManagerPathsTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ManagerPathsDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <Border Padding="14"
+                  Classes="surface-card">
+            <StackPanel Spacing="8">
+              <CheckBox x:Name="AllowCustomManagerPathsCheckBox"
+                        Content="Allow changing the paths for package manager executables" />
+              <TextBlock x:Name="AllowCustomManagerPathsHintBlock"
+                         Opacity="0.68"
+                         TextWrapping="Wrap" />
+              <Border x:Name="AllowCustomManagerPathsPendingBadge"
+                      Padding="8,4"
+                      Classes="surface-card warning-panel"
+                      IsVisible="False">
+                <TextBlock x:Name="AllowCustomManagerPathsPendingText"
+                           FontSize="12"
+                           TextWrapping="Wrap" />
+              </Border>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <!-- Secure settings — bundle import -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ImportSecureTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ImportSecureDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <!-- Import CLI arguments -->
+          <Border Padding="14"
+                  Classes="surface-card">
+            <StackPanel Spacing="8">
+              <CheckBox x:Name="AllowImportingCLIArgumentsCheckBox"
+                        Content="Allow importing custom command-line arguments from a bundle" />
+              <TextBlock x:Name="AllowImportingCLIArgumentsHintBlock"
+                         Opacity="0.68"
+                         TextWrapping="Wrap" />
+              <Border x:Name="AllowImportingCLIArgumentsPendingBadge"
+                      Padding="8,4"
+                      Classes="surface-card warning-panel"
+                      IsVisible="False">
+                <TextBlock x:Name="AllowImportingCLIArgumentsPendingText"
+                           FontSize="12"
+                           TextWrapping="Wrap" />
+              </Border>
+            </StackPanel>
+          </Border>
+          <!-- Import pre/post commands -->
+          <Border Padding="14"
+                  Classes="surface-card">
+            <StackPanel Spacing="8">
+              <CheckBox x:Name="AllowImportingPrePostCommandsCheckBox"
+                        Content="Allow importing custom pre/post-install commands from a bundle" />
+              <TextBlock x:Name="AllowImportingPrePostCommandsHintBlock"
+                         Opacity="0.68"
+                         TextWrapping="Wrap" />
+              <Border x:Name="AllowImportingPrePostCommandsPendingBadge"
+                      Padding="8,4"
+                      Classes="surface-card warning-panel"
+                      IsVisible="False">
+                <TextBlock x:Name="AllowImportingPrePostCommandsPendingText"
+                           FontSize="12"
+                           TextWrapping="Wrap" />
+              </Border>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/AdministratorSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/AdministratorSettingsView.axaml.cs
@@ -1,0 +1,285 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class AdministratorSettingsView : UserControl, ISettingsSectionView
+{
+    // Regular CheckBoxes
+    private CheckBox DoCacheAdminRightsForBatchesCheckBoxControl => GetControl<CheckBox>("DoCacheAdminRightsForBatchesCheckBox");
+    private CheckBox DoCacheAdminRightsCheckBoxControl => GetControl<CheckBox>("DoCacheAdminRightsCheckBox");
+    private CheckBox ProhibitElevationCheckBoxControl => GetControl<CheckBox>("ProhibitElevationCheckBox");
+
+    // Secure CheckBoxes
+    private CheckBox AllowCLIArgumentsCheckBoxControl => GetControl<CheckBox>("AllowCLIArgumentsCheckBox");
+    private CheckBox AllowPrePostCommandsCheckBoxControl => GetControl<CheckBox>("AllowPrePostCommandsCheckBox");
+    private CheckBox AllowCustomManagerPathsCheckBoxControl => GetControl<CheckBox>("AllowCustomManagerPathsCheckBox");
+    private CheckBox AllowImportingCLIArgumentsCheckBoxControl => GetControl<CheckBox>("AllowImportingCLIArgumentsCheckBox");
+    private CheckBox AllowImportingPrePostCommandsCheckBoxControl => GetControl<CheckBox>("AllowImportingPrePostCommandsCheckBox");
+
+    // Pending UAC badges
+    private Border AllowCLIArgumentsPendingBadgeControl => GetControl<Border>("AllowCLIArgumentsPendingBadge");
+    private Border AllowPrePostCommandsPendingBadgeControl => GetControl<Border>("AllowPrePostCommandsPendingBadge");
+    private Border AllowCustomManagerPathsPendingBadgeControl => GetControl<Border>("AllowCustomManagerPathsPendingBadge");
+    private Border AllowImportingCLIArgumentsPendingBadgeControl => GetControl<Border>("AllowImportingCLIArgumentsPendingBadge");
+    private Border AllowImportingPrePostCommandsPendingBadgeControl => GetControl<Border>("AllowImportingPrePostCommandsPendingBadge");
+
+    // Pending UAC badge texts
+    private TextBlock AllowCLIArgumentsPendingTextControl => GetControl<TextBlock>("AllowCLIArgumentsPendingText");
+    private TextBlock AllowPrePostCommandsPendingTextControl => GetControl<TextBlock>("AllowPrePostCommandsPendingText");
+    private TextBlock AllowCustomManagerPathsPendingTextControl => GetControl<TextBlock>("AllowCustomManagerPathsPendingText");
+    private TextBlock AllowImportingCLIArgumentsPendingTextControl => GetControl<TextBlock>("AllowImportingCLIArgumentsPendingText");
+    private TextBlock AllowImportingPrePostCommandsPendingTextControl => GetControl<TextBlock>("AllowImportingPrePostCommandsPendingText");
+
+    // Label TextBlocks
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+    private TextBlock WarningTitleText => GetControl<TextBlock>("WarningTitleBlock");
+    private TextBlock WarningDescriptionText => GetControl<TextBlock>("WarningDescriptionBlock");
+    private TextBlock ElevationTitleText => GetControl<TextBlock>("ElevationTitleBlock");
+    private TextBlock ElevationDescriptionText => GetControl<TextBlock>("ElevationDescriptionBlock");
+    private TextBlock ElevationHintText => GetControl<TextBlock>("ElevationHintBlock");
+    private TextBlock ProhibitTitleText => GetControl<TextBlock>("ProhibitTitleBlock");
+    private TextBlock ProhibitDescriptionText => GetControl<TextBlock>("ProhibitDescriptionBlock");
+    private TextBlock ProhibitHintText => GetControl<TextBlock>("ProhibitHintBlock");
+    private TextBlock OperationsSecureTitleText => GetControl<TextBlock>("OperationsSecureTitleBlock");
+    private TextBlock OperationsSecureDescriptionText => GetControl<TextBlock>("OperationsSecureDescriptionBlock");
+    private TextBlock AllowCLIArgumentsHintText => GetControl<TextBlock>("AllowCLIArgumentsHintBlock");
+    private TextBlock AllowPrePostCommandsHintText => GetControl<TextBlock>("AllowPrePostCommandsHintBlock");
+    private TextBlock ManagerPathsTitleText => GetControl<TextBlock>("ManagerPathsTitleBlock");
+    private TextBlock ManagerPathsDescriptionText => GetControl<TextBlock>("ManagerPathsDescriptionBlock");
+    private TextBlock AllowCustomManagerPathsHintText => GetControl<TextBlock>("AllowCustomManagerPathsHintBlock");
+    private TextBlock ImportSecureTitleText => GetControl<TextBlock>("ImportSecureTitleBlock");
+    private TextBlock ImportSecureDescriptionText => GetControl<TextBlock>("ImportSecureDescriptionBlock");
+    private TextBlock AllowImportingCLIArgumentsHintText => GetControl<TextBlock>("AllowImportingCLIArgumentsHintBlock");
+    private TextBlock AllowImportingPrePostCommandsHintText => GetControl<TextBlock>("AllowImportingPrePostCommandsHintBlock");
+
+    public AdministratorSettingsView()
+    {
+        InitializeComponent();
+
+        DoCacheAdminRightsForBatchesCheckBoxControl.Click += DoCacheAdminRightsForBatches_OnClick;
+        DoCacheAdminRightsCheckBoxControl.Click += DoCacheAdminRights_OnClick;
+        ProhibitElevationCheckBoxControl.Click += ProhibitElevation_OnClick;
+        AllowCLIArgumentsCheckBoxControl.Click += AllowCLIArguments_OnClick;
+        AllowPrePostCommandsCheckBoxControl.Click += AllowPrePostCommands_OnClick;
+        AllowCustomManagerPathsCheckBoxControl.Click += AllowCustomManagerPaths_OnClick;
+        AllowImportingCLIArgumentsCheckBoxControl.Click += AllowImportingCLIArguments_OnClick;
+        AllowImportingPrePostCommandsCheckBoxControl.Click += AllowImportingPrePostCommands_OnClick;
+
+        SectionTitle = CoreTools.Translate("Administrator privileges preferences");
+        SectionSubtitle = CoreTools.Translate("Administrator rights and other dangerous settings");
+        SectionStatus = CoreTools.Translate("Show the live output");
+
+        ApplyLocalizedText();
+        LoadStoredValues();
+        ApplyControlState();
+    }
+
+    public string SectionTitle { get; }
+    public string SectionSubtitle { get; }
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Administrator rights and other dangerous settings");
+        LeadDescriptionText.Text = CoreTools.Translate("Select which <b>package managers</b> to use ({0}), configure how packages are installed, manage how administrator rights are handled, etc.", "package managers");
+
+        WarningTitleText.Text = CoreTools.Translate("Warning") + "!";
+        WarningDescriptionText.Text = CoreTools.Translate("The following settings may pose a security risk, hence they are disabled by default.")
+            + " "
+            + CoreTools.Translate("Enable the settings below if and only if you fully understand what they do, and the implications they may have.")
+            + "\n\n"
+            + CoreTools.Translate("The settings will list, in their descriptions, the potential security issues they may have.");
+
+        ElevationTitleText.Text = CoreTools.Translate("Administrator rights");
+        ElevationDescriptionText.Text = CoreTools.Translate("Change how operations request administrator rights");
+        DoCacheAdminRightsForBatchesCheckBoxControl.Content = CoreTools.Translate("Ask for administrator privileges once for each batch of operations");
+        DoCacheAdminRightsCheckBoxControl.Content = CoreTools.Translate("Ask only once for administrator privileges");
+        ElevationHintText.Text = CoreTools.Translate("Cache administrator rights, but elevate installers only when required");
+
+        ProhibitTitleText.Text = CoreTools.Translate("Administrator rights");
+        ProhibitDescriptionText.Text = CoreTools.Translate("Ask for administrator rights when required");
+        ProhibitElevationCheckBoxControl.Content = CoreTools.Translate("Prohibit any kind of Elevation via UniGetUI Elevator or GSudo");
+        ProhibitHintText.Text = CoreTools.Translate("This option WILL cause issues. Any operation incapable of elevating itself WILL FAIL. Install/update/uninstall as administrator will NOT WORK.");
+
+        OperationsSecureTitleText.Text = CoreTools.Translate("Restrictions on package operations");
+        OperationsSecureDescriptionText.Text = CoreTools.Translate("The following settings may pose a security risk, hence they are disabled by default.");
+
+        AllowCLIArgumentsCheckBoxControl.Content = CoreTools.Translate("Allow custom command-line arguments");
+        AllowCLIArgumentsHintText.Text = CoreTools.Translate("Custom command-line arguments can change the way in which programs are installed, upgraded or uninstalled, in a way UniGetUI cannot control. Using custom command-lines can break packages. Proceed with caution.");
+
+        AllowPrePostCommandsCheckBoxControl.Content = CoreTools.Translate("Ignore custom pre-install and post-install commands when importing packages from a bundle");
+        AllowPrePostCommandsHintText.Text = CoreTools.Translate("Pre and post install commands will be run before and after a package gets installed, upgraded or uninstalled. Be aware that they may break things unless used carefully");
+
+        ManagerPathsTitleText.Text = CoreTools.Translate("Restrictions on package managers");
+        ManagerPathsDescriptionText.Text = CoreTools.Translate("Restrictions on package managers");
+        AllowCustomManagerPathsCheckBoxControl.Content = CoreTools.Translate("Allow changing the paths for package manager executables");
+        AllowCustomManagerPathsHintText.Text = CoreTools.Translate("Turning this on enables changing the executable file used to interact with package managers. While this allows finer-grained customization of your install processes, it may also be dangerous");
+
+        ImportSecureTitleText.Text = CoreTools.Translate("Restrictions when importing package bundles");
+        ImportSecureDescriptionText.Text = CoreTools.Translate("Restrictions on package operations");
+        AllowImportingCLIArgumentsCheckBoxControl.Content = CoreTools.Translate("Allow importing custom command-line arguments when importing packages from a bundle");
+        AllowImportingCLIArgumentsHintText.Text = CoreTools.Translate("Malformed command-line arguments can break packages, or even allow a malicious actor to gain privileged execution. Therefore, importing custom command-line arguments is disabled by default");
+        AllowImportingPrePostCommandsCheckBoxControl.Content = CoreTools.Translate("Allow importing custom pre-install and post-install commands when importing packages from a bundle");
+        AllowImportingPrePostCommandsHintText.Text = CoreTools.Translate("Pre and post install commands can do very nasty things to your device, if designed to do so. It can be very dangerous to import the commands from a bundle, unless you trust the source of that package bundle");
+    }
+
+    private void LoadStoredValues()
+    {
+        DoCacheAdminRightsForBatchesCheckBoxControl.IsChecked = Settings.Get(Settings.K.DoCacheAdminRightsForBatches);
+        DoCacheAdminRightsCheckBoxControl.IsChecked = Settings.Get(Settings.K.DoCacheAdminRights);
+        ProhibitElevationCheckBoxControl.IsChecked = Settings.Get(Settings.K.ProhibitElevation);
+
+        AllowCLIArgumentsCheckBoxControl.IsChecked = SecureSettings.Get(SecureSettings.K.AllowCLIArguments);
+        AllowPrePostCommandsCheckBoxControl.IsChecked = SecureSettings.Get(SecureSettings.K.AllowPrePostOpCommand);
+        AllowCustomManagerPathsCheckBoxControl.IsChecked = SecureSettings.Get(SecureSettings.K.AllowCustomManagerPaths);
+        AllowImportingCLIArgumentsCheckBoxControl.IsChecked = SecureSettings.Get(SecureSettings.K.AllowImportingCLIArguments);
+        AllowImportingPrePostCommandsCheckBoxControl.IsChecked = SecureSettings.Get(SecureSettings.K.AllowImportPrePostOpCommands);
+    }
+
+    private void ApplyControlState()
+    {
+        bool prohibitEnabled = ProhibitElevationCheckBoxControl.IsChecked == true;
+        DoCacheAdminRightsForBatchesCheckBoxControl.IsEnabled = !prohibitEnabled;
+        DoCacheAdminRightsCheckBoxControl.IsEnabled = !prohibitEnabled;
+
+        AllowImportingCLIArgumentsCheckBoxControl.IsEnabled =
+            AllowCLIArgumentsCheckBoxControl.IsChecked == true;
+        AllowImportingPrePostCommandsCheckBoxControl.IsEnabled =
+            AllowPrePostCommandsCheckBoxControl.IsChecked == true;
+    }
+
+    // ── Regular settings (no UAC needed) ──────────────────────────────────
+
+    private void DoCacheAdminRightsForBatches_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Settings.Set(Settings.K.DoCacheAdminRightsForBatches,
+            DoCacheAdminRightsForBatchesCheckBoxControl.IsChecked == true);
+        _ = CoreTools.ResetUACForCurrentProcess();
+    }
+
+    private void DoCacheAdminRights_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Settings.Set(Settings.K.DoCacheAdminRights,
+            DoCacheAdminRightsCheckBoxControl.IsChecked == true);
+        _ = CoreTools.ResetUACForCurrentProcess();
+    }
+
+    private void ProhibitElevation_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Settings.Set(Settings.K.ProhibitElevation,
+            ProhibitElevationCheckBoxControl.IsChecked == true);
+        ApplyControlState();
+    }
+
+    // ── Secure settings (UAC-elevated subprocess on Windows) ────────────
+
+    private async void AllowCLIArguments_OnClick(object? sender, RoutedEventArgs e)
+    {
+        bool desired = AllowCLIArgumentsCheckBoxControl.IsChecked == true;
+        await ApplySecureSetting(
+            SecureSettings.K.AllowCLIArguments,
+            desired,
+            AllowCLIArgumentsCheckBoxControl,
+            AllowCLIArgumentsPendingBadgeControl,
+            AllowCLIArgumentsPendingTextControl
+        );
+        ApplyControlState();
+    }
+
+    private async void AllowPrePostCommands_OnClick(object? sender, RoutedEventArgs e)
+    {
+        bool desired = AllowPrePostCommandsCheckBoxControl.IsChecked == true;
+        await ApplySecureSetting(
+            SecureSettings.K.AllowPrePostOpCommand,
+            desired,
+            AllowPrePostCommandsCheckBoxControl,
+            AllowPrePostCommandsPendingBadgeControl,
+            AllowPrePostCommandsPendingTextControl
+        );
+        ApplyControlState();
+    }
+
+    private async void AllowCustomManagerPaths_OnClick(object? sender, RoutedEventArgs e)
+    {
+        bool desired = AllowCustomManagerPathsCheckBoxControl.IsChecked == true;
+        await ApplySecureSetting(
+            SecureSettings.K.AllowCustomManagerPaths,
+            desired,
+            AllowCustomManagerPathsCheckBoxControl,
+            AllowCustomManagerPathsPendingBadgeControl,
+            AllowCustomManagerPathsPendingTextControl
+        );
+    }
+
+    private async void AllowImportingCLIArguments_OnClick(object? sender, RoutedEventArgs e)
+    {
+        bool desired = AllowImportingCLIArgumentsCheckBoxControl.IsChecked == true;
+        await ApplySecureSetting(
+            SecureSettings.K.AllowImportingCLIArguments,
+            desired,
+            AllowImportingCLIArgumentsCheckBoxControl,
+            AllowImportingCLIArgumentsPendingBadgeControl,
+            AllowImportingCLIArgumentsPendingTextControl
+        );
+    }
+
+    private async void AllowImportingPrePostCommands_OnClick(object? sender, RoutedEventArgs e)
+    {
+        bool desired = AllowImportingPrePostCommandsCheckBoxControl.IsChecked == true;
+        await ApplySecureSetting(
+            SecureSettings.K.AllowImportPrePostOpCommands,
+            desired,
+            AllowImportingPrePostCommandsCheckBoxControl,
+            AllowImportingPrePostCommandsPendingBadgeControl,
+            AllowImportingPrePostCommandsPendingTextControl
+        );
+    }
+
+    /// <summary>
+    /// Applies a UAC-protected secure setting, shows a pending badge during the UAC prompt,
+    /// and reverts the checkbox if the user cancels or the elevation fails.
+    /// </summary>
+    private static async Task ApplySecureSetting(
+        SecureSettings.K key,
+        bool desired,
+        CheckBox checkbox,
+        Border pendingBadge,
+        TextBlock pendingText)
+    {
+        checkbox.IsEnabled = false;
+        pendingText.Text = desired
+            ? CoreTools.Translate("Please wait...")
+            : CoreTools.Translate("Please wait...");
+        pendingBadge.IsVisible = true;
+
+        bool success = await SecureSettings.TrySet(key, desired);
+
+        pendingBadge.IsVisible = false;
+        checkbox.IsEnabled = true;
+
+        if (!success)
+        {
+            // Revert UI to the actual persisted value (UAC was cancelled or failed)
+            checkbox.IsChecked = SecureSettings.Get(key);
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/BackupSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/BackupSettingsView.axaml
@@ -1,0 +1,150 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.BackupSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+
+      <!-- Lead info banner -->
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="BulletPackageListBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="BulletNoBinaryBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="BulletSmallSizeBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="BulletAutoBackupBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Restart notice (hidden until a restart-required setting changes) -->
+      <Border x:Name="RestartNoticeCard"
+              Padding="18"
+              Classes="surface-card warning-panel"
+              IsVisible="False">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="RestartTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="RestartDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+          <Button x:Name="RestartAppButton"
+                  HorizontalAlignment="Left"
+                  Click="RestartAppButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Cloud backup section -->
+      <TextBlock x:Name="CloudSectionTitleBlock"
+                 Margin="4,12,4,4"
+                 FontSize="16"
+                 FontWeight="SemiBold" />
+
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="CloudNotAvailableDescriptionBlock"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="CloudStatusBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <StackPanel Orientation="Horizontal"
+                      Spacing="8">
+            <Button x:Name="LoginCloudButton" />
+            <Button x:Name="LogoutCloudButton" />
+          </StackPanel>
+          <CheckBox x:Name="EnableCloudBackupCheckBox" />
+          <StackPanel Orientation="Horizontal"
+                      Spacing="8">
+            <Button x:Name="BackupToCloudButton" />
+            <Button x:Name="RestoreFromCloudButton" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <!-- Local backup section -->
+      <TextBlock x:Name="LocalSectionTitleBlock"
+                 Margin="4,12,4,4"
+                 FontSize="16"
+                 FontWeight="SemiBold" />
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="LocalSectionDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableLocalBackupCheckBox" />
+          <Button x:Name="BackupNowButton"
+                  Click="BackupNowButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Backup directory -->
+      <TextBlock x:Name="DirectorySectionTitleBlock"
+                 Margin="4,12,4,4"
+                 FontSize="16"
+                 FontWeight="SemiBold" />
+
+      <Border x:Name="DirectoryCard"
+              Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="DirectoryDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <Border Padding="10,8"
+                  Classes="surface-card">
+            <TextBlock x:Name="BackupDirCurrentLabel"
+                       FontSize="13"
+                       Opacity="0.88"
+                       TextWrapping="Wrap" />
+          </Border>
+          <StackPanel Orientation="Horizontal"
+                      Spacing="8">
+            <Button x:Name="ChangeBackupDirButton" />
+            <Button x:Name="ResetBackupDirButton" />
+            <Button x:Name="OpenBackupDirButton" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <!-- Advanced options: custom file name + timestamping -->
+      <TextBlock x:Name="AdvancedSectionTitleBlock"
+                 Margin="4,12,4,4"
+                 FontSize="16"
+                 FontWeight="SemiBold" />
+
+      <Border x:Name="AdvancedCard"
+              Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="FilenameDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <TextBox x:Name="BackupFilenameTextBox"
+                   MaxLength="256" />
+          <TextBlock x:Name="FilenameHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="BackupTimestampingCheckBox" />
+        </StackPanel>
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/BackupSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/BackupSettingsView.axaml.cs
@@ -1,0 +1,699 @@
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Views;
+using UniGetUI.Avalonia.Views.Pages;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SecureSettings;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.PackageLoader;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class BackupSettingsView : UserControl, ISettingsSectionView
+{
+    private bool _isLoading;
+    private bool _isCloudLoading;
+    private bool _isCloudLoggedIn;
+    private readonly DispatcherTimer _filenameSaveTimer;
+
+    // Checkboxes
+    private CheckBox EnableLocalBackupCheckBoxControl => GetControl<CheckBox>("EnableLocalBackupCheckBox");
+    private CheckBox EnableCloudBackupCheckBoxControl => GetControl<CheckBox>("EnableCloudBackupCheckBox");
+    private CheckBox BackupTimestampingCheckBoxControl => GetControl<CheckBox>("BackupTimestampingCheckBox");
+
+    // Buttons
+    private Button LoginCloudButtonControl => GetControl<Button>("LoginCloudButton");
+    private Button LogoutCloudButtonControl => GetControl<Button>("LogoutCloudButton");
+    private Button ChangeBackupDirButtonControl => GetControl<Button>("ChangeBackupDirButton");
+    private Button ResetBackupDirButtonControl => GetControl<Button>("ResetBackupDirButton");
+    private Button OpenBackupDirButtonControl => GetControl<Button>("OpenBackupDirButton");
+    private Button BackupToCloudButtonControl => GetControl<Button>("BackupToCloudButton");
+    private Button RestoreFromCloudButtonControl => GetControl<Button>("RestoreFromCloudButton");
+    private Button BackupNowButtonControl => GetControl<Button>("BackupNowButton");
+
+    // TextBox
+    private TextBox BackupFilenameTextBoxControl => GetControl<TextBox>("BackupFilenameTextBox");
+
+    // Panels / cards
+    private Border RestartNoticeCardControl => GetControl<Border>("RestartNoticeCard");
+    private Button RestartAppBtnCtrl => GetControl<Button>("RestartAppButton");
+    private Border DirectoryCardControl => GetControl<Border>("DirectoryCard");
+    private Border AdvancedCardControl => GetControl<Border>("AdvancedCard");
+
+    // Labels
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+    private TextBlock BulletPackageListText => GetControl<TextBlock>("BulletPackageListBlock");
+    private TextBlock BulletNoBinaryText => GetControl<TextBlock>("BulletNoBinaryBlock");
+    private TextBlock BulletSmallSizeText => GetControl<TextBlock>("BulletSmallSizeBlock");
+    private TextBlock BulletAutoBackupText => GetControl<TextBlock>("BulletAutoBackupBlock");
+    private TextBlock RestartTitleText => GetControl<TextBlock>("RestartTitleBlock");
+    private TextBlock RestartDescriptionText => GetControl<TextBlock>("RestartDescriptionBlock");
+    private TextBlock CloudSectionTitleText => GetControl<TextBlock>("CloudSectionTitleBlock");
+    private TextBlock CloudNotAvailableDescriptionText => GetControl<TextBlock>("CloudNotAvailableDescriptionBlock");
+    private TextBlock CloudStatusText => GetControl<TextBlock>("CloudStatusBlock");
+    private TextBlock LocalSectionTitleText => GetControl<TextBlock>("LocalSectionTitleBlock");
+    private TextBlock LocalSectionDescriptionText => GetControl<TextBlock>("LocalSectionDescriptionBlock");
+    private TextBlock DirectorySectionTitleText => GetControl<TextBlock>("DirectorySectionTitleBlock");
+    private TextBlock DirectoryDescriptionText => GetControl<TextBlock>("DirectoryDescriptionBlock");
+    private TextBlock BackupDirCurrentLabelText => GetControl<TextBlock>("BackupDirCurrentLabel");
+    private TextBlock AdvancedSectionTitleText => GetControl<TextBlock>("AdvancedSectionTitleBlock");
+    private TextBlock FilenameDescriptionText => GetControl<TextBlock>("FilenameDescriptionBlock");
+    private TextBlock FilenameHintText => GetControl<TextBlock>("FilenameHintBlock");
+
+    public BackupSettingsView()
+    {
+        _filenameSaveTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(600) };
+        _filenameSaveTimer.Tick += FilenameSaveTimer_OnTick;
+
+        InitializeComponent();
+
+        EnableLocalBackupCheckBoxControl.Click += EnableLocalBackupCheckBox_OnClick;
+        EnableCloudBackupCheckBoxControl.Click += EnableCloudBackupCheckBox_OnClick;
+        BackupTimestampingCheckBoxControl.Click += BackupTimestampingCheckBox_OnClick;
+        ChangeBackupDirButtonControl.Click += ChangeBackupDir_OnClick;
+        ResetBackupDirButtonControl.Click += ResetBackupDir_OnClick;
+        OpenBackupDirButtonControl.Click += OpenBackupDir_OnClick;
+        LoginCloudButtonControl.Click += LoginCloudButton_OnClick;
+        LogoutCloudButtonControl.Click += LogoutCloudButton_OnClick;
+        BackupToCloudButtonControl.Click += BackupToCloudButton_OnClick;
+        RestoreFromCloudButtonControl.Click += RestoreFromCloudButton_OnClick;
+
+        SectionTitle = CoreTools.Translate("Backup and Restore");
+        SectionSubtitle = CoreTools.Translate("Automatically save a list of your installed packages on your computer.");
+        SectionStatus = CoreTools.Translate("Backup and Restore");
+
+        ApplyLocalizedText();
+
+        if (Design.IsDesignMode)
+        {
+            LoadPreviewValues();
+            return;
+        }
+
+        LoadStoredValues();
+
+        // Subscribe after loading to avoid spurious saves at init
+        BackupFilenameTextBoxControl.TextChanged += BackupFilenameTextBox_OnTextChanged;
+    }
+
+    public string SectionTitle { get; }
+    public string SectionSubtitle { get; }
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Package backup");
+        BulletPackageListText.Text = " \u25cf " + CoreTools.Translate("The backup will include the complete list of the installed packages and their installation options. Ignored updates and skipped versions will also be saved.");
+        BulletNoBinaryText.Text = " \u25cf " + CoreTools.Translate("The backup will NOT include any binary file nor any program's saved data.");
+        BulletSmallSizeText.Text = " \u25cf " + CoreTools.Translate("The size of the backup is estimated to be less than 1MB.");
+        BulletAutoBackupText.Text = " \u25cf " + CoreTools.Translate("The backup will be performed after login.");
+
+        RestartTitleText.Text = CoreTools.Translate("Restart required");
+        RestartDescriptionText.Text = CoreTools.Translate("Restart WingetUI to fully apply changes");
+        RestartAppBtnCtrl.Content = CoreTools.Translate("Restart UniGetUI");
+
+        CloudSectionTitleText.Text = CoreTools.Translate("Cloud package backup");
+        CloudNotAvailableDescriptionText.Text = CoreTools.Translate("Cloud backup uses a private GitHub Gist to store a list of installed packages");
+        CloudStatusText.Text = CoreTools.Translate("Current status: Not logged in");
+        LoginCloudButtonControl.Content = CoreTools.Translate("Log in");
+        LogoutCloudButtonControl.Content = CoreTools.Translate("Log out");
+        EnableCloudBackupCheckBoxControl.Content = CoreTools.Translate("Periodically perform a cloud backup of the installed packages");
+        BackupToCloudButtonControl.Content = CoreTools.Translate("Backup");
+        RestoreFromCloudButtonControl.Content = CoreTools.Translate("Select backup");
+
+        LocalSectionTitleText.Text = CoreTools.Translate("Local package backup");
+        LocalSectionDescriptionText.Text = CoreTools.Translate("Automatically save a list of all your installed packages to easily restore them.");
+        EnableLocalBackupCheckBoxControl.Content = CoreTools.Translate("Periodically perform a local backup of the installed packages");
+        BackupNowButtonControl.Content = CoreTools.Translate("Perform a backup now");
+
+        DirectorySectionTitleText.Text = CoreTools.Translate("Backup location");
+        DirectoryDescriptionText.Text = CoreTools.Translate("Change backup output directory");
+        ChangeBackupDirButtonControl.Content = CoreTools.Translate("Select");
+        ResetBackupDirButtonControl.Content = CoreTools.Translate("Reset");
+        OpenBackupDirButtonControl.Content = CoreTools.Translate("Open");
+
+        AdvancedSectionTitleText.Text = CoreTools.Translate("Local backup advanced options");
+        FilenameDescriptionText.Text = CoreTools.Translate("Set a custom backup file name");
+        BackupFilenameTextBoxControl.Watermark = CoreTools.Translate("Leave empty for default");
+        FilenameHintText.Text = CoreTools.Translate("Leave empty for default");
+        BackupTimestampingCheckBoxControl.Content = CoreTools.Translate("Add a timestamp to the backup file names");
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        bool localEnabled = Settings.Get(Settings.K.EnablePackageBackup_LOCAL);
+        bool cloudEnabled = Settings.Get(Settings.K.EnablePackageBackup_CLOUD);
+        EnableLocalBackupCheckBoxControl.IsChecked = localEnabled;
+        EnableCloudBackupCheckBoxControl.IsChecked = cloudEnabled;
+        BackupTimestampingCheckBoxControl.IsChecked = Settings.Get(Settings.K.EnableBackupTimestamping);
+        BackupFilenameTextBoxControl.Text = Settings.GetValue(Settings.K.ChangeBackupFileName);
+
+        UpdateDirectoryLabel();
+        ApplyLocalBackupEnabledState(localEnabled);
+        BackupNowButtonControl.IsEnabled = localEnabled;
+        UpdateCloudControlsEnabled();
+
+        RestartNoticeCardControl.IsVisible = false;
+        _isLoading = false;
+
+        _ = RefreshCloudStatusAsync();
+    }
+
+    private void LoadPreviewValues()
+    {
+        EnableLocalBackupCheckBoxControl.IsChecked = true;
+        EnableCloudBackupCheckBoxControl.IsChecked = true;
+        BackupTimestampingCheckBoxControl.IsChecked = true;
+        BackupFilenameTextBoxControl.Text = CoreTools.Translate("Package backup");
+        BackupDirCurrentLabelText.Text = CoreData.UniGetUI_DefaultBackupDirectory;
+        CloudStatusText.Text = CoreTools.Translate("You are logged in as {0} (@{1})", "Preview User", "preview-user");
+        _isCloudLoggedIn = true;
+        ApplyLocalBackupEnabledState(enabled: true);
+        UpdateCloudControlsEnabled();
+        RestartNoticeCardControl.IsVisible = true;
+    }
+
+    private void UpdateDirectoryLabel()
+    {
+        bool hasCustomDir = Settings.Get(Settings.K.ChangeBackupOutputDirectory);
+        if (hasCustomDir)
+        {
+            string customPath = Settings.GetValue(Settings.K.ChangeBackupOutputDirectory);
+            BackupDirCurrentLabelText.Text = string.IsNullOrWhiteSpace(customPath)
+                ? CoreData.UniGetUI_DefaultBackupDirectory
+                : customPath;
+            ResetBackupDirButtonControl.IsEnabled = true;
+        }
+        else
+        {
+            BackupDirCurrentLabelText.Text = CoreData.UniGetUI_DefaultBackupDirectory;
+            ResetBackupDirButtonControl.IsEnabled = false;
+        }
+    }
+
+    private void ApplyLocalBackupEnabledState(bool enabled)
+    {
+        DirectoryCardControl.IsEnabled = enabled;
+        AdvancedCardControl.IsEnabled = enabled;
+        BackupNowButtonControl.IsEnabled = enabled;
+    }
+
+    private void UpdateCloudControlsEnabled()
+    {
+        LoginCloudButtonControl.IsEnabled = !_isCloudLoading && !_isCloudLoggedIn;
+        LogoutCloudButtonControl.IsEnabled = !_isCloudLoading && _isCloudLoggedIn;
+        EnableCloudBackupCheckBoxControl.IsEnabled = !_isCloudLoading && _isCloudLoggedIn;
+
+        bool cloudEnabled = _isCloudLoggedIn && EnableCloudBackupCheckBoxControl.IsChecked == true;
+        BackupToCloudButtonControl.IsEnabled = !_isCloudLoading && cloudEnabled;
+        RestoreFromCloudButtonControl.IsEnabled = !_isCloudLoading && _isCloudLoggedIn;
+    }
+
+    private async Task RefreshCloudStatusAsync()
+    {
+        if (_isCloudLoading)
+            return;
+
+        var client = GitHubCloudBackupService.CreateGitHubClient();
+        if (client is null)
+        {
+            _isCloudLoggedIn = false;
+            CloudStatusText.Text = CoreTools.Translate("Current status: Not logged in");
+            UpdateCloudControlsEnabled();
+            return;
+        }
+
+        try
+        {
+            var (userLogin, userName) = await GitHubCloudBackupService.GetCurrentUserAsync();
+            _isCloudLoggedIn = true;
+
+            Settings.SetValue(Settings.K.GitHubUserLogin, userLogin);
+
+            CloudStatusText.Text = CoreTools.Translate(
+                "You are logged in as {0} (@{1})",
+                userName,
+                userLogin
+            );
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Cloud backup token validation failed.");
+            Logger.Warn(ex);
+            _isCloudLoggedIn = false;
+            SecureGHTokenManager.DeleteToken();
+            Settings.SetValue(Settings.K.GitHubUserLogin, string.Empty);
+            CloudStatusText.Text = CoreTools.Translate("Current status: Not logged in");
+        }
+
+        UpdateCloudControlsEnabled();
+    }
+
+    // ── Click handlers ────────────────────────────────────────────────────
+
+    private void EnableLocalBackupCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        bool enabled = EnableLocalBackupCheckBoxControl.IsChecked == true;
+        Settings.Set(Settings.K.EnablePackageBackup_LOCAL, enabled);
+        ApplyLocalBackupEnabledState(enabled);
+        ShowRestartNotice();
+    }
+
+    private void EnableCloudBackupCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.EnablePackageBackup_CLOUD, EnableCloudBackupCheckBoxControl.IsChecked == true);
+        ShowRestartNotice();
+        UpdateCloudControlsEnabled();
+    }
+
+    private void BackupTimestampingCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.EnableBackupTimestamping, BackupTimestampingCheckBoxControl.IsChecked == true);
+    }
+
+    private async void ChangeBackupDir_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null) return;
+
+        var result = await storageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = CoreTools.Translate("Select a folder"),
+            AllowMultiple = false,
+        });
+
+        if (result.Count > 0)
+        {
+            string? path = result[0].TryGetLocalPath();
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                Settings.SetValue(Settings.K.ChangeBackupOutputDirectory, path);
+                Settings.Set(Settings.K.ChangeBackupOutputDirectory, true);
+                UpdateDirectoryLabel();
+            }
+        }
+    }
+
+    private void ResetBackupDir_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Settings.Set(Settings.K.ChangeBackupOutputDirectory, false);
+        UpdateDirectoryLabel();
+    }
+
+    private void OpenBackupDir_OnClick(object? sender, RoutedEventArgs e)
+    {
+        string directory = Settings.GetValue(Settings.K.ChangeBackupOutputDirectory);
+        if (string.IsNullOrWhiteSpace(directory))
+            directory = CoreData.UniGetUI_DefaultBackupDirectory;
+
+        directory = directory.Replace("/", "\\");
+        if (!Directory.Exists(directory))
+            Directory.CreateDirectory(directory);
+
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = directory,
+            UseShellExecute = true,
+        });
+    }
+
+    // ── Filename debounced save ───────────────────────────────────────────
+
+    private void BackupFilenameTextBox_OnTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_isLoading) return;
+        _filenameSaveTimer.Stop();
+        _filenameSaveTimer.Start();
+    }
+
+    private void FilenameSaveTimer_OnTick(object? sender, EventArgs e)
+    {
+        _filenameSaveTimer.Stop();
+        Settings.SetValue(Settings.K.ChangeBackupFileName, BackupFilenameTextBoxControl.Text ?? string.Empty);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private void ShowRestartNotice()
+    {
+        RestartNoticeCardControl.IsVisible = true;
+    }
+
+    private async void BackupNowButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        BackupNowButtonControl.IsEnabled = false;
+        try
+        {
+            var packages = InstalledPackagesLoader.Instance.Packages;
+            string contents = await BundlesPageView.CreateBundleStringAsync(packages);
+
+            string dirName = Settings.GetValue(Settings.K.ChangeBackupOutputDirectory);
+            if (string.IsNullOrWhiteSpace(dirName))
+                dirName = CoreData.UniGetUI_DefaultBackupDirectory;
+
+            if (!Directory.Exists(dirName))
+                Directory.CreateDirectory(dirName);
+
+            string fileName = Settings.GetValue(Settings.K.ChangeBackupFileName);
+            if (string.IsNullOrWhiteSpace(fileName))
+                fileName = CoreTools.Translate("{pcName} installed packages",
+                    new Dictionary<string, object?> { { "pcName", Environment.MachineName } });
+
+            if (Settings.Get(Settings.K.EnableBackupTimestamping))
+                fileName += " " + DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss");
+
+            fileName += ".ubundle";
+            string filePath = Path.Combine(dirName, fileName);
+            await File.WriteAllTextAsync(filePath, contents);
+            Logger.ImportantInfo("Backup saved to " + filePath);
+            CoreTools.Launch(dirName);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred during manual backup");
+            Logger.Error(ex);
+        }
+        finally
+        {
+            BackupNowButtonControl.IsEnabled = Settings.Get(Settings.K.EnablePackageBackup_LOCAL);
+        }
+    }
+
+    private async void LoginCloudButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        string? token = await PromptForTokenAsync();
+        if (string.IsNullOrWhiteSpace(token))
+            return;
+
+        _isCloudLoading = true;
+        UpdateCloudControlsEnabled();
+
+        try
+        {
+            SecureGHTokenManager.StoreToken(token);
+
+            var (userLogin, _) = await GitHubCloudBackupService.GetCurrentUserAsync();
+            if (string.IsNullOrWhiteSpace(userLogin))
+                throw new InvalidOperationException("The GitHub token did not return a valid user.");
+
+            Settings.SetValue(Settings.K.GitHubUserLogin, userLogin);
+            await ShowInfoDialogAsync(
+                CoreTools.Translate("Done!"),
+                CoreTools.Translate("You are logged in as {0} (@{1})", userLogin, userLogin)
+            );
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Cloud backup sign-in failed");
+            Logger.Error(ex);
+            SecureGHTokenManager.DeleteToken();
+            Settings.SetValue(Settings.K.GitHubUserLogin, string.Empty);
+            await ShowInfoDialogAsync(
+                CoreTools.Translate("Backup Failed"),
+                CoreTools.Translate("Could not back up packages to GitHub Gist: ") + ex.Message
+            );
+        }
+        finally
+        {
+            _isCloudLoading = false;
+            await RefreshCloudStatusAsync();
+        }
+    }
+
+    private async void LogoutCloudButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        SecureGHTokenManager.DeleteToken();
+        Settings.SetValue(Settings.K.GitHubUserLogin, string.Empty);
+        _isCloudLoggedIn = false;
+        await RefreshCloudStatusAsync();
+    }
+
+    private async void BackupToCloudButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _isCloudLoading = true;
+        UpdateCloudControlsEnabled();
+
+        try
+        {
+            string contents = await BundlesPageView.CreateBundleStringAsync(InstalledPackagesLoader.Instance.Packages);
+            await GitHubCloudBackupService.UploadPackageBundleAsync(contents);
+            await ShowInfoDialogAsync(
+                CoreTools.Translate("Backup Successful"),
+                CoreTools.Translate("The cloud backup completed successfully.")
+            );
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Could not back up packages to GitHub Gist");
+            Logger.Error(ex);
+            await ShowInfoDialogAsync(
+                CoreTools.Translate("Backup Failed"),
+                CoreTools.Translate("Could not back up packages to GitHub Gist: ") + ex.Message
+            );
+        }
+        finally
+        {
+            _isCloudLoading = false;
+            UpdateCloudControlsEnabled();
+        }
+    }
+
+    private async void RestoreFromCloudButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _isCloudLoading = true;
+        UpdateCloudControlsEnabled();
+
+        try
+        {
+            var backups = await GitHubCloudBackupService.GetAvailableBackupsAsync();
+            if (backups.Count == 0)
+            {
+                return;
+            }
+
+            string? selectedKey = await PromptForBackupSelectionAsync(backups);
+            if (string.IsNullOrWhiteSpace(selectedKey))
+                return;
+
+            string backupContents = await GitHubCloudBackupService.GetBackupContentsAsync(selectedKey);
+
+            string filePath = Path.Combine(
+                Path.GetTempPath(),
+                "UniGetUI-cloud-" + DateTime.UtcNow.ToString("yyyyMMddHHmmss") + ".ubundle"
+            );
+            await File.WriteAllTextAsync(filePath, backupContents);
+
+            var shell = this.FindAncestorOfType<MainShellView>();
+            if (shell is null)
+            {
+                await ShowInfoDialogAsync(
+                    CoreTools.Translate("Backup Failed"),
+                    CoreTools.Translate("An error occurred while loading a backup: ") + "Could not access shell navigation"
+                );
+                return;
+            }
+
+            await shell.OpenBundleFromFileAsync(filePath);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while restoring a cloud backup");
+            Logger.Error(ex);
+            await ShowInfoDialogAsync(
+                CoreTools.Translate("Backup Failed"),
+                CoreTools.Translate("An error occurred while loading a backup: ") + ex.Message
+            );
+        }
+        finally
+        {
+            _isCloudLoading = false;
+            UpdateCloudControlsEnabled();
+        }
+    }
+
+    private async Task<string?> PromptForTokenAsync()
+    {
+        if (VisualRoot is not Window owner)
+            return null;
+
+        string? token = null;
+        var tokenBox = new TextBox
+        {
+            Watermark = CoreTools.Translate("Leave empty for default"),
+            Width = 460,
+        };
+
+        var dialog = new Window
+        {
+            Width = 560,
+            Height = 220,
+            CanResize = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Title = CoreTools.Translate("Cloud package backup"),
+        };
+
+        var saveBtn = new Button { Content = CoreTools.Translate("Log in"), MinWidth = 100 };
+        var cancelBtn = new Button { Content = CoreTools.Translate("Cancel"), MinWidth = 100 };
+
+        saveBtn.Click += (_, _) =>
+        {
+            token = tokenBox.Text?.Trim();
+            dialog.Close();
+        };
+        cancelBtn.Click += (_, _) => dialog.Close();
+
+        dialog.Content = new StackPanel
+        {
+            Spacing = 12,
+            Margin = new Thickness(16),
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = CoreTools.Translate("Log in with GitHub to enable cloud package backup."),
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                },
+                tokenBox,
+                new StackPanel
+                {
+                    Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+                    Spacing = 8,
+                    HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right,
+                    Children = { cancelBtn, saveBtn },
+                },
+            },
+        };
+
+        await dialog.ShowDialog(owner);
+
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    private async Task<string?> PromptForBackupSelectionAsync(IReadOnlyList<GitHubCloudBackupService.CloudBackupEntry> backups)
+    {
+        if (VisualRoot is not Window owner)
+            return null;
+
+        string? selectedKey = null;
+        var selector = new ComboBox
+        {
+            Width = 420,
+            ItemsSource = backups.Select(b => b.Display).ToArray(),
+            SelectedIndex = backups.Count > 0 ? 0 : -1,
+        };
+
+        var dialog = new Window
+        {
+            Width = 520,
+            Height = 210,
+            CanResize = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Title = CoreTools.Translate("Select backup"),
+        };
+
+        var openBtn = new Button { Content = CoreTools.Translate("Open"), MinWidth = 100 };
+        var cancelBtn = new Button { Content = CoreTools.Translate("Cancel"), MinWidth = 100 };
+
+        openBtn.Click += (_, _) =>
+        {
+            if (selector.SelectedIndex >= 0 && selector.SelectedIndex < backups.Count)
+                selectedKey = backups[selector.SelectedIndex].Key;
+            dialog.Close();
+        };
+        cancelBtn.Click += (_, _) => dialog.Close();
+
+        dialog.Content = new StackPanel
+        {
+            Spacing = 12,
+            Margin = new Thickness(16),
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = CoreTools.Translate("Select the backup you want to open. Later, you will be able to review which packages you want to install."),
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                },
+                selector,
+                new StackPanel
+                {
+                    Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+                    Spacing = 8,
+                    HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right,
+                    Children = { cancelBtn, openBtn },
+                },
+            },
+        };
+
+        await dialog.ShowDialog(owner);
+        return selectedKey;
+    }
+
+    private async Task ShowInfoDialogAsync(string title, string message)
+    {
+        if (VisualRoot is not Window owner)
+            return;
+
+        var dialog = new Window
+        {
+            Width = 520,
+            Height = 210,
+            CanResize = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Title = title,
+        };
+
+        var okBtn = new Button
+        {
+            Content = CoreTools.Translate("OK"),
+            MinWidth = 100,
+            HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right,
+        };
+        okBtn.Click += (_, _) => dialog.Close();
+
+        dialog.Content = new StackPanel
+        {
+            Spacing = 12,
+            Margin = new Thickness(16),
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = message,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                },
+                okBtn,
+            },
+        };
+
+        await dialog.ShowDialog(owner);
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+
+    private void RestartAppButton_OnClick(object? sender, RoutedEventArgs e)
+        => MainWindow.KillAndRestart();
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/ExperimentalSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/ExperimentalSettingsView.axaml
@@ -1,0 +1,172 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.ExperimentalSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+
+      <!-- Lead banner -->
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Restart notice (hidden until a restart-required setting changes) -->
+      <Border x:Name="RestartNoticeCard"
+              Padding="18"
+              Classes="surface-card warning-panel"
+              IsVisible="False">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="RestartTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="RestartDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+          <Button x:Name="RestartAppButton"
+                  HorizontalAlignment="Left"
+                  Click="RestartAppButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Background services -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ServicesTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ServicesDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableApiCheckBox"
+                    Content="Enable the background package API (UniGetUI Widgets, port 7058)" />
+          <TextBlock x:Name="ServicesHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Language and icon data -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="LanguageTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="LanguageDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="DownloadLangUpdatesCheckBox"
+                    Content="Download updated language files from GitHub automatically" />
+          <TextBlock x:Name="IconDbTitleBlock"
+                     FontWeight="SemiBold"
+                     Opacity="0.88"
+                     TextWrapping="Wrap" />
+          <TextBox x:Name="IconDbUrlTextBox"
+                   Watermark="Leave empty for default"
+                   MaxLength="512" />
+          <TextBlock x:Name="IconDbHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Performance -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="PerfTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="PerfDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="DisableTimeoutCheckBox"
+                    Content="Disable the 1-minute timeout for package-related operations" />
+          <TextBlock x:Name="DisableTimeoutHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableDmwOptimizationsCheckBox"
+                    Content="Enable background CPU usage optimizations" />
+          <TextBlock x:Name="DmwOptimizationsHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Startup integrity -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="IntegrityTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="IntegrityDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="PerformIntegrityChecksCheckBox"
+                    Content="Perform integrity checks at startup" />
+          <TextBlock x:Name="IntegrityHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Elevation — ForceUserGSudo (secure setting) -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ElevationTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ElevationDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="ForceUserGSudoCheckBox"
+                    Content="Use installed GSudo instead of UniGetUI Elevator" />
+          <TextBlock x:Name="ElevationHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+          <Border x:Name="GsudoPendingBadge"
+                  Padding="8,4"
+                  Classes="surface-card warning-panel"
+                  IsVisible="False">
+            <TextBlock x:Name="GsudoPendingText"
+                       FontSize="12"
+                       TextWrapping="Wrap" />
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <!-- Bundle behavior -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="BundleTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="BundleDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="InstallInstalledPackagesCheckBox"
+                    Content="Also install already-installed packages when batch-installing from a bundle" />
+          <TextBlock x:Name="BundleHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/ExperimentalSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/ExperimentalSettingsView.axaml.cs
@@ -1,0 +1,267 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using UniGetUI.Avalonia;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class ExperimentalSettingsView : UserControl, ISettingsSectionView
+{
+    private bool _isLoading;
+    private readonly DispatcherTimer _iconDbSaveTimer;
+
+    // Checkboxes
+    private CheckBox EnableApiCheckBoxControl => GetControl<CheckBox>("EnableApiCheckBox");
+    private CheckBox DownloadLangUpdatesCheckBoxControl => GetControl<CheckBox>("DownloadLangUpdatesCheckBox");
+    private CheckBox DisableTimeoutCheckBoxControl => GetControl<CheckBox>("DisableTimeoutCheckBox");
+    private CheckBox EnableDmwOptimizationsCheckBoxControl => GetControl<CheckBox>("EnableDmwOptimizationsCheckBox");
+    private CheckBox PerformIntegrityChecksCheckBoxControl => GetControl<CheckBox>("PerformIntegrityChecksCheckBox");
+    private CheckBox ForceUserGSudoCheckBoxControl => GetControl<CheckBox>("ForceUserGSudoCheckBox");
+    private CheckBox InstallInstalledPackagesCheckBoxControl => GetControl<CheckBox>("InstallInstalledPackagesCheckBox");
+
+    // Icon DB
+    private TextBox IconDbUrlTextBoxControl => GetControl<TextBox>("IconDbUrlTextBox");
+
+    // Restart notice
+    private Border RestartNoticeCardControl => GetControl<Border>("RestartNoticeCard");
+    private Button RestartAppBtnCtrl => GetControl<Button>("RestartAppButton");
+
+    // GSudo UAC pending
+    private Border GsudoPendingBadgeControl => GetControl<Border>("GsudoPendingBadge");
+    private TextBlock GsudoPendingTextControl => GetControl<TextBlock>("GsudoPendingText");
+
+    // Label TextBlocks
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+    private TextBlock RestartTitleText => GetControl<TextBlock>("RestartTitleBlock");
+    private TextBlock RestartDescriptionText => GetControl<TextBlock>("RestartDescriptionBlock");
+    private TextBlock ServicesTitleText => GetControl<TextBlock>("ServicesTitleBlock");
+    private TextBlock ServicesDescriptionText => GetControl<TextBlock>("ServicesDescriptionBlock");
+    private TextBlock ServicesHintText => GetControl<TextBlock>("ServicesHintBlock");
+    private TextBlock LanguageTitleText => GetControl<TextBlock>("LanguageTitleBlock");
+    private TextBlock LanguageDescriptionText => GetControl<TextBlock>("LanguageDescriptionBlock");
+    private TextBlock IconDbTitleText => GetControl<TextBlock>("IconDbTitleBlock");
+    private TextBlock IconDbHintText => GetControl<TextBlock>("IconDbHintBlock");
+    private TextBlock PerfTitleText => GetControl<TextBlock>("PerfTitleBlock");
+    private TextBlock PerfDescriptionText => GetControl<TextBlock>("PerfDescriptionBlock");
+    private TextBlock DisableTimeoutHintText => GetControl<TextBlock>("DisableTimeoutHintBlock");
+    private TextBlock DmwOptimizationsHintText => GetControl<TextBlock>("DmwOptimizationsHintBlock");
+    private TextBlock IntegrityTitleText => GetControl<TextBlock>("IntegrityTitleBlock");
+    private TextBlock IntegrityDescriptionText => GetControl<TextBlock>("IntegrityDescriptionBlock");
+    private TextBlock IntegrityHintText => GetControl<TextBlock>("IntegrityHintBlock");
+    private TextBlock ElevationTitleText => GetControl<TextBlock>("ElevationTitleBlock");
+    private TextBlock ElevationDescriptionText => GetControl<TextBlock>("ElevationDescriptionBlock");
+    private TextBlock ElevationHintText => GetControl<TextBlock>("ElevationHintBlock");
+    private TextBlock BundleTitleText => GetControl<TextBlock>("BundleTitleBlock");
+    private TextBlock BundleDescriptionText => GetControl<TextBlock>("BundleDescriptionBlock");
+    private TextBlock BundleHintText => GetControl<TextBlock>("BundleHintBlock");
+
+    public ExperimentalSettingsView()
+    {
+        _iconDbSaveTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(600) };
+        _iconDbSaveTimer.Tick += IconDbSaveTimer_OnTick;
+
+        InitializeComponent();
+
+        EnableApiCheckBoxControl.Click += EnableApiCheckBox_OnClick;
+        DownloadLangUpdatesCheckBoxControl.Click += DownloadLangUpdatesCheckBox_OnClick;
+        DisableTimeoutCheckBoxControl.Click += DisableTimeoutCheckBox_OnClick;
+        EnableDmwOptimizationsCheckBoxControl.Click += EnableDmwOptimizationsCheckBox_OnClick;
+        PerformIntegrityChecksCheckBoxControl.Click += PerformIntegrityChecksCheckBox_OnClick;
+        ForceUserGSudoCheckBoxControl.Click += ForceUserGSudoCheckBox_OnClick;
+        InstallInstalledPackagesCheckBoxControl.Click += InstallInstalledPackagesCheckBox_OnClick;
+
+        SectionTitle = CoreTools.Translate("Experimental settings and developer options");
+        SectionSubtitle = CoreTools.Translate("Beta features and other options that shouldn't be touched");
+        SectionStatus = CoreTools.Translate("Experimental settings and developer options");
+
+        ApplyLocalizedText();
+        LoadStoredValues();
+
+        // Subscribe TextChanged after loading to avoid spurious timer starts at init
+        IconDbUrlTextBoxControl.TextChanged += IconDbUrlTextBox_OnTextChanged;
+    }
+
+    public string SectionTitle { get; }
+    public string SectionSubtitle { get; }
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Experimental settings and developer options");
+        LeadDescriptionText.Text = CoreTools.Translate("Beta features and other options that shouldn't be touched");
+
+        RestartTitleText.Text = CoreTools.Translate("Restart required");
+        RestartDescriptionText.Text = CoreTools.Translate("Restart WingetUI to fully apply changes");
+        RestartAppBtnCtrl.Content = CoreTools.Translate("Restart UniGetUI");
+
+        ServicesTitleText.Text = CoreTools.Translate("Experimental settings and developer options");
+        ServicesDescriptionText.Text = string.Empty;
+        EnableApiCheckBoxControl.Content = CoreTools.Translate("Enable background api (WingetUI Widgets and Sharing, port 7058)");
+        ServicesHintText.Text = CoreTools.Translate("Restart WingetUI to fully apply changes");
+
+        LanguageTitleText.Text = CoreTools.Translate("Language");
+        LanguageDescriptionText.Text = string.Empty;
+        DownloadLangUpdatesCheckBoxControl.Content = CoreTools.Translate("Download updated language files from GitHub automatically");
+        IconDbTitleText.Text = CoreTools.Translate("Use a custom icon and screenshot database URL");
+        IconDbUrlTextBoxControl.Watermark = CoreTools.Translate("Leave empty for default");
+        IconDbHintText.Text = CoreTools.Translate("Restart WingetUI to fully apply changes");
+
+        PerfTitleText.Text = CoreTools.Translate("Experimental settings and developer options");
+        PerfDescriptionText.Text = string.Empty;
+        DisableTimeoutCheckBoxControl.Content = CoreTools.Translate("Disable the 1-minute timeout for package-related operations");
+        DisableTimeoutHintText.Text = string.Empty;
+        EnableDmwOptimizationsCheckBoxControl.Content = CoreTools.Translate("Enable background CPU Usage optimizations (see Pull Request #3278)");
+        DmwOptimizationsHintText.Text = string.Empty;
+
+        IntegrityTitleText.Text = CoreTools.Translate("Perform integrity checks at startup");
+        IntegrityDescriptionText.Text = string.Empty;
+        PerformIntegrityChecksCheckBoxControl.Content = CoreTools.Translate("Perform integrity checks at startup");
+        IntegrityHintText.Text = string.Empty;
+
+        ElevationTitleText.Text = CoreTools.Translate("Use installed GSudo instead of UniGetUI Elevator");
+        ElevationDescriptionText.Text = string.Empty;
+        ForceUserGSudoCheckBoxControl.Content = CoreTools.Translate("Use installed GSudo instead of UniGetUI Elevator");
+        ElevationHintText.Text = string.Empty;
+
+        BundleTitleText.Text = CoreTools.Translate("When batch installing packages from a bundle, install also packages that are already installed");
+        BundleDescriptionText.Text = string.Empty;
+        InstallInstalledPackagesCheckBoxControl.Content = CoreTools.Translate("When batch installing packages from a bundle, install also packages that are already installed");
+        BundleHintText.Text = string.Empty;
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        // Inverted: EnableAPI = !DisableApi
+        EnableApiCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableApi);
+        // Inverted: DownloadLangUpdates = !DisableLangAutoUpdater
+        DownloadLangUpdatesCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableLangAutoUpdater);
+        // Icon DB URL — value setting
+        IconDbUrlTextBoxControl.Text = Settings.GetValue(Settings.K.IconDataBaseURL);
+        // Not inverted: timeout disabled = setting=true
+        DisableTimeoutCheckBoxControl.IsChecked = Settings.Get(Settings.K.DisableTimeoutOnPackageListingTasks);
+        // Inverted: OptimizationsEnabled = !DisableDMWThreadOptimizations
+        EnableDmwOptimizationsCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableDMWThreadOptimizations);
+        // Inverted: PerformIntegrity = !DisableIntegrityChecks
+        PerformIntegrityChecksCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableIntegrityChecks);
+        // SecureSetting
+        ForceUserGSudoCheckBoxControl.IsChecked = SecureSettings.Get(SecureSettings.K.ForceUserGSudo);
+        // Not inverted
+        InstallInstalledPackagesCheckBoxControl.IsChecked = Settings.Get(Settings.K.InstallInstalledPackagesBundlesPage);
+
+        RestartNoticeCardControl.IsVisible = false;
+        _isLoading = false;
+    }
+
+    // ── Click handlers ────────────────────────────────────────────────────
+
+    private void EnableApiCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        // Inverted: checkbox checked = API enabled = DisableApi=false
+        Settings.Set(Settings.K.DisableApi, EnableApiCheckBoxControl.IsChecked != true);
+        ShowRestartNotice();
+    }
+
+    private void DownloadLangUpdatesCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableLangAutoUpdater, DownloadLangUpdatesCheckBoxControl.IsChecked != true);
+        ShowRestartNotice();
+    }
+
+    private void DisableTimeoutCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableTimeoutOnPackageListingTasks, DisableTimeoutCheckBoxControl.IsChecked == true);
+    }
+
+    private void EnableDmwOptimizationsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableDMWThreadOptimizations, EnableDmwOptimizationsCheckBoxControl.IsChecked != true);
+        ShowRestartNotice();
+    }
+
+    private void PerformIntegrityChecksCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableIntegrityChecks, PerformIntegrityChecksCheckBoxControl.IsChecked != true);
+    }
+
+    private async void ForceUserGSudoCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        bool desired = ForceUserGSudoCheckBoxControl.IsChecked == true;
+
+        ForceUserGSudoCheckBoxControl.IsEnabled = false;
+        GsudoPendingTextControl.Text = CoreTools.Translate("Please wait...");
+        GsudoPendingBadgeControl.IsVisible = true;
+
+        bool success = await SecureSettings.TrySet(SecureSettings.K.ForceUserGSudo, desired);
+
+        GsudoPendingBadgeControl.IsVisible = false;
+        ForceUserGSudoCheckBoxControl.IsEnabled = true;
+
+        if (!success)
+        {
+            _isLoading = true;
+            ForceUserGSudoCheckBoxControl.IsChecked = SecureSettings.Get(SecureSettings.K.ForceUserGSudo);
+            _isLoading = false;
+        }
+        else
+        {
+            ShowRestartNotice();
+        }
+    }
+
+    private void InstallInstalledPackagesCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.InstallInstalledPackagesBundlesPage, InstallInstalledPackagesCheckBoxControl.IsChecked == true);
+    }
+
+    // ── Icon DB URL debounced save ────────────────────────────────────────
+
+    private void IconDbUrlTextBox_OnTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_isLoading) return;
+        _iconDbSaveTimer.Stop();
+        _iconDbSaveTimer.Start();
+    }
+
+    private void IconDbSaveTimer_OnTick(object? sender, EventArgs e)
+    {
+        _iconDbSaveTimer.Stop();
+        Settings.SetValue(Settings.K.IconDataBaseURL, IconDbUrlTextBoxControl.Text ?? string.Empty);
+        ShowRestartNotice();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private void ShowRestartNotice()
+    {
+        RestartNoticeCardControl.IsVisible = true;
+    }
+
+    private void RestartAppButton_OnClick(object? sender, RoutedEventArgs e)
+        => MainWindow.KillAndRestart();
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/GeneralSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/GeneralSettingsView.axaml
@@ -1,0 +1,146 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.GeneralSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border x:Name="RestartNoticeCard"
+              Padding="18"
+              Classes="surface-card warning-panel"
+              IsVisible="False">
+        <StackPanel Spacing="10">
+          <TextBlock x:Name="RestartTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="RestartDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+          <Button x:Name="RestartAppButton"
+                  HorizontalAlignment="Left"
+                  Click="RestartAppButton_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="LanguageTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="LanguageDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <ComboBox x:Name="LanguageSelector"
+                    MaxDropDownHeight="320"
+                    SelectionChanged="LanguageSelector_OnSelectionChanged" />
+          <TextBlock x:Name="LanguageHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="TitleBarTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="TitleBarDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="ShowVersionOnTitleBarCheckBox"
+                    Content="Show the current UniGetUI version in the window title" />
+          <TextBlock x:Name="TitleBarHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="TelemetryTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="TelemetryDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="DisableTelemetryCheckBox"
+                    Content="Disable anonymous usage data collection" />
+          <Button x:Name="ManageTelemetryBtn"
+                  Content="Manage telemetry settings"
+                  Click="ManageTelemetryBtn_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Updater -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="UpdaterTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="UpdaterDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableAutoUpdateCheckBox" />
+          <CheckBox x:Name="EnableBetaCheckBox" />
+          <TextBlock x:Name="UpdaterHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+          <Button x:Name="CheckForUpdatesNowBtn"
+                  Click="CheckForUpdatesNowBtn_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Settings management -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="SettingsMgmtTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="SettingsMgmtDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <StackPanel Orientation="Horizontal"
+                      Spacing="8">
+            <Button x:Name="ImportSettingsBtn"
+                    Click="ImportSettingsBtn_OnClick" />
+            <Button x:Name="ExportSettingsBtn"
+                    Click="ExportSettingsBtn_OnClick" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <!-- Reset -->
+      <Border Padding="18"
+              Classes="surface-card danger-panel">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ResetTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ResetDescriptionBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <Button x:Name="ResetSettingsBtn"
+                  Click="ResetSettingsBtn_OnClick" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/GeneralSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/GeneralSettingsView.axaml.cs
@@ -1,0 +1,381 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using UniGetUI.Avalonia;
+using UniGetUI.Avalonia.Infrastructure;
+using UniGetUI.Avalonia.Views.Pages;
+using UniGetUI.Core.Language;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class GeneralSettingsView : UserControl, ISettingsSectionView
+{
+    private bool _isLoading;
+    private string _initialPreferredLanguage = "default";
+
+    private Border RestartNoticeCardControl => GetControl<Border>("RestartNoticeCard");
+
+    private Button RestartAppBtnCtrl => GetControl<Button>("RestartAppButton");
+
+    private ComboBox LanguageSelectorControl => GetControl<ComboBox>("LanguageSelector");
+
+    private CheckBox ShowVersionOnTitleBarCheckBoxControl => GetControl<CheckBox>("ShowVersionOnTitleBarCheckBox");
+
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+
+    private TextBlock RestartTitleText => GetControl<TextBlock>("RestartTitleBlock");
+
+    private TextBlock RestartDescriptionText => GetControl<TextBlock>("RestartDescriptionBlock");
+
+    private TextBlock LanguageTitleText => GetControl<TextBlock>("LanguageTitleBlock");
+
+    private TextBlock LanguageDescriptionText => GetControl<TextBlock>("LanguageDescriptionBlock");
+
+    private TextBlock LanguageHintText => GetControl<TextBlock>("LanguageHintBlock");
+
+    private TextBlock TitleBarTitleText => GetControl<TextBlock>("TitleBarTitleBlock");
+
+    private TextBlock TitleBarDescriptionText => GetControl<TextBlock>("TitleBarDescriptionBlock");
+
+    private TextBlock TitleBarHintText => GetControl<TextBlock>("TitleBarHintBlock");
+
+    private TextBlock TelemetryTitleText => GetControl<TextBlock>("TelemetryTitleBlock");
+
+    private TextBlock TelemetryDescriptionText => GetControl<TextBlock>("TelemetryDescriptionBlock");
+
+    private CheckBox DisableTelemetryCheckBoxControl => GetControl<CheckBox>("DisableTelemetryCheckBox");
+
+    private Button ManageTelemetryBtnCtrl => GetControl<Button>("ManageTelemetryBtn");
+
+    private TextBlock UpdaterTitleText => GetControl<TextBlock>("UpdaterTitleBlock");
+    private TextBlock UpdaterDescriptionText => GetControl<TextBlock>("UpdaterDescriptionBlock");
+    private CheckBox EnableAutoUpdateCheckBoxControl => GetControl<CheckBox>("EnableAutoUpdateCheckBox");
+    private CheckBox EnableBetaCheckBoxControl => GetControl<CheckBox>("EnableBetaCheckBox");
+    private TextBlock UpdaterHintText => GetControl<TextBlock>("UpdaterHintBlock");
+
+    private TextBlock SettingsMgmtTitleText => GetControl<TextBlock>("SettingsMgmtTitleBlock");
+
+    private TextBlock SettingsMgmtDescriptionText => GetControl<TextBlock>("SettingsMgmtDescriptionBlock");
+
+    private Button CheckForUpdatesNowBtnCtrl => GetControl<Button>("CheckForUpdatesNowBtn");
+
+    private Button ImportSettingsBtnCtrl => GetControl<Button>("ImportSettingsBtn");
+
+    private Button ExportSettingsBtnCtrl => GetControl<Button>("ExportSettingsBtn");
+
+    private TextBlock ResetTitleText => GetControl<TextBlock>("ResetTitleBlock");
+
+    private TextBlock ResetDescriptionText => GetControl<TextBlock>("ResetDescriptionBlock");
+
+    private Button ResetSettingsBtnCtrl => GetControl<Button>("ResetSettingsBtn");
+
+    public GeneralSettingsView()
+    {
+        InitializeComponent();
+        ShowVersionOnTitleBarCheckBoxControl.Click += ShowVersionOnTitleBarCheckBox_OnClick;
+        DisableTelemetryCheckBoxControl.Click += DisableTelemetryCheckBox_OnClick;
+        EnableAutoUpdateCheckBoxControl.Click += EnableAutoUpdateCheckBox_OnClick;
+        EnableBetaCheckBoxControl.Click += EnableBetaCheckBox_OnClick;
+
+        SectionTitle = CoreTools.Translate("General preferences");
+        SectionSubtitle = CoreTools.Translate("Language, theme and other miscellaneous preferences");
+        SectionStatus = CoreTools.Translate("Manage UniGetUI settings");
+
+        ApplyLocalizedText();
+        PopulateLanguageSelector();
+        LoadStoredValues();
+    }
+
+    public string SectionTitle { get; }
+
+    public string SectionSubtitle { get; }
+
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Language");
+        LeadDescriptionText.Text = CoreTools.Translate("WingetUI display language:");
+        RestartTitleText.Text = CoreTools.Translate("Restart required");
+        RestartDescriptionText.Text = CoreTools.Translate("Restart WingetUI to fully apply changes");
+        RestartAppBtnCtrl.Content = CoreTools.Translate("Restart UniGetUI");
+        LanguageTitleText.Text = CoreTools.Translate("Language");
+        LanguageDescriptionText.Text = CoreTools.Translate("WingetUI display language:");
+        LanguageHintText.Text = CoreTools.Translate("Is your language missing or incomplete?");
+        TitleBarTitleText.Text = CoreTools.Translate("General preferences");
+        TitleBarDescriptionText.Text = CoreTools.Translate("Show UniGetUI's version and build number on the titlebar.");
+        ShowVersionOnTitleBarCheckBoxControl.Content = CoreTools.Translate("Show UniGetUI's version and build number on the titlebar.");
+        TitleBarHintText.Text = string.Empty;
+        TelemetryTitleText.Text = CoreTools.Translate("Telemetry");
+        TelemetryDescriptionText.Text = CoreTools.Translate("UniGetUI collects anonymous usage data in order to improve the user experience.");
+        DisableTelemetryCheckBoxControl.Content = CoreTools.Translate("Share anonymous usage data");
+        ManageTelemetryBtnCtrl.Content = CoreTools.Translate("Manage telemetry settings");
+        UpdaterTitleText.Text = CoreTools.Translate("UniGetUI updater");
+        UpdaterDescriptionText.Text = CoreTools.Translate("Check for updates regularly, and automatically install available ones.");
+        EnableAutoUpdateCheckBoxControl.Content = CoreTools.Translate("Update WingetUI automatically");
+        EnableBetaCheckBoxControl.Content = CoreTools.Translate("Install prerelease versions of UniGetUI");
+        UpdaterHintText.Text = string.Empty;
+        CheckForUpdatesNowBtnCtrl.Content = CoreTools.Translate("Check for updates");
+        SettingsMgmtTitleText.Text = CoreTools.Translate("Manage UniGetUI settings");
+        SettingsMgmtDescriptionText.Text = CoreTools.Translate("Import settings from a local file");
+        ImportSettingsBtnCtrl.Content = CoreTools.Translate("Import");
+        ExportSettingsBtnCtrl.Content = CoreTools.Translate("Export");
+        ResetTitleText.Text = CoreTools.Translate("Reset UniGetUI");
+        ResetDescriptionText.Text = CoreTools.Translate("Reset WingetUI and its preferences");
+        ResetSettingsBtnCtrl.Content = CoreTools.Translate("Reset WingetUI");
+    }
+
+    private void PopulateLanguageSelector()
+    {
+        LanguageSelectorControl.Items.Clear();
+        LanguageSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Default"), "default"));
+
+        foreach (var entry in BuildLanguageEntries())
+        {
+            LanguageSelectorControl.Items.Add(CreateComboBoxItem(entry.Label, entry.Value));
+        }
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        _initialPreferredLanguage = NormalizePreferredLanguageValue(Settings.GetValue(Settings.K.PreferredLanguage));
+        SelectComboBoxValue(LanguageSelectorControl, _initialPreferredLanguage, fallbackValue: "default");
+        ShowVersionOnTitleBarCheckBoxControl.IsChecked = Settings.Get(Settings.K.ShowVersionNumberOnTitlebar);
+        DisableTelemetryCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableTelemetry);
+        EnableAutoUpdateCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableAutoUpdateWingetUI);
+        EnableBetaCheckBoxControl.IsChecked = Settings.Get(Settings.K.EnableUniGetUIBeta);
+        SetRestartNoticeVisible(false);
+
+        _isLoading = false;
+    }
+
+    private void LanguageSelector_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        var selectedLanguage = NormalizePreferredLanguageValue(GetSelectedValue(LanguageSelectorControl));
+        Settings.SetValue(Settings.K.PreferredLanguage, selectedLanguage);
+        SetRestartNoticeVisible(selectedLanguage != _initialPreferredLanguage);
+    }
+
+    private void ShowVersionOnTitleBarCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.ShowVersionNumberOnTitlebar, ShowVersionOnTitleBarCheckBoxControl.IsChecked == true);
+        FindWindow()?.RefreshWindowTitle();
+    }
+
+    private void DisableTelemetryCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableTelemetry, DisableTelemetryCheckBoxControl.IsChecked != true);
+    }
+
+    private void ManageTelemetryBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var owner = TopLevel.GetTopLevel(this) as Window;
+        var dialog = new TelemetryConsentWindow();
+        if (owner is not null)
+        {
+            _ = dialog.ShowDialog(owner);
+        }
+        else
+        {
+            dialog.Show();
+        }
+    }
+
+    private void EnableAutoUpdateCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableAutoUpdateWingetUI, EnableAutoUpdateCheckBoxControl.IsChecked != true);
+    }
+
+    private void EnableBetaCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.EnableUniGetUIBeta, EnableBetaCheckBoxControl.IsChecked == true);
+    }
+
+    private void CheckForUpdatesNowBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _ = AvaloniaAutoUpdater.CheckAndInstallUpdatesAsync();
+    }
+
+    private async void ImportSettingsBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var result = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = CoreTools.Translate("Import settings from a local file"),
+            AllowMultiple = false,
+            FileTypeFilter = [new FilePickerFileType("JSON (*.json)") { Patterns = ["*.json"] }],
+        });
+
+        if (result.Count > 0)
+        {
+            string? path = result[0].TryGetLocalPath();
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                try
+                {
+                    await Task.Run(() => Settings.ImportFromFile_JSON(path));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Error importing settings");
+                    Logger.Error(ex);
+                }
+                SetRestartNoticeVisible(true);
+            }
+        }
+    }
+
+    private async void ExportSettingsBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var result = await storage.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = CoreTools.Translate("Export settings to a local file"),
+            SuggestedFileName = "UniGetUI Settings.json",
+            FileTypeChoices = [new FilePickerFileType("JSON (*.json)") { Patterns = ["*.json"] }],
+        });
+
+        if (result is not null)
+        {
+            string? path = result.TryGetLocalPath();
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                try
+                {
+                    await Task.Run(() => Settings.ExportToFile_JSON(path));
+                    CoreTools.Launch(path);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Error exporting settings");
+                    Logger.Error(ex);
+                }
+            }
+        }
+    }
+
+    private void ResetSettingsBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Settings.ResetSettings();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Error resetting settings");
+            Logger.Error(ex);
+        }
+        SetRestartNoticeVisible(true);
+    }
+
+    private void SetRestartNoticeVisible(bool isVisible)
+    {
+        RestartNoticeCardControl.IsVisible = isVisible;
+    }
+
+    private void RestartAppButton_OnClick(object? sender, RoutedEventArgs e)
+        => MainWindow.KillAndRestart();
+
+    private static List<(string Label, string Value)> BuildLanguageEntries()
+    {
+        return LanguageData.LanguageReference
+            .Select(entry =>
+            {
+                var label = entry.Value;
+                if (
+                    entry.Key != "en"
+                    && LanguageData.TranslationPercentages.TryGetValue(entry.Key, out var percentage)
+                )
+                {
+                    label = $"{label} ({percentage})";
+                }
+
+                return (Label: label, Value: entry.Key);
+            })
+            .OrderBy(entry => entry.Label, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+    }
+
+    private MainWindow? FindWindow()
+    {
+        return TopLevel.GetTopLevel(this) as MainWindow;
+    }
+
+    private static ComboBoxItem CreateComboBoxItem(string label, string value)
+    {
+        return new ComboBoxItem
+        {
+            Content = label,
+            Tag = value,
+        };
+    }
+
+    private static string GetSelectedValue(ComboBox comboBox)
+    {
+        return comboBox.SelectedItem is ComboBoxItem { Tag: string value }
+            ? value
+            : string.Empty;
+    }
+
+    private static string NormalizePreferredLanguageValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "default" : value;
+    }
+
+    private static void SelectComboBoxValue(ComboBox comboBox, string selectedValue, string fallbackValue)
+    {
+        var desiredValue = string.IsNullOrWhiteSpace(selectedValue) ? fallbackValue : selectedValue;
+
+        for (var index = 0; index < comboBox.Items.Count; index++)
+        {
+            if (comboBox.Items[index] is ComboBoxItem { Tag: string value } && value == desiredValue)
+            {
+                comboBox.SelectedIndex = index;
+                return;
+            }
+        }
+
+        comboBox.SelectedIndex = 0;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/ISettingsSectionStateNotifier.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/ISettingsSectionStateNotifier.cs
@@ -1,0 +1,6 @@
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+internal interface ISettingsSectionStateNotifier
+{
+    event EventHandler? SectionStateChanged;
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/ISettingsSectionView.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/ISettingsSectionView.cs
@@ -1,0 +1,10 @@
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+internal interface ISettingsSectionView
+{
+    string SectionTitle { get; }
+
+    string SectionSubtitle { get; }
+
+    string SectionStatus { get; }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/InterfaceSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/InterfaceSettingsView.axaml
@@ -1,0 +1,132 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.InterfaceSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ThemeTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ThemeDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <ComboBox x:Name="ThemeSelector"
+                    MaxDropDownHeight="220"
+                    SelectionChanged="ThemeSelector_OnSelectionChanged" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="StartupTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="StartupDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <ComboBox x:Name="StartupPageSelector"
+                    MaxDropDownHeight="260"
+                    SelectionChanged="StartupPageSelector_OnSelectionChanged" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="NavigationTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="NavigationDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="CollapseNavigationCheckBox"
+                    Content="Collapse the navigation menu on wide screens" />
+          <TextBlock x:Name="NavigationNoteBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <!-- Package list icons -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="IconsTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="IconsDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="DisableIconsCheckBox"
+                    Content="Disable icons on package lists" />
+          <TextBlock x:Name="IconCacheSizeBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+          <Button x:Name="ResetIconCacheBtn"
+                  Click="ResetIconCacheBtn_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- Updates defaults -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="UpdatesDefaultsTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="UpdatesDefaultsDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="DisableSelectingUpdatesByDefaultCheckBox"
+                    Content="Do not select updates by default" />
+        </StackPanel>
+      </Border>
+
+      <!-- Startup / autostart -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="AutostartTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="AutostartDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <Button x:Name="EditAutostartBtn"
+                  Click="EditAutostartBtn_OnClick" />
+        </StackPanel>
+      </Border>
+
+      <!-- System tray -->
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="SystemTrayTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="SystemTrayDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableSystemTrayCheckBox" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/InterfaceSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/InterfaceSettingsView.axaml.cs
@@ -1,0 +1,314 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using UniGetUI.Avalonia;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class InterfaceSettingsView : UserControl, ISettingsSectionView
+{
+    private bool _isLoading;
+
+    private ComboBox ThemeSelectorControl => GetControl<ComboBox>("ThemeSelector");
+
+    private ComboBox StartupPageSelectorControl => GetControl<ComboBox>("StartupPageSelector");
+
+    private CheckBox CollapseNavigationCheckBoxControl => GetControl<CheckBox>("CollapseNavigationCheckBox");
+
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+
+    private TextBlock ThemeTitleText => GetControl<TextBlock>("ThemeTitleBlock");
+
+    private TextBlock ThemeDescriptionText => GetControl<TextBlock>("ThemeDescriptionBlock");
+
+    private TextBlock StartupTitleText => GetControl<TextBlock>("StartupTitleBlock");
+
+    private TextBlock StartupDescriptionText => GetControl<TextBlock>("StartupDescriptionBlock");
+
+    private TextBlock NavigationTitleText => GetControl<TextBlock>("NavigationTitleBlock");
+
+    private TextBlock NavigationDescriptionText => GetControl<TextBlock>("NavigationDescriptionBlock");
+
+    private TextBlock NavigationNoteText => GetControl<TextBlock>("NavigationNoteBlock");
+
+    private TextBlock IconsTitleText => GetControl<TextBlock>("IconsTitleBlock");
+
+    private TextBlock IconsDescriptionText => GetControl<TextBlock>("IconsDescriptionBlock");
+
+    private CheckBox DisableIconsCheckBoxControl => GetControl<CheckBox>("DisableIconsCheckBox");
+
+    private TextBlock IconCacheSizeText => GetControl<TextBlock>("IconCacheSizeBlock");
+
+    private Button ResetIconCacheBtnCtrl => GetControl<Button>("ResetIconCacheBtn");
+
+    private TextBlock UpdatesDefaultsTitleText => GetControl<TextBlock>("UpdatesDefaultsTitleBlock");
+
+    private TextBlock UpdatesDefaultsDescriptionText => GetControl<TextBlock>("UpdatesDefaultsDescriptionBlock");
+
+    private CheckBox DisableSelectingUpdatesByDefaultCheckBoxControl => GetControl<CheckBox>("DisableSelectingUpdatesByDefaultCheckBox");
+
+    private TextBlock AutostartTitleText => GetControl<TextBlock>("AutostartTitleBlock");
+
+    private TextBlock AutostartDescriptionText => GetControl<TextBlock>("AutostartDescriptionBlock");
+
+    private TextBlock SystemTrayTitleText => GetControl<TextBlock>("SystemTrayTitleBlock");
+
+    private TextBlock SystemTrayDescriptionText => GetControl<TextBlock>("SystemTrayDescriptionBlock");
+
+    private CheckBox EnableSystemTrayCheckBoxControl => GetControl<CheckBox>("EnableSystemTrayCheckBox");
+
+    private Button EditAutostartBtnCtrl => GetControl<Button>("EditAutostartBtn");
+
+    public InterfaceSettingsView()
+    {
+        InitializeComponent();
+        CollapseNavigationCheckBoxControl.Click += CollapseNavigationCheckBox_OnClick;
+        DisableIconsCheckBoxControl.Click += DisableIconsCheckBox_OnClick;
+        DisableSelectingUpdatesByDefaultCheckBoxControl.Click += DisableSelectingUpdatesByDefault_OnClick;
+        EnableSystemTrayCheckBoxControl.Click += EnableSystemTrayCheckBox_OnClick;
+
+        SectionTitle = CoreTools.Translate("User interface preferences");
+        SectionSubtitle = CoreTools.Translate("Application theme, startup page, package icons, clear successful installs automatically");
+        SectionStatus = CoreTools.Translate("Show the live output");
+
+        ApplyLocalizedText();
+        PopulateThemeSelector();
+        PopulateStartupPageSelector();
+        LoadStoredValues();
+    }
+
+    public string SectionTitle { get; }
+
+    public string SectionSubtitle { get; }
+
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("User interface preferences");
+        LeadDescriptionText.Text = CoreTools.Translate("Language, theme and other miscellaneous preferences");
+        ThemeTitleText.Text = CoreTools.Translate("Application theme:");
+        ThemeDescriptionText.Text = CoreTools.Translate("Application theme, startup page, package icons, clear successful installs automatically");
+        StartupTitleText.Text = CoreTools.Translate("UniGetUI startup page:");
+        StartupDescriptionText.Text = CoreTools.Translate("WingetUI autostart behaviour, application launch settings");
+        NavigationTitleText.Text = CoreTools.Translate("User interface preferences");
+        NavigationDescriptionText.Text = CoreTools.Translate("Language, theme and other miscellaneous preferences");
+        CollapseNavigationCheckBoxControl.Content = CoreTools.Translate("Toggle search filters pane");
+        NavigationNoteText.Text = CoreTools.Translate("Show the live output");
+        IconsTitleText.Text = CoreTools.Translate("Show package icons on package lists");
+        IconsDescriptionText.Text = CoreTools.Translate("Show package icons on package lists");
+        DisableIconsCheckBoxControl.Content = CoreTools.Translate("Show package icons on package lists");
+        ResetIconCacheBtnCtrl.Content = CoreTools.Translate("Clear the local icon cache");
+        UpdatesDefaultsTitleText.Text = CoreTools.Translate("Change default options");
+        UpdatesDefaultsDescriptionText.Text = CoreTools.Translate("Select upgradable packages by default");
+        DisableSelectingUpdatesByDefaultCheckBoxControl.Content = CoreTools.Translate("Select upgradable packages by default");
+        AutostartTitleText.Text = CoreTools.Translate("WingetUI autostart behaviour, application launch settings");
+        AutostartDescriptionText.Text = CoreTools.Translate("Manage WingetUI autostart behaviour from the Settings app");
+        EditAutostartBtnCtrl.Content = CoreTools.Translate("Manage WingetUI autostart behaviour from the Settings app");
+        SystemTrayTitleText.Text = CoreTools.Translate("UniGetUI on the background and system tray");
+        SystemTrayDescriptionText.Text = CoreTools.Translate("Close UniGetUI to the system tray");
+        EnableSystemTrayCheckBoxControl.Content = CoreTools.Translate("Show UniGetUI on the system tray");
+    }
+
+    private void PopulateThemeSelector()
+    {
+        ThemeSelectorControl.Items.Clear();
+        ThemeSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Light"), "light"));
+        ThemeSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Dark"), "dark"));
+        ThemeSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Follow system color scheme"), "auto"));
+    }
+
+    private void PopulateStartupPageSelector()
+    {
+        StartupPageSelectorControl.Items.Clear();
+        StartupPageSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Default"), "default"));
+        StartupPageSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Discover Packages"), "discover"));
+        StartupPageSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Software Updates"), "updates"));
+        StartupPageSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Installed Packages"), "installed"));
+        StartupPageSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Package Bundles"), "bundles"));
+        StartupPageSelectorControl.Items.Add(CreateComboBoxItem(CoreTools.Translate("Settings"), "settings"));
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        var preferredTheme = Settings.GetValue(Settings.K.PreferredTheme);
+        if (string.IsNullOrWhiteSpace(preferredTheme))
+        {
+            preferredTheme = "auto";
+            Settings.SetValue(Settings.K.PreferredTheme, preferredTheme);
+        }
+
+        SelectComboBoxValue(ThemeSelectorControl, preferredTheme, fallbackValue: "auto");
+        SelectComboBoxValue(StartupPageSelectorControl, Settings.GetValue(Settings.K.StartupPage), fallbackValue: "default");
+        CollapseNavigationCheckBoxControl.IsChecked = Settings.Get(Settings.K.CollapseNavMenuOnWideScreen);
+        DisableIconsCheckBoxControl.IsChecked = Settings.Get(Settings.K.DisableIconsOnPackageLists);
+        DisableSelectingUpdatesByDefaultCheckBoxControl.IsChecked = Settings.Get(Settings.K.DisableSelectingUpdatesByDefault);
+        EnableSystemTrayCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableSystemTray);
+        _ = UpdateIconCacheSizeAsync();
+
+        _isLoading = false;
+    }
+
+    private void ThemeSelector_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        var selectedTheme = GetSelectedValue(ThemeSelectorControl);
+        Settings.SetValue(Settings.K.PreferredTheme, selectedTheme);
+
+        if (TopLevel.GetTopLevel(this) is Window window)
+        {
+            window.RequestedThemeVariant = selectedTheme switch
+            {
+                "dark" => ThemeVariant.Dark,
+                "light" => ThemeVariant.Light,
+                _ => ThemeVariant.Default,
+            };
+        }
+    }
+
+    private void StartupPageSelector_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.SetValue(Settings.K.StartupPage, GetSelectedValue(StartupPageSelectorControl));
+    }
+
+    private void CollapseNavigationCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        var collapseOnWideScreen = CollapseNavigationCheckBoxControl.IsChecked == true;
+        Settings.Set(Settings.K.CollapseNavMenuOnWideScreen, collapseOnWideScreen);
+        FindShell()?.SetNavigationCollapsedPreference(collapseOnWideScreen);
+    }
+
+    private void DisableIconsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableIconsOnPackageLists, DisableIconsCheckBoxControl.IsChecked == true);
+    }
+
+    private void DisableSelectingUpdatesByDefault_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableSelectingUpdatesByDefault, DisableSelectingUpdatesByDefaultCheckBoxControl.IsChecked == true);
+    }
+
+    private void ResetIconCacheBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Directory.Delete(CoreData.UniGetUICacheDirectory_Icons, true);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while deleting icon cache");
+            Logger.Error(ex);
+        }
+        _ = UpdateIconCacheSizeAsync();
+    }
+
+    private async Task UpdateIconCacheSizeAsync()
+    {
+        double mb = await Task.Run(() =>
+        {
+            try
+            {
+                long bytes = Directory
+                    .GetFiles(CoreData.UniGetUICacheDirectory_Icons, "*", SearchOption.AllDirectories)
+                    .Sum(f => new FileInfo(f).Length);
+                return bytes / 1_048_576d;
+            }
+            catch
+            {
+                return 0d;
+            }
+        });
+
+        double rounded = Math.Round(mb, 2);
+        IconCacheSizeText.Text = CoreTools.Translate("The local icon cache currently takes {0} MB", rounded);
+    }
+
+    private void EditAutostartBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        CoreTools.Launch("ms-settings:startupapps");
+    }
+
+    private void EnableSystemTrayCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.DisableSystemTray, EnableSystemTrayCheckBoxControl.IsChecked != true);
+        if (TopLevel.GetTopLevel(this) is MainWindow mainWindow)
+            mainWindow.ApplyTrayIconVisibility();
+    }
+
+    private MainShellView? FindShell()
+    {
+        return this.GetSelfAndVisualAncestors().OfType<MainShellView>().FirstOrDefault();
+    }
+
+    private static ComboBoxItem CreateComboBoxItem(string label, string value)
+    {
+        return new ComboBoxItem
+        {
+            Content = label,
+            Tag = value,
+        };
+    }
+
+    private static string GetSelectedValue(ComboBox comboBox)
+    {
+        return comboBox.SelectedItem is ComboBoxItem { Tag: string value }
+            ? value
+            : string.Empty;
+    }
+
+    private static void SelectComboBoxValue(ComboBox comboBox, string selectedValue, string fallbackValue)
+    {
+        var desiredValue = string.IsNullOrWhiteSpace(selectedValue) ? fallbackValue : selectedValue;
+
+        for (var index = 0; index < comboBox.Items.Count; index++)
+        {
+            if (comboBox.Items[index] is ComboBoxItem { Tag: string value } && value == desiredValue)
+            {
+                comboBox.SelectedIndex = index;
+                return;
+            }
+        }
+
+        comboBox.SelectedIndex = 0;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/InternetSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/InternetSettingsView.axaml
@@ -1,0 +1,107 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.InternetSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ProxyTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ProxyDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableProxyCheckBox"
+                    Content="Connect to the internet using a custom proxy" />
+          <TextBlock x:Name="ProxyUrlLabelBlock"
+                     Classes="data-header" />
+          <TextBox x:Name="ProxyUrlTextBox"
+                   Watermark="Enter proxy URL here" />
+          <TextBlock x:Name="ProxyHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="AuthTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="AuthDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableProxyAuthCheckBox"
+                    Content="Authenticate to the proxy with a username and password" />
+          <Grid ColumnDefinitions="*,*"
+                ColumnSpacing="12">
+            <StackPanel Spacing="6">
+              <TextBlock x:Name="UsernameLabelBlock"
+                         Classes="data-header" />
+              <TextBox x:Name="UsernameTextBox"
+                       Watermark="Username" />
+            </StackPanel>
+            <StackPanel Grid.Column="1"
+                        Spacing="6">
+              <TextBlock x:Name="PasswordLabelBlock"
+                         Classes="data-header" />
+              <TextBox x:Name="PasswordTextBox"
+                       PasswordChar="●"
+                       Watermark="Password" />
+            </StackPanel>
+          </Grid>
+          <TextBlock x:Name="CredentialsStateBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="CompatibilityTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="CompatibilityDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <StackPanel x:Name="CompatibilityRowsPanel"
+                      Spacing="8" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ConnectivityTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ConnectivityDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="WaitForInternetCheckBox"
+                    Content="Wait for the device to be connected to the internet before running tasks that require connectivity" />
+          <TextBlock x:Name="ConnectivityHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/InternetSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/InternetSettingsView.axaml.cs
@@ -1,0 +1,425 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.ManagerClasses.Manager;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class InternetSettingsView : UserControl, ISettingsSectionView
+{
+    private readonly DispatcherTimer _credentialsSaveTimer;
+    private readonly DispatcherTimer _proxyUrlSaveTimer;
+    private bool _isLoading;
+
+    private CheckBox EnableProxyCheckBoxControl => GetControl<CheckBox>("EnableProxyCheckBox");
+
+    private TextBox ProxyUrlTextBoxControl => GetControl<TextBox>("ProxyUrlTextBox");
+
+    private CheckBox EnableProxyAuthCheckBoxControl => GetControl<CheckBox>("EnableProxyAuthCheckBox");
+
+    private TextBox UsernameTextBoxControl => GetControl<TextBox>("UsernameTextBox");
+
+    private TextBox PasswordTextBoxControl => GetControl<TextBox>("PasswordTextBox");
+
+    private TextBlock CredentialsStateText => GetControl<TextBlock>("CredentialsStateBlock");
+
+    private StackPanel CompatibilityRowsPanelControl => GetControl<StackPanel>("CompatibilityRowsPanel");
+
+    private CheckBox WaitForInternetCheckBoxControl => GetControl<CheckBox>("WaitForInternetCheckBox");
+
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+
+    private TextBlock ProxyTitleText => GetControl<TextBlock>("ProxyTitleBlock");
+
+    private TextBlock ProxyDescriptionText => GetControl<TextBlock>("ProxyDescriptionBlock");
+
+    private TextBlock ProxyUrlLabelText => GetControl<TextBlock>("ProxyUrlLabelBlock");
+
+    private TextBlock ProxyHintText => GetControl<TextBlock>("ProxyHintBlock");
+
+    private TextBlock AuthTitleText => GetControl<TextBlock>("AuthTitleBlock");
+
+    private TextBlock AuthDescriptionText => GetControl<TextBlock>("AuthDescriptionBlock");
+
+    private TextBlock UsernameLabelText => GetControl<TextBlock>("UsernameLabelBlock");
+
+    private TextBlock PasswordLabelText => GetControl<TextBlock>("PasswordLabelBlock");
+
+    private TextBlock CompatibilityTitleText => GetControl<TextBlock>("CompatibilityTitleBlock");
+
+    private TextBlock CompatibilityDescriptionText => GetControl<TextBlock>("CompatibilityDescriptionBlock");
+
+    private TextBlock ConnectivityTitleText => GetControl<TextBlock>("ConnectivityTitleBlock");
+
+    private TextBlock ConnectivityDescriptionText => GetControl<TextBlock>("ConnectivityDescriptionBlock");
+
+    private TextBlock ConnectivityHintText => GetControl<TextBlock>("ConnectivityHintBlock");
+
+    public InternetSettingsView()
+    {
+        _credentialsSaveTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(500),
+        };
+        _credentialsSaveTimer.Tick += CredentialsSaveTimer_OnTick;
+
+        _proxyUrlSaveTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(500),
+        };
+        _proxyUrlSaveTimer.Tick += ProxyUrlSaveTimer_OnTick;
+
+        InitializeComponent();
+        EnableProxyCheckBoxControl.Click += EnableProxyCheckBox_OnClick;
+        EnableProxyAuthCheckBoxControl.Click += EnableProxyAuthCheckBox_OnClick;
+        WaitForInternetCheckBoxControl.Click += WaitForInternetCheckBox_OnClick;
+
+        SectionTitle = CoreTools.Translate("Internet connection settings");
+        SectionSubtitle = CoreTools.Translate("Proxy settings, etc.");
+        SectionStatus = CoreTools.Translate("Show the live output");
+
+        ApplyLocalizedText();
+        PopulateCompatibilityRows();
+        LoadStoredValues();
+
+        ProxyUrlTextBoxControl.TextChanged += ProxyUrlTextBox_OnTextChanged;
+        UsernameTextBoxControl.TextChanged += CredentialsTextBox_OnTextChanged;
+        PasswordTextBoxControl.TextChanged += CredentialsTextBox_OnTextChanged;
+    }
+
+    public string SectionTitle { get; }
+
+    public string SectionSubtitle { get; }
+
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Internet connection settings");
+        LeadDescriptionText.Text = CoreTools.Translate("Proxy settings, etc.");
+        ProxyTitleText.Text = CoreTools.Translate("Proxy settings");
+        ProxyDescriptionText.Text = CoreTools.Translate("Proxy settings, etc.");
+        EnableProxyCheckBoxControl.Content = CoreTools.Translate("Connect the internet using a custom proxy");
+        ProxyUrlLabelText.Text = CoreTools.Translate("Proxy URL");
+        ProxyUrlTextBoxControl.Watermark = CoreTools.Translate("Enter proxy URL here");
+        ProxyHintText.Text = CoreTools.Translate("Proxy compatibility table");
+        AuthTitleText.Text = CoreTools.Translate("Compatible with authentication");
+        AuthDescriptionText.Text = CoreTools.Translate("It is not guaranteed that the provided credentials will be stored safely, so you may as well not use the credentials of your bank account");
+        EnableProxyAuthCheckBoxControl.Content = CoreTools.Translate("Authenticate to the proxy with an user and a password");
+        UsernameLabelText.Text = CoreTools.Translate("Username");
+        UsernameTextBoxControl.Watermark = CoreTools.Translate("Username");
+        PasswordLabelText.Text = CoreTools.Translate("Password");
+        PasswordTextBoxControl.Watermark = CoreTools.Translate("Password");
+        CompatibilityTitleText.Text = CoreTools.Translate("Proxy compatibility table");
+        CompatibilityDescriptionText.Text = CoreTools.Translate("Compatible with proxy");
+        ConnectivityTitleText.Text = CoreTools.Translate("Internet connection settings");
+        ConnectivityDescriptionText.Text = CoreTools.Translate("Wait for the device to be connected to the internet before attempting to do tasks that require internet connectivity.");
+        WaitForInternetCheckBoxControl.Content = CoreTools.Translate("Wait for the device to be connected to the internet before attempting to do tasks that require internet connectivity.");
+        ConnectivityHintText.Text = CoreTools.Translate("Wait for the device to be connected to the internet before attempting to do tasks that require internet connectivity.");
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        EnableProxyCheckBoxControl.IsChecked = Settings.Get(Settings.K.EnableProxy);
+        ProxyUrlTextBoxControl.Text = Settings.GetValue(Settings.K.ProxyURL);
+        EnableProxyAuthCheckBoxControl.IsChecked = Settings.Get(Settings.K.EnableProxyAuth);
+
+        var credentials = Settings.GetProxyCredentials();
+        UsernameTextBoxControl.Text = credentials?.UserName ?? string.Empty;
+        PasswordTextBoxControl.Text = credentials?.Password ?? string.Empty;
+        WaitForInternetCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableWaitForInternetConnection);
+
+        ApplyInternetControlState();
+        _isLoading = false;
+    }
+
+    private void EnableProxyCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.EnableProxy, EnableProxyCheckBoxControl.IsChecked == true);
+        ApplyInternetControlState();
+        MainWindow.ApplyProxyVariableToProcess();
+    }
+
+    private void ProxyUrlTextBox_OnTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        _proxyUrlSaveTimer.Stop();
+        _proxyUrlSaveTimer.Start();
+    }
+
+    private void ProxyUrlSaveTimer_OnTick(object? sender, EventArgs e)
+    {
+        _proxyUrlSaveTimer.Stop();
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.SetValue(Settings.K.ProxyURL, ProxyUrlTextBoxControl.Text ?? string.Empty);
+        MainWindow.ApplyProxyVariableToProcess();
+    }
+
+    private void EnableProxyAuthCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.EnableProxyAuth, EnableProxyAuthCheckBoxControl.IsChecked == true);
+        ApplyInternetControlState();
+        MainWindow.ApplyProxyVariableToProcess();
+    }
+
+    private void CredentialsTextBox_OnTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        if (!UsernameTextBoxControl.IsFocused && !PasswordTextBoxControl.IsFocused)
+        {
+            SetCredentialsStatusText();
+            return;
+        }
+
+        SetCredentialsStatusText(CoreTools.Translate("Saving packages, please wait..."));
+        _credentialsSaveTimer.Stop();
+        _credentialsSaveTimer.Start();
+    }
+
+    private void CredentialsSaveTimer_OnTick(object? sender, EventArgs e)
+    {
+        _credentialsSaveTimer.Stop();
+
+        if (_isLoading)
+        {
+            return;
+        }
+
+        if (EnableProxyCheckBoxControl.IsChecked != true || EnableProxyAuthCheckBoxControl.IsChecked != true)
+        {
+            SetCredentialsStatusText();
+            return;
+        }
+
+        Settings.SetProxyCredentials(
+            UsernameTextBoxControl.Text ?? string.Empty,
+            PasswordTextBoxControl.Text ?? string.Empty
+        );
+        MainWindow.ApplyProxyVariableToProcess();
+        SetCredentialsStatusText(CoreTools.Translate("Success!"));
+    }
+
+    private void WaitForInternetCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableWaitForInternetConnection, WaitForInternetCheckBoxControl.IsChecked != true);
+    }
+
+    private void ApplyInternetControlState()
+    {
+        var proxyEnabled = EnableProxyCheckBoxControl.IsChecked == true;
+        ProxyUrlTextBoxControl.IsEnabled = proxyEnabled;
+        EnableProxyAuthCheckBoxControl.IsEnabled = proxyEnabled;
+
+        var authEnabled = proxyEnabled && EnableProxyAuthCheckBoxControl.IsChecked == true;
+        UsernameTextBoxControl.IsEnabled = authEnabled;
+        PasswordTextBoxControl.IsEnabled = authEnabled;
+        CredentialsStateText.IsEnabled = authEnabled;
+
+        SetCredentialsStatusText();
+    }
+
+    private void SetCredentialsStatusText(string? overrideText = null)
+    {
+        if (
+            !string.IsNullOrWhiteSpace(overrideText)
+            && EnableProxyCheckBoxControl.IsChecked == true
+            && EnableProxyAuthCheckBoxControl.IsChecked == true
+        )
+        {
+            CredentialsStateText.Text = overrideText;
+        }
+        else if (EnableProxyCheckBoxControl.IsChecked != true)
+        {
+            CredentialsStateText.Text = CoreTools.Translate("Proxy settings, etc.");
+        }
+        else if (EnableProxyAuthCheckBoxControl.IsChecked != true)
+        {
+            CredentialsStateText.Text = CoreTools.Translate("Compatible with authentication");
+        }
+        else if (_credentialsSaveTimer.IsEnabled)
+        {
+            CredentialsStateText.Text = CoreTools.Translate("Saving packages, please wait...");
+        }
+        else
+        {
+            CredentialsStateText.Text = CoreTools.Translate("It is not guaranteed that the provided credentials will be stored safely, so you may as well not use the credentials of your bank account");
+        }
+    }
+
+    private void PopulateCompatibilityRows()
+    {
+        CompatibilityRowsPanelControl.Children.Clear();
+        CompatibilityRowsPanelControl.Children.Add(CreateCompatibilityHeader());
+
+        foreach (var manager in PEInterface.Managers)
+        {
+            CompatibilityRowsPanelControl.Children.Add(CreateCompatibilityRow(manager));
+        }
+    }
+
+    private static Control CreateCompatibilityHeader()
+    {
+        var proxyLabel = new TextBlock
+        {
+            Text = CoreTools.Translate("Compatible with proxy"),
+            FontWeight = FontWeight.SemiBold,
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        var authLabel = new TextBlock
+        {
+            Text = CoreTools.Translate("Compatible with authentication"),
+            FontWeight = FontWeight.SemiBold,
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        Grid.SetColumn(proxyLabel, 1);
+        Grid.SetColumn(authLabel, 2);
+        return new Border
+        {
+            Padding = new Thickness(14, 4, 14, 4),
+            Child = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("2*,Auto,Auto"),
+                ColumnSpacing = 12,
+                Children = { proxyLabel, authLabel },
+            },
+        };
+    }
+
+    private static Control CreateCompatibilityRow(IPackageManager manager)
+    {
+        var proxySupport = manager.Capabilities.SupportsProxy;
+        var (_, executablePath) = manager.GetExecutableFile();
+        var proxyBadge = CreateBadge(
+            proxySupport switch
+            {
+                ProxySupport.Yes => CoreTools.Translate("Yes"),
+                ProxySupport.Partially => CoreTools.Translate("Partially"),
+                _ => CoreTools.Translate("No"),
+            },
+            proxySupport switch
+            {
+                ProxySupport.Yes => "success-panel",
+                ProxySupport.Partially => "warning-panel",
+                _ => "danger-panel",
+            }
+        );
+
+        var authBadge = CreateBadge(
+            manager.Capabilities.SupportsProxyAuth ? CoreTools.Translate("Yes") : CoreTools.Translate("No"),
+            manager.Capabilities.SupportsProxyAuth ? "success-panel" : "danger-panel"
+        );
+
+        Grid.SetColumn(proxyBadge, 1);
+        Grid.SetRowSpan(proxyBadge, 2);
+        Grid.SetColumn(authBadge, 2);
+        Grid.SetRowSpan(authBadge, 2);
+
+        return new Border
+        {
+            Classes = { "surface-card", "subtle-panel" },
+            Padding = new Thickness(14),
+            Child = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("2*,Auto,Auto"),
+                ColumnSpacing = 12,
+                RowDefinitions = new RowDefinitions("Auto,Auto"),
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = manager.DisplayName,
+                        FontWeight = FontWeight.SemiBold,
+                        TextWrapping = TextWrapping.Wrap,
+                    },
+                    CreateExecutablePathBlock(executablePath),
+                    proxyBadge,
+                    authBadge,
+                }
+            }
+        };
+    }
+
+    private static Border CreateBadge(string text, string panelClass)
+    {
+        var badge = new Border
+        {
+            Padding = new Thickness(10, 4),
+            Classes = { "surface-card", "badge-panel", panelClass },
+            Child = new TextBlock
+            {
+                Text = text,
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+            },
+        };
+
+        return badge;
+    }
+
+    private static TextBlock CreateExecutablePathBlock(string executablePath)
+    {
+        var pathBlock = new TextBlock
+        {
+            Opacity = 0.72,
+            Classes = { "mono-data" },
+            Text = string.IsNullOrWhiteSpace(executablePath)
+                ? CoreTools.Translate("Please wait...")
+                : executablePath,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        Grid.SetRow(pathBlock, 1);
+        return pathBlock;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/ManagersSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/ManagersSettingsView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.ManagersSettingsView">
+  <Grid RowDefinitions="Auto,*"
+        RowSpacing="12">
+    <Button x:Name="BackToOverviewButton"
+            HorizontalAlignment="Left"
+            Classes="toolbar-secondary"
+            IsVisible="False"
+            Click="BackToOverviewButton_OnClick"
+            Content="Back to managers" />
+
+    <ContentControl x:Name="SectionContentHost"
+                    Grid.Row="1" />
+  </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/ManagersSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/ManagersSettingsView.axaml.cs
@@ -1,0 +1,105 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Avalonia.Views.Pages.ManagersPages;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class ManagersSettingsView : UserControl, ISettingsSectionView, ISettingsSectionStateNotifier
+{
+    private readonly Dictionary<string, ManagerDetailView> _detailCache = [];
+
+    private ManagersHomeView? _homeView;
+    private IPackageManager? _selectedManager;
+
+    private Button BackToOverviewButtonControl => GetControl<Button>("BackToOverviewButton");
+
+    private ContentControl SectionContentHostControl => GetControl<ContentControl>("SectionContentHost");
+
+    public ManagersSettingsView()
+    {
+        InitializeComponent();
+        BackToOverviewButtonControl.Content = CoreTools.Translate("Package managers");
+        NavigateHome();
+    }
+
+    public event EventHandler? SectionStateChanged;
+
+    public string SectionTitle => _selectedManager is null
+        ? CoreTools.Translate("Package manager preferences")
+        : CoreTools.Translate("{0} settings", _selectedManager.DisplayName);
+
+    public string SectionSubtitle => _selectedManager is null
+        ? CoreTools.Translate("Enable and disable package managers, change default install options, etc.")
+        : CoreTools.Translate("Package manager preferences");
+
+    public string SectionStatus => _selectedManager is null
+        ? CoreTools.Translate("{0} settings", PEInterface.Managers.Length)
+        : BuildStatus(_selectedManager);
+
+    private void NavigateHome()
+    {
+        _selectedManager = null;
+
+        if (_homeView is null)
+        {
+            _homeView = new ManagersHomeView();
+            _homeView.NavigationRequested += HomeView_NavigationRequested;
+        }
+
+        SectionContentHostControl.Content = _homeView;
+        BackToOverviewButtonControl.IsVisible = false;
+        SectionStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void NavigateToManager(IPackageManager manager)
+    {
+        _selectedManager = manager;
+
+        if (!_detailCache.TryGetValue(manager.Name, out var detailView))
+        {
+            detailView = new ManagerDetailView();
+            _detailCache[manager.Name] = detailView;
+        }
+
+        detailView.LoadManager(manager);
+        SectionContentHostControl.Content = detailView;
+        BackToOverviewButtonControl.IsVisible = true;
+        SectionStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static string BuildStatus(IPackageManager manager)
+    {
+        if (!manager.IsEnabled())
+            return CoreTools.Translate("Disabled");
+
+        return manager.Status.Found
+            ? CoreTools.Translate("Ready")
+            : CoreTools.Translate("Not found");
+    }
+
+    private void HomeView_NavigationRequested(object? sender, IPackageManager manager)
+    {
+        NavigateToManager(manager);
+    }
+
+    private void BackToOverviewButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        NavigateHome();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/NotificationsSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/NotificationsSettingsView.axaml
@@ -1,0 +1,77 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.NotificationsSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border x:Name="SystemTrayWarningCard"
+              Padding="18"
+              Classes="surface-card warning-panel"
+              IsVisible="False">
+        <StackPanel Spacing="6">
+          <TextBlock x:Name="SystemTrayWarningTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="SystemTrayWarningDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.82"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="NotificationsTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="NotificationsDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnableNotificationsCheckBox"
+                    Content="Enable UniGetUI notifications" />
+          <TextBlock x:Name="NotificationsHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="TypesTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="TypesDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="ShowUpdatesNotificationsCheckBox"
+                    Content="Show a notification when there are available updates" />
+          <CheckBox x:Name="ShowProgressNotificationsCheckBox"
+                    Content="Show a silent notification when an operation is running" />
+          <CheckBox x:Name="ShowErrorNotificationsCheckBox"
+                    Content="Show a notification when an operation fails" />
+          <CheckBox x:Name="ShowSuccessNotificationsCheckBox"
+                    Content="Show a notification when an operation finishes successfully" />
+          <TextBlock x:Name="TypesHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/NotificationsSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/NotificationsSettingsView.axaml.cs
@@ -1,0 +1,179 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class NotificationsSettingsView : UserControl, ISettingsSectionView
+{
+    private bool _isLoading;
+
+    private Border SystemTrayWarningCardControl => GetControl<Border>("SystemTrayWarningCard");
+
+    private CheckBox EnableNotificationsCheckBoxControl => GetControl<CheckBox>("EnableNotificationsCheckBox");
+
+    private CheckBox ShowUpdatesNotificationsCheckBoxControl => GetControl<CheckBox>("ShowUpdatesNotificationsCheckBox");
+
+    private CheckBox ShowProgressNotificationsCheckBoxControl => GetControl<CheckBox>("ShowProgressNotificationsCheckBox");
+
+    private CheckBox ShowErrorNotificationsCheckBoxControl => GetControl<CheckBox>("ShowErrorNotificationsCheckBox");
+
+    private CheckBox ShowSuccessNotificationsCheckBoxControl => GetControl<CheckBox>("ShowSuccessNotificationsCheckBox");
+
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+
+    private TextBlock SystemTrayWarningTitleText => GetControl<TextBlock>("SystemTrayWarningTitleBlock");
+
+    private TextBlock SystemTrayWarningDescriptionText => GetControl<TextBlock>("SystemTrayWarningDescriptionBlock");
+
+    private TextBlock NotificationsTitleText => GetControl<TextBlock>("NotificationsTitleBlock");
+
+    private TextBlock NotificationsDescriptionText => GetControl<TextBlock>("NotificationsDescriptionBlock");
+
+    private TextBlock NotificationsHintText => GetControl<TextBlock>("NotificationsHintBlock");
+
+    private TextBlock TypesTitleText => GetControl<TextBlock>("TypesTitleBlock");
+
+    private TextBlock TypesDescriptionText => GetControl<TextBlock>("TypesDescriptionBlock");
+
+    private TextBlock TypesHintText => GetControl<TextBlock>("TypesHintBlock");
+
+    public NotificationsSettingsView()
+    {
+        InitializeComponent();
+        EnableNotificationsCheckBoxControl.Click += EnableNotificationsCheckBox_OnClick;
+        ShowUpdatesNotificationsCheckBoxControl.Click += ShowUpdatesNotificationsCheckBox_OnClick;
+        ShowProgressNotificationsCheckBoxControl.Click += ShowProgressNotificationsCheckBox_OnClick;
+        ShowErrorNotificationsCheckBoxControl.Click += ShowErrorNotificationsCheckBox_OnClick;
+        ShowSuccessNotificationsCheckBoxControl.Click += ShowSuccessNotificationsCheckBox_OnClick;
+
+        SectionTitle = CoreTools.Translate("Notification preferences");
+        SectionSubtitle = CoreTools.Translate("Show notifications on different events");
+        SectionStatus = CoreTools.Translate("Show the live output");
+
+        ApplyLocalizedText();
+        LoadStoredValues();
+    }
+
+    public string SectionTitle { get; }
+
+    public string SectionSubtitle { get; }
+
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Notification preferences");
+        LeadDescriptionText.Text = CoreTools.Translate("Show notifications on different events");
+        SystemTrayWarningTitleText.Text = CoreTools.Translate("Attention required");
+        SystemTrayWarningDescriptionText.Text = CoreTools.Translate("The system tray icon must be enabled in order for notifications to work");
+        NotificationsTitleText.Text = CoreTools.Translate("Notification preferences");
+        NotificationsDescriptionText.Text = CoreTools.Translate("Show notifications on different events");
+        EnableNotificationsCheckBoxControl.Content = CoreTools.Translate("Show notifications on different events");
+        NotificationsHintText.Text = CoreTools.Translate("Show notifications on different events");
+        TypesTitleText.Text = CoreTools.Translate("Notification types");
+        TypesDescriptionText.Text = CoreTools.Translate("Show notifications on different events");
+        ShowUpdatesNotificationsCheckBoxControl.Content = CoreTools.Translate("Show a notification when there are available updates");
+        ShowProgressNotificationsCheckBoxControl.Content = CoreTools.Translate("Show a silent notification when an operation is running");
+        ShowErrorNotificationsCheckBoxControl.Content = CoreTools.Translate("Show a notification when an operation fails");
+        ShowSuccessNotificationsCheckBoxControl.Content = CoreTools.Translate("Show a notification when an operation finishes successfully");
+        TypesHintText.Text = CoreTools.Translate("Show notifications on different events");
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        EnableNotificationsCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableNotifications);
+        ShowUpdatesNotificationsCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableUpdatesNotifications);
+        ShowProgressNotificationsCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableProgressNotifications);
+        ShowErrorNotificationsCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableErrorNotifications);
+        ShowSuccessNotificationsCheckBoxControl.IsChecked = !Settings.Get(Settings.K.DisableSuccessNotifications);
+
+        ApplyNotificationControlState();
+
+        _isLoading = false;
+    }
+
+    private void EnableNotificationsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableNotifications, EnableNotificationsCheckBoxControl.IsChecked != true);
+        ApplyNotificationControlState();
+    }
+
+    private void ShowUpdatesNotificationsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableUpdatesNotifications, ShowUpdatesNotificationsCheckBoxControl.IsChecked != true);
+    }
+
+    private void ShowProgressNotificationsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableProgressNotifications, ShowProgressNotificationsCheckBoxControl.IsChecked != true);
+    }
+
+    private void ShowErrorNotificationsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableErrorNotifications, ShowErrorNotificationsCheckBoxControl.IsChecked != true);
+    }
+
+    private void ShowSuccessNotificationsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableSuccessNotifications, ShowSuccessNotificationsCheckBoxControl.IsChecked != true);
+    }
+
+    private void ApplyNotificationControlState()
+    {
+        var isTrayAvailable = !Settings.Get(Settings.K.DisableSystemTray);
+        var notificationsEnabled = EnableNotificationsCheckBoxControl.IsChecked == true;
+
+        SystemTrayWarningCardControl.IsVisible = !isTrayAvailable;
+        EnableNotificationsCheckBoxControl.IsEnabled = isTrayAvailable;
+
+        var enableChildControls = isTrayAvailable && notificationsEnabled;
+        ShowUpdatesNotificationsCheckBoxControl.IsEnabled = enableChildControls;
+        ShowProgressNotificationsCheckBoxControl.IsEnabled = enableChildControls;
+        ShowErrorNotificationsCheckBoxControl.IsEnabled = enableChildControls;
+        ShowSuccessNotificationsCheckBoxControl.IsEnabled = enableChildControls;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/OperationsSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/OperationsSettingsView.axaml
@@ -1,0 +1,89 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.OperationsSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ParallelTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ParallelDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <ComboBox x:Name="ParallelOperationsSelector"
+                    MaxDropDownHeight="280"
+                    SelectionChanged="ParallelOperationsSelector_OnSelectionChanged" />
+          <TextBlock x:Name="ParallelHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="RetentionTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="RetentionDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="KeepSuccessfulOperationsCheckBox"
+                    Content="Keep successful operations in the queue until you clear them manually" />
+          <TextBlock x:Name="RetentionHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card warning-panel">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ForceKillTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ForceKillDescriptionBlock"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="ForceKillCheckBox"
+                    Content="Try to kill processes that refuse to close when requested" />
+          <TextBlock x:Name="ForceKillHintBlock"
+                     Opacity="0.8"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="ShortcutsTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="ShortcutsDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="AskShortcutsCheckBox"
+                    Click="AskShortcutsCheckBox_OnClick" />
+          <Button x:Name="ManageShortcutsBtn"
+                  Click="ManageShortcutsBtn_OnClick" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/OperationsSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/OperationsSettingsView.axaml.cs
@@ -1,0 +1,219 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Avalonia.Views.Pages;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageOperations;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class OperationsSettingsView : UserControl, ISettingsSectionView
+{
+    private static readonly int[] ParallelOperationOptions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 50, 75, 100];
+
+    private bool _isLoading;
+
+    private ComboBox ParallelOperationsSelectorControl => GetControl<ComboBox>("ParallelOperationsSelector");
+
+    private CheckBox KeepSuccessfulOperationsCheckBoxControl => GetControl<CheckBox>("KeepSuccessfulOperationsCheckBox");
+
+    private CheckBox ForceKillCheckBoxControl => GetControl<CheckBox>("ForceKillCheckBox");
+
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+
+    private TextBlock ParallelTitleText => GetControl<TextBlock>("ParallelTitleBlock");
+
+    private TextBlock ParallelDescriptionText => GetControl<TextBlock>("ParallelDescriptionBlock");
+
+    private TextBlock ParallelHintText => GetControl<TextBlock>("ParallelHintBlock");
+
+    private TextBlock RetentionTitleText => GetControl<TextBlock>("RetentionTitleBlock");
+
+    private TextBlock RetentionDescriptionText => GetControl<TextBlock>("RetentionDescriptionBlock");
+
+    private TextBlock RetentionHintText => GetControl<TextBlock>("RetentionHintBlock");
+
+    private TextBlock ForceKillTitleText => GetControl<TextBlock>("ForceKillTitleBlock");
+
+    private TextBlock ForceKillDescriptionText => GetControl<TextBlock>("ForceKillDescriptionBlock");
+
+    private TextBlock ForceKillHintText => GetControl<TextBlock>("ForceKillHintBlock");
+
+    private TextBlock ShortcutsTitleText => GetControl<TextBlock>("ShortcutsTitleBlock");
+    private TextBlock ShortcutsDescriptionText => GetControl<TextBlock>("ShortcutsDescriptionBlock");
+    private CheckBox AskShortcutsCheckBoxCtrl => GetControl<CheckBox>("AskShortcutsCheckBox");
+    private Button ManageShortcutsBtnCtrl => GetControl<Button>("ManageShortcutsBtn");
+
+    public OperationsSettingsView()
+    {
+        InitializeComponent();
+        KeepSuccessfulOperationsCheckBoxControl.Click += KeepSuccessfulOperationsCheckBox_OnClick;
+        ForceKillCheckBoxControl.Click += ForceKillCheckBox_OnClick;
+
+        SectionTitle = CoreTools.Translate("Package operation preferences");
+        SectionSubtitle = CoreTools.Translate("Change how UniGetUI handles install, update and uninstall operations.");
+        SectionStatus = CoreTools.Translate("Show the live output");
+
+        ApplyLocalizedText();
+        PopulateParallelOperationsSelector();
+        LoadStoredValues();
+    }
+
+    public string SectionTitle { get; }
+
+    public string SectionSubtitle { get; }
+
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Change how UniGetUI handles install, update and uninstall operations.");
+        LeadDescriptionText.Text = CoreTools.Translate("Clear successful operations from the operation list after a 5 second delay");
+        ParallelTitleText.Text = CoreTools.Translate("Concurrency and execution");
+        ParallelDescriptionText.Text = CoreTools.Translate("Choose how many operations shouls be performed in parallel");
+        ParallelHintText.Text = CoreTools.Translate("Allow package operations to be performed in parallel");
+        RetentionTitleText.Text = CoreTools.Translate("Operation history");
+        RetentionDescriptionText.Text = CoreTools.Translate("Clear successful operations from the operation list after a 5 second delay");
+        KeepSuccessfulOperationsCheckBoxControl.Content = CoreTools.Translate("Do not remove successful operations from the list automatically");
+        RetentionHintText.Text = CoreTools.Translate("Download operations are not affected by this setting");
+        ForceKillTitleText.Text = CoreTools.Translate("Restrictions on package operations");
+        ForceKillDescriptionText.Text = CoreTools.Translate("Try to kill the processes that refuse to close when requested to");
+        ForceKillCheckBoxControl.Content = CoreTools.Translate("Try to kill the processes that refuse to close when requested to");
+        ForceKillHintText.Text = CoreTools.Translate("There are ongoing operations. Quitting WingetUI may cause them to fail. Do you want to continue?");
+        ShortcutsTitleText.Text = CoreTools.Translate("Automatic desktop shortcut remover");
+        ShortcutsDescriptionText.Text = CoreTools.Translate("Here you can change UniGetUI's behaviour regarding the following shortcuts. Checking a shortcut will make UniGetUI delete it if if gets created on a future upgrade. Unchecking it will keep the shortcut intact");
+        AskShortcutsCheckBoxCtrl.Content = CoreTools.Translate("Ask to delete desktop shortcuts created during an install or upgrade.");
+        ManageShortcutsBtnCtrl.Content = CoreTools.Translate("Manage shortcuts");
+    }
+
+    private void PopulateParallelOperationsSelector()
+    {
+        ParallelOperationsSelectorControl.Items.Clear();
+
+        foreach (var option in ParallelOperationOptions)
+        {
+            var text = option == 1
+                ? CoreTools.Translate("(Number {0} in the queue)", option)
+                : CoreTools.Translate("(Number {0} in the queue)", option);
+            ParallelOperationsSelectorControl.Items.Add(CreateComboBoxItem(text, option.ToString()));
+        }
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        var selectedValue = Settings.GetValue(Settings.K.ParallelOperationCount);
+        if (!int.TryParse(selectedValue, out var maxOperations))
+        {
+            maxOperations = 1;
+            Settings.SetValue(Settings.K.ParallelOperationCount, maxOperations.ToString());
+        }
+
+        SelectComboBoxValue(ParallelOperationsSelectorControl, maxOperations.ToString(), fallbackValue: "1");
+        AbstractOperation.MAX_OPERATIONS = maxOperations;
+        KeepSuccessfulOperationsCheckBoxControl.IsChecked = Settings.Get(Settings.K.MaintainSuccessfulInstalls);
+        ForceKillCheckBoxControl.IsChecked = Settings.Get(Settings.K.KillProcessesThatRefuseToDie);
+        AskShortcutsCheckBoxCtrl.IsChecked = Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts);
+
+        _isLoading = false;
+    }
+
+    private void ParallelOperationsSelector_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        var selectedValue = GetSelectedValue(ParallelOperationsSelectorControl);
+        Settings.SetValue(Settings.K.ParallelOperationCount, selectedValue);
+
+        if (int.TryParse(selectedValue, out var maxOperations))
+        {
+            AbstractOperation.MAX_OPERATIONS = maxOperations;
+        }
+    }
+
+    private void KeepSuccessfulOperationsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.MaintainSuccessfulInstalls, KeepSuccessfulOperationsCheckBoxControl.IsChecked == true);
+    }
+
+    private void ForceKillCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.KillProcessesThatRefuseToDie, ForceKillCheckBoxControl.IsChecked == true);
+    }
+
+    private void AskShortcutsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading) return;
+        Settings.Set(Settings.K.AskToDeleteNewDesktopShortcuts, AskShortcutsCheckBoxCtrl.IsChecked == true);
+    }
+
+    private async void ManageShortcutsBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var window = new DesktopShortcutsWindow();
+        if (VisualRoot is Window owner)
+            await window.ShowDialog(owner);
+        else
+            window.Show();
+    }
+
+    private static ComboBoxItem CreateComboBoxItem(string label, string value)
+    {
+        return new ComboBoxItem
+        {
+            Content = label,
+            Tag = value,
+        };
+    }
+
+    private static string GetSelectedValue(ComboBox comboBox)
+    {
+        return comboBox.SelectedItem is ComboBoxItem { Tag: string value }
+            ? value
+            : string.Empty;
+    }
+
+    private static void SelectComboBoxValue(ComboBox comboBox, string selectedValue, string fallbackValue)
+    {
+        var desiredValue = string.IsNullOrWhiteSpace(selectedValue) ? fallbackValue : selectedValue;
+
+        for (var index = 0; index < comboBox.Items.Count; index++)
+        {
+            if (comboBox.Items[index] is ComboBoxItem { Tag: string value } && value == desiredValue)
+            {
+                comboBox.SelectedIndex = index;
+                return;
+            }
+        }
+
+        comboBox.SelectedIndex = 0;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsHomeView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsHomeView.axaml
@@ -1,0 +1,28 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.SettingsHomeView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="IntroTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="IntroDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <TextBlock x:Name="SectionsLabelBlock"
+                 Classes="data-header"
+                 Text="Sections" />
+
+      <StackPanel x:Name="SectionButtonsPanel"
+                  Spacing="10" />
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsHomeView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsHomeView.axaml.cs
@@ -1,0 +1,141 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class SettingsHomeView : UserControl, ISettingsSectionView
+{
+    private StackPanel SectionButtonsHost => GetControl<StackPanel>("SectionButtonsPanel");
+
+    private TextBlock IntroTitleText => GetControl<TextBlock>("IntroTitleBlock");
+
+    private TextBlock IntroDescriptionText => GetControl<TextBlock>("IntroDescriptionBlock");
+
+    private TextBlock SectionsLabelText => GetControl<TextBlock>("SectionsLabelBlock");
+
+    public SettingsHomeView()
+    {
+        InitializeComponent();
+        IntroTitleText.Text = CoreTools.Translate("General preferences");
+        IntroDescriptionText.Text = CoreTools.Translate("Default preferences - suitable for regular users");
+        SectionsLabelText.Text = CoreTools.Translate("Settings");
+
+        AddSectionButton(
+            SettingsSectionRoute.Interface,
+            CoreTools.Translate("User interface preferences"),
+            CoreTools.Translate("Application theme, startup page, package icons, clear successful installs automatically")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Managers,
+            CoreTools.Translate("Package manager preferences"),
+            CoreTools.Translate("Enable and disable package managers, change default install options, etc.")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.General,
+            CoreTools.Translate("General preferences"),
+            CoreTools.Translate("Language, theme and other miscellaneous preferences")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Updates,
+            CoreTools.Translate("Updates preferences"),
+            CoreTools.Translate("Update check frequency, automatically install updates, etc.")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Notifications,
+            CoreTools.Translate("Notification preferences"),
+            CoreTools.Translate("Show notifications on different events")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Operations,
+            CoreTools.Translate("Package operation preferences"),
+            CoreTools.Translate("Install and update preferences")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Internet,
+            CoreTools.Translate("Internet connection settings"),
+            CoreTools.Translate("Proxy settings, etc.")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Administrator,
+            CoreTools.Translate("Administrator privileges preferences"),
+            CoreTools.Translate("Change how operations request administrator rights")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Backup,
+            CoreTools.Translate("Backup and Restore"),
+            CoreTools.Translate("Backup installed packages")
+        );
+        AddSectionButton(
+            SettingsSectionRoute.Experimental,
+            CoreTools.Translate("Experimental settings and developer options"),
+            CoreTools.Translate("Experimental settings and developer options")
+        );
+    }
+
+    internal event EventHandler<SettingsSectionRoute>? NavigationRequested;
+
+    public string SectionTitle => CoreTools.Translate("Settings");
+
+    public string SectionSubtitle => CoreTools.Translate("General preferences");
+
+    public string SectionStatus => CoreTools.Translate("Settings");
+
+    private void AddSectionButton(SettingsSectionRoute route, string title, string description)
+    {
+        var button = new Button
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Tag = route,
+        };
+        button.Classes.Add("settings-tile");
+        button.Click += SectionButton_OnClick;
+
+        button.Content = new StackPanel
+        {
+            Spacing = 4,
+            Children =
+            {
+                new TextBlock
+                {
+                    FontSize = 16,
+                    FontWeight = FontWeight.SemiBold,
+                    Text = title,
+                    TextWrapping = TextWrapping.Wrap,
+                },
+                new TextBlock
+                {
+                    Opacity = 0.74,
+                    Text = description,
+                    TextWrapping = TextWrapping.Wrap,
+                },
+            },
+        };
+
+        SectionButtonsHost.Children.Add(button);
+    }
+
+    private void SectionButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: SettingsSectionRoute route })
+        {
+            NavigationRequested?.Invoke(this, route);
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPageView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPageView.axaml
@@ -1,0 +1,50 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.SettingsPageView">
+  <Grid RowDefinitions="Auto,*"
+        RowSpacing="12">
+    <Border Padding="18"
+            Classes="surface-card">
+      <Grid ColumnDefinitions="Auto,*,Auto"
+            ColumnSpacing="14">
+        <Button x:Name="SectionBackButton"
+                Width="36"
+                Height="36"
+                Padding="0"
+                IsVisible="False"
+                Classes="icon-shell"
+                Click="SectionBackButton_OnClick"
+                Content="←" />
+
+        <StackPanel Grid.Column="1"
+                    Spacing="2">
+          <TextBlock x:Name="SectionKickerBlock"
+                     Classes="data-header"
+                     Text="Settings" />
+          <TextBlock x:Name="SectionTitleBlock"
+                     FontSize="28"
+                     FontWeight="Black"
+                     Classes="hero-title"
+                     Text="Settings" />
+          <TextBlock x:Name="SectionSubtitleBlock"
+                     MaxWidth="860"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Border Grid.Column="2"
+                Padding="10,4"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Classes="surface-card badge-panel">
+          <TextBlock x:Name="SectionStatusBlock"
+                     Opacity="0.82"
+                     Text="" />
+        </Border>
+      </Grid>
+    </Border>
+
+    <ContentControl x:Name="SectionContentHost"
+                    Grid.Row="1" />
+  </Grid>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPageView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPageView.axaml.cs
@@ -1,0 +1,181 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class SettingsPageView : UserControl, IShellPage
+{
+    private readonly Dictionary<SettingsSectionRoute, Control> _sectionCache = [];
+    private readonly List<SettingsSectionRoute> _history = [];
+
+    private ISettingsSectionStateNotifier? _sectionStateNotifier;
+    private SettingsSectionRoute _currentSection;
+
+    private Button SectionBackNavigationButton => GetControl<Button>("SectionBackButton");
+
+    private TextBlock SectionKickerText => GetControl<TextBlock>("SectionKickerBlock");
+
+    private TextBlock SectionTitleText => GetControl<TextBlock>("SectionTitleBlock");
+
+    private TextBlock SectionSubtitleText => GetControl<TextBlock>("SectionSubtitleBlock");
+
+    private TextBlock SectionStatusText => GetControl<TextBlock>("SectionStatusBlock");
+
+    private ContentControl SectionContentPresenter => GetControl<ContentControl>("SectionContentHost");
+
+    public SettingsPageView()
+    {
+        Title = CoreTools.Translate("Settings");
+        Subtitle = CoreTools.Translate("Default preferences - suitable for regular users");
+        SupportsSearch = false;
+        SearchPlaceholder = string.Empty;
+
+        InitializeComponent();
+        SectionKickerText.Text = CoreTools.Translate("Settings");
+        NavigateTo(SettingsSectionRoute.Home, false);
+    }
+
+    public string Title { get; }
+
+    public string Subtitle { get; }
+
+    public bool SupportsSearch { get; }
+
+    public string SearchPlaceholder { get; }
+
+    public void UpdateSearchQuery(string query)
+    {
+    }
+
+    internal void OpenSection(SettingsSectionRoute route)
+    {
+        NavigateTo(route);
+    }
+
+    private void NavigateTo(SettingsSectionRoute route, bool addToHistory = true)
+    {
+        if (_currentSection == route && SectionContentPresenter.Content is not null)
+        {
+            return;
+        }
+
+        if (addToHistory && SectionContentPresenter.Content is not null)
+        {
+            _history.Add(_currentSection);
+        }
+
+        _currentSection = route;
+        SetSectionContent(GetSection(route));
+        ApplySectionChrome();
+    }
+
+    private void SetSectionContent(Control section)
+    {
+        if (_sectionStateNotifier is not null)
+        {
+            _sectionStateNotifier.SectionStateChanged -= SectionStateNotifier_SectionStateChanged;
+            _sectionStateNotifier = null;
+        }
+
+        SectionContentPresenter.Content = section;
+
+        if (section is ISettingsSectionStateNotifier notifier)
+        {
+            _sectionStateNotifier = notifier;
+            _sectionStateNotifier.SectionStateChanged += SectionStateNotifier_SectionStateChanged;
+        }
+    }
+
+    private Control GetSection(SettingsSectionRoute route)
+    {
+        if (_sectionCache.TryGetValue(route, out var existingSection))
+        {
+            return existingSection;
+        }
+
+        Control section = route switch
+        {
+            SettingsSectionRoute.Home => CreateHomeSection(),
+            SettingsSectionRoute.Interface => new InterfaceSettingsView(),
+            SettingsSectionRoute.General => new GeneralSettingsView(),
+            SettingsSectionRoute.Managers => new ManagersSettingsView(),
+            SettingsSectionRoute.Updates => new UpdatesSettingsView(),
+            SettingsSectionRoute.Notifications => new NotificationsSettingsView(),
+            SettingsSectionRoute.Operations => new OperationsSettingsView(),
+            SettingsSectionRoute.Internet => new InternetSettingsView(),
+            SettingsSectionRoute.Administrator => new AdministratorSettingsView(),
+            SettingsSectionRoute.Backup => new BackupSettingsView(),
+            SettingsSectionRoute.Experimental => new ExperimentalSettingsView(),
+            _ => throw new InvalidOperationException($"Unsupported settings section {route}"),
+        };
+
+        _sectionCache[route] = section;
+        return section;
+    }
+
+    private SettingsHomeView CreateHomeSection()
+    {
+        var homeSection = new SettingsHomeView();
+        homeSection.NavigationRequested += HomeSection_NavigationRequested;
+        return homeSection;
+    }
+
+    private void ApplySectionChrome()
+    {
+        if (SectionContentPresenter.Content is not ISettingsSectionView sectionView)
+        {
+            throw new InvalidCastException("The current settings section does not implement ISettingsSectionView.");
+        }
+
+        SectionTitleText.Text = sectionView.SectionTitle;
+        SectionSubtitleText.Text = sectionView.SectionSubtitle;
+        SectionStatusText.Text = sectionView.SectionStatus;
+        SectionBackNavigationButton.IsVisible = _history.Count > 0;
+
+        if (_currentSection == SettingsSectionRoute.Home)
+        {
+            SectionKickerText.IsVisible = false;
+        }
+        else
+        {
+            SectionKickerText.IsVisible = true;
+            SectionKickerText.Text = CoreTools.Translate("Settings");
+        }
+    }
+
+    private void HomeSection_NavigationRequested(object? sender, SettingsSectionRoute route)
+    {
+        NavigateTo(route);
+    }
+
+    private void SectionStateNotifier_SectionStateChanged(object? sender, EventArgs e)
+    {
+        ApplySectionChrome();
+    }
+
+    private void SectionBackButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_history.Count == 0)
+        {
+            return;
+        }
+
+        var targetSection = _history[^1];
+        _history.RemoveAt(_history.Count - 1);
+        NavigateTo(targetSection, false);
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPlaceholderSectionView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPlaceholderSectionView.axaml
@@ -1,0 +1,23 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.SettingsPlaceholderSectionView">
+  <Border Padding="24"
+          Classes="surface-card subtle-panel">
+    <StackPanel Spacing="10">
+      <TextBlock x:Name="LeadBlock"
+                 FontSize="20"
+                 FontWeight="SemiBold"
+                 TextWrapping="Wrap" />
+      <TextBlock x:Name="DescriptionBlock"
+                 Opacity="0.78"
+                 TextWrapping="Wrap" />
+      <Border Padding="16"
+              Margin="0,6,0,0"
+              Classes="surface-card">
+        <TextBlock x:Name="NextStepBlock"
+                   Opacity="0.78"
+                   TextWrapping="Wrap" />
+      </Border>
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPlaceholderSectionView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsPlaceholderSectionView.axaml.cs
@@ -1,0 +1,49 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class SettingsPlaceholderSectionView : UserControl, ISettingsSectionView
+{
+    private TextBlock LeadText => GetControl<TextBlock>("LeadBlock");
+
+    private TextBlock DescriptionText => GetControl<TextBlock>("DescriptionBlock");
+
+    private TextBlock NextStepText => GetControl<TextBlock>("NextStepBlock");
+
+    public SettingsPlaceholderSectionView()
+        : this(string.Empty, string.Empty, string.Empty)
+    {
+    }
+
+    public SettingsPlaceholderSectionView(string title, string description, string nextStep)
+    {
+        SectionTitle = title;
+        SectionSubtitle = description;
+        SectionStatus = CoreTools.Translate("Please wait");
+
+        InitializeComponent();
+        LeadText.Text = title;
+        DescriptionText.Text = description;
+        NextStepText.Text = nextStep;
+    }
+
+    public string SectionTitle { get; }
+
+    public string SectionSubtitle { get; }
+
+    public string SectionStatus { get; }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsSectionRoute.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/SettingsSectionRoute.cs
@@ -1,0 +1,16 @@
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+internal enum SettingsSectionRoute
+{
+    Home,
+    General,
+    Interface,
+    Managers,
+    Updates,
+    Notifications,
+    Operations,
+    Internet,
+    Administrator,
+    Backup,
+    Experimental,
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/UpdatesSettingsView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/UpdatesSettingsView.axaml
@@ -1,0 +1,64 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SettingsPages.UpdatesSettingsView">
+  <ScrollViewer>
+    <StackPanel Spacing="12">
+      <Border Padding="18"
+              Classes="surface-card subtle-panel">
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="LeadTitleBlock"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock x:Name="LeadDescriptionBlock"
+                     MaxWidth="860"
+                     Opacity="0.78"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="CheckingTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="CheckingDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="EnablePeriodicChecksCheckBox"
+                    Content="Check for package updates periodically" />
+          <ComboBox x:Name="UpdatesCheckIntervalSelector"
+                    MaxDropDownHeight="280"
+                    SelectionChanged="UpdatesCheckIntervalSelector_OnSelectionChanged" />
+          <TextBlock x:Name="CheckingHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="18"
+              Classes="surface-card">
+        <StackPanel Spacing="12">
+          <TextBlock x:Name="AutomaticTitleBlock"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock x:Name="AutomaticDescriptionBlock"
+                     Opacity="0.72"
+                     TextWrapping="Wrap" />
+          <CheckBox x:Name="AutomaticallyUpdatePackagesCheckBox"
+                    Content="Install available updates automatically" />
+          <CheckBox x:Name="DisableOnMeteredConnectionsCheckBox"
+                    Content="Do not automatically install updates when the network connection is metered" />
+          <CheckBox x:Name="DisableOnBatteryCheckBox"
+                    Content="Do not automatically install updates when the device runs on battery" />
+          <CheckBox x:Name="DisableOnBatterySaverCheckBox"
+                    Content="Do not automatically install updates when the battery saver is on" />
+          <TextBlock x:Name="AutomaticHintBlock"
+                     Opacity="0.68"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/Settings/UpdatesSettingsView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/Settings/UpdatesSettingsView.axaml.cs
@@ -1,0 +1,273 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+using UniGetUI.PackageEngine.PackageLoader;
+
+namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
+
+public partial class UpdatesSettingsView : UserControl, ISettingsSectionView
+{
+    private static readonly (string Label, string Value, int? Number)[] UpdateIntervalOptions =
+    [
+        ("{0} minutes", "600", 10),
+        ("{0} minutes", "1800", 30),
+        ("1 hour", "3600", null),
+        ("{0} hours", "7200", 2),
+        ("{0} hours", "14400", 4),
+        ("{0} hours", "28800", 8),
+        ("{0} hours", "43200", 12),
+        ("1 day", "86400", null),
+        ("{0} days", "172800", 2),
+        ("{0} days", "259200", 3),
+        ("1 week", "604800", null),
+    ];
+
+    private bool _isLoading;
+
+    private CheckBox EnablePeriodicChecksCheckBoxControl => GetControl<CheckBox>("EnablePeriodicChecksCheckBox");
+
+    private ComboBox UpdatesCheckIntervalSelectorControl => GetControl<ComboBox>("UpdatesCheckIntervalSelector");
+
+    private CheckBox AutomaticallyUpdatePackagesCheckBoxControl => GetControl<CheckBox>("AutomaticallyUpdatePackagesCheckBox");
+
+    private CheckBox DisableOnMeteredConnectionsCheckBoxControl => GetControl<CheckBox>("DisableOnMeteredConnectionsCheckBox");
+
+    private CheckBox DisableOnBatteryCheckBoxControl => GetControl<CheckBox>("DisableOnBatteryCheckBox");
+
+    private CheckBox DisableOnBatterySaverCheckBoxControl => GetControl<CheckBox>("DisableOnBatterySaverCheckBox");
+
+    private TextBlock LeadTitleText => GetControl<TextBlock>("LeadTitleBlock");
+
+    private TextBlock LeadDescriptionText => GetControl<TextBlock>("LeadDescriptionBlock");
+
+    private TextBlock CheckingTitleText => GetControl<TextBlock>("CheckingTitleBlock");
+
+    private TextBlock CheckingDescriptionText => GetControl<TextBlock>("CheckingDescriptionBlock");
+
+    private TextBlock CheckingHintText => GetControl<TextBlock>("CheckingHintBlock");
+
+    private TextBlock AutomaticTitleText => GetControl<TextBlock>("AutomaticTitleBlock");
+
+    private TextBlock AutomaticDescriptionText => GetControl<TextBlock>("AutomaticDescriptionBlock");
+
+    private TextBlock AutomaticHintText => GetControl<TextBlock>("AutomaticHintBlock");
+
+    public UpdatesSettingsView()
+    {
+        InitializeComponent();
+        EnablePeriodicChecksCheckBoxControl.Click += EnablePeriodicChecksCheckBox_OnClick;
+        AutomaticallyUpdatePackagesCheckBoxControl.Click += AutomaticallyUpdatePackagesCheckBox_OnClick;
+        DisableOnMeteredConnectionsCheckBoxControl.Click += DisableOnMeteredConnectionsCheckBox_OnClick;
+        DisableOnBatteryCheckBoxControl.Click += DisableOnBatteryCheckBox_OnClick;
+        DisableOnBatterySaverCheckBoxControl.Click += DisableOnBatterySaverCheckBox_OnClick;
+
+        SectionTitle = CoreTools.Translate("Updates preferences");
+        SectionSubtitle = CoreTools.Translate("Update check frequency, automatically install updates, etc.");
+        SectionStatus = CoreTools.Translate("Show the live output");
+
+        ApplyLocalizedText();
+        PopulateUpdateIntervalSelector();
+        LoadStoredValues();
+    }
+
+    public string SectionTitle { get; }
+
+    public string SectionSubtitle { get; }
+
+    public string SectionStatus { get; }
+
+    private void ApplyLocalizedText()
+    {
+        LeadTitleText.Text = CoreTools.Translate("Updates preferences");
+        LeadDescriptionText.Text = CoreTools.Translate("Update check frequency, automatically install updates, etc.");
+        CheckingTitleText.Text = CoreTools.Translate("Update checking");
+        CheckingDescriptionText.Text = CoreTools.Translate("Check for updates periodically");
+        EnablePeriodicChecksCheckBoxControl.Content = CoreTools.Translate("Check for package updates periodically");
+        CheckingHintText.Text = CoreTools.Translate("Check for updates periodically");
+        AutomaticTitleText.Text = CoreTools.Translate("Automatic updates");
+        AutomaticDescriptionText.Text = CoreTools.Translate("Install updates automatically");
+        AutomaticallyUpdatePackagesCheckBoxControl.Content = CoreTools.Translate("Install available updates automatically");
+        DisableOnMeteredConnectionsCheckBoxControl.Content = CoreTools.Translate("Do not automatically install updates when the network connection is metered");
+        DisableOnBatteryCheckBoxControl.Content = CoreTools.Translate("Do not automatically install updates when the device runs on battery");
+        DisableOnBatterySaverCheckBoxControl.Content = CoreTools.Translate("Do not automatically install updates when the battery saver is on");
+        AutomaticHintText.Text = CoreTools.Translate("Update check frequency, automatically install updates, etc.");
+    }
+
+    private void PopulateUpdateIntervalSelector()
+    {
+        UpdatesCheckIntervalSelectorControl.Items.Clear();
+
+        foreach (var option in BuildIntervalItems())
+        {
+            UpdatesCheckIntervalSelectorControl.Items.Add(CreateComboBoxItem(option.Label, option.Value));
+        }
+    }
+
+    private void LoadStoredValues()
+    {
+        _isLoading = true;
+
+        var isPeriodicCheckEnabled = !Settings.Get(Settings.K.DisableAutoCheckforUpdates);
+        EnablePeriodicChecksCheckBoxControl.IsChecked = isPeriodicCheckEnabled;
+
+        var intervalValue = Settings.GetValue(Settings.K.UpdatesCheckInterval);
+        if (string.IsNullOrWhiteSpace(intervalValue))
+        {
+            intervalValue = "3600";
+            Settings.SetValue(Settings.K.UpdatesCheckInterval, intervalValue);
+        }
+
+        SelectComboBoxValue(UpdatesCheckIntervalSelectorControl, intervalValue, fallbackValue: "3600");
+        AutomaticallyUpdatePackagesCheckBoxControl.IsChecked = Settings.Get(Settings.K.AutomaticallyUpdatePackages);
+        DisableOnMeteredConnectionsCheckBoxControl.IsChecked = Settings.Get(Settings.K.DisableAUPOnMeteredConnections);
+        DisableOnBatteryCheckBoxControl.IsChecked = Settings.Get(Settings.K.DisableAUPOnBattery);
+        DisableOnBatterySaverCheckBoxControl.IsChecked = Settings.Get(Settings.K.DisableAUPOnBatterySaver);
+        ApplyAutomaticUpdateControlState();
+
+        _isLoading = false;
+    }
+
+    private void EnablePeriodicChecksCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        var isPeriodicCheckEnabled = EnablePeriodicChecksCheckBoxControl.IsChecked == true;
+        Settings.Set(Settings.K.DisableAutoCheckforUpdates, !isPeriodicCheckEnabled);
+        ApplyAutomaticUpdateControlState();
+        RefreshUpdatesLoader();
+    }
+
+    private void UpdatesCheckIntervalSelector_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.SetValue(Settings.K.UpdatesCheckInterval, GetSelectedValue(UpdatesCheckIntervalSelectorControl));
+        RefreshUpdatesLoader();
+    }
+
+    private void AutomaticallyUpdatePackagesCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.AutomaticallyUpdatePackages, AutomaticallyUpdatePackagesCheckBoxControl.IsChecked == true);
+    }
+
+    private void DisableOnMeteredConnectionsCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableAUPOnMeteredConnections, DisableOnMeteredConnectionsCheckBoxControl.IsChecked == true);
+    }
+
+    private void DisableOnBatteryCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableAUPOnBattery, DisableOnBatteryCheckBoxControl.IsChecked == true);
+    }
+
+    private void DisableOnBatterySaverCheckBox_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        Settings.Set(Settings.K.DisableAUPOnBatterySaver, DisableOnBatterySaverCheckBoxControl.IsChecked == true);
+    }
+
+    private void ApplyAutomaticUpdateControlState()
+    {
+        var isPeriodicCheckEnabled = EnablePeriodicChecksCheckBoxControl.IsChecked == true;
+        UpdatesCheckIntervalSelectorControl.IsEnabled = isPeriodicCheckEnabled;
+        AutomaticallyUpdatePackagesCheckBoxControl.IsEnabled = isPeriodicCheckEnabled;
+        DisableOnMeteredConnectionsCheckBoxControl.IsEnabled = isPeriodicCheckEnabled;
+        DisableOnBatteryCheckBoxControl.IsEnabled = isPeriodicCheckEnabled;
+        DisableOnBatterySaverCheckBoxControl.IsEnabled = isPeriodicCheckEnabled;
+    }
+
+    private static IEnumerable<(string Label, string Value)> BuildIntervalItems()
+    {
+        foreach (var option in UpdateIntervalOptions)
+        {
+            yield return option.Number is int number
+                ? (CoreTools.Translate(option.Label, number), option.Value)
+                : (CoreTools.Translate(option.Label), option.Value);
+        }
+    }
+
+    private static void RefreshUpdatesLoader()
+    {
+        try
+        {
+            if (!UpgradablePackagesLoader.Instance.IsLoading)
+            {
+                _ = UpgradablePackagesLoader.Instance.ReloadPackages();
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private static ComboBoxItem CreateComboBoxItem(string label, string value)
+    {
+        return new ComboBoxItem
+        {
+            Content = label,
+            Tag = value,
+        };
+    }
+
+    private static string GetSelectedValue(ComboBox comboBox)
+    {
+        return comboBox.SelectedItem is ComboBoxItem { Tag: string value }
+            ? value
+            : string.Empty;
+    }
+
+    private static void SelectComboBoxValue(ComboBox comboBox, string selectedValue, string fallbackValue)
+    {
+        var desiredValue = string.IsNullOrWhiteSpace(selectedValue) ? fallbackValue : selectedValue;
+
+        for (var index = 0; index < comboBox.Items.Count; index++)
+        {
+            if (comboBox.Items[index] is ComboBoxItem { Tag: string value } && value == desiredValue)
+            {
+                comboBox.SelectedIndex = index;
+                return;
+            }
+        }
+
+        comboBox.SelectedIndex = 0;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/SimplePageView.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SimplePageView.axaml
@@ -1,0 +1,22 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="UniGetUI.Avalonia.Views.Pages.SimplePageView">
+  <Border Padding="28"
+          Classes="surface-card">
+    <StackPanel Spacing="12">
+      <TextBlock x:Name="BodyLeadBlock"
+       FontSize="20"
+       FontWeight="SemiBold"
+                 Opacity="0.76"
+                 TextWrapping="Wrap" />
+      <Border Padding="18"
+              Margin="0,12,0,0"
+              Classes="surface-card subtle-panel"
+              CornerRadius="18">
+        <TextBlock x:Name="BodyDescriptionBlock"
+                   Opacity="0.76"
+                   TextWrapping="Wrap" />
+      </Border>
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/src/UniGetUI.Avalonia/Views/Pages/SimplePageView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SimplePageView.axaml.cs
@@ -1,0 +1,52 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class SimplePageView : UserControl, IShellPage
+{
+    private TextBlock BodyLeadText => GetControl<TextBlock>("BodyLeadBlock");
+
+    private TextBlock BodyDescriptionText => GetControl<TextBlock>("BodyDescriptionBlock");
+
+    public SimplePageView()
+        : this(string.Empty, string.Empty, string.Empty, string.Empty)
+    {
+    }
+
+    public SimplePageView(string title, string subtitle, string lead, string description)
+    {
+        Title = title;
+        Subtitle = subtitle;
+        SupportsSearch = false;
+        SearchPlaceholder = string.Empty;
+
+        InitializeComponent();
+        BodyLeadText.Text = lead;
+        BodyDescriptionText.Text = description;
+    }
+
+    public string Title { get; }
+
+    public string Subtitle { get; }
+
+    public bool SupportsSearch { get; }
+
+    public string SearchPlaceholder { get; }
+
+    public void UpdateSearchQuery(string query)
+    {
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private T GetControl<T>(string name)
+        where T : Control
+    {
+        return this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"Control '{name}' was not found.");
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/TelemetryConsentWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/TelemetryConsentWindow.axaml
@@ -1,0 +1,67 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.Pages.TelemetryConsentWindow"
+        Width="520"
+        Height="330"
+        MinWidth="380"
+        MinHeight="280"
+        Title="Share anonymous usage data"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <StyleInclude Source="/Styles/AppStyles.axaml" />
+  </Window.Styles>
+
+  <Grid RowDefinitions="Auto,*,Auto"
+        Margin="20">
+
+    <!-- Title -->
+    <TextBlock x:Name="TitleBlock"
+               Grid.Row="0"
+               FontSize="18"
+               FontWeight="SemiBold"
+               TextWrapping="Wrap"
+               Margin="0,0,0,12" />
+
+    <!-- Message content -->
+    <StackPanel Grid.Row="1"
+                Spacing="8"
+                VerticalAlignment="Top">
+      <TextBlock x:Name="CollectionBlock"
+                 TextWrapping="Wrap"
+                 Opacity="0.82"
+                 FontSize="13" />
+      <TextBlock x:Name="AnonymousBlock"
+                 TextWrapping="Wrap"
+                 Opacity="0.82"
+                 FontSize="13" />
+      <TextBlock x:Name="PrivacyLinkBlock"
+                 TextWrapping="Wrap"
+                 Opacity="0.72"
+                 FontSize="12" />
+      <TextBlock x:Name="QuestionBlock"
+                 TextWrapping="Wrap"
+                 FontSize="13"
+                 FontWeight="SemiBold" />
+    </StackPanel>
+
+    <!-- Footer buttons -->
+    <Grid Grid.Row="2"
+          Margin="0,14,0,0"
+          ColumnDefinitions="*,Auto,Auto"
+          ColumnSpacing="8">
+      <Button x:Name="DeclineBtn"
+              Grid.Column="1"
+              MinWidth="90"
+              Content="Decline"
+              Click="DeclineBtn_OnClick" />
+      <Button x:Name="AcceptBtn"
+              Grid.Column="2"
+              MinWidth="90"
+              Classes="accent"
+              Content="Accept"
+              Click="AcceptBtn_OnClick" />
+    </Grid>
+
+  </Grid>
+</Window>

--- a/src/UniGetUI.Avalonia/Views/Pages/TelemetryConsentWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/TelemetryConsentWindow.axaml.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Views.Pages;
+
+public partial class TelemetryConsentWindow : Window
+{
+    public TelemetryConsentWindow()
+    {
+        InitializeComponent();
+
+        Title = CoreTools.Translate("Share anonymous usage data");
+        TitleBlock.Text = CoreTools.Translate("Share anonymous usage data");
+        CollectionBlock.Text = CoreTools.Translate(
+            "UniGetUI collects anonymous usage data with the sole purpose of understanding and improving the user experience."
+        );
+        AnonymousBlock.Text = CoreTools.Translate(
+            "No personal information is collected nor sent, and the collected data is anonymized, so it can't be back-tracked to you."
+        );
+        PrivacyLinkBlock.Text = CoreTools.Translate("More details about the shared data and how it will be processed")
+            + " https://www.marticliment.com/unigetui/privacy/";
+        QuestionBlock.Text = CoreTools.Translate(
+            "Do you accept that UniGetUI collects and sends anonymous usage statistics, with the sole purpose of understanding and improving the user experience?"
+        );
+        AcceptBtn.Content = CoreTools.Translate("Accept");
+        DeclineBtn.Content = CoreTools.Translate("Decline");
+    }
+
+    private void AcceptBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Settings.Set(Settings.K.DisableTelemetry, false);
+        Settings.Set(Settings.K.ShownTelemetryBanner, true);
+        Close();
+    }
+
+    private void DeclineBtn_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Settings.Set(Settings.K.DisableTelemetry, true);
+        Settings.Set(Settings.K.ShownTelemetryBanner, true);
+        Close();
+    }
+}


### PR DESCRIPTION
## Summary
- experimental Avalonia port as a cross-platform app shell and page stack
- align translation key usage with existing language entries
- finish startup/runtime improvements (single-instance behavior, dependency prompts, auto-update gating)
- remove Avalonia AVLN3001 constructor warnings by adding loader-friendly parameterless constructors
- update CI to validate Avalonia formatting/style/build separately without adding Avalonia to `UniGetUI.sln`

## Validation
- dotnet test (all): passing
- dotnet build src/UniGetUI.Avalonia.slnx: passing
- dotnet build src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj -r linux-x64: passing
- dotnet build src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj -r osx-x64: passing
- dotnet build src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj -r osx-arm64: passing