### PR TITLE
Remove share package feature

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -108,14 +108,6 @@ internal static class AvaloniaBootstrapper
                     MainWindow.Instance?.ShowFromTray();
                 });
 
-            _backgroundApi.OnShowSharedPackage += (_, pkg) =>
-                Dispatcher.UIThread.Post(() =>
-                {
-                    Logger.Info($"BackgroundApi: ShowSharedPackage {pkg.Key}/{pkg.Value}");
-                    MainWindow.Instance?.ShowFromTray();
-                    MainWindow.Instance?.OpenSharedPackage(pkg.Key, pkg.Value);
-                });
-
             _backgroundApi.OnUpgradeAll += (_, _) =>
                 Dispatcher.UIThread.Post(() => _ = AvaloniaPackageOperationHelper.UpdateAllAsync());
 

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -167,11 +167,6 @@ public partial class PackagesPageViewModel : ViewModelBase
     public event Action? HelpRequested;
     /// <summary>Fired when the ViewModel wants to show the Manage-Ignored-Updates dialog.</summary>
     public event Action? ManageIgnoredRequested;
-    /// <summary>
-    /// Fired when the ViewModel has built a share URL.
-    /// Arguments: (packageName, url). Both null means "nothing to share".
-    /// </summary>
-    public event Action<string?, string?>? SharePackageRequested;
 
     // ─── Constructor ─────────────────────────────────────────────────────────
     public PackagesPageViewModel(PackagesPageData data)
@@ -716,22 +711,6 @@ public partial class PackagesPageViewModel : ViewModelBase
     [RelayCommand] private void ClearSourceSelection_Cmd() { ClearSourceSelection(); FilterPackages(); }
     [RelayCommand] private void RequestHelp() => HelpRequested?.Invoke();
     [RelayCommand] private void RequestManageIgnored() => ManageIgnoredRequested?.Invoke();
-
-    [RelayCommand]
-    public void RequestShare(IPackage? package)
-    {
-        if (package is null || package.Source.IsVirtualManager)
-        {
-            SharePackageRequested?.Invoke(null, null);
-            return;
-        }
-        var url = "https://marticliment.com/unigetui/share?"
-            + "name=" + System.Web.HttpUtility.UrlEncode(package.Name)
-            + "&id=" + System.Web.HttpUtility.UrlEncode(package.Id)
-            + "&sourceName=" + System.Web.HttpUtility.UrlEncode(package.Source.Name)
-            + "&managerName=" + System.Web.HttpUtility.UrlEncode(package.Manager.Name);
-        SharePackageRequested?.Invoke(package.Name, url);
-    }
 
     // ─── Sort commands ────────────────────────────────────────────────────────
     [RelayCommand] private void SortByName() => SortFieldIndex = 0;

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -237,13 +237,6 @@ public partial class MainWindow : Window
             as IClassicDesktopStyleApplicationLifetime)?.Shutdown();
     }
 
-    public void OpenSharedPackage(string managerName, string packageId)
-    {
-        // TODO: open package details for the shared package
-        Logger.Info($"OpenSharedPackage: {managerName}/{packageId}");
-        Navigate(PageType.Discover);
-    }
-
     public static void ApplyProxyVariableToProcess()
     {
         try

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -34,22 +34,6 @@ public abstract partial class AbstractPackagesPage : UserControl,
             if (GetMainWindow() is { } win)
                 await new ManageIgnoredUpdatesWindow().ShowDialog(win);
         };
-        ViewModel.SharePackageRequested += async (pkgName, url) =>
-        {
-            if (GetMainWindow() is not { } win) return;
-            if (url is null)
-            {
-                await ViewModel.ShowInfoDialog(win,
-                    CoreTools.Translate("Nothing to share"),
-                    CoreTools.Translate("Please select a package first."));
-                return;
-            }
-            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
-            if (clipboard is not null) await clipboard.SetTextAsync(url);
-            await ViewModel.ShowInfoDialog(win,
-                CoreTools.Translate("Share link copied"),
-                CoreTools.Translate("The share link for {0} has been copied to the clipboard.", pkgName ?? ""));
-        };
 
         // "New version" sort option is only relevant on the updates page
         OrderByNewVersion_Menu.IsVisible = ViewModel.RoleIsUpdateLike;

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/DiscoverSoftwarePage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/DiscoverSoftwarePage.cs
@@ -1,4 +1,3 @@
-using System.Web;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -73,8 +72,6 @@ public class DiscoverSoftwarePage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("info_round", CoreTools.Translate("Package details"),
             () => _ = ShowDetailsForPackage(SelectedItem), showLabel: false);
-        ViewModel.AddToolbarButton("share", CoreTools.Translate("Share"),
-            () => vm.RequestShareCommand.Execute(SelectedItem), showLabel: false);
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("add_to", CoreTools.Translate("Add selection to bundle"),
             () => _ = ExportSelectionToBundleAsync(vm));
@@ -121,9 +118,6 @@ public class DiscoverSoftwarePage : AbstractPackagesPage
         var menuInstallOptions = new MenuItem { Header = CoreTools.AutoTranslated("Install options"), Icon = LoadMenuIcon("options") };
         menuInstallOptions.Click += (_, _) => _ = ShowInstallationOptionsForPackage(SelectedItem);
 
-        var menuShare = new MenuItem { Header = CoreTools.AutoTranslated("Share this package"), Icon = LoadMenuIcon("share") };
-        menuShare.Click += (_, _) => ViewModel.RequestShareCommand.Execute(SelectedItem);
-
         var menuDetails = new MenuItem { Header = CoreTools.AutoTranslated("Package details"), Icon = LoadMenuIcon("info_round") };
         menuDetails.Click += (_, _) => _ = ShowDetailsForPackage(SelectedItem);
 
@@ -137,7 +131,6 @@ public class DiscoverSoftwarePage : AbstractPackagesPage
         menu.Items.Add(_menuSkipHash);
         menu.Items.Add(_menuDownloadInstaller);
         menu.Items.Add(new Separator());
-        menu.Items.Add(menuShare);
         menu.Items.Add(menuDetails);
 
         return menu;

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
@@ -27,7 +27,6 @@ public class InstalledPackagesPage : AbstractPackagesPage
     private MenuItem? _menuReinstall;
     private MenuItem? _menuUninstallThenReinstall;
     private MenuItem? _menuIgnoreUpdates;
-    private MenuItem? _menuShare;
     private MenuItem? _menuDetails;
     private MenuItem? _menuOpenInstallLocation;
     private MenuItem? _menuDownloadInstaller;
@@ -90,8 +89,6 @@ public class InstalledPackagesPage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("info_round", CoreTools.Translate("Package details"),
             () => _ = ShowDetailsForPackage(SelectedItem), showLabel: false);
-        ViewModel.AddToolbarButton("share", CoreTools.Translate("Share"),
-            () => vm.RequestShareCommand.Execute(SelectedItem), showLabel: false);
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("pin", CoreTools.Translate("Ignore selected packages"), async () =>
         {
@@ -188,13 +185,6 @@ public class InstalledPackagesPage : AbstractPackagesPage
         };
         _menuIgnoreUpdates.Click += (_, _) => _ = ToggleIgnoreUpdatesAsync(SelectedItem);
 
-        _menuShare = new MenuItem
-        {
-            Header = CoreTools.AutoTranslated("Share this package"),
-            Icon = LoadMenuIcon("share"),
-        };
-        _menuShare.Click += (_, _) => ViewModel.RequestShareCommand.Execute(SelectedItem);
-
         _menuDetails = new MenuItem
         {
             Header = CoreTools.AutoTranslated("Package details"),
@@ -219,7 +209,6 @@ public class InstalledPackagesPage : AbstractPackagesPage
         menu.Items.Add(new Separator());
         menu.Items.Add(_menuIgnoreUpdates);
         menu.Items.Add(new Separator());
-        menu.Items.Add(_menuShare);
         menu.Items.Add(_menuDetails);
 
         return menu;
@@ -230,7 +219,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
         if (_menuAsAdmin is null || _menuInteractive is null || _menuRemoveData is null
             || _menuInstallationOptions is null || _menuReinstall is null
             || _menuUninstallThenReinstall is null || _menuIgnoreUpdates is null
-            || _menuShare is null || _menuDetails is null
+            || _menuDetails is null
             || _menuOpenInstallLocation is null || _menuDownloadInstaller is null)
         {
             Logger.Warn("Context menu items are null on InstalledPackagesPage");
@@ -247,7 +236,6 @@ public class InstalledPackagesPage : AbstractPackagesPage
         _menuInstallationOptions.IsEnabled = !isLocal;
         _menuReinstall.IsEnabled = !isLocal;
         _menuUninstallThenReinstall.IsEnabled = !isLocal;
-        _menuShare.IsEnabled = !isLocal;
         _menuDetails.IsEnabled = !isLocal;
         _menuOpenInstallLocation.IsEnabled =
             package.Manager.DetailsHelper.GetInstallLocation(package) is not null;

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
@@ -34,7 +34,6 @@ public class PackageBundlesPage : AbstractPackagesPage
     private MenuItem? _menuInteractive;
     private MenuItem? _menuSkipHash;
     private MenuItem? _menuDownloadInstaller;
-    private MenuItem? _menuShare;
     private MenuItem? _menuDetails;
 
     private readonly PackageBundlesLoader _loader;
@@ -113,8 +112,6 @@ public class PackageBundlesPage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("info_round", CoreTools.Translate("Package details"),
             () => _ = ShowDetailsForPackage(SelectedItem), showLabel: false);
-        ViewModel.AddToolbarButton("share", CoreTools.Translate("Share"),
-            () => vm.RequestShareCommand.Execute(SelectedItem), showLabel: false);
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("help", CoreTools.Translate("Help"),
             () => vm.RequestHelpCommand.Execute(null));
@@ -168,9 +165,6 @@ public class PackageBundlesPage : AbstractPackagesPage
             }
         };
 
-        _menuShare = new MenuItem { Header = CoreTools.AutoTranslated("Share this package"), Icon = LoadMenuIcon("share") };
-        _menuShare.Click += (_, _) => ViewModel.RequestShareCommand.Execute(SelectedItem);
-
         _menuDetails = new MenuItem { Header = CoreTools.AutoTranslated("Package details"), Icon = LoadMenuIcon("info_round") };
         _menuDetails.Click += (_, _) => _ = ShowDetailsForPackage(SelectedItem);
 
@@ -186,7 +180,6 @@ public class PackageBundlesPage : AbstractPackagesPage
         menu.Items.Add(new Separator());
         menu.Items.Add(menuRemoveFromList);
         menu.Items.Add(new Separator());
-        menu.Items.Add(_menuShare);
         menu.Items.Add(_menuDetails);
         return menu;
     }
@@ -195,7 +188,7 @@ public class PackageBundlesPage : AbstractPackagesPage
     {
         if (_menuInstall is null || _menuInstallOptions is null || _menuAsAdmin is null
             || _menuInteractive is null || _menuSkipHash is null || _menuDownloadInstaller is null
-            || _menuShare is null || _menuDetails is null)
+            || _menuDetails is null)
         {
             Logger.Warn("Context menu items are null on PackageBundlesPage");
             return;
@@ -210,7 +203,6 @@ public class PackageBundlesPage : AbstractPackagesPage
         _menuInteractive.IsEnabled = isValid && caps.CanRunInteractively;
         _menuSkipHash.IsEnabled = isValid && caps.CanSkipIntegrityChecks;
         _menuDownloadInstaller.IsEnabled = isValid && caps.CanDownloadInstaller;
-        _menuShare.IsEnabled = isValid;
         _menuDetails.IsEnabled = isValid;
     }
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -84,8 +84,6 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("info_round", CoreTools.Translate("Package details"),
             () => _ = ShowDetailsForPackage(SelectedItem), showLabel: false);
-        ViewModel.AddToolbarButton("share", CoreTools.Translate("Share"),
-            () => vm.RequestShareCommand.Execute(SelectedItem), showLabel: false);
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("pin", CoreTools.Translate("Ignore selected packages"), async () =>
         {
@@ -229,13 +227,6 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
             menuPause.Items.Add(item);
         }
 
-        var menuShare = new MenuItem
-        {
-            Header = CoreTools.AutoTranslated("Share this package"),
-            Icon = LoadMenuIcon("share"),
-        };
-        menuShare.Click += (_, _) => ViewModel.RequestShareCommand.Execute(SelectedItem);
-
         var menuDetails = new MenuItem
         {
             Header = CoreTools.AutoTranslated("Package details"),
@@ -261,7 +252,6 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         menu.Items.Add(menuSkipVersion);
         menu.Items.Add(menuPause);
         menu.Items.Add(new Separator());
-        menu.Items.Add(menuShare);
         menu.Items.Add(menuDetails);
 
         return menu;

--- a/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
+++ b/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
@@ -25,7 +25,6 @@ namespace UniGetUI.Interface
     {
         public event EventHandler<EventArgs>? OnOpenWindow;
         public event EventHandler<EventArgs>? OnOpenUpdatesPage;
-        public event EventHandler<KeyValuePair<string, string>>? OnShowSharedPackage;
         public event EventHandler<EventArgs>? OnUpgradeAll;
         public event EventHandler<string>? OnUpgradeAllForManager;
         public event EventHandler<string>? OnUpgradePackage;
@@ -62,7 +61,6 @@ namespace UniGetUI.Interface
                     app.UseRouting();
                     app.UseEndpoints(endpoints =>
                     {
-                        // Share endpoints
                         endpoints.MapGet("/v2/show-package", V2_ShowPackage);
                         endpoints.MapGet("/is-running", API_IsRunning);
                         // Widgets v1 API
@@ -98,21 +96,10 @@ namespace UniGetUI.Interface
 
         private async Task V2_ShowPackage(HttpContext context)
         {
-            var query = context.Request.Query;
-            if (string.IsNullOrEmpty(query["pid"]) || string.IsNullOrEmpty(query["psource"]))
-            {
-                context.Response.StatusCode = 400;
-                return;
-            }
-
-            string packageId = query["pid"].ToString();
-            string packageSource = query["psource"].ToString();
-            OnShowSharedPackage?.Invoke(
-                null,
-                new KeyValuePair<string, string>(packageId, packageSource)
+            context.Response.StatusCode = StatusCodes.Status410Gone;
+            await context.Response.WriteAsync(
+                "{\"status\": \"removed\", \"message\": \"package sharing has been removed\"}"
             );
-
-            await context.Response.WriteAsync("{\"status\": \"success\"}");
         }
 
         private async Task API_IsRunning(HttpContext context)

--- a/src/UniGetUI.Interface.Telemetry/TelemetryHandler.cs
+++ b/src/UniGetUI.Interface.Telemetry/TelemetryHandler.cs
@@ -19,7 +19,6 @@ public enum TEL_InstallReferral
 {
     DIRECT_SEARCH,
     FROM_BUNDLE,
-    FROM_WEB_SHARE,
     ALREADY_INSTALLED,
 }
 
@@ -207,9 +206,6 @@ public static class TelemetryHandler
 
     public static void PackageDetails(IPackage package, string eventSource) =>
         _ = TrackPackageEventAsync(package, "details", eventSource: eventSource);
-
-    public static void SharedPackage(IPackage package, string eventSource) =>
-        _ = TrackPackageEventAsync(package, "share", eventSource: eventSource);
 
     private static async Task TrackPackageEventAsync(
         IPackage package,

--- a/src/UniGetUI/App.xaml.cs
+++ b/src/UniGetUI/App.xaml.cs
@@ -418,12 +418,6 @@ namespace UniGetUI
                         MainWindow?.Activate();
                     });
 
-                BackgroundApi.OnShowSharedPackage += (_, package) =>
-                    MainWindow.DispatcherQueue.TryEnqueue(() =>
-                    {
-                        DialogHelper.ShowSharedPackage_ThreadSafe(package.Key, package.Value);
-                    });
-
                 BackgroundApi.OnUpgradeAll += (_, _) =>
                     MainWindow.DispatcherQueue.TryEnqueue(() =>
                     {

--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -311,28 +311,7 @@ namespace UniGetUI.Interface
 
             if (baseUrl.StartsWith("showPackage"))
             {
-                string Id = Regex.Match(baseUrl, "id=([^&]+)").Value.Split("=")[^1];
-                string CombinedManagerName = Regex
-                    .Match(baseUrl, "combinedManagerName=([^&]+)")
-                    .Value.Split("=")[^1];
-                string ManagerName = Regex.Match(baseUrl, "managerName=([^&]+)").Value.Split("=")[
-                    ^1
-                ];
-                string SourceName = Regex.Match(baseUrl, "sourceName=([^&]+)").Value.Split("=")[^1];
-
-                if (Id != "" && CombinedManagerName != "" && ManagerName == "" && SourceName == "")
-                {
-                    Logger.Warn($"URI {link} follows old scheme");
-                    DialogHelper.ShowSharedPackage_ThreadSafe(Id, CombinedManagerName);
-                }
-                else if (Id != "" && ManagerName != "" && SourceName != "")
-                {
-                    DialogHelper.ShowSharedPackage_ThreadSafe(Id, ManagerName, SourceName);
-                }
-                else
-                {
-                    Logger.Error(new UriFormatException($"Malformed URL {link}"));
-                }
+                Logger.Warn($"Ignoring unsupported package-share deep link: {link}");
             }
             else if (baseUrl.StartsWith("showUniGetUI"))
             {

--- a/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
+++ b/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
@@ -1,4 +1,3 @@
-using System.Web;
 using ABI.Microsoft.UI.Text;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
@@ -17,7 +16,6 @@ using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.PackageLoader;
 using UniGetUI.PackageEngine.Serializable;
 using UniGetUI.Pages.SettingsPages.GeneralPages;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Text;
 
 namespace UniGetUI.Pages.DialogPages;
@@ -181,84 +179,6 @@ public static partial class DialogHelper
         return await ShowDialogAsync(dialog) is ContentDialogResult.Primary;
     }
 
-    public static void ShowSharedPackage_ThreadSafe(string id, string combinedSourceName)
-    {
-        var contents = combinedSourceName.Split(':');
-        string managerName = contents[0];
-        string sourceName = "";
-        if (contents.Length > 1)
-            sourceName = contents[1];
-        _ = GetPackageFromIdAndManager(id, managerName, sourceName, "LEGACY_COMBINEDSOURCE");
-    }
-
-    public static void ShowSharedPackage_ThreadSafe(
-        string id,
-        string managerName,
-        string sourceName
-    )
-    {
-        MainApp.Instance.MainWindow.DispatcherQueue.TryEnqueue(() =>
-        {
-            _ = GetPackageFromIdAndManager(id, managerName, sourceName, "DEFAULT");
-        });
-    }
-
-    private static async Task GetPackageFromIdAndManager(
-        string id,
-        string managerName,
-        string sourceName,
-        string eventSource
-    )
-    {
-        int loadingId = ShowLoadingDialog(CoreTools.Translate("Please wait..."));
-        try
-        {
-            Window.Activate();
-
-            var findResult = await Task.Run(() =>
-                DiscoverablePackagesLoader.Instance.GetPackageFromIdAndManager(
-                    id,
-                    managerName,
-                    sourceName
-                )
-            );
-
-            HideLoadingDialog(loadingId);
-
-            if (findResult.Item1 is null)
-                throw new KeyNotFoundException(findResult.Item2 ?? "Unknown error");
-
-            TelemetryHandler.SharedPackage(findResult.Item1, eventSource);
-            _ = ShowPackageDetails(
-                findResult.Item1,
-                OperationType.Install,
-                TEL_InstallReferral.FROM_WEB_SHARE
-            );
-        }
-        catch (Exception ex)
-        {
-            Logger.Error($"An error occurred while attempting to show the package with id {id}");
-            HideLoadingDialog(loadingId);
-
-            var warningDialog = new ContentDialog
-            {
-                Title = CoreTools.Translate("Package not found"),
-                Content =
-                    CoreTools.Translate(
-                        "An error occurred when attempting to show the package with Id {0}",
-                        id
-                    )
-                    + ":\n"
-                    + ex.Message,
-                CloseButtonText = CoreTools.Translate("Ok"),
-                DefaultButton = ContentDialogButton.Close,
-                XamlRoot = MainApp.Instance.MainWindow.Content.XamlRoot, // Ensure the dialog is shown in the correct context
-            };
-
-            await ShowDialogAsync(warningDialog);
-        }
-    }
-
     public static async Task ShowBundleSecurityReport(
         Dictionary<string, List<BundleReportEntry>> packageReport
     )
@@ -388,56 +308,6 @@ public static partial class DialogHelper
         };
         dialog.SecondaryButtonText = CoreTools.Translate("Close");
         await ShowDialogAsync(dialog);
-    }
-
-    public static void SharePackage(IPackage? package)
-    {
-        if (package is null)
-            return;
-
-        if (package.Source.IsVirtualManager || package is InvalidImportedPackage)
-        {
-            DialogHelper.ShowDismissableBalloon(
-                CoreTools.Translate("Something went wrong"),
-                CoreTools.Translate("\"{0}\" is a local package and can't be shared", package.Name)
-            );
-            return;
-        }
-
-        IntPtr hWnd = Window.GetWindowHandle();
-
-        NativeHelpers.IDataTransferManagerInterop interop =
-            DataTransferManager.As<NativeHelpers.IDataTransferManagerInterop>();
-
-        IntPtr result = interop.GetForWindow(hWnd, NativeHelpers._dtm_iid);
-        DataTransferManager dataTransferManager =
-            WinRT.MarshalInterface<DataTransferManager>.FromAbi(result);
-
-        dataTransferManager.DataRequested += (_, args) =>
-        {
-            DataRequest dataPackage = args.Request;
-            Uri ShareUrl = new(
-                "https://marticliment.com/unigetui/share?"
-                    + "name="
-                    + HttpUtility.UrlEncode(package.Name)
-                    + "&id="
-                    + HttpUtility.UrlEncode(package.Id)
-                    + "&sourceName="
-                    + HttpUtility.UrlEncode(package.Source.Name)
-                    + "&managerName="
-                    + HttpUtility.UrlEncode(package.Manager.DisplayName)
-            );
-
-            dataPackage.Data.SetWebLink(ShareUrl);
-            dataPackage.Data.Properties.Title = "Sharing " + package.Name;
-            dataPackage.Data.Properties.ApplicationName = "WingetUI";
-            dataPackage.Data.Properties.ContentSourceWebLink = ShareUrl;
-            dataPackage.Data.Properties.Description =
-                "Share " + package.Name + " with your friends";
-            dataPackage.Data.Properties.PackageFamilyName = "WingetUI";
-        };
-
-        interop.ShowShareUIForWindow(hWnd);
     }
 
     /// <summary>

--- a/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml
+++ b/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml
@@ -118,38 +118,16 @@
           </Paragraph>
         </RichTextBlock>
 
-        <!--  Install and Share button  -->
+        <!--  Main action button  -->
         <Grid Name="ActionsPanel" VerticalAlignment="Top" ColumnSpacing="8" RowSpacing="8">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="10000*" MaxWidth="250" />
-            <ColumnDefinition Width="*" MinWidth="16" />
             <ColumnDefinition Width="10000*" MaxWidth="250" />
           </Grid.ColumnDefinitions>
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
           </Grid.RowDefinitions>
-          <Button
-            Name="ShareButton"
-            Grid.Column="0"
-            Height="40"
-            HorizontalAlignment="Stretch"
-            HorizontalContentAlignment="Center"
-            Click="ShareButton_Click"
-            CornerRadius="8"
-          >
-            <StackPanel
-              HorizontalAlignment="Center"
-              VerticalAlignment="Center"
-              Orientation="Horizontal"
-              Spacing="8"
-            >
-              <widgets:LocalIcon Width="20" Height="20" Icon="share" />
-              <widgets:TranslatedTextBlock VerticalAlignment="Center" Text="Share this package" />
-            </StackPanel>
-          </Button>
-
-          <Grid Grid.Column="2">
+          <Grid Grid.Column="0">
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="*" />
               <ColumnDefinition Width="Auto" />

--- a/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/PackageDetailsPage.xaml.cs
@@ -558,11 +558,6 @@ namespace UniGetUI.Interface.Dialogs
             PackageDetailsPage_SizeChanged();
         }
 
-        public void ShareButton_Click(object sender, RoutedEventArgs e)
-        {
-            DialogHelper.SharePackage(Package);
-        }
-
         public void DownloadInstallerButton_Click(object sender, RoutedEventArgs e)
         {
             if (!Package.Manager.Capabilities.CanDownloadInstaller)

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -1219,14 +1219,6 @@ namespace UniGetUI.Interface
             CoreTools.Launch(path);
         }
 
-        protected void SharePackage(IPackage? package)
-        {
-            if (package is null)
-                return;
-
-            DialogHelper.SharePackage(package);
-        }
-
         protected async Task ShowInstallationOptionsForPackage(IPackage? package)
         {
             if (package is null)

--- a/src/UniGetUI/Pages/SoftwarePages/DiscoverSoftwarePage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/DiscoverSoftwarePage.cs
@@ -141,14 +141,6 @@ namespace UniGetUI.Interface.SoftwarePages
 
             menu.Items.Add(new MenuFlyoutSeparator { Height = 5 });
 
-            BetterMenuItem menuShare = new()
-            {
-                Text = CoreTools.AutoTranslated("Share this package"),
-                IconName = IconType.Share,
-            };
-            menuShare.Click += MenuShare_Invoked;
-            menu.Items.Add(menuShare);
-
             BetterMenuItem menuDetails = new()
             {
                 Text = CoreTools.AutoTranslated("Package details"),
@@ -186,7 +178,6 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton InstallationSettings = new();
 
             AppBarButton PackageDetails = new();
-            AppBarButton SharePackage = new();
 
             AppBarButton ExportSelection = new();
 
@@ -196,7 +187,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ToolBar.PrimaryCommands.Add(InstallationSettings);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(PackageDetails);
-            ToolBar.PrimaryCommands.Add(SharePackage);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(ExportSelection);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
@@ -211,7 +201,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { DownloadInstallers, CoreTools.Translate("Download selected installers") },
                 { InstallationSettings, CoreTools.Translate("Install options") },
                 { PackageDetails, " " + CoreTools.Translate("Package details") },
-                { SharePackage, " " + CoreTools.Translate("Share") },
                 { ExportSelection, CoreTools.Translate("Add selection to bundle") },
                 { HelpButton, CoreTools.Translate("Help") },
             };
@@ -224,7 +213,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { DownloadInstallers, IconType.Download },
                 { InstallInteractive, IconType.Interactive },
                 { PackageDetails, IconType.Info_Round },
-                { SharePackage, IconType.Share },
                 { ExportSelection, IconType.AddTo },
                 { HelpButton, IconType.Help },
             };
@@ -267,7 +255,6 @@ namespace UniGetUI.Interface.SoftwarePages
                     TEL_InstallReferral.DIRECT_SEARCH
                 );
 
-            SharePackage.Click += (_, _) => DialogHelper.SharePackage(SelectedItem);
         }
 
         public override async Task LoadPackages()
@@ -329,14 +316,6 @@ namespace UniGetUI.Interface.SoftwarePages
         private void MenuDetails_Invoked(object sender, RoutedEventArgs e)
         {
             ShowDetailsForPackage(SelectedItem, TEL_InstallReferral.DIRECT_SEARCH);
-        }
-
-        private void MenuShare_Invoked(object sender, RoutedEventArgs e)
-        {
-            if (SelectedItem is null)
-                return;
-
-            DialogHelper.SharePackage(SelectedItem);
         }
 
         private void MenuInstall_Invoked(object sender, RoutedEventArgs e) =>

--- a/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
@@ -30,7 +30,6 @@ namespace UniGetUI.Interface.SoftwarePages
         private BetterMenuItem? MenuReinstallPackage;
         private BetterMenuItem? MenuUninstallThenReinstall;
         private BetterMenuItem? MenuIgnoreUpdates;
-        private BetterMenuItem? MenuSharePackage;
         private BetterMenuItem? MenuPackageDetails;
         private BetterMenuItem? MenuOpenInstallLocation;
         private BetterMenuItem? MenuDownloadInstaller;
@@ -168,14 +167,6 @@ namespace UniGetUI.Interface.SoftwarePages
 
             menu.Items.Add(new MenuFlyoutSeparator());
 
-            MenuSharePackage = new()
-            {
-                Text = CoreTools.AutoTranslated("Share this package"),
-                IconName = IconType.Share,
-            };
-            MenuSharePackage.Click += MenuShare_Invoked;
-            menu.Items.Add(MenuSharePackage);
-
             MenuPackageDetails = new()
             {
                 Text = CoreTools.AutoTranslated("Package details"),
@@ -211,7 +202,6 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton InstallationSettings = new();
 
             AppBarButton PackageDetails = new();
-            AppBarButton SharePackage = new();
 
             AppBarButton IgnoreSelected = new();
             AppBarButton ManageIgnored = new();
@@ -223,7 +213,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ToolBar.PrimaryCommands.Add(InstallationSettings);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(PackageDetails);
-            ToolBar.PrimaryCommands.Add(SharePackage);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(IgnoreSelected);
             ToolBar.PrimaryCommands.Add(ManageIgnored);
@@ -240,7 +229,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { DownloadInstallers, CoreTools.Translate("Download selected installers") },
                 { InstallationSettings, " " + CoreTools.Translate("Uninstall options") },
                 { PackageDetails, " " + CoreTools.Translate("Package details") },
-                { SharePackage, " " + CoreTools.Translate("Share") },
                 { IgnoreSelected, CoreTools.Translate("Ignore selected packages") },
                 { ManageIgnored, CoreTools.Translate("Manage ignored updates") },
                 { ExportSelection, CoreTools.Translate("Add selection to bundle") },
@@ -254,7 +242,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { DownloadInstallers, IconType.Download },
                 { InstallationSettings, IconType.Options },
                 { PackageDetails, IconType.Info_Round },
-                { SharePackage, IconType.Share },
                 { IgnoreSelected, IconType.Pin },
                 { ManageIgnored, IconType.ClipboardList },
                 { ExportSelection, IconType.AddTo },
@@ -300,7 +287,6 @@ namespace UniGetUI.Interface.SoftwarePages
                     FilteredPackages.GetCheckedPackages(),
                     TEL_InstallReferral.ALREADY_INSTALLED
                 );
-            SharePackage.Click += (_, _) => DialogHelper.SharePackage(SelectedItem);
         }
 
         protected override void WhenPackageCountUpdated()
@@ -353,7 +339,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 || MenuUninstallThenReinstall is null
                 || MenuReinstallPackage is null
                 || MenuIgnoreUpdates is null
-                || MenuSharePackage is null
                 || MenuPackageDetails is null
                 || MenuOpenInstallLocation is null
                 || MenuDownloadInstaller is null
@@ -373,7 +358,6 @@ namespace UniGetUI.Interface.SoftwarePages
             MenuReinstallPackage.IsEnabled = !IS_LOCAL;
             MenuUninstallThenReinstall.IsEnabled = !IS_LOCAL;
             MenuIgnoreUpdates.IsEnabled = false; // Will be set on the lines below;
-            MenuSharePackage.IsEnabled = !IS_LOCAL;
             MenuPackageDetails.IsEnabled = !IS_LOCAL;
             MenuDownloadInstaller.IsEnabled =
                 !IS_LOCAL && package.Manager.Capabilities.CanDownloadInstaller;
@@ -525,14 +509,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 await package.AddToIgnoredUpdatesAsync();
                 UpgradablePackagesLoader.Instance.Remove(package);
             }
-        }
-
-        private void MenuShare_Invoked(object sender, RoutedEventArgs args)
-        {
-            if (SelectedItem is null)
-                return;
-
-            DialogHelper.SharePackage(SelectedItem);
         }
 
         private void MenuDetails_Invoked(object sender, RoutedEventArgs args)

--- a/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
@@ -31,7 +31,6 @@ namespace UniGetUI.Interface.SoftwarePages
     {
         private BetterMenuItem? MenuInstallOptions;
         private BetterMenuItem? MenuInstall;
-        private BetterMenuItem? MenuShare;
         private BetterMenuItem? MenuDetails;
         private BetterMenuItem? MenuAsAdmin;
         private BetterMenuItem? MenuInteractive;
@@ -162,14 +161,6 @@ namespace UniGetUI.Interface.SoftwarePages
             menu.Items.Add(menuRemoveFromList);
             menu.Items.Add(new MenuFlyoutSeparator());
 
-            MenuShare = new()
-            {
-                Text = CoreTools.AutoTranslated("Share this package"),
-                IconName = IconType.Share,
-            };
-            MenuShare.Click += MenuShare_Invoked;
-            menu.Items.Add(MenuShare);
-
             MenuDetails = new()
             {
                 Text = CoreTools.AutoTranslated("Package details"),
@@ -212,7 +203,6 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton ToBatchScript = new();
             AppBarButton AddPackagesToBundle = new();
             AppBarButton PackageDetails = new();
-            AppBarButton SharePackage = new();
             AppBarButton HelpButton = new();
 
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
@@ -226,7 +216,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ToolBar.PrimaryCommands.Add(RemoveSelected);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(PackageDetails);
-            ToolBar.PrimaryCommands.Add(SharePackage);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(HelpButton);
 
@@ -244,7 +233,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { SaveBundle, CoreTools.Translate("Save as") },
                 { AddPackagesToBundle, CoreTools.Translate("Add packages to bundle") },
                 { PackageDetails, " " + CoreTools.Translate("Package details") },
-                { SharePackage, " " + CoreTools.Translate("Share") },
                 { HelpButton, CoreTools.Translate("Help") },
             };
 
@@ -261,7 +249,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { SaveBundle, IconType.SaveAs },
                 { AddPackagesToBundle, IconType.AddTo },
                 { PackageDetails, IconType.Info_Round },
-                { SharePackage, IconType.Share },
                 { HelpButton, IconType.Help },
             };
 
@@ -277,7 +264,7 @@ namespace UniGetUI.Interface.SoftwarePages
                     DialogHelper.ShowDismissableBalloon(
                         CoreTools.Translate("Something went wrong"),
                         CoreTools.Translate(
-                            "\"{0}\" is a local package and can't be shared",
+                            "\"{0}\" is a local package and is not compatible with this feature",
                             SelectedItem.Name
                         )
                     );
@@ -330,13 +317,6 @@ namespace UniGetUI.Interface.SoftwarePages
             OpenBundle.Click += async (_, _) => await AskOpenFromFile();
             SaveBundle.Click += async (_, _) => await SaveFile();
             ToBatchScript.Click += (_, _) => _ = CreateBatchScript();
-
-            SharePackage.Click += (_, _) =>
-            {
-                IPackage? package = SelectedItem;
-                if (package is not null)
-                    DialogHelper.SharePackage(package);
-            };
 
             AddPackagesToBundle.Click += (_, _) => _ = DialogHelper.HowToAddPackagesToBundle();
         }
@@ -407,7 +387,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 || MenuInteractive is null
                 || MenuSkipHash is null
                 || MenuDetails is null
-                || MenuShare is null
                 || MenuInstall is null
                 || MenuInstallOptions is null
                 || MenuDownloadInstaller is null
@@ -425,7 +404,6 @@ namespace UniGetUI.Interface.SoftwarePages
             MenuSkipHash.IsEnabled =
                 IS_VALID && package.Manager.Capabilities.CanSkipIntegrityChecks;
             MenuDetails.IsEnabled = IS_VALID;
-            MenuShare.IsEnabled = IS_VALID;
             MenuInstall.IsEnabled = IS_VALID;
             MenuInstallOptions.IsEnabled = IS_VALID;
             MenuDownloadInstaller.IsEnabled =
@@ -458,13 +436,6 @@ namespace UniGetUI.Interface.SoftwarePages
             if (SelectedItem is null)
                 return;
             _ = ImportAndInstallPackage([SelectedItem], skiphash: true);
-        }
-
-        private void MenuShare_Invoked(object sender, RoutedEventArgs args)
-        {
-            if (SelectedItem is null)
-                return;
-            DialogHelper.SharePackage(SelectedItem);
         }
 
         private void MenuDetails_Invoked(object sender, RoutedEventArgs args)

--- a/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
@@ -151,13 +151,6 @@ namespace UniGetUI.Interface.SoftwarePages
             };
             menuSkipVersion.Click += MenuSkipVersion_Invoked;
 
-            BetterMenuItem menuShare = new()
-            {
-                Text = CoreTools.AutoTranslated("Share this package"),
-                IconName = IconType.Share,
-            };
-            menuShare.Click += (_, _) => SharePackage(SelectedItem);
-
             BetterMenuItem menuDetails = new()
             {
                 Text = CoreTools.AutoTranslated("Package details"),
@@ -217,7 +210,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ContextMenu.Items.Add(menuSkipVersion);
             ContextMenu.Items.Add(menuPause);
             ContextMenu.Items.Add(new MenuFlyoutSeparator());
-            ContextMenu.Items.Add(menuShare);
             ContextMenu.Items.Add(menuDetails);
 
             return ContextMenu;
@@ -274,7 +266,6 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton InstallationSettings = new();
 
             AppBarButton PackageDetails = new();
-            AppBarButton SharePackage = new();
 
             AppBarButton IgnoreSelected = new();
             AppBarButton ManageIgnored = new();
@@ -285,7 +276,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ToolBar.PrimaryCommands.Add(InstallationSettings);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(PackageDetails);
-            ToolBar.PrimaryCommands.Add(SharePackage);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(IgnoreSelected);
             ToolBar.PrimaryCommands.Add(ManageIgnored);
@@ -302,7 +292,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { UninstallSelection, CoreTools.Translate("Uninstall selected packages") },
                 { InstallationSettings, " " + CoreTools.Translate("Update options") },
                 { PackageDetails, " " + CoreTools.Translate("Package details") },
-                { SharePackage, " " + CoreTools.Translate("Share") },
                 { IgnoreSelected, CoreTools.Translate("Ignore selected packages") },
                 { ManageIgnored, CoreTools.Translate("Manage ignored updates") },
                 { HelpButton, CoreTools.Translate("Help") },
@@ -317,7 +306,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { DownloadInstallers, IconType.Download },
                 { UninstallSelection, IconType.Delete },
                 { PackageDetails, IconType.Info_Round },
-                { SharePackage, IconType.Share },
                 { IgnoreSelected, IconType.Pin },
                 { ManageIgnored, IconType.ClipboardList },
                 { HelpButton, IconType.Help },
@@ -359,7 +347,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 );
             UninstallSelection.Click += (_, _) =>
                 _ = MainApp.Operations.ConfirmAndUninstall(FilteredPackages.GetCheckedPackages());
-            SharePackage.Click += (_, _) => DialogHelper.SharePackage(SelectedItem);
         }
 
         protected override void WhenPackageCountUpdated()


### PR DESCRIPTION
Removes the share package feature across both WinUI and Avalonia frontends.

## Changes
- Removed share UI from all package pages (toolbar buttons, context menu items) in both WinUI and Avalonia
- Removed share button from package details page (WinUI)
- Retired `/v2/show-package` background API endpoint (now returns HTTP 410 Gone)
- Removed `OnShowSharedPackage` event from `BackgroundApi`
- Removed `showPackage` deep-link handling from both `MainWindow` implementations
- Removed `SharePackageRequested` event and `RequestShare` command from Avalonia ViewModel
- Removed `SharePackage()` and `ShowSharedPackage_ThreadSafe()` from `DialogHelper_Packages`
- Removed `FROM_WEB_SHARE` referral enum value and `SharedPackage()` telemetry method
