### PR TITLE
Fix navigation bar accessibility for screen readers

### DIFF
--- a/src/UniGetUI/Controls/CustomNavViewItem.cs
+++ b/src/UniGetUI/Controls/CustomNavViewItem.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface;
@@ -47,6 +48,7 @@ internal sealed partial class CustomNavViewItem : NavigationViewItem
             string text = CoreTools.Translate(value);
             _textBlock.Text = text;
             ToolTipService.SetToolTip(this, text);
+            AutomationProperties.SetName(this, text);
         }
     }
 


### PR DESCRIPTION
Added AutomationProperties.SetName to the CustomNavViewItem control to ensure screen readers correctly announce the localized names for navigation options like 'Software Updates' and 'Installed Packages'.

Relates to #1767
