### PR TITLE
Fix issue #4588 --daemon flag being ignored on startup

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Styling;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.Views;
 using UniGetUI.Avalonia.Views.DialogPages;
+using UniGetUI.Core.Data;
 using UniGetUI.PackageEngine;
 using CoreSettings = global::UniGetUI.Core.SettingsEngine.Settings;
 
@@ -48,6 +49,13 @@ public partial class App : Application
             ApplyTheme(CoreSettings.GetValue(CoreSettings.K.PreferredTheme));
             var mainWindow = new MainWindow();
             desktop.MainWindow = mainWindow;
+
+            if (CoreData.WasDaemon)
+            {
+                // Start silently: hide the window as soon as Avalonia opens it.
+                mainWindow.Opened += (_, _) => mainWindow.Hide();
+            }
+
             _ = StartupAsync(mainWindow);
         }
 
@@ -94,7 +102,13 @@ public partial class App : Application
                 // Yield once so the main window has time to open before
                 // ShowDialog tries to attach to it as owner.
                 await Task.Yield();
+
+                // ShowDialog requires a visible owner. In daemon mode the main window
+                // is hidden, so temporarily show it and re-hide after the dialog closes.
+                bool reshide = CoreData.WasDaemon;
+                if (reshide) mainWindow.Show();
                 await new CrashReportWindow(report).ShowDialog(mainWindow);
+                if (reshide) mainWindow.Hide();
             }
             catch { /* must not prevent normal startup */ }
         }

--- a/src/UniGetUI.Avalonia/Program.cs
+++ b/src/UniGetUI.Avalonia/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia;
+using UniGetUI.Core.Data;
 
 namespace UniGetUI.Avalonia;
 
@@ -13,6 +14,8 @@ sealed class Program
     {
         AppDomain.CurrentDomain.UnhandledException += (_, e) =>
             CrashHandler.ReportFatalException((Exception)e.ExceptionObject);
+
+        CoreData.WasDaemon = CoreData.IsDaemon = args.Contains("--daemon");
 
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
     }

--- a/src/UniGetUI/App.xaml.cs
+++ b/src/UniGetUI/App.xaml.cs
@@ -332,7 +332,8 @@ namespace UniGetUI
 
                 // Create MainWindow
                 InitializeMainWindow();
-                MainWindow.Activate();
+                if (!CoreData.WasDaemon)
+                    MainWindow.Activate();
 
                 // Show crash report from the previous session on top of the loading
                 // screen and wait for the user to dismiss it before continuing.
@@ -340,6 +341,15 @@ namespace UniGetUI
                 {
                     try
                     {
+                        // In daemon mode the DWM/XAML threads are suspended; resume them
+                        // temporarily so the crash window can render, then re-suspend.
+                        bool resumedForCrash = CoreData.WasDaemon;
+                        if (resumedForCrash)
+                        {
+                            DWMThreadHelper.ChangeState_DWM(false);
+                            DWMThreadHelper.ChangeState_XAML(false);
+                        }
+
                         string report = File.ReadAllText(CrashHandler.PendingCrashFile);
                         File.Delete(CrashHandler.PendingCrashFile);
                         var tcs = new TaskCompletionSource();
@@ -347,6 +357,12 @@ namespace UniGetUI
                         crashWindow.Closed += (_, _) => tcs.TrySetResult();
                         crashWindow.Activate();
                         await tcs.Task;
+
+                        if (resumedForCrash)
+                        {
+                            DWMThreadHelper.ChangeState_DWM(true);
+                            DWMThreadHelper.ChangeState_XAML(true);
+                        }
                     }
                     catch { /* must not prevent normal startup */ }
                 }
@@ -505,7 +521,8 @@ namespace UniGetUI
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
-            MainWindow?.Activate();
+            if (!CoreData.WasDaemon)
+                MainWindow?.Activate();
         }
 
         public async Task ShowMainWindowFromRedirectAsync(AppActivationArguments rawArgs)


### PR DESCRIPTION
 ## Problem
Since version 2026.1.5, launching UniGetUI with `--daemon`  always opened the main window instead of silently starting in the system tray.

 ## Fix 
  - Guard both `Activate()` calls with `!CoreData.WasDaemon`.
  - In daemon mode, if a pending crash report exists, temporarily resume the DWM/XAML threads (which the constructor suspends via `SuspendThread`) so the `CrashReportWindow` can render, then re-suspend them after the user dismisses it.
