### PR TITLE
Restore self-contained Windows App SDK packaging

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,12 +36,6 @@
     <PropertyGroup Condition="$([System.String]::Copy('$(TargetFramework)').Contains('-windows'))">
         <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
         <WindowsSdkPackageVersion>10.0.26100.56</WindowsSdkPackageVersion>
-        <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
-        <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
-        <RuntimeIdentifier
-            Condition="'$(Platform)' != '' and '$(Platform)' != 'AnyCPU' and '$(Platform)' != 'Any CPU'"
-            >win-$(Platform)</RuntimeIdentifier
-        >
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -14,6 +14,12 @@
         <!-- .NET & AppSdk publish options -->
         <WindowsAppSDKWinUI>true</WindowsAppSDKWinUI>
         <WindowsPackageType>None</WindowsPackageType>
+        <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+        <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifier
+            Condition="'$(Platform)' != '' and '$(Platform)' != 'AnyCPU' and '$(Platform)' != 'Any CPU'"
+            >win-$(Platform)</RuntimeIdentifier
+        >
 
         <!--PublishAot>true</PublishAot-->
         <PublishTrimmed>true</PublishTrimmed>


### PR DESCRIPTION
## Summary
- restore app-local Windows App SDK packaging for the WinUI app
- move the self-contained Windows App SDK settings into UniGetUI.csproj, where TargetFramework is already known
- ensure release artifacts bundle Microsoft.WindowsAppRuntime.dll again on clean machines

## Root Cause
A shared-target-framework refactor moved the Windows App SDK self-contained settings into Directory.Build.props behind a condition that depends on TargetFramework. Directory.Build.props is imported before UniGetUI.csproj sets TargetFramework, so the condition stopped matching for the app project. That silently disabled app-local Windows App SDK packaging and release artifacts stopped including Microsoft.WindowsAppRuntime.dll.

## Validation
- rebuilt the focused fix artifact and verified it contains Microsoft.WindowsAppRuntime.Bootstrap.dll
- rebuilt the focused fix artifact and verified it contains Microsoft.WindowsAppRuntime.dll
- rebuilt the focused fix artifact and verified it contains Microsoft.WindowsAppRuntime.Insights.Resource.dll
- confirmed the repaired build works in the previously failing environment

Fixes #4487