### PR TITLE
Fix Scoop update/uninstall failing for packages installed via manifest URL

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgDetailsHelper.cs
@@ -42,10 +42,11 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             }
 
             string packageId;
-            // If source is ellpised or source is a local path, omit source argument
+            // If source is ellipsed, a local path, or a URL manifest, omit source argument
             if (
                 details.Package.Source.Name.Contains("...")
                 || details.Package.Source.Name.Contains(":\\")
+                || details.Package.Source.Name.StartsWith("http")
             )
                 packageId = $"{details.Package.Id}";
             else

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgOperationHelper.cs
@@ -28,8 +28,8 @@ internal sealed class ScoopPkgOperationHelper : BasePkgOperationHelper
             },
         ];
 
-        // If source is ellpised or source is a local path, omit source argument
-        if (package.Source.Name.Contains("...") || package.Source.Name.Contains(":\\"))
+        // If source is ellipsed, a local path, or a URL manifest, omit source argument
+        if (package.Source.Name.Contains("...") || package.Source.Name.Contains(":\\") || package.Source.Name.StartsWith("http"))
             parameters.Add($"{package.Id}");
         else
             parameters.Add($"{package.Source.Name}/{package.Id}");


### PR DESCRIPTION
Fix for issue #4535 - When a Scoop package is installed via a manifest URL (e.g. `scoop install https://raw.githubusercontent.com/... pomotroid.json`), UniGetUI stores that URL as the package source. When building the operation command, the source was being prepended to the package ID, producing an invalid identifier

## Fix

The condition that decides whether to omit the source prefix already handled ellipsed (`...`) and local path sources (`:\`). This PR extends it to also skip the prefix when the source is a URL (`http`/`https`), in both the operation helper (install/update/uninstall commands) and the details helper (`scoop cat` command).

