### PR TITLE
Replace test asset URLs with GitHub raw links

### DIFF
--- a/src/UniGetUI.Core.IconEngine.Tests/IconCacheEngineTests.cs
+++ b/src/UniGetUI.Core.IconEngine.Tests/IconCacheEngineTests.cs
@@ -4,10 +4,16 @@ namespace UniGetUI.Core.IconEngine.Tests
 {
     public static class IconCacheEngineTests
     {
+        private const string UniGetUiIconUrl =
+            "https://raw.githubusercontent.com/Devolutions/UniGetUI/main/src/UniGetUI.Core.IconEngine.Tests/TestData/unigetui.png";
+
+        private const string ElevenClockIconUrl =
+            "https://raw.githubusercontent.com/Devolutions/UniGetUI/main/src/UniGetUI.Core.IconEngine.Tests/TestData/elevenclock.png";
+
         [Fact]
         public static void TestCacheEngineForSha256()
         {
-            Uri ICON_1 = new Uri("https://marticliment.com/resources/unigetui.png");
+            Uri ICON_1 = new Uri(UniGetUiIconUrl);
             byte[] HASH_1 =
             [
                 0xB7,
@@ -43,7 +49,7 @@ namespace UniGetUI.Core.IconEngine.Tests
                 0xAF,
                 0xFF,
             ];
-            Uri ICON_2 = new Uri("https://marticliment.com/resources/elevenclock.png");
+            Uri ICON_2 = new Uri(ElevenClockIconUrl);
             byte[] HASH_2 =
             [
                 0x9E,
@@ -134,7 +140,7 @@ namespace UniGetUI.Core.IconEngine.Tests
         [Fact]
         public static void TestCacheEngineForPackageVersion()
         {
-            Uri URI = new Uri("https://marticliment.com/resources/unigetui.png");
+            Uri URI = new Uri(UniGetUiIconUrl);
             string VERSION = "v3.01";
             string MANAGER_NAME = "TestManager";
             string PACKAGE_ID = "Package2";
@@ -189,8 +195,8 @@ namespace UniGetUI.Core.IconEngine.Tests
         [Fact]
         public static void TestCacheEngineForIconUri()
         {
-            Uri URI_1 = new Uri("https://marticliment.com/resources/unigetui.png");
-            Uri URI_2 = new Uri("https://marticliment.com/resources/elevenclock.png");
+            Uri URI_1 = new Uri(UniGetUiIconUrl);
+            Uri URI_2 = new Uri(ElevenClockIconUrl);
             string managerName = "TestManager";
             string packageId = "Package12";
 
@@ -239,9 +245,9 @@ namespace UniGetUI.Core.IconEngine.Tests
         [Fact]
         public static void TestCacheEngineForPackageSize()
         {
-            Uri ICON_1 = new Uri("https://marticliment.com/resources/unigetui.png");
+            Uri ICON_1 = new Uri(UniGetUiIconUrl);
             int ICON_1_SIZE = 19788;
-            Uri ICON_2 = new Uri("https://marticliment.com/resources/elevenclock.png");
+            Uri ICON_2 = new Uri(ElevenClockIconUrl);
             int ICON_2_SIZE = 19747;
             string managerName = "TestManager";
             string packageId = "Package3";

--- a/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
+++ b/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
@@ -270,7 +270,7 @@ namespace UniGetUI.Core.Tools.Tests
             "https://invalid.url.com/this/is/an/invalid.php?file=to_test&if=the&code_returns=zero",
             0
         )]
-        [InlineData("https://marticliment.com/resources/unigetui.png", 19788)]
+        [InlineData("https://raw.githubusercontent.com/Devolutions/UniGetUI/main/src/UniGetUI.Core.IconEngine.Tests/TestData/unigetui.png", 19788)]
         public async Task TestFileSizeLoader(string uri, long expectedSize)
         {
             long size = await CoreTools.GetFileSizeAsLongAsync(uri != "" ? new Uri(uri) : null);


### PR DESCRIPTION
## Summary

- marticliment.com test image links were replaced with GitHub raw URLs for checked-in test assets
- Expected sizes and hashes remain unchanged

## Tests run

- `dotnet test src/UniGetUI.Core.IconEngine.Tests/UniGetUI.Core.IconEngine.Tests.csproj --verbosity minimal --nologo`
- `dotnet test src/UniGetUI.Core.Tools.Tests/UniGetUI.Core.Tools.Tests.csproj --verbosity minimal --nologo`