### PR TITLE
Implement fix for application crash

### DIFF
--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -426,7 +426,8 @@ public partial class AutoUpdater
         // Check if the user has disabled updates
         if (!ManualCheck && Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
         {
-            Banner.IsOpen = false;
+            // Banner is a UI element; always touch it from the UI thread.
+            Window.DispatcherQueue.TryEnqueue(() => Banner.IsOpen = false);
             Logger.Warn("User disabled updates!");
             return true;
         }

--- a/src/UniGetUI/CrashHandler.cs
+++ b/src/UniGetUI/CrashHandler.cs
@@ -135,11 +135,22 @@ public static class CrashHandler
             }
         }
 
+        // Run the integrity check on a background thread with a tight timeout.
+        // Running it synchronously on the UI thread can block for 20-30 s on slow
+        // disks, and calling Environment.Exit while the UI thread holds WinRT locks
+        // causes a native crash in coreclr!ProcessCLRException (null read @ 0x0).
         string iReport;
         try
         {
-            var integrityReport = IntegrityTester.CheckIntegrity(false);
-            iReport = IntegrityTester.GetReadableReport(integrityReport);
+            var integrityTask = Task.Run(() => IntegrityTester.CheckIntegrity(false));
+            if (integrityTask.Wait(TimeSpan.FromSeconds(5)))
+            {
+                iReport = IntegrityTester.GetReadableReport(integrityTask.Result);
+            }
+            else
+            {
+                iReport = "Integrity check timed out (> 5 s) — skipped in crash report";
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Fix for issue #4625
This pull request focuses on improving application stability and responsiveness by ensuring UI operations are performed on the correct thread and by preventing UI thread blocking during crash handling. The most important changes are grouped below:

**UI Thread Safety:**

* Ensured that the `Banner.IsOpen` property is always updated from the UI thread by using `Window.DispatcherQueue.TryEnqueue`, preventing potential threading issues when the user has disabled updates.

**Crash Handling and Responsiveness:**

* Modified the integrity check in the crash handler to run on a background thread with a 5-second timeout, avoiding long UI thread blocks and preventing native crashes caused by `Environment.Exit` while holding WinRT locks. If the check exceeds 5 seconds, it is skipped in the crash report.<!-- Provide a general summary of your changes in the title above -->
