### PR TITLE
[DEVOPS] fix(chocolatey): correct URL format for UniGetUI installer

### DIFF
--- a/package/chocolatey/unigetui/tools/chocolateyInstall.template.ps1
+++ b/package/chocolatey/unigetui/tools/chocolateyInstall.template.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 $PackageName = 'unigetui'
-$Url = 'https://cdn.devolutions.net/download/Devolutions.UniGetUI.win-x64.$VAR1$.0.exe'
+$Url = 'https://cdn.devolutions.net/download/Devolutions.UniGetUI.win-x64.$VAR1$.exe'
 
 $PackageArgs = @{
   packageName   = $PackageName


### PR DESCRIPTION
it was pointing to `2026.1.3.0.0`