### PR TITLE
Remove python from CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,8 +43,6 @@ jobs:
         include:
         - language: csharp
           build-mode: none
-        - language: python
-          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
This change disables CodeQL scans for python. The CodeQL workflows are reporting errors as this repository does not contain python code (see run https://github.com/Devolutions/UniGetUI/actions/runs/24014095018).