### PR TITLE
Migrate crash reporting to Devolutions Cloud and port to Avalonia 

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Platform;
 using Avalonia.Styling;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.Views;
+using UniGetUI.Avalonia.Views.DialogPages;
 using UniGetUI.PackageEngine;
 using CoreSettings = global::UniGetUI.Core.SettingsEngine.Settings;
 
@@ -47,7 +48,7 @@ public partial class App : Application
             ApplyTheme(CoreSettings.GetValue(CoreSettings.K.PreferredTheme));
             var mainWindow = new MainWindow();
             desktop.MainWindow = mainWindow;
-            _ = AvaloniaBootstrapper.InitializeAsync();
+            _ = StartupAsync(mainWindow);
         }
 
         base.OnFrameworkInitializationCompleted();
@@ -78,6 +79,27 @@ public partial class App : Application
                 Environment.SetEnvironmentVariable("PATH", shellPath);
         }
         catch { /* keep the existing PATH if the shell can't be launched */ }
+    }
+
+    private static async Task StartupAsync(MainWindow mainWindow)
+    {
+        // Show crash report from the previous session and wait for the user
+        // to dismiss it before continuing with normal startup.
+        if (File.Exists(CrashHandler.PendingCrashFile))
+        {
+            try
+            {
+                string report = File.ReadAllText(CrashHandler.PendingCrashFile);
+                File.Delete(CrashHandler.PendingCrashFile);
+                // Yield once so the main window has time to open before
+                // ShowDialog tries to attach to it as owner.
+                await Task.Yield();
+                await new CrashReportWindow(report).ShowDialog(mainWindow);
+            }
+            catch { /* must not prevent normal startup */ }
+        }
+
+        await AvaloniaBootstrapper.InitializeAsync();
     }
 
     public static void ApplyTheme(string value)

--- a/src/UniGetUI.Avalonia/CrashHandler.cs
+++ b/src/UniGetUI.Avalonia/CrashHandler.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics;
+using System.Text;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia;
+
+public static class CrashHandler
+{
+    public static readonly string PendingCrashFile =
+        Path.Combine(Path.GetTempPath(), "UniGetUI_pending_crash.txt");
+
+    public static void ReportFatalException(Exception e)
+    {
+        Debugger.Break();
+
+        string langName = "Unknown";
+        try
+        {
+            langName = CoreTools.GetCurrentLocale();
+        }
+        catch { }
+
+        static string GetExceptionData(Exception ex)
+        {
+            try
+            {
+                var b = new StringBuilder();
+                foreach (var key in ex.Data.Keys)
+                    b.AppendLine($"{key}: {ex.Data[key]}");
+                string r = b.ToString();
+                return r.Any() ? r : "No extra data was provided";
+            }
+            catch (Exception inner)
+            {
+                return $"Failed to get exception Data with exception {inner.Message}";
+            }
+        }
+
+        string iReport;
+        try
+        {
+            var integrityReport = IntegrityTester.CheckIntegrity(false);
+            iReport = IntegrityTester.GetReadableReport(integrityReport);
+        }
+        catch (Exception ex)
+        {
+            iReport = "Failed to compute integrity report: " + ex.GetType() + ": " + ex.Message;
+        }
+
+        string errorString = $$"""
+            Environment details:
+                    OS version: {{Environment.OSVersion.VersionString}}
+                    Language: {{langName}}
+                    APP Version: {{CoreData.VersionName}}
+                    APP Build number: {{CoreData.BuildNumber}}
+                    Executable: {{Environment.ProcessPath}}
+                    Command-line arguments: {{Environment.CommandLine}}
+
+            Integrity report:
+                {{iReport.Replace("\n", "\n    ")}}
+
+            Exception type: {{e.GetType()?.Name}} ({{e.GetType()}})
+                Crash HResult: 0x{{(uint)e.HResult:X}} ({{(uint)e.HResult}}, {{e.HResult}})
+                Crash Message: {{e.Message}}
+
+                Crash Data:
+                    {{GetExceptionData(e).Replace("\n", "\n        ")}}
+
+                Crash Trace:
+                    {{e.StackTrace?.Replace("\n", "\n        ")}}
+            """;
+
+        try
+        {
+            int depth = 0;
+            while (e.InnerException is not null)
+            {
+                depth++;
+                e = e.InnerException;
+                errorString +=
+                    "\n\n\n\n"
+                    + $$"""
+                        ———————————————————————————————————————————————————————————
+                        Inner exception details (depth level: {{depth}})
+                            Crash HResult: 0x{{(uint)e.HResult:X}} ({{(uint)e.HResult}}, {{e.HResult}})
+                            Crash Message: {{e.Message}}
+
+                            Crash Data:
+                                {{GetExceptionData(e).Replace("\n", "\n        ")}}
+
+                            Crash Traceback:
+                                {{e.StackTrace?.Replace("\n", "\n        ")}}
+                        """;
+            }
+
+            if (depth == 0)
+                errorString += "\n\n\nNo inner exceptions found";
+        }
+        catch { }
+
+        Console.WriteLine(errorString);
+
+        // Persist crash data so the next normal app launch can show the report.
+        try
+        {
+            File.WriteAllText(PendingCrashFile, errorString, Encoding.UTF8);
+        }
+        catch
+        {
+            // If we can't write the file, nothing more we can do — just exit.
+        }
+
+        Environment.Exit(1);
+    }
+}

--- a/src/UniGetUI.Avalonia/Program.cs
+++ b/src/UniGetUI.Avalonia/Program.cs
@@ -9,8 +9,13 @@ sealed class Program
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            CrashHandler.ReportFatalException((Exception)e.ExceptionObject);
+
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -167,6 +167,9 @@
         <DependentUpon>ManagersHomepage.axaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
+      <Compile Update="Views\DialogPages\CrashReportWindow.axaml.cs">
+        <DependentUpon>CrashReportWindow.axaml</DependentUpon>
+      </Compile>
       <Compile Update="Views\DialogPages\OperationOutputWindow.axaml.cs">
         <DependentUpon>OperationOutputWindow.axaml</DependentUpon>
       </Compile>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
@@ -1,7 +1,8 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.CrashReportWindow"
-        Title="UniGetUI – Crash Report"
+        Title="{t:Translate UniGetUI – Crash Report}"
         Width="800" MinWidth="500"
         Height="580" MinHeight="380"
         CanResize="True"
@@ -14,34 +15,34 @@
 
             <!-- Title + description -->
             <StackPanel Spacing="4">
-                <TextBlock Text="UniGetUI has crashed"
+                <TextBlock Text="{t:Translate UniGetUI has crashed}"
                            FontSize="22"
                            FontWeight="SemiBold"/>
-                <TextBlock Text="Help us fix this by sending a crash report to Devolutions. All fields below are optional."
+                <TextBlock Text="{t:Translate Text='Help us fix this by sending a crash report to Devolutions. All fields below are optional.'}"
                            Opacity="0.7"
                            TextWrapping="Wrap"/>
             </StackPanel>
 
             <!-- Email field -->
             <StackPanel Spacing="4">
-                <TextBlock Text="Email (optional)" FontSize="12" Opacity="0.7"/>
+                <TextBlock Text="{t:Translate Text='Email (optional)'}" FontSize="12" Opacity="0.7"/>
                 <TextBox x:Name="EmailBox"
-                         Watermark="your@email.com"/>
+                         PlaceholderText="{t:Translate Text='your@email.com'}"/>
             </StackPanel>
 
             <!-- Additional details field -->
             <StackPanel Spacing="4">
-                <TextBlock Text="Additional details (optional)" FontSize="12" Opacity="0.7"/>
+                <TextBlock Text="{t:Translate Text='Additional details (optional)'}" FontSize="12" Opacity="0.7"/>
                 <TextBox x:Name="DetailsBox"
                          AcceptsReturn="True"
                          Height="90"
-                         Watermark="Describe what you were doing when the crash occurred…"
+                         PlaceholderText="{t:Translate Text='Describe what you were doing when the crash occurred…'}"
                          TextWrapping="Wrap"/>
             </StackPanel>
 
             <!-- Crash report (read-only) -->
             <StackPanel Spacing="4">
-                <TextBlock Text="Crash report" FontSize="12" Opacity="0.7"/>
+                <TextBlock Text="{t:Translate Text='Crash report'}" FontSize="12" Opacity="0.7"/>
                 <TextBox x:Name="CrashReportText"
                          AcceptsReturn="True"
                          FontFamily="Cascadia Code,Cascadia Mono,Consolas,Menlo,monospace"
@@ -51,15 +52,13 @@
                          TextWrapping="NoWrap"/>
             </StackPanel>
 
-            <!-- Action buttons -->
+            <!-- Action buttons (content set in code-behind for translation) -->
             <StackPanel HorizontalAlignment="Right"
                         Orientation="Horizontal"
                         Spacing="8">
                 <Button x:Name="DontSendButton"
-                        Content="Don't Send"
                         Click="DontSend_Click"/>
                 <Button x:Name="SendButton"
-                        Content="Send Report"
                         Classes="accent"
                         Click="SendReport_Click"/>
             </StackPanel>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
@@ -1,0 +1,70 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="UniGetUI.Avalonia.Views.DialogPages.CrashReportWindow"
+        Title="UniGetUI – Crash Report"
+        Width="800" MinWidth="500"
+        Height="580" MinHeight="380"
+        CanResize="True"
+        ShowInTaskbar="False"
+        Background="{DynamicResource AppDialogBackground}"
+        WindowStartupLocation="CenterOwner">
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="24,20,24,24" Spacing="16">
+
+            <!-- Title + description -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="UniGetUI has crashed"
+                           FontSize="22"
+                           FontWeight="SemiBold"/>
+                <TextBlock Text="Help us fix this by sending a crash report to Devolutions. All fields below are optional."
+                           Opacity="0.7"
+                           TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Email field -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="Email (optional)" FontSize="12" Opacity="0.7"/>
+                <TextBox x:Name="EmailBox"
+                         Watermark="your@email.com"/>
+            </StackPanel>
+
+            <!-- Additional details field -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="Additional details (optional)" FontSize="12" Opacity="0.7"/>
+                <TextBox x:Name="DetailsBox"
+                         AcceptsReturn="True"
+                         Height="90"
+                         Watermark="Describe what you were doing when the crash occurred…"
+                         TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Crash report (read-only) -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="Crash report" FontSize="12" Opacity="0.7"/>
+                <TextBox x:Name="CrashReportText"
+                         AcceptsReturn="True"
+                         FontFamily="Cascadia Code,Cascadia Mono,Consolas,Menlo,monospace"
+                         FontSize="11"
+                         Height="160"
+                         IsReadOnly="True"
+                         TextWrapping="NoWrap"/>
+            </StackPanel>
+
+            <!-- Action buttons -->
+            <StackPanel HorizontalAlignment="Right"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                <Button x:Name="DontSendButton"
+                        Content="Don't Send"
+                        Click="DontSend_Click"/>
+                <Button x:Name="SendButton"
+                        Content="Send Report"
+                        Classes="accent"
+                        Click="SendReport_Click"/>
+            </StackPanel>
+
+        </StackPanel>
+    </ScrollViewer>
+
+</Window>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
@@ -17,13 +17,15 @@ internal sealed partial class CrashReportWindow : Window
         _crashReport = crashReport;
         InitializeComponent();
         CrashReportText.Text = crashReport;
+        DontSendButton.Content = CoreTools.Translate("Don't Send");
+        SendButton.Content = CoreTools.Translate("Send Report");
     }
 
     private async void SendReport_Click(object? sender, RoutedEventArgs e)
     {
         SendButton.IsEnabled = false;
         DontSendButton.IsEnabled = false;
-        SendButton.Content = "Sending…";
+        SendButton.Content = CoreTools.Translate("Sending…");
 
         string email = EmailBox.Text?.Trim() ?? string.Empty;
         string details = DetailsBox.Text?.Trim() ?? string.Empty;

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Nodes;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using UniGetUI.Core.Data;
+using UniGetUI.Core.Tools;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
@@ -46,7 +47,7 @@ internal sealed partial class CrashReportWindow : Window
                 ["productInfo"] = $"UniGetUI {CoreData.VersionName} (Build {CoreData.BuildNumber})"
             };
 
-            using var client = new HttpClient();
+            using var client = new HttpClient(CoreTools.GenericHttpClientParameters);
             client.Timeout = TimeSpan.FromSeconds(10);
             using var content = new StringContent(
                 node.ToJsonString(), Encoding.UTF8, "application/json");

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
@@ -1,0 +1,62 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using UniGetUI.Core.Data;
+
+namespace UniGetUI.Avalonia.Views.DialogPages;
+
+internal sealed partial class CrashReportWindow : Window
+{
+    private readonly string _crashReport;
+
+    public CrashReportWindow(string crashReport)
+    {
+        _crashReport = crashReport;
+        InitializeComponent();
+        CrashReportText.Text = crashReport;
+    }
+
+    private async void SendReport_Click(object? sender, RoutedEventArgs e)
+    {
+        SendButton.IsEnabled = false;
+        DontSendButton.IsEnabled = false;
+        SendButton.Content = "Sending…";
+
+        string email = EmailBox.Text?.Trim() ?? string.Empty;
+        string details = DetailsBox.Text?.Trim() ?? string.Empty;
+
+        await Task.Run(() => SendReport(_crashReport, email, details));
+
+        Close();
+    }
+
+    private void DontSend_Click(object? sender, RoutedEventArgs e) => Close();
+
+    private static void SendReport(string errorBody, string email, string message)
+    {
+        try
+        {
+            var node = new JsonObject
+            {
+                ["email"] = email,
+                ["message"] = message,
+                ["errorMessage"] = errorBody,
+                ["productInfo"] = $"UniGetUI {CoreData.VersionName} (Build {CoreData.BuildNumber})"
+            };
+
+            using var client = new HttpClient();
+            client.Timeout = TimeSpan.FromSeconds(10);
+            using var content = new StringContent(
+                node.ToJsonString(), Encoding.UTF8, "application/json");
+            client.PostAsync(
+                "https://cloud.devolutions.net/api/senderrormessage", content)
+                .GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Network failures must not prevent the window from closing.
+        }
+    }
+}

--- a/src/UniGetUI.Core.LanguageEngine/Assets/Languages/lang_en.json
+++ b/src/UniGetUI.Core.LanguageEngine/Assets/Languages/lang_en.json
@@ -1129,5 +1129,16 @@
   "{pm} could not be found": "{pm} could not be found",
   "{pm} found: {state}": "{pm} found: {state}",
   "{pm} package manager specific preferences": "{pm} package manager specific preferences",
-  "{pm} preferences": "{pm} preferences"
+  "{pm} preferences": "{pm} preferences",
+  "Additional details (optional)": "Additional details (optional)",
+  "Crash report": "Crash report",
+  "Describe what you were doing when the crash occurred…": "Describe what you were doing when the crash occurred…",
+  "Don't Send": "Don't Send",
+  "Email (optional)": "Email (optional)",
+  "Help us fix this by sending a crash report to Devolutions. All fields below are optional.": "Help us fix this by sending a crash report to Devolutions. All fields below are optional.",
+  "Send Report": "Send Report",
+  "Sending…": "Sending…",
+  "UniGetUI – Crash Report": "UniGetUI – Crash Report",
+  "UniGetUI has crashed": "UniGetUI has crashed",
+  "your@email.com": "your@email.com"
 }

--- a/src/UniGetUI/App.xaml.cs
+++ b/src/UniGetUI/App.xaml.cs
@@ -332,6 +332,24 @@ namespace UniGetUI
 
                 // Create MainWindow
                 InitializeMainWindow();
+                MainWindow.Activate();
+
+                // Show crash report from the previous session on top of the loading
+                // screen and wait for the user to dismiss it before continuing.
+                if (File.Exists(CrashHandler.PendingCrashFile))
+                {
+                    try
+                    {
+                        string report = File.ReadAllText(CrashHandler.PendingCrashFile);
+                        File.Delete(CrashHandler.PendingCrashFile);
+                        var tcs = new TaskCompletionSource();
+                        var crashWindow = new CrashReportWindow(report);
+                        crashWindow.Closed += (_, _) => tcs.TrySetResult();
+                        crashWindow.Activate();
+                        await tcs.Task;
+                    }
+                    catch { /* must not prevent normal startup */ }
+                }
 
                 IEnumerable<Task> iniTasks =
                 [

--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.AppNotifications;

--- a/src/UniGetUI/CrashHandler.cs
+++ b/src/UniGetUI/CrashHandler.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.UI.Xaml.Markup;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Tools;
 
@@ -9,6 +8,8 @@ namespace UniGetUI;
 
 public static class CrashHandler
 {
+    public static readonly string PendingCrashFile =
+        Path.Combine(Path.GetTempPath(), "UniGetUI_pending_crash.txt");
     private const uint MB_ICONSTOP = 0x00000010;
     private const uint MB_OKCANCEL = 0x00000001;
     private const uint MB_YESNOCANCEL = 0x00000003;
@@ -16,12 +17,10 @@ public static class CrashHandler
     private const int IDYES = 6;
     private const int IDNO = 7;
 
-    [System.Runtime.InteropServices.DllImport(
-        "user32.dll",
-        CharSet = System.Runtime.InteropServices.CharSet.Unicode
-    )]
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     private static extern int MessageBox(IntPtr hWnd, string lpText, string lpCaption, uint uType);
 
+    // ── Missing-files handler ─────────────────────────────────────────────────
     private static void _reportMissingFiles(out bool showDetailedReport)
     {
         try
@@ -206,19 +205,16 @@ public static class CrashHandler
 
         Console.WriteLine(Error_String);
 
-        string ErrorUrl =
-            $"https://www.marticliment.com/error-report/"
-            + $"?appName=UniGetUI"
-            + $"&appVersion={Uri.EscapeDataString(CoreData.VersionName)}"
-            + $"&buildNumber={Uri.EscapeDataString(CoreData.BuildNumber.ToString())}"
-            + $"&errorBody={Uri.EscapeDataString(Error_String)}";
-        Console.WriteLine(ErrorUrl);
+        // Persist crash data so the next normal app launch can show the report.
+        try
+        {
+            File.WriteAllText(PendingCrashFile, Error_String, Encoding.UTF8);
+        }
+        catch
+        {
+            // If we can't write the file, nothing more we can do — just exit.
+        }
 
-        using Process p = new();
-        p.StartInfo.FileName = ErrorUrl;
-        p.StartInfo.CreateNoWindow = true;
-        p.StartInfo.UseShellExecute = true;
-        p.Start();
         Environment.Exit(1);
     }
 }

--- a/src/UniGetUI/CrashHandler.cs
+++ b/src/UniGetUI/CrashHandler.cs
@@ -10,6 +10,7 @@ public static class CrashHandler
 {
     public static readonly string PendingCrashFile =
         Path.Combine(Path.GetTempPath(), "UniGetUI_pending_crash.txt");
+
     private const uint MB_ICONSTOP = 0x00000010;
     private const uint MB_OKCANCEL = 0x00000001;
     private const uint MB_YESNOCANCEL = 0x00000003;

--- a/src/UniGetUI/CrashReportWindow.xaml
+++ b/src/UniGetUI/CrashReportWindow.xaml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Window
+  x:Class="UniGetUI.CrashReportWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  mc:Ignorable="d"
+  Title="UniGetUI – Crash Report"
+>
+  <Window.SystemBackdrop>
+    <MicaBackdrop Kind="Base" />
+  </Window.SystemBackdrop>
+
+  <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <StackPanel Padding="24" Spacing="16" Margin="0,32,0,0">
+
+      <!-- Title + description -->
+      <StackPanel Spacing="4">
+        <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="UniGetUI has crashed" />
+        <TextBlock
+          Opacity="0.7"
+          Style="{StaticResource BodyTextBlockStyle}"
+          Text="Help us fix this by sending a crash report to Devolutions. All fields below are optional."
+          TextWrapping="WrapWholeWords"
+        />
+      </StackPanel>
+
+      <!-- Optional contact fields -->
+      <TextBox x:Name="EmailBox" Header="Email (optional)" PlaceholderText="your@email.com" />
+      <TextBox
+        x:Name="DetailsBox"
+        AcceptsReturn="True"
+        Header="Additional details (optional)"
+        Height="100"
+        PlaceholderText="Describe what you were doing when the crash occurred…"
+        ScrollViewer.VerticalScrollBarVisibility="Auto"
+        TextWrapping="Wrap"
+      />
+
+      <!-- Crash report (read-only, selectable) -->
+      <TextBox
+        x:Name="CrashReportText"
+        AcceptsReturn="True"
+        FontFamily="Cascadia Code, Consolas"
+        FontSize="11"
+        Header="Crash report"
+        Height="180"
+        IsReadOnly="True"
+        ScrollViewer.HorizontalScrollBarVisibility="Auto"
+        ScrollViewer.VerticalScrollBarVisibility="Auto"
+        TextWrapping="NoWrap"
+      />
+
+      <!-- Action buttons -->
+      <StackPanel
+        HorizontalAlignment="Right"
+        Orientation="Horizontal"
+        Spacing="8"
+      >
+        <Button x:Name="DontSendButton" Click="DontSend_Click" Content="Don't Send" />
+        <Button
+          x:Name="SendButton"
+          Click="SendReport_Click"
+          Content="Send Report"
+          Style="{StaticResource AccentButtonStyle}"
+        />
+      </StackPanel>
+
+    </StackPanel>
+  </ScrollViewer>
+</Window>

--- a/src/UniGetUI/CrashReportWindow.xaml
+++ b/src/UniGetUI/CrashReportWindow.xaml
@@ -17,23 +17,21 @@
 
       <!-- Title + description -->
       <StackPanel Spacing="4">
-        <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="UniGetUI has crashed" />
+        <TextBlock x:Name="TitleText" Style="{StaticResource TitleTextBlockStyle}" />
         <TextBlock
+          x:Name="DescriptionText"
           Opacity="0.7"
           Style="{StaticResource BodyTextBlockStyle}"
-          Text="Help us fix this by sending a crash report to Devolutions. All fields below are optional."
           TextWrapping="WrapWholeWords"
         />
       </StackPanel>
 
       <!-- Optional contact fields -->
-      <TextBox x:Name="EmailBox" Header="Email (optional)" PlaceholderText="your@email.com" />
+      <TextBox x:Name="EmailBox" />
       <TextBox
         x:Name="DetailsBox"
         AcceptsReturn="True"
-        Header="Additional details (optional)"
         Height="100"
-        PlaceholderText="Describe what you were doing when the crash occurred…"
         ScrollViewer.VerticalScrollBarVisibility="Auto"
         TextWrapping="Wrap"
       />
@@ -44,7 +42,6 @@
         AcceptsReturn="True"
         FontFamily="Cascadia Code, Consolas"
         FontSize="11"
-        Header="Crash report"
         Height="180"
         IsReadOnly="True"
         ScrollViewer.HorizontalScrollBarVisibility="Auto"
@@ -52,17 +49,16 @@
         TextWrapping="NoWrap"
       />
 
-      <!-- Action buttons -->
+      <!-- Action buttons (content set in code-behind for translation) -->
       <StackPanel
         HorizontalAlignment="Right"
         Orientation="Horizontal"
         Spacing="8"
       >
-        <Button x:Name="DontSendButton" Click="DontSend_Click" Content="Don't Send" />
+        <Button x:Name="DontSendButton" Click="DontSend_Click" />
         <Button
           x:Name="SendButton"
           Click="SendReport_Click"
-          Content="Send Report"
           Style="{StaticResource AccentButtonStyle}"
         />
       </StackPanel>

--- a/src/UniGetUI/CrashReportWindow.xaml.cs
+++ b/src/UniGetUI/CrashReportWindow.xaml.cs
@@ -3,9 +3,9 @@ using System.Text;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
-using Windows.Graphics;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Tools;
+using Windows.Graphics;
 
 namespace UniGetUI;
 
@@ -31,14 +31,24 @@ internal sealed partial class CrashReportWindow : Window
             ));
         }
 
+        Title = CoreTools.Translate("UniGetUI – Crash Report");
+        TitleText.Text = CoreTools.Translate("UniGetUI has crashed");
+        DescriptionText.Text = CoreTools.Translate("Help us fix this by sending a crash report to Devolutions. All fields below are optional.");
+        EmailBox.Header = CoreTools.Translate("Email (optional)");
+        EmailBox.PlaceholderText = CoreTools.Translate("your@email.com");
+        DetailsBox.Header = CoreTools.Translate("Additional details (optional)");
+        DetailsBox.PlaceholderText = CoreTools.Translate("Describe what you were doing when the crash occurred…");
+        CrashReportText.Header = CoreTools.Translate("Crash report");
         CrashReportText.Text = crashReport;
+        DontSendButton.Content = CoreTools.Translate("Don't Send");
+        SendButton.Content = CoreTools.Translate("Send Report");
     }
 
     private async void SendReport_Click(object sender, RoutedEventArgs e)
     {
         SendButton.IsEnabled = false;
         DontSendButton.IsEnabled = false;
-        SendButton.Content = "Sending…";
+        SendButton.Content = CoreTools.Translate("Sending…");
 
         string email = EmailBox.Text.Trim();
         string details = DetailsBox.Text.Trim();

--- a/src/UniGetUI/CrashReportWindow.xaml.cs
+++ b/src/UniGetUI/CrashReportWindow.xaml.cs
@@ -1,0 +1,80 @@
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using UniGetUI.Core.Data;
+using Windows.Graphics;
+
+namespace UniGetUI;
+
+internal sealed partial class CrashReportWindow : Window
+{
+    private readonly string _crashReport;
+
+    public CrashReportWindow(string crashReport)
+    {
+        _crashReport = crashReport;
+        InitializeComponent();
+        ExtendsContentIntoTitleBar = true;
+
+        var area = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Primary);
+        int w = 1200;
+        int h = 1175;
+        AppWindow.Resize(new SizeInt32(w, h));
+        if (area is not null)
+        {
+            AppWindow.Move(new PointInt32(
+                (area.WorkArea.Width - w) / 2,
+                (area.WorkArea.Height - h) / 2
+            ));
+        }
+
+        CrashReportText.Text = crashReport;
+    }
+
+    private async void SendReport_Click(object sender, RoutedEventArgs e)
+    {
+        SendButton.IsEnabled = false;
+        DontSendButton.IsEnabled = false;
+        SendButton.Content = "Sending…";
+
+        string email = EmailBox.Text.Trim();
+        string details = DetailsBox.Text.Trim();
+
+        await Task.Run(() => SendReport(_crashReport, email, details));
+
+        Close();
+    }
+
+    private void DontSend_Click(object sender, RoutedEventArgs e) => Close();
+
+    private static void SendReport(
+        string errorBody,
+        string email,
+        string message)
+    {
+        try
+        {
+            var node = new JsonObject
+            {
+                ["email"]  = email,
+                ["message"] = message,
+                ["errorMessage"] = errorBody,
+                ["productInfo"] = $"UniGetUI {CoreData.VersionName} (Build {CoreData.BuildNumber})"
+            };
+
+            using var client = new HttpClient();
+            client.Timeout = TimeSpan.FromSeconds(10);
+            using var content = new StringContent(
+                node.ToJsonString(), Encoding.UTF8, "application/json");
+            client.PostAsync(
+                "https://cloud.devolutions.net/api/senderrormessage", content)
+                .GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Network failures must not prevent the window from closing.
+        }
+    }
+}

--- a/src/UniGetUI/CrashReportWindow.xaml.cs
+++ b/src/UniGetUI/CrashReportWindow.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using UniGetUI.Core.Data;
 using Windows.Graphics;
+using UniGetUI.Core.Tools;
 
 namespace UniGetUI;
 
@@ -64,7 +65,7 @@ internal sealed partial class CrashReportWindow : Window
                 ["productInfo"] = $"UniGetUI {CoreData.VersionName} (Build {CoreData.BuildNumber})"
             };
 
-            using var client = new HttpClient();
+            using var client = new HttpClient(CoreTools.GenericHttpClientParameters);
             client.Timeout = TimeSpan.FromSeconds(10);
             using var content = new StringContent(
                 node.ToJsonString(), Encoding.UTF8, "application/json");

--- a/src/UniGetUI/CrashReportWindow.xaml.cs
+++ b/src/UniGetUI/CrashReportWindow.xaml.cs
@@ -3,8 +3,8 @@ using System.Text;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
-using UniGetUI.Core.Data;
 using Windows.Graphics;
+using UniGetUI.Core.Data;
 using UniGetUI.Core.Tools;
 
 namespace UniGetUI;

--- a/src/UniGetUI/CrashReportWindow.xaml.cs
+++ b/src/UniGetUI/CrashReportWindow.xaml.cs
@@ -1,8 +1,8 @@
-using Microsoft.UI.Windowing;
-using Microsoft.UI.Xaml;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json.Nodes;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
 using UniGetUI.Core.Data;
 using Windows.Graphics;
 
@@ -58,7 +58,7 @@ internal sealed partial class CrashReportWindow : Window
         {
             var node = new JsonObject
             {
-                ["email"]  = email,
+                ["email"] = email,
                 ["message"] = message,
                 ["errorMessage"] = errorBody,
                 ["productInfo"] = $"UniGetUI {CoreData.VersionName} (Build {CoreData.BuildNumber})"


### PR DESCRIPTION
- Replaces the old crash-report flow (opening a browser URL) with a POST to `https://cloud.devolutions.net/api/senderrormessage`, so reports land in a structured way without requiring the user to leave the app.
- Adds `CrashReportWindow` (WinUI + Avalonia) — a modal dialog shown on the next normal launch after a crash, letting the user optionally attach their email and additional context before sending or dismissing.
-  Ports the full crash-handler pipeline to the Avalonia shell: `CrashHandler` (cross-platform, no `user32.dll`), `AppDomain.CurrentDomain.UnhandledException` hook in `Program.Main`, and the modal startup gate in `App.axaml.cs`.

### How it works

1.  When the app crashes, `CrashHandler.ReportFatalException` writes the crash report to `%TEMP% UniGetUI_pending_crash.txt` and exits.
2. On the next launch, `StartupAsync` detects the file, deletes it, and shows `CrashReportWindow` as a modal dialog over the main window — the rest of startup is blocked until the user sends or dismisses the report.
3. Sending POSTs a JSON payload `{ email, message, errorMessage, productInfo }` to the Devolutions endpoint; network failures are swallowed silently.

