### PR TITLE
vcpkg - prevent crash when duplicate triplets exist in triplets directories

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Vcpkg/Vcpkg.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Vcpkg/Vcpkg.cs
@@ -550,13 +550,11 @@ namespace UniGetUI.PackageEngine.Managers.VcpkgManager
 
                 foreach (string tripletFile in tripletFiles)
                 {
-                    string triplet = Path.GetFileNameWithoutExtension(tripletFile);
-                    if (!Triplets.Contains(triplet))
-                        Triplets.Add(triplet);
+                    Triplets.Add(Path.GetFileNameWithoutExtension(tripletFile));
                 }
             }
 
-            return Triplets;
+            return Triplets.Distinct().ToList();
         }
     }
 }


### PR DESCRIPTION
GetSystemTriplets() concatenates triplets from both triplets/ and triplets/community/, which can produce duplicate names when the same triplet exists in both directories.    
                            
ComboboxCard.AddItem uses the triplet name as a dictionary key, causing an ArgumentException crash when navigating to the vcpkg settings page.

Fixed by skipping already-seen triplet names when building the list
