### PR TITLE
Update main UniGetUI homepage links to Devolutions

### DIFF
--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -18,7 +18,7 @@ namespace UniGetUI.Core.Data
         public const int BuildNumber = 106; // Do not modify this line, use file scripts/set-version.ps1
 
         public const string UserAgentString =
-            $"UniGetUI/{VersionName} (https://marticliment.com/unigetui/; contact@marticliment.com)";
+            $"UniGetUI/{VersionName} (https://devolutions.net/unigetui; unigetui@devolutions.net)";
 
         public const string AppIdentifier = "MartiCliment.UniGetUI";
         public const string MainWindowIdentifier = "MartiCliment.UniGetUI.MainInterface";

--- a/src/UniGetUI.Core.Data/Licenses.cs
+++ b/src/UniGetUI.Core.Data/Licenses.cs
@@ -100,7 +100,7 @@ namespace UniGetUI.Core.Data
 
         public static Dictionary<string, Uri> HomepageUrls = new()
         {
-            { "UniGetUI", new Uri("https://marticliment.com/unigetui") },
+            { "UniGetUI", new Uri("https://devolutions.net/unigetui") },
             // C# Libraries
             { "Pickers", new Uri("https://github.com/PavlikBender/Pickers/") },
             { "Community Toolkit", new Uri("https://github.com/CommunityToolkit/Windows/") },

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/SourceFactory.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/SourceFactory.cs
@@ -7,7 +7,7 @@ namespace UniGetUI.PackageEngine.Classes.Manager
     {
         private readonly IPackageManager __manager;
         private readonly ConcurrentDictionary<string, IManagerSource> __reference;
-        private readonly Uri __default_uri = new("https://marticliment.com/unigetui/");
+        private readonly Uri __default_uri = new("https://devolutions.net/unigetui");
 
         public SourceFactory(IPackageManager manager)
         {

--- a/src/UniGetUI/Pages/AboutPages/AboutUniGetUI.xaml
+++ b/src/UniGetUI/Pages/AboutPages/AboutUniGetUI.xaml
@@ -48,7 +48,7 @@
       />
       <HyperlinkButton
         HorizontalAlignment="Stretch"
-        NavigateUri="https://www.marticliment.com/unigetui"
+        NavigateUri="https://devolutions.net/unigetui"
       >
         <widgets:TranslatedTextBlock Text="WingetUI Homepage" />
       </HyperlinkButton>


### PR DESCRIPTION
## Summary
- replace exact homepage references from marticliment.com/unigetui with devolutions.net/unigetui
- update the default source placeholder URL and homepage metadata to the new root page
- keep deeper legacy subpage links unchanged
