### PR TITLE
Fixed progressRing not centered (Issue 4534)

### DIFF
--- a/src/UniGetUI/Controls/CustomNavViewItem.cs
+++ b/src/UniGetUI/Controls/CustomNavViewItem.cs
@@ -70,6 +70,8 @@ internal sealed partial class CustomNavViewItem : NavigationViewItem
 
         _progressRing = new ProgressRing
         {
+            Width = 24,
+            Height = 24,
             Margin = new Thickness(-42, 0, 0, 0),
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Center,


### PR DESCRIPTION
The ProgressRing defaulted to WinUI’s large size (~80px wide), causing misalignment with the icon.
Setting its Width and Height to 24 (matching the icon) resolves the issue.