### PR TITLE
Retry pip user installs before breaking system packages

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Pip/Helpers/PipPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pip/Helpers/PipPkgOperationHelper.cs
@@ -83,10 +83,19 @@ internal sealed class PipPkgOperationHelper : BasePkgOperationHelper
 
         string output_string = string.Join("\n", processOutput);
 
-        if (output_string.Contains("externally-managed-environment") && !package.OverridenOptions.Pip_BreakSystemPackages)
+        if (output_string.Contains("externally-managed-environment"))
         {
-            package.OverridenOptions.Pip_BreakSystemPackages = true;
-            return OperationVeredict.AutoRetry;
+            if (package.OverridenOptions.Scope != PackageScope.User)
+            {
+                package.OverridenOptions.Scope = PackageScope.User;
+                return OperationVeredict.AutoRetry;
+            }
+
+            if (!package.OverridenOptions.Pip_BreakSystemPackages)
+            {
+                package.OverridenOptions.Pip_BreakSystemPackages = true;
+                return OperationVeredict.AutoRetry;
+            }
         }
 
         if (output_string.Contains("--user") && package.OverridenOptions.Scope != PackageScope.User)
@@ -94,6 +103,7 @@ internal sealed class PipPkgOperationHelper : BasePkgOperationHelper
             package.OverridenOptions.Scope = PackageScope.User;
             return OperationVeredict.AutoRetry;
         }
+
         return OperationVeredict.Failure;
     }
 }


### PR DESCRIPTION
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

This adjusts the pip retry flow for externally managed environments.

When pip reports `externally-managed-environment`, UniGetUI currently retries immediately with `--break-system-packages`. This change makes the first retry use `--user` instead, and only falls back to `--break-system-packages` if the user-scoped retry still cannot proceed.

That keeps the existing fallback in place, but prefers the less invasive pip path first.

Validation:
- Restored and built `src/UniGetUI.PackageEngine.Managers.Pip/UniGetUI.PackageEngine.Managers.Pip.csproj` locally on Windows with `.NET SDK 10.0.104`.
- Restored and built `src/UniGetUI.sln` locally on Windows with `-p:Platform=x64`.
- Used `MSBuildEnableWorkloadResolver=false` during local validation due SDK workload-resolver issues on this machine.

Follow-up to #4542
