### PR TITLE
Fix missing WinGet updates (issue 4545)

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -480,42 +480,49 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.OtherTask);
         logger.Log("OtherTask: GetWinGetPackagesForUpdates");
 
-        CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = Factory.CreateCreateCompositePackageCatalogOptions();
-        foreach (var catalogRef in WinGetManager.GetPackageCatalogs().ToArray())
+        try
         {
-            logger.Log($"Adding catalog {catalogRef.Info.Name} to composite catalog");
-            createCompositePackageCatalogOptions.Catalogs.Add(catalogRef);
+            CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = Factory.CreateCreateCompositePackageCatalogOptions();
+            foreach (var catalogRef in WinGetManager.GetPackageCatalogs().ToArray())
+            {
+                logger.Log($"Adding catalog {catalogRef.Info.Name} to composite catalog");
+                createCompositePackageCatalogOptions.Catalogs.Add(catalogRef);
+            }
+
+            createCompositePackageCatalogOptions.CompositeSearchBehavior = CompositeSearchBehavior.RemotePackagesFromAllCatalogs;
+            var updateSearchCatalogRef = WinGetManager.CreateCompositePackageCatalog(createCompositePackageCatalogOptions);
+            updateSearchCatalogRef.AcceptSourceAgreements = true;
+            var connectResult = updateSearchCatalogRef.Connect();
+
+            if (connectResult.Status != ConnectResultStatus.Ok)
+            {
+                logger.Error("Failed to connect to update catalog. Aborting.");
+                throw new InvalidOperationException("WinGet: Failed to connect to update catalog.");
+            }
+
+            FindPackagesOptions findPackagesOptions = Factory.CreateFindPackagesOptions();
+            PackageMatchFilter filter = Factory.CreatePackageMatchFilter();
+            filter.Field = PackageMatchField.Id;
+            filter.Option = PackageFieldMatchOption.StartsWithCaseInsensitive;
+            filter.Value = "";
+            findPackagesOptions.Filters.Add(filter);
+
+            var taskResult = connectResult.PackageCatalog.FindPackages(findPackagesOptions);
+            List<CatalogPackage> foundPackages = [];
+            foreach (var match in taskResult.Matches.ToArray())
+            {
+                if (match.CatalogPackage.InstalledVersion is not null)
+                    foundPackages.Add(match.CatalogPackage);
+            }
+
+            logger.Close(0);
+            return foundPackages;
         }
-
-        createCompositePackageCatalogOptions.CompositeSearchBehavior = CompositeSearchBehavior.RemotePackagesFromAllCatalogs;
-        var updateSearchCatalogRef = WinGetManager.CreateCompositePackageCatalog(createCompositePackageCatalogOptions);
-        updateSearchCatalogRef.AcceptSourceAgreements = true;
-        var connectResult = updateSearchCatalogRef.Connect();
-
-        if (connectResult.Status != ConnectResultStatus.Ok)
+        catch
         {
-            logger.Error("Failed to connect to update catalog. Aborting.");
             logger.Close(1);
-            throw new InvalidOperationException("WinGet: Failed to connect to update catalog.");
+            throw;
         }
-
-        FindPackagesOptions findPackagesOptions = Factory.CreateFindPackagesOptions();
-        PackageMatchFilter filter = Factory.CreatePackageMatchFilter();
-        filter.Field = PackageMatchField.Id;
-        filter.Option = PackageFieldMatchOption.StartsWithCaseInsensitive;
-        filter.Value = "";
-        findPackagesOptions.Filters.Add(filter);
-
-        var taskResult = connectResult.PackageCatalog.FindPackages(findPackagesOptions);
-        List<CatalogPackage> foundPackages = [];
-        foreach (var match in taskResult.Matches.ToArray())
-        {
-            if (match.CatalogPackage.InstalledVersion is not null)
-                foundPackages.Add(match.CatalogPackage);
-        }
-
-        logger.Close(0);
-        return foundPackages;
     }
 
     public IReadOnlyList<IManagerSource> GetSources_UnSafe()


### PR DESCRIPTION
## Problem
Users reported that some packages shown as upgradable by `winget upgrade` were not appearing in the UniGetUI updates list. This regression was introduced in d324a0fc, which changed WinGet COM activation to prefer the bundled in-proc DLL over the system COM registration.
The bundled `WindowsPackageManager.dll` does not reliably populate `IsUpdateAvailable` when the composite catalog uses `CompositeSearchBehavior.LocalCatalogs`, causing most updates to be silently skipped.

## Fix
 Introduced `GetWinGetPackagesForUpdates()`, a dedicated catalog query method for update detection that uses `CompositeSearchBehavior.RemotePackagesFromAllCatalogs`. This mirrors the behavior of `winget upgrade` internally and correctly resolves update availability against remote catalog data regardless of which COM activation mode is in use.

The existing `GetLocalWinGetPackages()` with `LocalCatalogs` is preserved for installed packages listing, where it
remains correct and efficient.

Also added an explicit null guard on `DefaultInstallVersion` in `GetAvailableUpdates_UnSafe()` to surface skipped
packages as warnings rather than silent exceptions.