### PR TITLE
 Avalonia: package auto-update and macOS notifications

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -181,7 +181,10 @@ internal static partial class AvaloniaAutoUpdater
 
         // Notify UI (update banner + toast)
         Dispatcher.UIThread.Post(() => UpdateAvailable?.Invoke(versionName));
-        WindowsAppNotificationBridge.ShowSelfUpdateAvailableNotification(versionName);
+        if (OperatingSystem.IsWindows())
+            WindowsAppNotificationBridge.ShowSelfUpdateAvailableNotification(versionName);
+        else if (OperatingSystem.IsMacOS())
+            MacOsNotificationBridge.ShowSelfUpdateAvailableNotification(versionName);
 
         if (autoLaunch)
         {

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
@@ -126,10 +126,10 @@ public static class AvaloniaOperationRegistry
             $"{title}. {message}",
             AutomationLiveSetting.Polite);
 
-        if (WindowsAppNotificationBridge.ShowProgress(op))
+        if (OperatingSystem.IsWindows() && WindowsAppNotificationBridge.ShowProgress(op))
             return;
 
-        if (MacOsNotificationBridge.ShowProgress(op))
+        if (OperatingSystem.IsMacOS() && MacOsNotificationBridge.ShowProgress(op))
             return;
 
         if (TryGetMainWindow() is not { } mainWindow)
@@ -160,10 +160,10 @@ public static class AvaloniaOperationRegistry
 
         WindowsAppNotificationBridge.RemoveProgress(op);
 
-        if (WindowsAppNotificationBridge.ShowSuccess(op))
+        if (OperatingSystem.IsWindows() && WindowsAppNotificationBridge.ShowSuccess(op))
             return;
 
-        if (MacOsNotificationBridge.ShowSuccess(op))
+        if (OperatingSystem.IsMacOS() && MacOsNotificationBridge.ShowSuccess(op))
             return;
 
         if (TryGetMainWindow() is not { } mainWindow)
@@ -194,10 +194,10 @@ public static class AvaloniaOperationRegistry
 
         WindowsAppNotificationBridge.RemoveProgress(op);
 
-        if (WindowsAppNotificationBridge.ShowError(op))
+        if (OperatingSystem.IsWindows() && WindowsAppNotificationBridge.ShowError(op))
             return;
 
-        if (MacOsNotificationBridge.ShowError(op))
+        if (OperatingSystem.IsMacOS() && MacOsNotificationBridge.ShowError(op))
             return;
 
         if (TryGetMainWindow() is not { } mainWindow)

--- a/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
@@ -9,37 +10,18 @@ using UniGetUI.PackageOperations;
 namespace UniGetUI.Avalonia.Infrastructure;
 
 /// <summary>
-/// macOS system notification delivery via NSUserNotificationCenter (ObjC runtime P/Invoke).
-/// Mirrors the pattern of WindowsAppNotificationBridge: guards on OS check, silent fallback on failure.
+/// macOS system notification delivery via osascript (works on all macOS versions).
+/// NSUserNotificationCenter was removed in macOS 14; UNUserNotificationCenter requires
+/// ObjC blocks that are impractical via pure P/Invoke. osascript is always available.
+/// Callers are responsible for the OperatingSystem.IsMacOS() guard before invoking.
 /// </summary>
 internal static class MacOsNotificationBridge
 {
-    private static bool? _available;
-    private static readonly object _lock = new();
-
-    private static bool IsAvailable()
-    {
-        if (!OperatingSystem.IsMacOS()) return false;
-        lock (_lock)
-        {
-            if (_available.HasValue) return _available.Value;
-            try
-            {
-                _available = objc_getClass("NSUserNotificationCenter") != IntPtr.Zero;
-            }
-            catch
-            {
-                _available = false;
-            }
-            return _available.Value;
-        }
-    }
-
     // ── Operation notifications ────────────────────────────────────────────
 
     public static bool ShowProgress(AbstractOperation operation)
     {
-        if (!IsAvailable() || Settings.AreProgressNotificationsDisabled()) return false;
+        if (Settings.AreProgressNotificationsDisabled()) return false;
         try
         {
             string title = operation.Metadata.Title.Length > 0
@@ -61,7 +43,7 @@ internal static class MacOsNotificationBridge
 
     public static bool ShowSuccess(AbstractOperation operation)
     {
-        if (!IsAvailable() || Settings.AreSuccessNotificationsDisabled()) return false;
+        if (Settings.AreSuccessNotificationsDisabled()) return false;
         try
         {
             string title = operation.Metadata.SuccessTitle.Length > 0
@@ -83,7 +65,7 @@ internal static class MacOsNotificationBridge
 
     public static bool ShowError(AbstractOperation operation)
     {
-        if (!IsAvailable() || Settings.AreErrorNotificationsDisabled()) return false;
+        if (Settings.AreErrorNotificationsDisabled()) return false;
         try
         {
             string title = operation.Metadata.FailureTitle.Length > 0
@@ -107,7 +89,7 @@ internal static class MacOsNotificationBridge
 
     public static void ShowUpdatesAvailableNotification(IReadOnlyList<IPackage> upgradable)
     {
-        if (!IsAvailable() || Settings.AreUpdatesNotificationsDisabled()) return;
+        if (Settings.AreUpdatesNotificationsDisabled()) return;
         try
         {
             string title, message;
@@ -131,9 +113,34 @@ internal static class MacOsNotificationBridge
         }
     }
 
+    public static void ShowUpgradingPackagesNotification(IReadOnlyList<IPackage> upgradable)
+    {
+        if (Settings.AreUpdatesNotificationsDisabled()) return;
+        try
+        {
+            string title, message;
+            if (upgradable.Count == 1)
+            {
+                title = CoreTools.Translate("An update was found!");
+                message = CoreTools.Translate("{0} is being updated to version {1}",
+                    upgradable[0].Name, upgradable[0].NewVersionString);
+            }
+            else
+            {
+                title = CoreTools.Translate("{0} packages are being updated", upgradable.Count);
+                message = string.Join(", ", upgradable.Select(p => p.Name));
+            }
+            DeliverNotification(title, message);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("macOS upgrading-packages notification failed");
+            Logger.Warn(ex);
+        }
+    }
+
     public static void ShowSelfUpdateAvailableNotification(string newVersion)
     {
-        if (!IsAvailable()) return;
         try
         {
             DeliverNotification(
@@ -149,7 +156,7 @@ internal static class MacOsNotificationBridge
 
     public static void ShowNewShortcutsNotification(IReadOnlyList<string> shortcuts)
     {
-        if (!IsAvailable() || Settings.AreNotificationsDisabled()) return;
+        if (Settings.AreNotificationsDisabled()) return;
         try
         {
             string title, message;
@@ -180,38 +187,25 @@ internal static class MacOsNotificationBridge
 
     private static void DeliverNotification(string title, string message)
     {
-        var centerClass = objc_getClass("NSUserNotificationCenter");
-        var center = MsgSend(centerClass, Sel("defaultUserNotificationCenter"));
-
-        var notifClass = objc_getClass("NSUserNotification");
-        var notif = MsgSend(MsgSend(notifClass, Sel("alloc")), Sel("init"));
-
-        MsgSend(notif, Sel("setTitle:"), ToNSString(title));
-        MsgSend(notif, Sel("setInformativeText:"), ToNSString(message));
-        MsgSend(center, Sel("deliverNotification:"), notif);
-        MsgSend(notif, Sel("autorelease"));
+        // NSUserNotificationCenter was removed in macOS 14; osascript works on all versions.
+        string script = "display notification " + AppleScriptString(message)
+                        + " with title " + AppleScriptString(title);
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "/usr/bin/osascript",
+            ArgumentList = { "-e", script },
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
     }
 
-    private static IntPtr ToNSString(string s)
-    {
-        IntPtr ptr = Marshal.StringToCoTaskMemUTF8(s);
-        try
-        {
-            return MsgSend(objc_getClass("NSString"), Sel("stringWithUTF8String:"), ptr);
-        }
-        finally
-        {
-            Marshal.FreeCoTaskMem(ptr);
-        }
-    }
-
-    private static IntPtr Sel(string name) => sel_registerName(name);
+    private static string AppleScriptString(string s) =>
+        "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
 
     // ── Dock icon ──────────────────────────────────────────────────────────
 
     public static void SetDockIcon(byte[] pngBytes)
     {
-        if (!OperatingSystem.IsMacOS()) return;
         try
         {
             var handle = GCHandle.Alloc(pngBytes, GCHandleType.Pinned);
@@ -241,7 +235,9 @@ internal static class MacOsNotificationBridge
         }
     }
 
-    // ── ObjC runtime P/Invoke ──────────────────────────────────────────────
+    private static IntPtr Sel(string name) => sel_registerName(name);
+
+    // ── ObjC runtime P/Invoke (used by SetDockIcon) ────────────────────────
 
     [DllImport("/usr/lib/libobjc.A.dylib")]
     private static extern IntPtr objc_getClass(string name);

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -212,6 +212,58 @@ internal static class WindowsAppNotificationBridge
     }
 
     /// <summary>
+    /// Shows a Windows toast notification when packages are actively being updated (auto-update triggered).
+    /// </summary>
+    public static void ShowUpgradingPackagesNotification(IReadOnlyList<IPackage> upgradable)
+    {
+        if (!EnsureRegistered()) return;
+        if (Settings.AreUpdatesNotificationsDisabled()) return;
+
+        bool sendNotification = upgradable.Any(p =>
+            !Settings.GetDictionaryItem<string, bool>(
+                Settings.K.DisabledPackageManagerNotifications, p.Manager.Name));
+        if (!sendNotification) return;
+
+        try
+        {
+            _removeByTagAsyncMethod?.Invoke(_managerDefault,
+                [CoreData.UpdatesAvailableNotificationTag.ToString()]);
+
+            if (upgradable.Count == 1)
+            {
+                ShowTextToast(
+                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
+                    scenario: ScenarioDefault,
+                    title: CoreTools.Translate("An update was found!"),
+                    message: CoreTools.Translate("{0} is being updated to version {1}",
+                        upgradable[0].Name, upgradable[0].NewVersionString),
+                    suppressDisplay: false,
+                    defaultAction: NotificationArguments.ShowOnUpdatesTab);
+            }
+            else
+            {
+                string attribution = string.Join(", ", upgradable
+                    .Where(p => !Settings.GetDictionaryItem<string, bool>(
+                        Settings.K.DisabledPackageManagerNotifications, p.Manager.Name))
+                    .Select(p => p.Name));
+
+                ShowTextToast(
+                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
+                    scenario: ScenarioDefault,
+                    title: CoreTools.Translate("{0} packages are being updated", upgradable.Count),
+                    message: attribution,
+                    suppressDisplay: false,
+                    defaultAction: NotificationArguments.ShowOnUpdatesTab);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not show upgrading-packages notification");
+            Logger.Warn(ex);
+        }
+    }
+
+    /// <summary>
     /// Shows a Windows toast offering a UniGetUI self-update with an "Update now" button.
     /// </summary>
     public static void ShowSelfUpdateAvailableNotification(string newVersion)

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -17,6 +17,7 @@ using UniGetUI.Avalonia.Views.Pages.SettingsPages;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
@@ -150,15 +151,11 @@ public partial class MainWindowViewModel : ViewModelBase
                 Dispatcher.UIThread.Post(() =>
                     Sidebar.UpdatesBadgeCount = upgLoader.Count());
             Sidebar.UpdatesBadgeCount = upgLoader.Count();
-
-            upgLoader.FinishedLoading += (_, _) =>
-            {
-                var upgradable = upgLoader.Packages.ToList();
-                if (upgradable.Count == 0) return;
-                WindowsAppNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
-                MacOsNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
-            };
+            // Notifications and auto-update logic are handled by SoftwareUpdatesPage.WhenPackagesLoaded
         }
+
+        WindowsAppNotificationBridge.NotificationActivated += action =>
+            Dispatcher.UIThread.Post(() => HandleNotificationActivation(action));
 
         BundlesPage.UnsavedChangesStateChanged += (_, _) =>
             Dispatcher.UIThread.Post(() =>
@@ -403,6 +400,28 @@ public partial class MainWindowViewModel : ViewModelBase
         if (owner is not null)
             await new AboutWindow().ShowDialog(owner);
         Sidebar.SelectNavButtonForPage(_currentPage);
+    }
+
+    // ─── Notification activation ─────────────────────────────────────────────
+    private void HandleNotificationActivation(string action)
+    {
+        if (action == NotificationArguments.UpdateAllPackages)
+        {
+            _ = AvaloniaPackageOperationHelper.UpdateAllAsync();
+        }
+        else if (action == NotificationArguments.ShowOnUpdatesTab)
+        {
+            NavigateTo(PageType.Updates);
+            MainWindow.Instance?.ShowFromTray();
+        }
+        else if (action == NotificationArguments.Show)
+        {
+            MainWindow.Instance?.ShowFromTray();
+        }
+        else if (action == NotificationArguments.ReleaseSelfUpdateLock)
+        {
+            AvaloniaAutoUpdater.ReleaseLockForAutoupdate_Notification = true;
+        }
     }
 
     // ─── Search box ──────────────────────────────────────────────────────────

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -1,10 +1,13 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Avalonia.Controls;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels.Pages;
 using UniGetUI.Avalonia.Views;
 using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
 using UniGetUI.Interface.Telemetry;
 using UniGetUI.PackageEngine.Classes.Manager.Classes;
 using UniGetUI.PackageEngine.Classes.Packages.Classes;
@@ -45,7 +48,9 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         MainSubtitle_StillLoading = CoreTools.Translate("Loading packages"),
         NoMatches_BackgroundText = CoreTools.Translate("No results were found matching the input criteria"),
     })
-    { }
+    {
+        ViewModel.PackagesLoaded += reason => { _ = WhenPackagesLoaded(); };
+    }
 
     protected override void GenerateToolBar(PackagesPageViewModel vm)
     {
@@ -365,5 +370,105 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         AvaloniaOperationRegistry.Add(updateOp);
         _ = uninstallOp.MainThread();
         _ = updateOp.MainThread();
+    }
+
+    // ─── Auto-update on load ──────────────────────────────────────────────────
+
+    private static async Task WhenPackagesLoaded()
+    {
+        try
+        {
+            var upgradable = UpgradablePackagesLoader.Instance.Packages
+                .Where(p => p.Tag is not PackageTag.OnQueue and not PackageTag.BeingProcessed)
+                .ToList();
+
+            if (upgradable.Count == 0) return;
+
+            if (Settings.Get(Settings.K.DisableAUPOnBattery) && IsOnBattery())
+            {
+                Logger.Warn("Updates will not be installed automatically because the device is on battery.");
+                ShowAvailableUpdatesNotification(upgradable);
+            }
+            else if (Settings.Get(Settings.K.DisableAUPOnBatterySaver) && IsBatterySaverOn())
+            {
+                Logger.Warn("Updates will not be installed automatically because battery saver is enabled.");
+                ShowAvailableUpdatesNotification(upgradable);
+            }
+            else if (Settings.Get(Settings.K.AutomaticallyUpdatePackages))
+            {
+                _ = AvaloniaPackageOperationHelper.UpdateAllAsync();
+                ShowUpgradingPackagesNotification(upgradable);
+            }
+            else if (Environment.GetCommandLineArgs().Contains("--updateapps"))
+            {
+                _ = AvaloniaPackageOperationHelper.UpdateAllAsync();
+                ShowUpgradingPackagesNotification(upgradable);
+                Logger.Warn("Automatic install of updates has been enabled via Command Line (user settings have been overriden)");
+            }
+            else
+            {
+                foreach (var package in upgradable)
+                {
+                    var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+                    if (opts.AutoUpdatePackage)
+                        await LaunchUpdate([package]);
+                }
+                ShowAvailableUpdatesNotification(upgradable);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+        }
+    }
+
+    private static void ShowAvailableUpdatesNotification(IReadOnlyList<IPackage> upgradable)
+    {
+        if (OperatingSystem.IsWindows())
+            WindowsAppNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
+        else if (OperatingSystem.IsMacOS())
+            MacOsNotificationBridge.ShowUpdatesAvailableNotification(upgradable);
+    }
+
+    private static void ShowUpgradingPackagesNotification(IReadOnlyList<IPackage> upgradable)
+    {
+        if (OperatingSystem.IsWindows())
+            WindowsAppNotificationBridge.ShowUpgradingPackagesNotification(upgradable);
+        else if (OperatingSystem.IsMacOS())
+            MacOsNotificationBridge.ShowUpgradingPackagesNotification(upgradable);
+    }
+
+    // ─── Battery / power helpers (Windows P/Invoke) ───────────────────────────
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SYSTEM_POWER_STATUS
+    {
+        public byte ACLineStatus;     // 0 = battery, 1 = AC, 255 = unknown
+        public byte BatteryFlag;
+        public byte BatteryLifePercent;
+        public byte SystemStatusFlag; // bit 0: battery saver active
+        public uint BatteryLifeTime;
+        public uint BatteryFullLifeTime;
+    }
+
+#pragma warning disable CA1416
+    [DllImport("kernel32.dll")]
+    private static extern bool GetSystemPowerStatus(out SYSTEM_POWER_STATUS status);
+#pragma warning restore CA1416
+
+    private static bool IsOnBattery()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+#pragma warning disable CA1416
+        return GetSystemPowerStatus(out var s) && s.ACLineStatus == 0;
+#pragma warning restore CA1416
+    }
+
+    private static bool IsBatterySaverOn()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+#pragma warning disable CA1416
+        return GetSystemPowerStatus(out var s) && (s.SystemStatusFlag & 0x01) != 0;
+#pragma warning restore CA1416
     }
 }


### PR DESCRIPTION
- Package auto-update on load — ports SoftwareUpdatesPage.WhenPackagesLoaded from WinUI: respects AutomaticallyUpdatePackages, DisableAUPOnBattery, DisableAUPOnBatterySaver, per-package AutoUpdatePackage flag, and the --updateapps CLI override
 - macOS notification delivery — replaced the removed NSUserNotificationCenter ObjC P/Invoke (dropped in macOS 14) with osascript, which works on all macOS versions without authorization setup
 - macOS self-update notification — AvaloniaAutoUpdater was only calling the Windows bridge; macOS bridge is now included
