### PR TITLE
docs: correct flag for Afrikaans

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ UniGetUI has a built-in autoupdater. However, it can also be updated like any ot
 
 UniGetUI translations are maintained directly in this repository. All supported languages are kept at 100% completion with AI instead of shipping partial translations. If you spot a mistake or want to improve a translation, please open a GitHub issue or submit a pull request.
 
-- <img src='https://flagcdn.com/af.svg' width=20> [Afrikaans](src/UniGetUI.Core.LanguageEngine/Assets/Languages/lang_af.json)
+- <img src='https://flagcdn.com/za.svg' width=20> [Afrikaans](src/UniGetUI.Core.LanguageEngine/Assets/Languages/lang_af.json)
 - <img src='https://flagcdn.com/al.svg' width=20> [Albanian](src/UniGetUI.Core.LanguageEngine/Assets/Languages/lang_sq.json)
 - <img src='https://flagcdn.com/sa.svg' width=20> [Arabic](src/UniGetUI.Core.LanguageEngine/Assets/Languages/lang_ar.json)
 - <img src='https://flagcdn.com/bd.svg' width=20> [Bangla](src/UniGetUI.Core.LanguageEngine/Assets/Languages/lang_bn.json)


### PR DESCRIPTION
The current flag for Afrikaans uses the `af` country code which is Afghanistan, switched to `za` for South Africa

<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

Afrikaans as an official language of [South Africa](https://en.wikipedia.org/wiki/Languages_of_South_Africa) and should use the ZA flag code. Currently the flag code is AF for [Afghanistan](https://en.wikipedia.org/wiki/Languages_of_Afghanistan), which has the official languages of Pashto and Dari.

-----

