### PR TITLE
Fix WinGet activation order and repair false positives

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/BundledWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/BundledWinGetHelper.cs
@@ -14,10 +14,14 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager;
 internal sealed class BundledWinGetHelper : IWinGetManagerHelper
 {
     private readonly WinGet Manager;
+    private readonly string _cliExecutablePath;
 
-    public BundledWinGetHelper(WinGet manager)
+    public BundledWinGetHelper(WinGet manager, string? cliExecutablePath = null)
     {
         Manager = manager;
+        _cliExecutablePath = string.IsNullOrWhiteSpace(cliExecutablePath)
+            ? WinGet.BundledWinGetPath
+            : cliExecutablePath;
     }
 
     public IReadOnlyList<Package> GetAvailableUpdates_UnSafe()
@@ -27,7 +31,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         {
             StartInfo = new()
             {
-                FileName = WinGet.BundledWinGetPath,
+                FileName = _cliExecutablePath,
                 Arguments =
                     Manager.Status.ExecutableCallArgs
                     + " update --include-unknown  --accept-source-agreements "
@@ -162,7 +166,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         {
             StartInfo = new()
             {
-                FileName = WinGet.BundledWinGetPath,
+                FileName = _cliExecutablePath,
                 Arguments =
                     Manager.Status.ExecutableCallArgs
                     + " list  --accept-source-agreements "
@@ -294,7 +298,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         {
             StartInfo = new()
             {
-                FileName = WinGet.BundledWinGetPath,
+                FileName = _cliExecutablePath,
                 Arguments =
                     Manager.Status.ExecutableCallArgs
                     + " search \""
@@ -417,7 +421,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         bool LocaleFound = true;
         ProcessStartInfo startInfo = new()
         {
-            FileName = WinGet.BundledWinGetPath,
+            FileName = _cliExecutablePath,
             Arguments =
                 Manager.Status.ExecutableCallArgs
                 + " show "
@@ -481,7 +485,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
             LocaleFound = true;
             startInfo = new()
             {
-                FileName = WinGet.BundledWinGetPath,
+                FileName = _cliExecutablePath,
                 Arguments =
                     Manager.Status.ExecutableCallArgs
                     + " show "
@@ -539,7 +543,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
             process = new Process();
             startInfo = new()
             {
-                FileName = WinGet.BundledWinGetPath,
+                FileName = _cliExecutablePath,
                 Arguments =
                     Manager.Status.ExecutableCallArgs
                     + " show "
@@ -714,7 +718,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         {
             StartInfo = new ProcessStartInfo
             {
-                FileName = WinGet.BundledWinGetPath,
+                FileName = _cliExecutablePath,
                 Arguments =
                     Manager.Status.ExecutableCallArgs
                     + " show "

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -42,7 +42,8 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             systemCliHelperFactory: null,
             skipInitialization: false,
             localPackagesProvider: null
-        ) { }
+        )
+    { }
 
     internal NativeWinGetHelper(
         WinGet manager,

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -21,14 +21,31 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     public PackageManager WinGetManager = null!;
     public static PackageManager? ExternalWinGetManager;
     private readonly WinGet Manager;
+    private readonly Func<WinGet, IWinGetManagerHelper> _bundledHelperFactory;
 
     public string ActivationMode { get; private set; } = string.Empty;
     public string ActivationSource { get; private set; } = string.Empty;
     private bool _isBundledActivation;
 
+    internal static IReadOnlyList<string> PreferredActivationModes =>
+    [
+        "packaged COM registration",
+        "lower-trust COM registration",
+        "bundled in-proc COM",
+    ];
+
     public NativeWinGetHelper(WinGet manager)
+        : this(manager, bundledHelperFactory: null, skipInitialization: false) { }
+
+    internal NativeWinGetHelper(
+        WinGet manager,
+        Func<WinGet, IWinGetManagerHelper>? bundledHelperFactory,
+        bool skipInitialization
+    )
     {
         Manager = manager;
+        _bundledHelperFactory =
+            bundledHelperFactory ?? (static manager => new BundledWinGetHelper(manager));
         if (CoreTools.IsAdministrator())
         {
             Logger.Info(
@@ -36,7 +53,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             );
         }
 
-        if (TryInitializeBundledFactory())
+        if (skipInitialization)
         {
             return;
         }
@@ -46,36 +63,47 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             return;
         }
 
-        InitializeLowerTrustFactory();
+        if (TryInitializeLowerTrustFactory())
+        {
+            return;
+        }
+
+        InitializeBundledFactory();
     }
 
-    private bool TryInitializeBundledFactory()
+    internal void UseBundledActivationForTesting()
+    {
+        _isBundledActivation = true;
+        ActivationMode = "bundled in-proc COM";
+        ActivationSource = "test";
+    }
+
+    private bool TryInitializeLowerTrustFactory()
     {
         try
         {
-            var factory = new WindowsPackageManagerBundledFactory();
+            var factory = new WindowsPackageManagerStandardFactory(allowLowerTrustRegistration: true);
             var winGetManager = factory.CreatePackageManager();
             ApplyFactory(
                 factory,
                 winGetManager,
-                "bundled in-proc COM",
-                factory.LibraryPath,
-                "Connected to WinGet API using bundled in-proc activation."
+                "lower-trust COM registration",
+                "system COM registration (allow lower trust)",
+                "Connected to WinGet API using lower-trust COM activation."
             );
-            _isBundledActivation = true;
             return true;
         }
         catch (WinGetComActivationException ex)
         {
             Logger.Warn(
-                $"Bundled WinGet in-proc activation failed ({ex.HResultHex}: {ex.Reason}), attempting packaged COM activation..."
+                $"Lower-trust WinGet COM activation failed ({ex.HResultHex}: {ex.Reason}), attempting bundled in-proc activation..."
             );
             return false;
         }
         catch (Exception ex)
         {
             Logger.Warn(
-                $"Bundled WinGet in-proc activation failed ({ex.Message}), attempting packaged COM activation..."
+                $"Lower-trust WinGet COM activation failed ({ex.Message}), attempting bundled in-proc activation..."
             );
             return false;
         }
@@ -112,17 +140,18 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         }
     }
 
-    private void InitializeLowerTrustFactory()
+    private void InitializeBundledFactory()
     {
-        var factory = new WindowsPackageManagerStandardFactory(allowLowerTrustRegistration: true);
+        var factory = new WindowsPackageManagerBundledFactory();
         var winGetManager = factory.CreatePackageManager();
         ApplyFactory(
             factory,
             winGetManager,
-            "lower-trust COM registration",
-            "system COM registration (allow lower trust)",
-            "Connected to WinGet API using lower-trust COM activation."
+            "bundled in-proc COM",
+            factory.LibraryPath,
+            "Connected to WinGet API using bundled in-proc activation."
         );
+        _isBundledActivation = true;
     }
 
     private void ApplyFactory(
@@ -273,7 +302,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         if (_isBundledActivation)
         {
             Logger.Info("WinGet is using bundled in-proc COM — falling back to CLI for update detection");
-            return new BundledWinGetHelper(Manager).GetAvailableUpdates_UnSafe();
+            return _bundledHelperFactory(Manager).GetAvailableUpdates_UnSafe();
         }
 
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListUpdates);
@@ -344,6 +373,12 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
 
     public IReadOnlyList<Package> GetInstalledPackages_UnSafe()
     {
+        if (_isBundledActivation)
+        {
+            Logger.Info("WinGet is using bundled in-proc COM — falling back to CLI for installed package detection");
+            return _bundledHelperFactory(Manager).GetInstalledPackages_UnSafe();
+        }
+
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListInstalledPackages);
         List<Package> packages = [];
         foreach (

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using Microsoft.Management.Deployment;
 using UniGetUI.Core.Classes;
 using UniGetUI.Core.Logging;
@@ -21,14 +22,40 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     public PackageManager WinGetManager = null!;
     public static PackageManager? ExternalWinGetManager;
     private readonly WinGet Manager;
+    private readonly Func<WinGet, IWinGetManagerHelper> _systemCliHelperFactory;
+    private readonly Func<IReadOnlyList<CatalogPackage>>? _localPackagesProvider;
+    private int _activeLocalPackageQueries;
+    private ExceptionDispatchInfo? _lastActivationException;
 
     public string ActivationMode { get; private set; } = string.Empty;
     public string ActivationSource { get; private set; } = string.Empty;
-    private bool _isBundledActivation;
+
+    internal static IReadOnlyList<string> PreferredActivationModes =>
+    [
+        "packaged COM registration",
+        "lower-trust COM registration",
+    ];
 
     public NativeWinGetHelper(WinGet manager)
+        : this(
+            manager,
+            systemCliHelperFactory: null,
+            skipInitialization: false,
+            localPackagesProvider: null
+        ) { }
+
+    internal NativeWinGetHelper(
+        WinGet manager,
+        Func<WinGet, IWinGetManagerHelper>? systemCliHelperFactory,
+        bool skipInitialization,
+        Func<IReadOnlyList<CatalogPackage>>? localPackagesProvider
+    )
     {
         Manager = manager;
+        _systemCliHelperFactory =
+            systemCliHelperFactory
+            ?? (static manager => new BundledWinGetHelper(manager, manager.Status.ExecutablePath));
+        _localPackagesProvider = localPackagesProvider;
         if (CoreTools.IsAdministrator())
         {
             Logger.Info(
@@ -36,7 +63,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             );
         }
 
-        if (TryInitializeBundledFactory())
+        if (skipInitialization)
         {
             return;
         }
@@ -46,36 +73,51 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             return;
         }
 
-        InitializeLowerTrustFactory();
+        if (TryInitializeLowerTrustFactory())
+        {
+            return;
+        }
+
+        _lastActivationException?.Throw();
+
+        throw new InvalidOperationException("WinGet: Failed to initialize system COM activation.");
     }
 
-    private bool TryInitializeBundledFactory()
+    internal bool HasActiveLocalPackageQuery => Volatile.Read(ref _activeLocalPackageQueries) > 0;
+
+    internal void SetLocalPackageQueryInProgressForTesting(bool value)
+    {
+        Interlocked.Exchange(ref _activeLocalPackageQueries, value ? 1 : 0);
+    }
+
+    private bool TryInitializeLowerTrustFactory()
     {
         try
         {
-            var factory = new WindowsPackageManagerBundledFactory();
+            var factory = new WindowsPackageManagerStandardFactory(allowLowerTrustRegistration: true);
             var winGetManager = factory.CreatePackageManager();
             ApplyFactory(
                 factory,
                 winGetManager,
-                "bundled in-proc COM",
-                factory.LibraryPath,
-                "Connected to WinGet API using bundled in-proc activation."
+                "lower-trust COM registration",
+                "system COM registration (allow lower trust)",
+                "Connected to WinGet API using lower-trust COM activation."
             );
-            _isBundledActivation = true;
             return true;
         }
         catch (WinGetComActivationException ex)
         {
+            _lastActivationException = ExceptionDispatchInfo.Capture(ex);
             Logger.Warn(
-                $"Bundled WinGet in-proc activation failed ({ex.HResultHex}: {ex.Reason}), attempting packaged COM activation..."
+                $"Lower-trust WinGet COM activation failed ({ex.HResultHex}: {ex.Reason})."
             );
             return false;
         }
         catch (Exception ex)
         {
+            _lastActivationException = ExceptionDispatchInfo.Capture(ex);
             Logger.Warn(
-                $"Bundled WinGet in-proc activation failed ({ex.Message}), attempting packaged COM activation..."
+                $"Lower-trust WinGet COM activation failed ({ex.Message})."
             );
             return false;
         }
@@ -98,6 +140,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         }
         catch (WinGetComActivationException ex)
         {
+            _lastActivationException = ExceptionDispatchInfo.Capture(ex);
             Logger.Warn(
                 $"Packaged WinGet COM activation failed ({ex.HResultHex}: {ex.Reason}), attempting lower-trust activation..."
             );
@@ -105,24 +148,12 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         }
         catch (Exception ex)
         {
+            _lastActivationException = ExceptionDispatchInfo.Capture(ex);
             Logger.Warn(
                 $"Packaged WinGet COM activation failed ({ex.Message}), attempting lower-trust activation..."
             );
             return false;
         }
-    }
-
-    private void InitializeLowerTrustFactory()
-    {
-        var factory = new WindowsPackageManagerStandardFactory(allowLowerTrustRegistration: true);
-        var winGetManager = factory.CreatePackageManager();
-        ApplyFactory(
-            factory,
-            winGetManager,
-            "lower-trust COM registration",
-            "system COM registration (allow lower trust)",
-            "Connected to WinGet API using lower-trust COM activation."
-        );
     }
 
     private void ApplyFactory(
@@ -270,19 +301,19 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
 
     public IReadOnlyList<Package> GetAvailableUpdates_UnSafe()
     {
-        if (_isBundledActivation)
+        var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListUpdates);
+        IReadOnlyList<CatalogPackage> nativePackages;
+        try
         {
-            Logger.Info("WinGet is using bundled in-proc COM — falling back to CLI for update detection");
-            return new BundledWinGetHelper(Manager).GetAvailableUpdates_UnSafe();
+            nativePackages = GetCachedLocalWinGetPackages(15);
+        }
+        catch (Exception ex) when (ShouldFallbackToCli(ex))
+        {
+            return GetAvailableUpdatesFromSystemCli(ex);
         }
 
-        var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListUpdates);
         List<Package> packages = [];
-        foreach (
-            var nativePackage in TaskRecycler<IReadOnlyList<CatalogPackage>>.RunOrAttach(
-                GetLocalWinGetPackages
-            )
-        )
+        foreach (var nativePackage in nativePackages)
         {
             try
             {
@@ -345,13 +376,18 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     public IReadOnlyList<Package> GetInstalledPackages_UnSafe()
     {
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListInstalledPackages);
+        IReadOnlyList<CatalogPackage> nativePackages;
+        try
+        {
+            nativePackages = GetCachedLocalWinGetPackages(15);
+        }
+        catch (Exception ex) when (ShouldFallbackToCli(ex))
+        {
+            return GetInstalledPackagesFromSystemCli(ex);
+        }
+
         List<Package> packages = [];
-        foreach (
-            var nativePackage in TaskRecycler<IReadOnlyList<CatalogPackage>>.RunOrAttach(
-                GetLocalWinGetPackages,
-                15
-            )
-        )
+        foreach (var nativePackage in nativePackages)
         {
             try
             {
@@ -393,6 +429,61 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         }
         logger.Close(0);
         return packages;
+    }
+
+    private IReadOnlyList<CatalogPackage> GetCachedLocalWinGetPackages(int? cacheSeconds = null)
+    {
+        if (_localPackagesProvider is not null)
+        {
+            return _localPackagesProvider();
+        }
+
+        return cacheSeconds is null
+            ? TaskRecycler<IReadOnlyList<CatalogPackage>>.RunOrAttach(GetLocalWinGetPackages)
+            : TaskRecycler<IReadOnlyList<CatalogPackage>>.RunOrAttach(
+                GetLocalWinGetPackages,
+                cacheSeconds.Value
+            );
+    }
+
+    private IReadOnlyList<Package> GetAvailableUpdatesFromSystemCli(Exception ex)
+    {
+        var unwrappedException = UnwrapException(ex);
+        Logger.Warn(
+            $"Native WinGet update enumeration failed with {unwrappedException.GetType().Name}: {unwrappedException.Message}. Falling back to system WinGet CLI."
+        );
+        return _systemCliHelperFactory(Manager).GetAvailableUpdates_UnSafe();
+    }
+
+    private IReadOnlyList<Package> GetInstalledPackagesFromSystemCli(Exception ex)
+    {
+        var unwrappedException = UnwrapException(ex);
+        Logger.Warn(
+            $"Native WinGet installed-package enumeration failed with {unwrappedException.GetType().Name}: {unwrappedException.Message}. Falling back to system WinGet CLI."
+        );
+        return _systemCliHelperFactory(Manager).GetInstalledPackages_UnSafe();
+    }
+
+    private static bool ShouldFallbackToCli(Exception ex)
+    {
+        var unwrappedException = UnwrapException(ex);
+        return
+            unwrappedException is InvalidOperationException
+            && string.Equals(
+                unwrappedException.Message,
+                "WinGet: Failed to connect to composite catalog.",
+                StringComparison.Ordinal
+            );
+    }
+
+    private static Exception UnwrapException(Exception ex)
+    {
+        while (ex is AggregateException aggregateException && aggregateException.InnerException is not null)
+        {
+            ex = aggregateException.InnerException;
+        }
+
+        return ex;
     }
 
     private static void LogSkippedPackage(
@@ -441,46 +532,133 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
 
     private IReadOnlyList<CatalogPackage> GetLocalWinGetPackages()
     {
+        Interlocked.Increment(ref _activeLocalPackageQueries);
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.OtherTask);
-        logger.Log("OtherTask: GetWinGetLocalPackages");
-        PackageCatalogReference installedSearchCatalogRef;
-        CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions =
-            Factory.CreateCreateCompositePackageCatalogOptions();
-        foreach (var catalogRef in WinGetManager.GetPackageCatalogs().ToArray())
+        try
         {
-            logger.Log($"Adding catalog {catalogRef.Info.Name} to composite catalog");
-            createCompositePackageCatalogOptions.Catalogs.Add(catalogRef);
-        }
-        createCompositePackageCatalogOptions.CompositeSearchBehavior =
-            CompositeSearchBehavior.LocalCatalogs;
-        installedSearchCatalogRef = WinGetManager.CreateCompositePackageCatalog(
-            createCompositePackageCatalogOptions
-        );
+            logger.Log("OtherTask: GetWinGetLocalPackages");
+            var availableCatalogs = GetReachableLocalCatalogReferences(logger);
+            PackageCatalogReference installedSearchCatalogRef = CreateLocalCompositeCatalog(
+                availableCatalogs,
+                logger
+            );
 
-        var ConnectResult = installedSearchCatalogRef.Connect();
-        if (ConnectResult.Status != ConnectResultStatus.Ok)
+            var ConnectResult = installedSearchCatalogRef.Connect();
+            if (ConnectResult.Status != ConnectResultStatus.Ok)
+            {
+                logger.Error("Failed to connect to installedSearchCatalogRef. Aborting.");
+                logger.Close(1);
+                throw new InvalidOperationException("WinGet: Failed to connect to composite catalog.");
+            }
+
+            FindPackagesOptions findPackagesOptions = Factory.CreateFindPackagesOptions();
+            PackageMatchFilter filter = Factory.CreatePackageMatchFilter();
+            filter.Field = PackageMatchField.Id;
+            filter.Option = PackageFieldMatchOption.StartsWithCaseInsensitive;
+            filter.Value = "";
+            findPackagesOptions.Filters.Add(filter);
+
+            var TaskResult = ConnectResult.PackageCatalog.FindPackages(findPackagesOptions);
+            List<CatalogPackage> foundPackages = [];
+            foreach (var match in TaskResult.Matches.ToArray())
+            {
+                foundPackages.Add(match.CatalogPackage);
+            }
+
+            logger.Close(0);
+            return foundPackages;
+        }
+        finally
         {
-            logger.Error("Failed to connect to installedSearchCatalogRef. Aborting.");
-            logger.Close(1);
+            Interlocked.Decrement(ref _activeLocalPackageQueries);
+        }
+    }
+
+    private IReadOnlyList<PackageCatalogReference> GetReachableLocalCatalogReferences(
+        INativeTaskLogger logger
+    )
+    {
+        return SelectReachableCatalogs(
+            WinGetManager.GetPackageCatalogs().ToArray(),
+            static catalogRef => catalogRef.Info.Name,
+            catalogRef => TryConnectLocalCatalog(catalogRef, logger),
+            catalogName =>
+            {
+                logger.Log($"Catalog {catalogName} is reachable for local package enumeration");
+            },
+            catalogName =>
+            {
+                string message =
+                    $"Skipping unavailable WinGet catalog {catalogName} while loading local packages";
+                logger.Error(message);
+                Logger.Warn(message);
+            }
+        );
+    }
+
+    internal static IReadOnlyList<TCatalog> SelectReachableCatalogs<TCatalog>(
+        IEnumerable<TCatalog> catalogs,
+        Func<TCatalog, string> describeCatalog,
+        Func<TCatalog, bool> isReachable,
+        Action<string>? onReachable = null,
+        Action<string>? onSkipped = null
+    )
+    {
+        List<TCatalog> reachableCatalogs = [];
+        foreach (var catalog in catalogs)
+        {
+            string catalogName = describeCatalog(catalog);
+            if (isReachable(catalog))
+            {
+                onReachable?.Invoke(catalogName);
+                reachableCatalogs.Add(catalog);
+            }
+            else
+            {
+                onSkipped?.Invoke(catalogName);
+            }
+        }
+
+        if (reachableCatalogs.Count == 0)
+        {
             throw new InvalidOperationException("WinGet: Failed to connect to composite catalog.");
         }
 
-        FindPackagesOptions findPackagesOptions = Factory.CreateFindPackagesOptions();
-        PackageMatchFilter filter = Factory.CreatePackageMatchFilter();
-        filter.Field = PackageMatchField.Id;
-        filter.Option = PackageFieldMatchOption.StartsWithCaseInsensitive;
-        filter.Value = "";
-        findPackagesOptions.Filters.Add(filter);
+        return reachableCatalogs;
+    }
 
-        var TaskResult = ConnectResult.PackageCatalog.FindPackages(findPackagesOptions);
-        List<CatalogPackage> foundPackages = [];
-        foreach (var match in TaskResult.Matches.ToArray())
+    private bool TryConnectLocalCatalog(PackageCatalogReference catalogRef, INativeTaskLogger logger)
+    {
+        var localCatalogRef = CreateLocalCompositeCatalog([catalogRef], logger);
+        var connectResult = localCatalogRef.Connect();
+        if (connectResult.Status == ConnectResultStatus.Ok)
         {
-            foundPackages.Add(match.CatalogPackage);
+            return true;
         }
 
-        logger.Close(0);
-        return foundPackages;
+        logger.Error(
+            $"WinGet: Catalog {catalogRef.Info.Name} failed local catalog connection with status {connectResult.Status}."
+        );
+        return false;
+    }
+
+    private PackageCatalogReference CreateLocalCompositeCatalog(
+        IEnumerable<PackageCatalogReference> catalogs,
+        INativeTaskLogger logger
+    )
+    {
+        CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions =
+            Factory.CreateCreateCompositePackageCatalogOptions();
+        foreach (var catalogRef in catalogs)
+        {
+            catalogRef.AcceptSourceAgreements = true;
+            logger.Log($"Adding catalog {catalogRef.Info.Name} to composite catalog");
+            createCompositePackageCatalogOptions.Catalogs.Add(catalogRef);
+        }
+
+        createCompositePackageCatalogOptions.CompositeSearchBehavior =
+            CompositeSearchBehavior.LocalCatalogs;
+        return WinGetManager.CreateCompositePackageCatalog(createCompositePackageCatalogOptions);
     }
 
     public IReadOnlyList<IManagerSource> GetSources_UnSafe()

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -409,6 +409,17 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                 TryRepairTempFolderPermissions();
                 if (WinGetHelper.Instance is NativeWinGetHelper)
                 {
+                    if (
+                        WinGetHelper.Instance is NativeWinGetHelper nativeHelper
+                        && nativeHelper.HasActiveLocalPackageQuery
+                    )
+                    {
+                        Logger.Warn(
+                            "WinGet local package enumeration is still running; skipping COM reconnection so the retry can attach to the in-flight task."
+                        );
+                        return;
+                    }
+
                     Logger.ImportantInfo("Attempting to reconnect to WinGet COM Server...");
                     ReRegisterCOMServer();
                     NO_PACKAGES_HAVE_BEEN_LOADED = false;

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -130,6 +130,116 @@ public sealed class WinGetManagerTests : IDisposable
         PackageAssert.Matches(Assert.Single(packages), "Contoso Tool", "Contoso.Tool", "1.2.3");
     }
 
+    [Fact]
+    public void NativeWinGetHelperPrefersSystemComBeforeBundledActivation()
+    {
+        Assert.Equal(
+            ["packaged COM registration", "lower-trust COM registration"],
+            NativeWinGetHelper.PreferredActivationModes
+        );
+    }
+
+    [Fact]
+    public void NativeWinGetHelperUsesSystemCliFallbackForInstalledPackagesWhenCompositeCatalogFails()
+    {
+        var manager = new TestableWinGet();
+        var expectedPackage = new PackageBuilder()
+            .WithManager(manager)
+            .WithName("Contoso Tool")
+            .WithId("Contoso.Tool")
+            .WithVersion("1.2.3")
+            .Build();
+        var systemCliFallbackHelper = new TestWinGetManagerHelper
+        {
+            GetInstalledPackagesHandler = () => [expectedPackage],
+        };
+        var helper = new NativeWinGetHelper(
+            manager,
+            systemCliHelperFactory: _ => systemCliFallbackHelper,
+            skipInitialization: true,
+            localPackagesProvider: () =>
+                throw new InvalidOperationException("WinGet: Failed to connect to composite catalog.")
+        );
+
+        var packages = helper.GetInstalledPackages_UnSafe();
+
+        PackageAssert.Matches(Assert.Single(packages), "Contoso Tool", "Contoso.Tool", "1.2.3");
+    }
+
+    [Fact]
+    public void NativeWinGetHelperUsesSystemCliFallbackForUpdatesWhenCompositeCatalogFails()
+    {
+        var manager = new TestableWinGet();
+        var expectedPackage = new PackageBuilder()
+            .WithManager(manager)
+            .WithName("Contoso Tool")
+            .WithId("Contoso.Tool")
+            .WithVersion("1.2.3")
+            .WithNewVersion("2.0.0")
+            .Build();
+        var systemCliFallbackHelper = new TestWinGetManagerHelper
+        {
+            GetAvailableUpdatesHandler = () => [expectedPackage],
+        };
+        var helper = new NativeWinGetHelper(
+            manager,
+            systemCliHelperFactory: _ => systemCliFallbackHelper,
+            skipInitialization: true,
+            localPackagesProvider: () =>
+                throw new InvalidOperationException("WinGet: Failed to connect to composite catalog.")
+        );
+
+        var packages = helper.GetAvailableUpdates_UnSafe();
+
+        var package = Assert.Single(packages);
+        Assert.Equal("Contoso.Tool", package.Id);
+        Assert.Equal("2.0.0", package.NewVersionString);
+    }
+
+    [Fact]
+    public void NativeWinGetHelperSelectReachableCatalogsSkipsUnavailableSources()
+    {
+        var reachableCatalogs = NativeWinGetHelper.SelectReachableCatalogs(
+            ["winget", "offline", "msstore"],
+            static catalog => catalog,
+            static catalog => catalog != "offline"
+        );
+
+        Assert.Equal(["winget", "msstore"], reachableCatalogs);
+    }
+
+    [Fact]
+    public void NativeWinGetHelperSelectReachableCatalogsThrowsWhenAllSourcesAreUnavailable()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            NativeWinGetHelper.SelectReachableCatalogs(
+                ["offline-a", "offline-b"],
+                static catalog => catalog,
+                static _ => false
+            )
+        );
+
+        Assert.Equal("WinGet: Failed to connect to composite catalog.", exception.Message);
+    }
+
+    [Fact]
+    public void AttemptFastRepairKeepsNativeHelperWhileLocalPackageEnumerationIsStillRunning()
+    {
+        var manager = new TestableWinGet();
+        var helper = new NativeWinGetHelper(
+            manager,
+            systemCliHelperFactory: null,
+            skipInitialization: true,
+            localPackagesProvider: null
+        );
+        helper.SetLocalPackageQueryInProgressForTesting(true);
+        WinGetHelper.Instance = helper;
+
+        manager.AttemptFastRepair();
+
+        Assert.Same(helper, WinGetHelper.Instance);
+    }
+
     private sealed class TestableWinGet : WinGet
     {
         public IReadOnlyList<Package> InvokeGetInstalledPackages() => base.GetInstalledPackages_UnSafe();

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -130,6 +130,41 @@ public sealed class WinGetManagerTests : IDisposable
         PackageAssert.Matches(Assert.Single(packages), "Contoso Tool", "Contoso.Tool", "1.2.3");
     }
 
+    [Fact]
+    public void NativeWinGetHelperPrefersSystemComBeforeBundledActivation()
+    {
+        Assert.Equal(
+            ["packaged COM registration", "lower-trust COM registration", "bundled in-proc COM"],
+            NativeWinGetHelper.PreferredActivationModes
+        );
+    }
+
+    [Fact]
+    public void NativeWinGetHelperUsesBundledFallbackForInstalledPackagesWhenBundledActivationIsSelected()
+    {
+        var manager = new TestableWinGet();
+        var expectedPackage = new PackageBuilder()
+            .WithManager(manager)
+            .WithName("Contoso Tool")
+            .WithId("Contoso.Tool")
+            .WithVersion("1.2.3")
+            .Build();
+        var bundledFallbackHelper = new TestWinGetManagerHelper
+        {
+            GetInstalledPackagesHandler = () => [expectedPackage],
+        };
+        var helper = new NativeWinGetHelper(
+            manager,
+            bundledHelperFactory: _ => bundledFallbackHelper,
+            skipInitialization: true
+        );
+        helper.UseBundledActivationForTesting();
+
+        var packages = helper.GetInstalledPackages_UnSafe();
+
+        PackageAssert.Matches(Assert.Single(packages), "Contoso Tool", "Contoso.Tool", "1.2.3");
+    }
+
     private sealed class TestableWinGet : WinGet
     {
         public IReadOnlyList<Package> InvokeGetInstalledPackages() => base.GetInstalledPackages_UnSafe();

--- a/src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs
@@ -193,17 +193,18 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
                     Text =
                         $"{CoreTools.Translate("Use bundled WinGet instead of system WinGet")} ({CoreTools.Translate("This may help if WinGet packages are not shown")})",
                     SettingName = Settings.K.ForceLegacyBundledWinGet,
-                    CornerRadius = new CornerRadius(0, 0, 8, 8),
-                    BorderThickness = new Thickness(1, 0, 1, 1),
+                    CornerRadius = new CornerRadius(0),
+                    BorderThickness = new Thickness(1, 0, 1, 0),
                 };
                 WinGet_UseBundled.StateChanged += (_, _) => _ = ReloadPackageManager();
                 ExtraControls.Children.Add(WinGet_UseBundled);
 
-                /*CheckboxCard WinGet_EnableTroubleshooter = new()
+                CheckboxCard WinGet_EnableTroubleshooter = new()
                 {
                     Text = CoreTools.Translate("Enable the automatic WinGet troubleshooter"),
                     SettingName = Settings.K.DisableWinGetMalfunctionDetector,
-                    CornerRadius = new CornerRadius(0),
+                    CornerRadius = new CornerRadius(0, 0, 8, 8),
+                    BorderThickness = new Thickness(1, 0, 1, 1),
                 };
                 WinGet_EnableTroubleshooter.StateChanged += (_, _) =>
                 {
@@ -211,21 +212,6 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
                     _ = InstalledPackagesLoader.Instance.ReloadPackages();
                 };
                 ExtraControls.Children.Add(WinGet_EnableTroubleshooter);
-
-                CheckboxCard WinGet_EnableTroubleshooter_v2 = new()
-                {
-                    Text = CoreTools.Translate("Enable an [experimental] improved WinGet troubleshooter"),
-                    SettingName = Settings.K.DisableNewWinGetTroubleshooter,
-                    // CornerRadius = new CornerRadius(0),
-                    CornerRadius = new CornerRadius(0, 0, 8, 8),
-                    BorderThickness = new Thickness(1, 0, 1, 0),
-                };
-                WinGet_EnableTroubleshooter_v2.StateChanged += (_, _) =>
-                {
-                    MainApp.Instance.MainWindow.WinGetWarningBanner.IsOpen = false;
-                    _ = InstalledPackagesLoader.Instance.ReloadPackages();
-                };
-                ExtraControls.Children.Add(WinGet_EnableTroubleshooter_v2);*/
 
                 /*CheckboxCard WinGet_HideNonApplicableUpdates = new()
                 {

--- a/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
@@ -309,12 +309,12 @@ namespace UniGetUI.Interface.SoftwarePages
                 }
             }
 
+            var infoBar = MainApp.Instance.MainWindow.WinGetWarningBanner;
             if (
                 WinGet.NO_PACKAGES_HAVE_BEEN_LOADED
                 && !Settings.Get(Settings.K.DisableWinGetMalfunctionDetector)
             )
             {
-                var infoBar = MainApp.Instance.MainWindow.WinGetWarningBanner;
                 infoBar.IsOpen = true;
                 infoBar.Title = CoreTools.Translate("WinGet malfunction detected");
                 infoBar.Message = CoreTools.Translate(
@@ -323,6 +323,11 @@ namespace UniGetUI.Interface.SoftwarePages
                 var button = new Button { Content = CoreTools.Translate("Repair WinGet") };
                 infoBar.ActionButton = button;
                 button.Click += (_, _) => _ = DialogHelper.HandleBrokenWinGet();
+            }
+            else
+            {
+                infoBar.IsOpen = false;
+                infoBar.ActionButton = null;
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes #4602.

This PR hardens UniGetUI's WinGet integration so it prefers the native WinGet COM API when available, avoids the bundled in-proc COM path for native API usage, tolerates unavailable sources more safely, and reduces false-positive repair behavior.

## Root cause
Recent WinGet changes had moved the native helper toward bundled in-proc COM activation and exposed a few brittle paths around source failures and retries:

- native activation no longer clearly favored system COM first
- one bad source could poison native local package enumeration
- timeout retries could restart the same slow WinGet work from scratch
- the repair warning could remain visible after recovery

## What changed
1. Restored the native WinGet API activation order to:
   - packaged/system COM registration
   - lower-trust COM registration
2. Removed bundled in-proc COM from the native WinGet API fallback chain.
   - If native COM activation is unavailable, UniGetUI now falls back to the CLI helper rather than using bundled COM for API calls.
3. Hardened native local package enumeration against unavailable sources.
   - UniGetUI now probes sources individually, skips unreachable catalogs, and rebuilds the local composite from reachable ones.
   - If native composite enumeration still fails, it falls back to the system winget.exe CLI path.
4. Reduced timeout retry thrash.
   - If a native local package query is already in flight, timeout recovery no longer reconnects WinGet COM and restart the enumeration from scratch.
5. Tightened the malfunction warning flow.
   - The Installed Packages warning banner now closes again after recovery.
   - The existing WinGet malfunction-detector toggle is exposed again in Settings.
6. Extended WinGet regression coverage around:
   - activation order
   - native-to-CLI fallback behavior
   - source skipping
   - timeout retry behavior

## Files changed
- src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/BundledWinGetHelper.cs
- src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
- src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
- src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
- src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs
- src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs

## Validation
- dotnet test .\\src\\UniGetUI.PackageEngine.Tests\\UniGetUI.PackageEngine.Tests.csproj --verbosity q --nologo --tl:off
- dotnet build .\\src\\UniGetUI\\UniGetUI.csproj -p:Platform=x64 --verbosity q --nologo --tl:off
- PR CI: .NET Tests / test-codebase passing