### PR TITLE
Fix Apt update detection on non-English locales

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
@@ -223,6 +223,8 @@ public class Apt : PackageManager
                 CreateNoWindow = true,
             },
         };
+        p.StartInfo.EnvironmentVariables["LANG"] = "C";
+        p.StartInfo.EnvironmentVariables["LC_ALL"] = "C";
         IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.ListUpdates, p);
         p.Start();
 

--- a/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
@@ -223,13 +223,16 @@ public class Apt : PackageManager
                 CreateNoWindow = true,
             },
         };
-        p.StartInfo.EnvironmentVariables["LANG"] = "C";
-        p.StartInfo.EnvironmentVariables["LC_ALL"] = "C";
+        p.StartInfo.Environment["LANG"] = "C";
+        p.StartInfo.Environment["LC_ALL"] = "C";
         IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.ListUpdates, p);
         p.Start();
 
-        // Output format: "<id>/<source>,... <new-ver> <arch> [upgradable from: <old-ver>]"
-        var pattern = new Regex(@"^([^/\s]+)/\S+\s+(\S+)\s+\S+\s+\[upgradable from: ([^\]]+)\]");
+        // Output format: "<id>/<source>,... <new-ver> <arch> [<localized-text> <old-ver>]"
+        // The bracketed suffix is locale-dependent (e.g. "upgradable from:" in English,
+        // "pouvant être mis à jour depuis :" in French). Match it by capturing the last
+        // whitespace-delimited token inside the brackets as the old version.
+        var pattern = new Regex(@"^([^/\s]+)/\S+\s+(\S+)\s+\S+\s+\[.*\s(\S+)\]");
         string? line;
         while ((line = p.StandardOutput.ReadLine()) is not null)
         {

--- a/src/UniGetUI.PackageEngine.Managers.Dnf/Helpers/DnfPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Dnf/Helpers/DnfPkgDetailsHelper.cs
@@ -27,6 +27,8 @@ internal sealed class DnfPkgDetailsHelper : BasePkgDetailsHelper
             },
         };
 
+        p.StartInfo.EnvironmentVariables["LANG"] = "C";
+        p.StartInfo.EnvironmentVariables["LC_ALL"] = "C";
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(
             LoggableTaskType.LoadPackageDetails, p);
         p.Start();

--- a/src/UniGetUI.PackageEngine.Managers.Dnf/Helpers/DnfPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Dnf/Helpers/DnfPkgDetailsHelper.cs
@@ -27,8 +27,8 @@ internal sealed class DnfPkgDetailsHelper : BasePkgDetailsHelper
             },
         };
 
-        p.StartInfo.EnvironmentVariables["LANG"] = "C";
-        p.StartInfo.EnvironmentVariables["LC_ALL"] = "C";
+        p.StartInfo.Environment["LANG"] = "C";
+        p.StartInfo.Environment["LC_ALL"] = "C";
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(
             LoggableTaskType.LoadPackageDetails, p);
         p.Start();

--- a/src/UniGetUI.PackageEngine.Managers.Pacman/Helpers/PacmanPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pacman/Helpers/PacmanPkgDetailsHelper.cs
@@ -27,8 +27,8 @@ internal sealed class PacmanPkgDetailsHelper : BasePkgDetailsHelper
             },
         };
 
-        p.StartInfo.EnvironmentVariables["LANG"] = "C";
-        p.StartInfo.EnvironmentVariables["LC_ALL"] = "C";
+        p.StartInfo.Environment["LANG"] = "C";
+        p.StartInfo.Environment["LC_ALL"] = "C";
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(
             LoggableTaskType.LoadPackageDetails, p);
         p.Start();

--- a/src/UniGetUI.PackageEngine.Managers.Pacman/Helpers/PacmanPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pacman/Helpers/PacmanPkgDetailsHelper.cs
@@ -27,6 +27,8 @@ internal sealed class PacmanPkgDetailsHelper : BasePkgDetailsHelper
             },
         };
 
+        p.StartInfo.EnvironmentVariables["LANG"] = "C";
+        p.StartInfo.EnvironmentVariables["LC_ALL"] = "C";
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(
             LoggableTaskType.LoadPackageDetails, p);
         p.Start();


### PR DESCRIPTION
## Summary

  - `GetAvailableUpdates_UnSafe` runs `apt list --upgradable` and parses each line with a regex that expects the English literal `[upgradable from: <version>]`

  - On non-English systems (e.g. French: `[pouvant être mis à jour depuis : <version>]`,  Portuguese, German, etc.) every line silently fails to match, returning an empty update list even though updates exist

  - Fix: set `LANG=C` / `LC_ALL=C` on the subprocess so `apt` always outputs in English regardless of the system locale

