### PR TITLE
Fix VC++ redistributable detection to avoid needless re-download (#4596)

### DIFF
--- a/InstallerExtras/CodeDependencies.iss
+++ b/InstallerExtras/CodeDependencies.iss
@@ -225,16 +225,58 @@ begin
   Result := ShellExec('', ExpandConstant('{tmp}{\}') + 'netcorecheck' + Dependency_ArchSuffix + '.exe', Version, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
 end;
 
+function Dependency_IsVCRuntimeInstalled(const Arch: String; const Major, Minor, Bld: Cardinal): Boolean;
+var
+  InstalledFlag, InstMajor, InstMinor, InstBld: Cardinal;
+  Key: String;
+begin
+  // Canonical VC++ runtime detection per Microsoft docs:
+  // https://learn.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files
+  // The redistributable installer writes these values to both registry views,
+  // so a plain HKLM read is correct from Inno Setup's 32-bit process.
+  Key := 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\' + Arch;
+  Result :=
+    RegQueryDWordValue(HKLM, Key, 'Installed', InstalledFlag) and (InstalledFlag = 1) and
+    RegQueryDWordValue(HKLM, Key, 'Major', InstMajor) and
+    RegQueryDWordValue(HKLM, Key, 'Minor', InstMinor) and
+    RegQueryDWordValue(HKLM, Key, 'Bld',   InstBld) and
+    ((InstMajor > Major) or
+     ((InstMajor = Major) and (InstMinor > Minor)) or
+     ((InstMajor = Major) and (InstMinor = Minor) and (InstBld >= Bld)));
+end;
+
 procedure Dependency_AddVC2015To2022;
+var
+  Arch, Url: String;
+  MinMajor, MinMinor, MinBld: Cardinal;
 begin
   // https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
-  if not IsMsiProductInstalled(Dependency_String('{91EE571B-0E8A-4C65-9EAF-2E2F5FC60C00}', '{91EE571B-0E8A-4C65-9EAF-2E2F5FC60C00}'), PackVersionComponents(14, 30, 30704, 0)) then begin
-    Dependency_Add('vcredist2022' + Dependency_ArchSuffix + '.exe',
-      '/passive /norestart',
-      'Visual C++ 2015-2022 Redistributable (x64)' + Dependency_ArchTitle,
-      Dependency_String('https://aka.ms/vc14/vc_redist.x64.exe', 'https://aka.ms/vc14/vc_redist.x64.exe'),
-      '', False, False);
+  MinMajor := 14;
+  MinMinor := 30;
+  MinBld   := 30704;
+
+  if IsARM64 then begin
+    Arch := 'arm64';
+    Url  := 'https://aka.ms/vc14/vc_redist.arm64.exe';
+  end else begin
+    Arch := 'x64';
+    Url  := 'https://aka.ms/vc14/vc_redist.x64.exe';
   end;
+
+  // Primary: registry-based detection (Microsoft's documented method, stable
+  // across installer builds). Fallback: MSI UpgradeCode lookup for x64 only
+  // (the x64 UpgradeCode {36F68A90-...} is verified; keeping a fallback helps
+  // on unusual install states). See issue #4596 for the regression this
+  // replaces, where a ProductCode was mistakenly used with IsMsiProductInstalled.
+  if Dependency_IsVCRuntimeInstalled(Arch, MinMajor, MinMinor, MinBld) then Exit;
+  if (Arch = 'x64') and IsMsiProductInstalled('{36F68A90-239C-34DF-B58C-64B30153CE35}',
+       PackVersionComponents(MinMajor, MinMinor, MinBld, 0)) then Exit;
+
+  Dependency_Add('vcredist2022_' + Arch + '.exe',
+    '/passive /norestart',
+    'Visual C++ 2015-2022 Redistributable (' + Arch + ')',
+    Url,
+    '', False, False);
 end;
 
 


### PR DESCRIPTION
Fixes #4596.

## Root cause

PR #4570 changed the GUID passed to `IsMsiProductInstalled` in `Dependency_AddVC2015To2022` from `{36F68A90-239C-34DF-B58C-64B30153CE35}` (an UpgradeCode) to `{91EE571B-0E8A-4C65-9EAF-2E2F5FC60C00}` (a ProductCode). `IsMsiProductInstalled` expects an UpgradeCode (stable across installer builds); ProductCodes change with every VC++ redistributable release. As a result, the detection returned false on any machine whose installed VC++ redist build didn't happen to match that specific ProductCode, causing the 18.5 MB `vc_redist.x64.exe` to be downloaded and re-run on every install.

Reproduced locally on a machine with VC++ 14.50.35719 already installed, confirmed via the Inno Setup `/LOG` output:

```
Downloading temporary file from https://aka.ms/vc14/vc_redist.x64.exe: ...\vcredist2022_x64.exe
...
18558944 of 18558944 bytes done.
```

## Fix

Switch primary detection to the registry method documented by [Microsoft](https://learn.microsoft.com/cpp/windows/redistributing-visual-cpp-files):

- Reads `HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\<arch>`
- Checks `Installed = 1` and `Major`/`Minor`/`Bld` >= required minimum (14.30.30704)
- Stable across installer builds, unaffected by future ProductCode churn
- Works natively for both `x64` and `arm64` (uses `IsARM64` to pick arch and download URL, matching the pattern already used in `Dependency_AddWebView2`)

Keeps the now-verified x64 UpgradeCode `{36F68A90-239C-34DF-B58C-64B30153CE35}` as a fallback for unusual install states. ARM64 deliberately uses only the registry path since I didn't independently verify an ARM64 UpgradeCode and would rather leave it out than plant another potentially-wrong GUID.

## Verification

Tested end-to-end on Windows 11 (10.0.26100, x64) with a test build of the installer from this branch. Both branches of the fix validated:

### 1. Runtime already present → no download (the reported bug)

Initial state: `HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64` → `Installed=1, v14.50.35719`.

Two independent runs (fresh install + reinstall over existing). Both logs show zero vcredist activity — `vc_redist`, `aka.ms`, `Downloading temporary`, `ShellExec`, `rollback` all have zero matches across 4,252-line logs. Clean `Log closed.` at EOF, exit code 0.

Before the fix this was a ~30 MB download + redundant redist execution on every install on the same machine.

### 2. Runtime registry key absent → downloads and installs

Removed both the registration registry key and the VC++ 2022 x64 Minimum/Additional Runtime MSI products, then reran the installer:

```
L18  16:12:53.873   Downloading temporary file from https://aka.ms/vc14/vc_redist.x64.exe: ...\vcredist2022_x64.exe
L75  16:12:58.289   18558944 of 18558944 bytes done.
     [11-second gap: vc_redist.x64.exe /install /quiet /norestart executes silently]
L78  16:13:09.545   Starting the installation process.
     ...
     Installation process succeeded.  (exit code 0)
```

Post-install state verified:
- Registry key restored: `Installed=1, v14.50.35719`
- MSI products restored: `Microsoft Visual C++ 2022 X64 {Minimum,Additional} Runtime - 14.50.35719`
- UniGetUI launched successfully

So the fix correctly short-circuits when the runtime is present (issue #4596) while preserving the legitimate install path on machines that truly don't have the runtime.
