### PR TITLE
fix: resolve release notes GitHub tag format

### DIFF
--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesWindow.axaml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,10 +14,8 @@ namespace UniGetUI.Avalonia.Views.Pages;
 
 public partial class ReleaseNotesWindow : Window
 {
-    private readonly string _releaseNotesUrl =
-        $"https://github.com/Devolutions/UniGetUI/releases/tag/{CoreData.VersionName}";
-    private readonly string _releaseNotesApiUrl =
-        $"https://api.github.com/repos/Devolutions/UniGetUI/releases/tags/{Uri.EscapeDataString(CoreData.VersionName)}";
+    private readonly string[] _releaseNotesTags = CoreData.GetGitHubReleaseTagCandidates();
+    private readonly string _releaseNotesUrl = CoreData.GetGitHubReleasePageUrl();
 
     private bool _hasLoadedReleaseNotes;
 
@@ -66,6 +65,7 @@ public partial class ReleaseNotesWindow : Window
     private async Task LoadReleaseNotesAsync()
     {
         SetLoadingState(isLoading: true);
+        string? lastAttemptedApiUrl = null;
 
         try
         {
@@ -75,37 +75,51 @@ public partial class ReleaseNotesWindow : Window
             );
             client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
 
-            using HttpResponseMessage response = await client.GetAsync(_releaseNotesApiUrl);
-            if (!response.IsSuccessStatusCode)
+            foreach (string releaseTag in _releaseNotesTags)
             {
-                throw new HttpRequestException(
-                    $"GitHub API returned status code {(int)response.StatusCode} ({response.StatusCode})."
+                lastAttemptedApiUrl = CoreData.GetGitHubReleaseApiUrlFromTag(releaseTag);
+
+                using HttpResponseMessage response = await client.GetAsync(lastAttemptedApiUrl);
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    continue;
+                }
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new HttpRequestException(
+                        $"GitHub API returned status code {(int)response.StatusCode} ({response.StatusCode})."
+                    );
+                }
+
+                await using Stream responseStream = await response.Content.ReadAsStreamAsync();
+                GitHubReleaseResponse? release = await JsonSerializer.DeserializeAsync<GitHubReleaseResponse>(
+                    responseStream,
+                    SerializationHelpers.DefaultOptions
                 );
+
+                string releaseBody = string.IsNullOrWhiteSpace(release?.Body)
+                    ? CoreTools.Translate("Please try again later")
+                    : release.Body.Replace("\r\n", "\n").Trim();
+
+                UrlTextBoxControl.Text = string.IsNullOrWhiteSpace(release?.HtmlUrl)
+                    ? CoreData.GetGitHubReleasePageUrlFromTag(releaseTag)
+                    : release.HtmlUrl;
+
+                ReleaseNotesTextBlockControl.Text = releaseBody;
+                StatusBlockControl.IsVisible = false;
+                RetryButtonControl.IsVisible = false;
+                LoadingProgressBarControl.IsVisible = false;
+                return;
             }
 
-            await using Stream responseStream = await response.Content.ReadAsStreamAsync();
-            GitHubReleaseResponse? release = await JsonSerializer.DeserializeAsync<GitHubReleaseResponse>(
-                responseStream,
-                SerializationHelpers.DefaultOptions
+            throw new HttpRequestException(
+                $"GitHub API returned 404 for all known release tags for version {CoreData.VersionName}."
             );
-
-            string releaseBody = string.IsNullOrWhiteSpace(release?.Body)
-                ? CoreTools.Translate("Please try again later")
-                : release.Body.Replace("\r\n", "\n").Trim();
-
-            if (!string.IsNullOrWhiteSpace(release?.HtmlUrl))
-            {
-                UrlTextBoxControl.Text = release.HtmlUrl;
-            }
-
-            ReleaseNotesTextBlockControl.Text = releaseBody;
-            StatusBlockControl.IsVisible = false;
-            RetryButtonControl.IsVisible = false;
-            LoadingProgressBarControl.IsVisible = false;
         }
         catch (Exception ex)
         {
-            Logger.Error($"Failed to load release notes from {_releaseNotesApiUrl}");
+            Logger.Error($"Failed to load release notes from {lastAttemptedApiUrl ?? _releaseNotesUrl}");
             Logger.Error(ex);
 
             ReleaseNotesTextBlockControl.Text = string.Empty;

--- a/src/UniGetUI.Core.Data.Tests/CoreTests.cs
+++ b/src/UniGetUI.Core.Data.Tests/CoreTests.cs
@@ -38,5 +38,36 @@ namespace UniGetUI.Core.Data.Tests
                 "The executable file does not exist"
             );
         }
+
+        [Theory]
+        [InlineData("3.3.7", "3.3.7")]
+        [InlineData("2026.1.2", "v2026.1.2")]
+        [InlineData("v2026.1.2", "v2026.1.2")]
+        public void CheckGitHubReleaseTag(string versionName, string expectedTag)
+        {
+            Assert.Equal(expectedTag, CoreData.GetGitHubReleaseTag(versionName));
+        }
+
+        [Fact]
+        public void CheckGitHubReleaseTagCandidatesForCalendarVersion()
+        {
+            Assert.Equal(
+                ["v2026.1.2", "2026.1.2"],
+                CoreData.GetGitHubReleaseTagCandidates("2026.1.2")
+            );
+        }
+
+        [Fact]
+        public void CheckGitHubReleaseUrlsUseEscapedResolvedTag()
+        {
+            Assert.Equal(
+                "https://github.com/Devolutions/UniGetUI/releases/tag/v2026.1.2",
+                CoreData.GetGitHubReleasePageUrlFromTag(CoreData.GetGitHubReleaseTag("2026.1.2"))
+            );
+            Assert.Equal(
+                "https://api.github.com/repos/Devolutions/UniGetUI/releases/tags/3.3.7-beta1",
+                CoreData.GetGitHubReleaseApiUrlFromTag("3.3.7-beta1")
+            );
+        }
     }
 }

--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -6,12 +6,15 @@ namespace UniGetUI.Core.Data
 {
     public static class CoreData
     {
+        private const string GitHubReleasePageBaseUrl = "https://github.com/Devolutions/UniGetUI/releases/tag/";
+        private const string GitHubReleaseApiBaseUrl = "https://api.github.com/repos/Devolutions/UniGetUI/releases/tags/";
+
         private static int? __code_page;
         public static int CODE_PAGE
         {
             get => __code_page ??= GetCodePage();
         }
-        public const string VersionName = "3.3.7"; // Do not modify this line, use file scripts/set-version.ps1
+        public const string VersionName = "2026.1.0"; // Do not modify this line, use file scripts/set-version.ps1
         public const int BuildNumber = 106; // Do not modify this line, use file scripts/set-version.ps1
 
         public const string UserAgentString =
@@ -19,6 +22,65 @@ namespace UniGetUI.Core.Data
 
         public const string AppIdentifier = "MartiCliment.UniGetUI";
         public const string MainWindowIdentifier = "MartiCliment.UniGetUI.MainInterface";
+
+        public static string GetGitHubReleaseTag()
+        {
+            return GetGitHubReleaseTag(VersionName);
+        }
+
+        public static string[] GetGitHubReleaseTagCandidates()
+        {
+            return GetGitHubReleaseTagCandidates(VersionName);
+        }
+
+        public static string GetGitHubReleaseTag(string versionName)
+        {
+            return GetGitHubReleaseTagCandidates(versionName)[0];
+        }
+
+        public static string[] GetGitHubReleaseTagCandidates(string versionName)
+        {
+            string normalizedVersion = string.IsNullOrWhiteSpace(versionName)
+                ? VersionName
+                : versionName.Trim();
+
+            if (normalizedVersion.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+            {
+                return [normalizedVersion];
+            }
+
+            string prefixedTag = $"v{normalizedVersion}";
+            return UsesPrefixedCalendarReleaseTags(normalizedVersion)
+                ? [prefixedTag, normalizedVersion]
+                : [normalizedVersion, prefixedTag];
+        }
+
+        public static string GetGitHubReleasePageUrl()
+        {
+            return GetGitHubReleasePageUrlFromTag(GetGitHubReleaseTag());
+        }
+
+        public static string GetGitHubReleasePageUrlFromTag(string releaseTag)
+        {
+            return GitHubReleasePageBaseUrl + releaseTag;
+        }
+
+        public static string GetGitHubReleaseApiUrlFromTag(string releaseTag)
+        {
+            return GitHubReleaseApiBaseUrl + Uri.EscapeDataString(releaseTag);
+        }
+
+        private static bool UsesPrefixedCalendarReleaseTags(string versionName)
+        {
+            int dotIndex = versionName.IndexOf('.');
+            if (dotIndex != 4 || dotIndex == versionName.Length - 1)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> year = versionName.AsSpan(0, dotIndex);
+            return int.TryParse(year, out int parsedYear) && parsedYear >= 2000;
+        }
 
         private static bool? IS_PORTABLE;
         private static string? PORTABLE_PATH;

--- a/src/UniGetUI/Pages/DialogPages/ReleaseNotes.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/ReleaseNotes.xaml.cs
@@ -32,9 +32,7 @@ namespace UniGetUI.Interface.Dialogs
         private async Task InitializeWebView()
         {
             await WebView.EnsureCoreWebView2Async();
-            WebView.Source = new Uri(
-                "https://github.com/Devolutions/UniGetUI/releases/tag/" + CoreData.VersionName
-            );
+            WebView.Source = new Uri(CoreData.GetGitHubReleasePageUrl());
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- centralize GitHub release tag and URL generation in CoreData
- fix WinUI release notes to open the resolved release page URL
- fix Avalonia release notes to try the resolved GitHub tag candidates before failing
- add regression tests for legacy and Devolutions calendar-version tag formats

## Root cause
Devolutions-branded releases use GitHub tags prefixed with v such as v2026.1.2, while the app was building release note URLs from the raw version string such as 2026.1.2. That caused the Release notes action to open a GitHub 404 page and the Avalonia API lookup to fail.

## Validation
- dotnet test src/UniGetUI.Core.Data.Tests/UniGetUI.Core.Data.Tests.csproj --verbosity minimal --nologo
- dotnet build src/UniGetUI/UniGetUI.csproj --nologo --verbosity minimal -p:Platform=x64 -p:RuntimeIdentifier=win-x64
- dotnet build src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj --nologo --verbosity minimal

Closes #4493