### PR TITLE
Fix for issue 4507 - Buttons in dark theme

### DIFF
--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -60,6 +60,7 @@ namespace UniGetUI.Interface
             ExtendsContentIntoTitleBar = true;
             AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
             SetTitleBar(MainContentGrid);
+            MainContentGrid.ActualThemeChanged += (_, _) => ApplyTitleBarButtonColors();
             AppWindow.SetIcon(
                 Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Images", "icon.ico")
             );
@@ -726,6 +727,11 @@ namespace UniGetUI.Interface
                 MainContentGrid.RequestedTheme = ElementTheme.Default;
             }
 
+            ApplyTitleBarButtonColors();
+        }
+
+        private void ApplyTitleBarButtonColors()
+        {
             if (AppWindowTitleBar.IsCustomizationSupported())
             {
                 if (MainApp.Instance.ThemeListener.CurrentTheme == ApplicationTheme.Light)


### PR DESCRIPTION
Fix for issue #4507

Buttons (Collapse, Expand, Close) were not visible in dark mode because they did not update their theme when switching between light and dark modes. This change ensures the buttons correctly adapt to the active theme.