### PR TITLE
Fix FileSaveDialog COM interop cast failure

### DIFF
--- a/src/ExternalLibraries.FilePickers/Interfaces/IFileOpenDialog.cs
+++ b/src/ExternalLibraries.FilePickers/Interfaces/IFileOpenDialog.cs
@@ -21,17 +21,8 @@ internal interface IFileOpenDialog : IFileDialog
     void GetSelectedItems([MarshalAs(UnmanagedType.Interface)] out IShellItemArray ppsai);
 }
 
+[ComImport(), Guid(IIDGuid.IFileSaveDialog), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface IFileSaveDialog : IFileDialog
 {
-    // Defined on IFileDialog - repeated here due to requirements of COM interop layer
-    [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
-    void SetFileTypes([In] uint cFileTypes, [In] ref COMDLG_FILTERSPEC rgFilterSpec);
-
-    // Defined by IFileOpenDialog
-    // ---------------------------------------------------------------------------------
-    [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
-    void GetResults([MarshalAs(UnmanagedType.Interface)] out IShellItemArray ppenum);
-
-    [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
-    void GetSelectedItems([MarshalAs(UnmanagedType.Interface)] out IShellItemArray ppsai);
+    // Marker interface for COM interop with IFileSaveDialog.
 }


### PR DESCRIPTION
## Summary
- fix COM interop definition for IFileSaveDialog
- add missing ComImport/Guid/InterfaceType attributes
- remove incorrect open-dialog members from IFileSaveDialog

## Problem
Creating a package bundle failed with an invalid cast when instantiating FileSaveDialog RCW.

## Validation
- built ExternalLibraries.FilePickers successfully
- built UniGetUI with RuntimeIdentifier=win-x64 and Platform=x64 successfully
- manually validated bundle creation flow opens save dialog without the cast error