### PR TITLE
Updating Devolutions.UniGetUi.Elevator to fix the issue #4579. CR:maforest

### DIFF
--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -157,7 +157,7 @@
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference
             Include="Devolutions.UniGetUI.Elevator"
-            Version="2.6.1.1"
+            Version="2.6.1.2"
             GeneratePathProperty="true"
             ExcludeAssets="build;buildTransitive"
         />


### PR DESCRIPTION
elevator is now version 2.6.1.2
