### PR TITLE
Harden Linux manager executable lookup to prevent PATH hijacking

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
@@ -52,8 +52,8 @@ public class Apt : PackageManager
 
     public override IReadOnlyList<string> FindCandidateExecutableFiles()
     {
-        var candidates = new List<string>(CoreTools.WhichMultiple("apt"));
-        foreach (var path in new[] { "/usr/bin/apt", "/usr/local/bin/apt" })
+        var candidates = new List<string>();
+        foreach (var path in new[] { "/usr/bin/apt", "/bin/apt" })
         {
             if (File.Exists(path) && !candidates.Contains(path))
                 candidates.Add(path);

--- a/src/UniGetUI.PackageEngine.Managers.Dnf/Dnf.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Dnf/Dnf.cs
@@ -55,13 +55,8 @@ public class Dnf : PackageManager
 
     public override IReadOnlyList<string> FindCandidateExecutableFiles()
     {
-        var candidates = new List<string>(CoreTools.WhichMultiple("dnf5"));
-        foreach (var path in CoreTools.WhichMultiple("dnf"))
-        {
-            if (!candidates.Contains(path))
-                candidates.Add(path);
-        }
-        foreach (var path in new[] { "/usr/bin/dnf5", "/usr/bin/dnf", "/usr/local/bin/dnf" })
+        var candidates = new List<string>();
+        foreach (var path in new[] { "/usr/bin/dnf5", "/usr/bin/dnf", "/bin/dnf5", "/bin/dnf" })
         {
             if (File.Exists(path) && !candidates.Contains(path))
                 candidates.Add(path);

--- a/src/UniGetUI.PackageEngine.Managers.Pacman/Pacman.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pacman/Pacman.cs
@@ -51,8 +51,8 @@ public class Pacman : PackageManager
 
     public override IReadOnlyList<string> FindCandidateExecutableFiles()
     {
-        var candidates = new List<string>(CoreTools.WhichMultiple("pacman"));
-        foreach (var path in new[] { "/usr/bin/pacman", "/usr/local/bin/pacman" })
+        var candidates = new List<string>();
+        foreach (var path in new[] { "/usr/bin/pacman", "/bin/pacman" })
         {
             if (File.Exists(path) && !candidates.Contains(path))
                 candidates.Add(path);


### PR DESCRIPTION
### Motivation
- Close a local privilege-escalation vector where `apt`, `dnf`, and `pacman` binaries were discovered from the user `PATH` and later invoked under an elevator (`sudo`/`pkexec`), which allowed a PATH-hijacked binary to be run as root after user approval. 
- Restrict manager executable discovery to known system locations to retain required elevation behavior while removing attacker-controlled `PATH` influence.

### Description
- Changed `FindCandidateExecutableFiles()` in `src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs` to only consider `/usr/bin/apt` and `/bin/apt` instead of using `CoreTools.WhichMultiple("apt")`.
- Changed `FindCandidateExecutableFiles()` in `src/UniGetUI.PackageEngine.Managers.Dnf/Dnf.cs` to only consider `/usr/bin/dnf5`, `/usr/bin/dnf`, `/bin/dnf5`, and `/bin/dnf` and removed `WhichMultiple` usage for `dnf` candidates.
- Changed `FindCandidateExecutableFiles()` in `src/UniGetUI.PackageEngine.Managers.Pacman/Pacman.cs` to only consider `/usr/bin/pacman` and `/bin/pacman` instead of using `CoreTools.WhichMultiple("pacman")`.
- Preserved the rest of the managers' behavior and the existing elevation flow, so the first available trusted path is still selected for operations that require admin rights.

### Testing
- No automated unit or integration tests were executed because the environment lacks the .NET toolchain; `dotnet --version` returned `command not found` so `dotnet test` could not be run. 
- Performed local code inspection and diff verification to ensure only the candidate discovery lists were modified and no operation/elevation code paths were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e288d3954c8323894ac9e74d19ff84)