### PR TITLE
Fix Homebrew installation error on Apple Silicon

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewPkgDetailsHelper.cs
@@ -17,15 +17,7 @@ internal sealed class HomebrewPkgDetailsHelper : BasePkgDetailsHelper
     {
         using var p = new Process
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = Manager.Status.ExecutablePath,
-                Arguments = $"info --json=v2 {details.Package.Id}",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
+            StartInfo = ((Homebrew)Manager).MakeBrewStartInfo($"info --json=v2 {details.Package.Id}"),
         };
 
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewPkgDetailsHelper.cs
@@ -10,14 +10,16 @@ namespace UniGetUI.PackageEngine.Managers.HomebrewManager;
 
 internal sealed class HomebrewPkgDetailsHelper : BasePkgDetailsHelper
 {
+    private readonly Homebrew _brew;
+
     public HomebrewPkgDetailsHelper(Homebrew manager)
-        : base(manager) { }
+        : base(manager) { _brew = manager; }
 
     protected override void GetDetails_UnSafe(IPackageDetails details)
     {
         using var p = new Process
         {
-            StartInfo = ((Homebrew)Manager).MakeBrewStartInfo($"info --json=v2 {details.Package.Id}"),
+            StartInfo = _brew.MakeBrewStartInfo($"info --json=v2 {details.Package.Id}"),
         };
 
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewSourceHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewSourceHelper.cs
@@ -10,8 +10,10 @@ namespace UniGetUI.PackageEngine.Managers.HomebrewManager;
 
 internal sealed class HomebrewSourceHelper : BaseSourceHelper
 {
+    private readonly Homebrew _brew;
+
     public HomebrewSourceHelper(Homebrew manager)
-        : base(manager) { }
+        : base(manager) { _brew = manager; }
 
     // ── Source listing ─────────────────────────────────────────────────────
 
@@ -21,7 +23,7 @@ internal sealed class HomebrewSourceHelper : BaseSourceHelper
 
         using var p = new Process
         {
-            StartInfo = ((Homebrew)Manager).MakeBrewStartInfo("tap"),
+            StartInfo = _brew.MakeBrewStartInfo("tap"),
         };
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListSources, p);
         p.Start();

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewSourceHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewSourceHelper.cs
@@ -21,15 +21,7 @@ internal sealed class HomebrewSourceHelper : BaseSourceHelper
 
         using var p = new Process
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = Manager.Status.ExecutablePath,
-                Arguments = "tap",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
+            StartInfo = ((Homebrew)Manager).MakeBrewStartInfo("tap"),
         };
         IProcessTaskLogger logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListSources, p);
         p.Start();

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
@@ -98,23 +98,35 @@ public class Homebrew : PackageManager
         out string callArguments)
     {
         (found, path) = GetExecutableFile();
-        callArguments = "";
+        // Force ARM64 when brew is at the Apple Silicon prefix. Without this, a
+        // Rosetta-translated UniGetUI process spawns the x86_64 slice of the fat
+        // brew binary, which then refuses to operate against /opt/homebrew.
+        if (path == "/opt/homebrew/bin/brew")
+        {
+            callArguments = $"-arm64 {path}";
+            path = "/usr/bin/arch";
+        }
+        else
+        {
+            callArguments = "";
+        }
     }
+
+    internal ProcessStartInfo MakeBrewStartInfo(string arguments) => new()
+    {
+        FileName = Status.ExecutablePath,
+        Arguments = Status.ExecutableCallArgs.Length > 0
+            ? $"{Status.ExecutableCallArgs} {arguments}"
+            : arguments,
+        UseShellExecute = false,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        CreateNoWindow = true,
+    };
 
     protected override void _loadManagerVersion(out string version)
     {
-        using var p = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = Status.ExecutablePath,
-                Arguments = "--version",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
-        };
+        using var p = new Process { StartInfo = MakeBrewStartInfo("--version") };
         p.Start();
         // First line: "Homebrew 4.x.x"
         version = p.StandardOutput.ReadLine()?.Replace("Homebrew ", "").Trim() ?? "";
@@ -125,18 +137,7 @@ public class Homebrew : PackageManager
 
     public override void RefreshPackageIndexes()
     {
-        using var p = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = Status.ExecutablePath,
-                Arguments = "update",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
-        };
+        using var p = new Process { StartInfo = MakeBrewStartInfo("update") };
         IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.RefreshIndexes, p);
         p.Start();
         logger.AddToStdOut(p.StandardOutput.ReadToEnd());
@@ -155,18 +156,7 @@ public class Homebrew : PackageManager
         IManagerSource caskSource = SourcesHelper.Factory.GetSourceOrDefault("Homebrew Cask");
         IManagerSource currentSection = formulaeSource;
 
-        using var p = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = Status.ExecutablePath,
-                Arguments = $"search {query}",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
-        };
+        using var p = new Process { StartInfo = MakeBrewStartInfo($"search {query}") };
         IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.FindPackages, p);
         p.Start();
 
@@ -209,18 +199,7 @@ public class Homebrew : PackageManager
         var packages = new List<Package>();
         IManagerSource source = SourcesHelper.Factory.GetSourceOrDefault(sourceName);
 
-        using var p = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = Status.ExecutablePath,
-                Arguments = $"list {typeFlag} --versions",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
-        };
+        using var p = new Process { StartInfo = MakeBrewStartInfo($"list {typeFlag} --versions") };
         IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.ListInstalledPackages, p);
         p.Start();
 
@@ -250,18 +229,7 @@ public class Homebrew : PackageManager
         foreach (var pkg in GetInstalledPackages())
             installed.TryAdd(pkg.Id, pkg);
 
-        using var p = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = Status.ExecutablePath,
-                Arguments = "outdated --verbose",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
-        };
+        using var p = new Process { StartInfo = MakeBrewStartInfo("outdated --verbose") };
         IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.ListUpdates, p);
         p.Start();
 

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
@@ -98,10 +99,13 @@ public class Homebrew : PackageManager
         out string callArguments)
     {
         (found, path) = GetExecutableFile();
-        // Force ARM64 when brew is at the Apple Silicon prefix. Without this, a
-        // Rosetta-translated UniGetUI process spawns the x86_64 slice of the fat
-        // brew binary, which then refuses to operate against /opt/homebrew.
-        if (path == "/opt/homebrew/bin/brew")
+        // Force ARM64 when brew is at the Apple Silicon prefix. Without this,
+        // .NET's posix_spawn may select the x86_64 slice of universal binaries
+        // (bash, ruby) in the brew script chain, causing Homebrew to detect a
+        // Rosetta 2 context even when UniGetUI itself is ARM64-native.
+        if (path == BREW_PATHS[0]
+            && OperatingSystem.IsMacOS()
+            && RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64)
         {
             callArguments = $"-arm64 {path}";
             path = "/usr/bin/arch";


### PR DESCRIPTION
Fix for issue #4624
This pull request refactors how the Homebrew package manager integration launches the `brew` executable by introducing a new helper method for process startup, improving maintainability and ensuring correct architecture handling on Apple Silicon systems. The most important changes are grouped below.

### Process invocation refactoring

* Introduced the `MakeBrewStartInfo` method in `Homebrew.cs` to centralize the creation of `ProcessStartInfo` for all `brew` commands, replacing repeated inline `ProcessStartInfo` constructions throughout the codebase. This makes the code cleaner and easier to maintain.
* Updated all usages of `ProcessStartInfo` for `brew` commands in `Homebrew.cs`, `HomebrewPkgDetailsHelper.cs`, and `HomebrewSourceHelper.cs` to use the new `MakeBrewStartInfo` method. This includes commands for searching, listing, updating, and retrieving package details and sources. [[1]](diffhunk://#diff-b68b79917bb31fcac4aad6a995b70328f73a3370c368c39bf20b4390ee3d7556L128-R140) [[2]](diffhunk://#diff-b68b79917bb31fcac4aad6a995b70328f73a3370c368c39bf20b4390ee3d7556L158-R159) [[3]](diffhunk://#diff-b68b79917bb31fcac4aad6a995b70328f73a3370c368c39bf20b4390ee3d7556L212-R202) [[4]](diffhunk://#diff-b68b79917bb31fcac4aad6a995b70328f73a3370c368c39bf20b4390ee3d7556L253-R232) [[5]](diffhunk://#diff-ee54b157a91e3e8b49da195508713e7aae99fe80207655e75d17b2ccde961385L20-R20) [[6]](diffhunk://#diff-c53d5905de8a6a142be2df488147f4c87d73cca7b58c682d54197b4550916a2eL24-R24)

### Apple Silicon architecture handling

* Modified the `_loadManagerExecutableFile` method to force the use of the ARM64 architecture when the `brew` binary is located at `/opt/homebrew/bin/brew` (Apple Silicon prefix). This prevents issues when running under Rosetta by ensuring the correct binary slice is used.

### Internal API simplification

* Updated the `_loadManagerVersion` method to use the new `MakeBrewStartInfo` helper, further reducing duplicated code for process creation.

These changes improve the robustness and maintainability of the Homebrew integration, especially for users on Apple Silicon Macs.<!-- Provide a general summary of your changes in the title above -->

