### PR TITLE
Display the last update check time on the reload button (Avalonia)

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -125,6 +125,7 @@ public partial class PackagesPageViewModel : ViewModelBase
     [ObservableProperty] private string _globalQueryText = "";
     [ObservableProperty] private bool _newVersionHeaderVisible;
     [ObservableProperty] private bool _reloadButtonVisible;
+    [ObservableProperty] private string _reloadButtonTooltip = "";
     [ObservableProperty] private bool _isFilterPaneOpen;
     [ObservableProperty] private PackageViewMode _viewMode;
     [ObservableProperty] private int _sortFieldIndex;
@@ -374,6 +375,7 @@ public partial class PackagesPageViewModel : ViewModelBase
         }
         IsLoading = false;
         _lastLoadTime = DateTime.Now;
+        ReloadButtonTooltip = CoreTools.Translate("Last checked: {0}", _lastLoadTime.ToString(CultureInfo.CurrentCulture));
         FilterPackages();
         PackagesLoaded?.Invoke(ReloadReason.External);
     }

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -136,6 +136,7 @@
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
                         Command="{Binding ReloadCommand}"
+                        ToolTip.Tip="{Binding ReloadButtonTooltip}"
                         automation:AutomationProperties.Name="{t:Translate Reload}"
                         automation:AutomationProperties.AcceleratorKey="F5"
                         IsVisible="{Binding ReloadButtonVisible}">


### PR DESCRIPTION
Brings the change from https://github.com/Devolutions/UniGetUI/pull/4610 to Avalonia.