### PR TITLE
Harden auto updater source selection

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -33,16 +33,6 @@ internal static partial class AvaloniaAutoUpdater
     private const string REG_SKIP_HASH_VALIDATION = "UpdaterSkipHashValidation";
     private const string REG_SKIP_SIGNER_THUMBPRINT_CHECK = "UpdaterSkipSignerThumbprintCheck";
     private const string REG_DISABLE_TLS_VALIDATION = "UpdaterDisableTlsValidation";
-    private const string REG_USE_LEGACY_GITHUB = "UpdaterUseLegacyGithub";
-
-    private const string STABLE_ENDPOINT =
-        "https://www.marticliment.com/versions/unigetui/stable.ver";
-    private const string BETA_ENDPOINT =
-        "https://www.marticliment.com/versions/unigetui/beta.ver";
-    private const string STABLE_INSTALLER_URL =
-        "https://github.com/Devolutions/UniGetUI/releases/latest/download/UniGetUI.Installer.exe";
-    private const string BETA_INSTALLER_URL =
-        "https://github.com/Devolutions/UniGetUI/releases/download/$TAG/UniGetUI.Installer.exe";
 
     private static readonly string[] DEVOLUTIONS_CERT_THUMBPRINTS =
     [
@@ -50,6 +40,17 @@ internal static partial class AvaloniaAutoUpdater
         "8db5a43bb8afe4d2ffb92da9007d8997a4cc4e13",
         "50f753333811ff11f1920274afde3ffd4468b210",
     ];
+
+#if !DEBUG
+    private static readonly string[] RELEASE_IGNORED_REGISTRY_VALUES =
+    [
+        REG_PRODUCTINFO_KEY,
+        REG_ALLOW_UNSAFE_URLS,
+        REG_SKIP_HASH_VALIDATION,
+        REG_SKIP_SIGNER_THUMBPRINT_CHECK,
+        REG_DISABLE_TLS_VALIDATION,
+    ];
+#endif
 
     private static readonly AutoUpdaterJsonContext _jsonContext = new(
         new JsonSerializerOptions(SerializationHelpers.DefaultOptions)
@@ -245,21 +246,7 @@ internal static partial class AvaloniaAutoUpdater
     // ------------------------------------------------------------------ update check sources
     private static async Task<UpdateCandidate> GetUpdateCandidateAsync(UpdaterOverrides overrides)
     {
-        if (overrides.UseLegacyGithub)
-        {
-            return await CheckFromLegacyGitHubAsync(overrides);
-        }
-
-        try
-        {
-            return await CheckFromProductInfoAsync(overrides);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn("ProductInfo source failed; falling back to legacy GitHub source.");
-            Logger.Warn(ex);
-            return await CheckFromLegacyGitHubAsync(overrides);
-        }
+        return await CheckFromProductInfoAsync(overrides);
     }
 
     private static async Task<UpdateCandidate> CheckFromProductInfoAsync(UpdaterOverrides overrides)
@@ -327,40 +314,6 @@ internal static partial class AvaloniaAutoUpdater
         );
 
         return new UpdateCandidate(upgradable, channel.Version, installer.Hash, installer.Url, "ProductInfo");
-    }
-
-    private static async Task<UpdateCandidate> CheckFromLegacyGitHubAsync(UpdaterOverrides overrides)
-    {
-        bool useBeta = Settings.Get(Settings.K.EnableUniGetUIBeta);
-        string endpoint = useBeta ? BETA_ENDPOINT : STABLE_ENDPOINT;
-        string installerUrl = useBeta ? BETA_INSTALLER_URL : STABLE_INSTALLER_URL;
-
-        Logger.Debug($"Checking updates via legacy GitHub endpoint: {endpoint}");
-
-        string[] parts;
-        using (HttpClient client = new(CreateHttpClientHandler(overrides)))
-        {
-            client.Timeout = TimeSpan.FromSeconds(600);
-            client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
-            parts = (await client.GetStringAsync(endpoint)).Split("////");
-        }
-
-        if (parts.Length >= 3)
-        {
-            int latestBuild = int.Parse(parts[0].Trim());
-            string hash = parts[1].Trim();
-            string versionName = parts[2].Trim();
-
-            return new UpdateCandidate(
-                latestBuild > CoreData.BuildNumber,
-                versionName,
-                hash,
-                installerUrl.Replace("$TAG", versionName),
-                "LegacyGitHub"
-            );
-        }
-
-        throw new FormatException("Legacy update file does not follow the expected format.");
     }
 
     // ------------------------------------------------------------------ validation helpers
@@ -488,9 +441,7 @@ internal static partial class AvaloniaAutoUpdater
         return uri.Host.EndsWith("devolutions.net", StringComparison.OrdinalIgnoreCase)
             || uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase)
             || uri.Host.Equals("objects.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
-            || uri.Host.Equals("release-assets.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
-            || uri.Host.Equals("marticliment.com", StringComparison.OrdinalIgnoreCase)
-            || uri.Host.EndsWith("marticliment.com", StringComparison.OrdinalIgnoreCase);
+            || uri.Host.Equals("release-assets.githubusercontent.com", StringComparison.OrdinalIgnoreCase);
     }
 
     private static ProductInfoFile SelectInstallerFile(List<ProductInfoFile> files)
@@ -531,11 +482,12 @@ internal static partial class AvaloniaAutoUpdater
     private static UpdaterOverrides LoadUpdaterOverrides()
     {
 #pragma warning disable CA1416
-        using RegistryKey? key = Registry.CurrentUser.OpenSubKey(REGISTRY_PATH);
+        using RegistryKey? key = Registry.LocalMachine.OpenSubKey(REGISTRY_PATH);
 
+#if DEBUG
         if (key is not null)
         {
-            Logger.Info($"Updater registry overrides loaded from HKCU\\{REGISTRY_PATH}");
+            Logger.Info($"Updater registry overrides loaded from HKLM\\{REGISTRY_PATH}");
         }
 
         return new UpdaterOverrides(
@@ -544,11 +496,45 @@ internal static partial class AvaloniaAutoUpdater
             GetRegistryBool(key, REG_ALLOW_UNSAFE_URLS),
             GetRegistryBool(key, REG_SKIP_HASH_VALIDATION),
             GetRegistryBool(key, REG_SKIP_SIGNER_THUMBPRINT_CHECK),
-            GetRegistryBool(key, REG_DISABLE_TLS_VALIDATION),
-            GetRegistryBool(key, REG_USE_LEGACY_GITHUB)
+            GetRegistryBool(key, REG_DISABLE_TLS_VALIDATION)
         );
+#else
+        LogIgnoredReleaseOverrides(key);
+        string productInfoUrl = GetRegistryString(key, REG_PRODUCTINFO_URL) ?? DEFAULT_PRODUCTINFO_URL;
+
+        return new UpdaterOverrides(
+            productInfoUrl,
+            DEFAULT_PRODUCTINFO_KEY,
+            false,
+            false,
+            false,
+            false
+        );
+#endif
 #pragma warning restore CA1416
     }
+
+#if !DEBUG
+    private static void LogIgnoredReleaseOverrides(RegistryKey? key)
+    {
+#pragma warning disable CA1416
+        if (key is null)
+        {
+            return;
+        }
+
+        foreach (string valueName in RELEASE_IGNORED_REGISTRY_VALUES)
+        {
+            if (key.GetValue(valueName) is not null)
+            {
+                Logger.Warn(
+                    $"Release build is ignoring updater registry value HKLM\\{REGISTRY_PATH}\\{valueName}."
+                );
+            }
+        }
+#pragma warning restore CA1416
+    }
+#endif
 
     private static string? GetRegistryString(RegistryKey? key, string valueName)
     {
@@ -558,6 +544,7 @@ internal static partial class AvaloniaAutoUpdater
         return string.IsNullOrWhiteSpace(parsed) ? null : parsed.Trim();
     }
 
+#if DEBUG
     private static bool GetRegistryBool(RegistryKey? key, string valueName)
     {
 #pragma warning disable CA1416
@@ -572,6 +559,7 @@ internal static partial class AvaloniaAutoUpdater
             || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
             || s.Equals("on", StringComparison.OrdinalIgnoreCase);
     }
+#endif
 
     // ------------------------------------------------------------------ data types
     private sealed record UpdateCandidate(
@@ -588,8 +576,7 @@ internal static partial class AvaloniaAutoUpdater
         bool AllowUnsafeUrls,
         bool SkipHashValidation,
         bool SkipSignerThumbprintCheck,
-        bool DisableTlsValidation,
-        bool UseLegacyGithub
+        bool DisableTlsValidation
     );
 
     private sealed class ProductInfoProduct

--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -30,7 +30,6 @@ public partial class AutoUpdater
     private const string REG_SKIP_HASH_VALIDATION = "UpdaterSkipHashValidation";
     private const string REG_SKIP_SIGNER_THUMBPRINT_CHECK = "UpdaterSkipSignerThumbprintCheck";
     private const string REG_DISABLE_TLS_VALIDATION = "UpdaterDisableTlsValidation";
-    private const string REG_USE_LEGACY_GITHUB = "UpdaterUseLegacyGithub";
 
     private static readonly string[] DEVOLUTIONS_CERT_THUMBPRINTS =
     [
@@ -39,21 +38,23 @@ public partial class AutoUpdater
         "50f753333811ff11f1920274afde3ffd4468b210",
     ];
 
+#if !DEBUG
+    private static readonly string[] RELEASE_IGNORED_REGISTRY_VALUES =
+    [
+        REG_PRODUCTINFO_KEY,
+        REG_ALLOW_UNSAFE_URLS,
+        REG_SKIP_HASH_VALIDATION,
+        REG_SKIP_SIGNER_THUMBPRINT_CHECK,
+        REG_DISABLE_TLS_VALIDATION,
+    ];
+#endif
+
     private static readonly AutoUpdaterJsonContext ProductInfoJsonContext = new(
         new JsonSerializerOptions(SerializationHelpers.DefaultOptions)
     );
 
     public static Window Window = null!;
     public static InfoBar Banner = null!;
-
-    //------------------------------------------------------------------------------------------------------------------
-    private const string STABLE_ENDPOINT =
-        "https://www.marticliment.com/versions/unigetui/stable.ver";
-    private const string BETA_ENDPOINT = "https://www.marticliment.com/versions/unigetui/beta.ver";
-    private const string STABLE_INSTALLER_URL =
-        "https://github.com/Devolutions/UniGetUI/releases/latest/download/UniGetUI.Installer.exe";
-    private const string BETA_INSTALLER_URL =
-        "https://github.com/Devolutions/UniGetUI/releases/download/$TAG/UniGetUI.Installer.exe";
 
     //------------------------------------------------------------------------------------------------------------------
     public static bool ReleaseLockForAutoupdate_Notification;
@@ -227,23 +228,7 @@ public partial class AutoUpdater
 
     private static async Task<UpdateCandidate> GetUpdateCandidate(UpdaterOverrides updaterOverrides)
     {
-        if (updaterOverrides.UseLegacyGithub)
-        {
-            return await CheckForUpdatesFromLegacyGitHub(updaterOverrides);
-        }
-
-        try
-        {
-            return await CheckForUpdatesFromProductInfo(updaterOverrides);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn(
-                "Productinfo updater source failed. Falling back to legacy GitHub updater source."
-            );
-            Logger.Warn(ex);
-            return await CheckForUpdatesFromLegacyGitHub(updaterOverrides);
-        }
+        return await CheckForUpdatesFromProductInfo(updaterOverrides);
     }
 
     /// <summary>
@@ -333,56 +318,6 @@ public partial class AutoUpdater
             installerFile.Hash,
             installerFile.Url,
             "ProductInfo"
-        );
-    }
-
-    /// <summary>
-    /// Legacy updater source. Kept for compatibility and manual fallback testing.
-    /// </summary>
-    private static async Task<UpdateCandidate> CheckForUpdatesFromLegacyGitHub(
-        UpdaterOverrides updaterOverrides
-    )
-    {
-        string endpoint = Settings.Get(Settings.K.EnableUniGetUIBeta)
-            ? BETA_ENDPOINT
-            : STABLE_ENDPOINT;
-        string installerDownloadUrl = Settings.Get(Settings.K.EnableUniGetUIBeta)
-            ? BETA_INSTALLER_URL
-            : STABLE_INSTALLER_URL;
-
-        Logger.Warn("Using legacy GitHub updater source due to registry override.");
-        Logger.Debug($"Begin check for updates on endpoint {endpoint}");
-
-        string[] updateResponse;
-        using (HttpClient client = new(CreateHttpClientHandler(updaterOverrides)))
-        {
-            client.Timeout = TimeSpan.FromSeconds(600);
-            client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
-            updateResponse = (await client.GetStringAsync(endpoint)).Split("////");
-        }
-
-        if (updateResponse.Length >= 3)
-        {
-            int latestVersion = int.Parse(
-                updateResponse[0].Replace("\n", "").Replace("\r", "").Trim()
-            );
-            string installerHash = updateResponse[1].Replace("\n", "").Replace("\r", "").Trim();
-            string versionName = updateResponse[2].Replace("\n", "").Replace("\r", "").Trim();
-            Logger.Debug(
-                $"Got response from endpoint: ({latestVersion}, {versionName}, {installerHash})"
-            );
-            return new UpdateCandidate(
-                latestVersion > CoreData.BuildNumber,
-                versionName,
-                installerHash,
-                installerDownloadUrl.Replace("$TAG", versionName),
-                "LegacyGitHub"
-            );
-        }
-
-        Logger.Warn($"Received update string is {updateResponse[0]}");
-        throw new FormatException(
-            "The updates file does not follow the FloatVersion////Sha256Hash////VersionName format"
         );
     }
 
@@ -699,9 +634,7 @@ public partial class AutoUpdater
             || uri.Host.Equals(
                 "release-assets.githubusercontent.com",
                 StringComparison.OrdinalIgnoreCase
-            )
-            || uri.Host.Equals("marticliment.com", StringComparison.OrdinalIgnoreCase)
-            || uri.Host.EndsWith("marticliment.com", StringComparison.OrdinalIgnoreCase);
+            );
     }
 
     private static ProductInfoFile SelectInstallerFile(List<ProductInfoFile> files)
@@ -769,38 +702,63 @@ public partial class AutoUpdater
 
     private static UpdaterOverrides LoadUpdaterOverrides()
     {
-        using RegistryKey? key = Registry.CurrentUser.OpenSubKey(REGISTRY_PATH);
+        using RegistryKey? key = Registry.LocalMachine.OpenSubKey(REGISTRY_PATH);
 
-        string productInfoUrl =
-            GetRegistryString(key, REG_PRODUCTINFO_URL) ?? DEFAULT_PRODUCTINFO_URL;
-        string productInfoProductKey =
-            GetRegistryString(key, REG_PRODUCTINFO_KEY) ?? DEFAULT_PRODUCTINFO_KEY;
-
-        bool allowUnsafeUrls = GetRegistryBool(key, REG_ALLOW_UNSAFE_URLS);
-        bool skipHashValidation = GetRegistryBool(key, REG_SKIP_HASH_VALIDATION);
-        bool skipSignerThumbprintCheck = GetRegistryBool(key, REG_SKIP_SIGNER_THUMBPRINT_CHECK);
-        bool disableTlsValidation = GetRegistryBool(key, REG_DISABLE_TLS_VALIDATION);
-        bool useLegacyGithub = GetRegistryBool(key, REG_USE_LEGACY_GITHUB);
-
+#if DEBUG
         if (key is not null)
         {
-            Logger.Info($"Updater registry overrides loaded from HKCU\\{REGISTRY_PATH}");
+            Logger.Info($"Updater registry overrides loaded from HKLM\\{REGISTRY_PATH}");
         }
 
         return new UpdaterOverrides(
-            productInfoUrl,
-            productInfoProductKey,
-            allowUnsafeUrls,
-            skipHashValidation,
-            skipSignerThumbprintCheck,
-            disableTlsValidation,
-            useLegacyGithub
+            GetRegistryString(key, REG_PRODUCTINFO_URL) ?? DEFAULT_PRODUCTINFO_URL,
+            GetRegistryString(key, REG_PRODUCTINFO_KEY) ?? DEFAULT_PRODUCTINFO_KEY,
+            GetRegistryBool(key, REG_ALLOW_UNSAFE_URLS),
+            GetRegistryBool(key, REG_SKIP_HASH_VALIDATION),
+            GetRegistryBool(key, REG_SKIP_SIGNER_THUMBPRINT_CHECK),
+            GetRegistryBool(key, REG_DISABLE_TLS_VALIDATION)
         );
+#else
+        LogIgnoredReleaseOverrides(key);
+        string productInfoUrl =
+            GetRegistryString(key, REG_PRODUCTINFO_URL) ?? DEFAULT_PRODUCTINFO_URL;
+
+        return new UpdaterOverrides(
+            productInfoUrl,
+            DEFAULT_PRODUCTINFO_KEY,
+            false,
+            false,
+            false,
+            false
+        );
+#endif
     }
+
+#if !DEBUG
+    private static void LogIgnoredReleaseOverrides(RegistryKey? key)
+    {
+        if (key is null)
+        {
+            return;
+        }
+
+        foreach (string valueName in RELEASE_IGNORED_REGISTRY_VALUES)
+        {
+            if (key.GetValue(valueName) is not null)
+            {
+                Logger.Warn(
+                    $"Release build is ignoring updater registry value HKLM\\{REGISTRY_PATH}\\{valueName}."
+                );
+            }
+        }
+    }
+#endif
 
     private static string? GetRegistryString(RegistryKey? key, string valueName)
     {
+#pragma warning disable CA1416
         object? value = key?.GetValue(valueName);
+#pragma warning restore CA1416
         if (value is null)
         {
             return null;
@@ -815,9 +773,12 @@ public partial class AutoUpdater
         return parsedValue.Trim();
     }
 
+#if DEBUG
     private static bool GetRegistryBool(RegistryKey? key, string valueName)
     {
+#pragma warning disable CA1416
         object? value = key?.GetValue(valueName);
+#pragma warning restore CA1416
         if (value is null)
         {
             return false;
@@ -839,6 +800,7 @@ public partial class AutoUpdater
             || normalized.Equals("yes", StringComparison.OrdinalIgnoreCase)
             || normalized.Equals("on", StringComparison.OrdinalIgnoreCase);
     }
+#endif
 
     private sealed record UpdateCandidate(
         bool IsUpgradable,
@@ -854,8 +816,7 @@ public partial class AutoUpdater
         bool AllowUnsafeUrls,
         bool SkipHashValidation,
         bool SkipSignerThumbprintCheck,
-        bool DisableTlsValidation,
-        bool UseLegacyGithub
+        bool DisableTlsValidation
     );
 
     private sealed class ProductInfoProduct

--- a/testing/UPDATE-TESTING.md
+++ b/testing/UPDATE-TESTING.md
@@ -1,8 +1,8 @@
-# UniGetUI Auto-Update Testing Guide (productinfo.json path)
+# UniGetUI Auto-Update Testing Guide (ProductInfo-only path)
 
-This guide validates the new default auto-update flow that reads from `productinfo.json`.
+This guide validates the ProductInfo-only auto-update flow that reads from `productinfo.json`.
 
-If `productinfo.json` lookup fails for any reason, UniGetUI now falls back to the legacy updater logic that uses the existing version endpoint and GitHub release download URL.
+UniGetUI no longer falls back to the legacy updater logic. If the ProductInfo lookup fails, the update check fails.
 
 ## Files used
 
@@ -15,11 +15,22 @@ If `productinfo.json` lookup fails for any reason, UniGetUI now falls back to th
 
 ## What is being tested
 
-- Default updater source is productinfo-based.
+- Default updater source is ProductInfo-based.
 - Product key lookup for `Devolutions.UniGetUI`.
 - Architecture-aware installer selection (`x64`/`arm64`, `exe` preferred).
 - Hash validation (enabled by default).
-- Test-only override behavior via registry keys under `HKCU\Software\Devolutions\UniGetUI`.
+- Debug-only override behavior via registry keys under `HKLM\Software\Devolutions\UniGetUI`.
+
+## Release vs Debug behavior
+
+- Release builds honor only `UpdaterProductInfoUrl` from `HKLM\Software\Devolutions\UniGetUI`.
+- Release builds ignore `UpdaterProductKey` and all validation-bypass flags.
+- Debug builds can read updater overrides from `HKLM\Software\Devolutions\UniGetUI` for local testing.
+- Dangerous validation bypasses are for Debug/dev testing only:
+	- `UpdaterAllowUnsafeUrls`
+	- `UpdaterSkipHashValidation`
+	- `UpdaterSkipSignerThumbprintCheck`
+	- `UpdaterDisableTlsValidation`
 
 ## 1) Host the test files locally
 
@@ -39,10 +50,12 @@ Make sure these URLs are reachable:
 
 ## 2) Configure updater overrides (test mode)
 
+These steps apply to a Debug build only.
+
 Run in PowerShell:
 
 ```powershell
-$regPath = 'HKCU:\Software\Devolutions\UniGetUI'
+$regPath = 'HKLM:\Software\Devolutions\UniGetUI'
 New-Item -Path $regPath -Force | Out-Null
 
 # Point updater to local productinfo
@@ -59,9 +72,6 @@ Set-ItemProperty -Path $regPath -Name 'UpdaterSkipHashValidation' -Type DWord -V
 
 # Keep signer thumbprint validation enabled for normal test pass
 Set-ItemProperty -Path $regPath -Name 'UpdaterSkipSignerThumbprintCheck' -Type DWord -Value 0
-
-# Keep legacy path disabled (productinfo path is default)
-Set-ItemProperty -Path $regPath -Name 'UpdaterUseLegacyGithub' -Type DWord -Value 0
 
 # Optional only for HTTPS cert troubleshooting in test environments
 Set-ItemProperty -Path $regPath -Name 'UpdaterDisableTlsValidation' -Type DWord -Value 0
@@ -97,7 +107,7 @@ Expected result:
 Set:
 
 ```powershell
-Set-ItemProperty -Path 'HKCU:\Software\Devolutions\UniGetUI' -Name 'UpdaterAllowUnsafeUrls' -Type DWord -Value 0
+Set-ItemProperty -Path 'HKLM:\Software\Devolutions\UniGetUI' -Name 'UpdaterAllowUnsafeUrls' -Type DWord -Value 0
 ```
 
 Expected result with local `http://127.0.0.1` URLs:
@@ -105,70 +115,57 @@ Expected result with local `http://127.0.0.1` URLs:
 - Updater rejects source/download URL as unsafe.
 - No installer launch.
 
-## 6) Optional: force legacy GitHub updater path
-
-```powershell
-Set-ItemProperty -Path 'HKCU:\Software\Devolutions\UniGetUI' -Name 'UpdaterUseLegacyGithub' -Type DWord -Value 1
-```
-
-Expected result:
-
-- Legacy endpoint/GitHub code path is used.
-- Productinfo path is bypassed for that run.
-
-## 7) Fallback test: broken productinfo with successful legacy fallback
+## 6) Negative test: broken ProductInfo source
 
 Use one of these methods:
 
 - Point `UpdaterProductInfoUrl` to a missing URL, or
 - Point `UpdaterProductInfoUrl` to a malformed JSON file, or
-- Point `UpdaterProductKey` to a non-existent product.
+- In a Debug build only, point `UpdaterProductKey` to a non-existent product.
 
 Example:
 
 ```powershell
-Set-ItemProperty -Path 'HKCU:\Software\Devolutions\UniGetUI' -Name 'UpdaterProductInfoUrl' -Value 'http://127.0.0.1:8080/does-not-exist.json'
-Set-ItemProperty -Path 'HKCU:\Software\Devolutions\UniGetUI' -Name 'UpdaterUseLegacyGithub' -Type DWord -Value 0
+Set-ItemProperty -Path 'HKLM:\Software\Devolutions\UniGetUI' -Name 'UpdaterProductInfoUrl' -Value 'http://127.0.0.1:8080/does-not-exist.json'
 ```
 
 Expected result:
 
 - Productinfo check fails.
-- UniGetUI logs that it is falling back to the legacy GitHub updater source.
-- Legacy updater path is used automatically.
-- If the legacy source has a newer version, the update flow continues normally.
+- UniGetUI reports the update-check failure.
+- No fallback source is used.
 
-## 8) Fallback test: both sources fail
-
-Use a broken productinfo override and also make the legacy source unavailable in your test environment.
-
-Expected result:
-
-- Productinfo check fails first.
-- UniGetUI attempts the legacy updater path.
-- The updater shows the existing terminal error because neither source succeeded.
-
-## 9) Optional: disable signer thumbprint check (test-only)
+## 7) Optional: disable signer thumbprint check (test-only)
 
 Use this only if your local installer is unsigned or signed with a non-Devolutions certificate.
 
 ```powershell
-Set-ItemProperty -Path 'HKCU:\Software\Devolutions\UniGetUI' -Name 'UpdaterSkipSignerThumbprintCheck' -Type DWord -Value 1
+Set-ItemProperty -Path 'HKLM:\Software\Devolutions\UniGetUI' -Name 'UpdaterSkipSignerThumbprintCheck' -Type DWord -Value 1
 ```
 
-## 10) Cleanup after testing
+## 8) Release-build hardening check
+
+Run the same registry override setup against a Release build.
+
+Expected result:
+
+- Release build honors `UpdaterProductInfoUrl` only if it still passes normal source validation.
+- Release build ignores `UpdaterProductKey`.
+- Release build ignores validation bypass flags.
+- Updater uses the configured ProductInfo URL and the built-in `Devolutions.UniGetUI` product key.
+
+## 9) Cleanup after testing
 
 Reset to default production behavior:
 
 ```powershell
-$regPath = 'HKCU:\Software\Devolutions\UniGetUI'
+$regPath = 'HKLM:\Software\Devolutions\UniGetUI'
 Remove-ItemProperty -Path $regPath -Name 'UpdaterProductInfoUrl' -ErrorAction SilentlyContinue
 Remove-ItemProperty -Path $regPath -Name 'UpdaterProductKey' -ErrorAction SilentlyContinue
 Remove-ItemProperty -Path $regPath -Name 'UpdaterAllowUnsafeUrls' -ErrorAction SilentlyContinue
 Remove-ItemProperty -Path $regPath -Name 'UpdaterSkipHashValidation' -ErrorAction SilentlyContinue
 Remove-ItemProperty -Path $regPath -Name 'UpdaterSkipSignerThumbprintCheck' -ErrorAction SilentlyContinue
 Remove-ItemProperty -Path $regPath -Name 'UpdaterDisableTlsValidation' -ErrorAction SilentlyContinue
-Remove-ItemProperty -Path $regPath -Name 'UpdaterUseLegacyGithub' -ErrorAction SilentlyContinue
 ```
 
 With all override values removed, UniGetUI uses:


### PR DESCRIPTION
## Summary
- remove the legacy updater fallback and make the updater rely on the Devolutions ProductInfo flow only
- move updater registry override reads from HKCU to HKLM
- keep Release builds hardened by honoring only `UpdaterProductInfoUrl`, while ignoring `UpdaterProductKey` and all validation-bypass flags
- update the manual updater test guide to reflect the ProductInfo-only and HKLM-based behavior

## Details
This change updates both updater implementations:
- `src/UniGetUI/AutoUpdater.cs`
- `src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs`

Behavior after this change:
- update checks use `https://devolutions.net/productinfo.json` by default
- there is no fallback to the previous marticliment/GitHub mechanism
- Debug builds can still use HKLM overrides for local testing
- Release builds only allow `UpdaterProductInfoUrl` to be overridden from HKLM
- Release builds ignore `UpdaterProductKey`, `UpdaterAllowUnsafeUrls`, `UpdaterSkipHashValidation`, `UpdaterSkipSignerThumbprintCheck`, and `UpdaterDisableTlsValidation`

## Verification
- `dotnet format --verify-no-changes` on the touched updater files
- `dotnet build src/UniGetUI/UniGetUI.csproj -c Debug -p:Platform=x64`
- `dotnet build src/UniGetUI/UniGetUI.csproj -c Release -p:Platform=x64`
- `dotnet build src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj -c Debug -p:Platform=x64`
- `dotnet build src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj -c Release -p:Platform=x64`