### PR TITLE
Clean up UI for WinUI and Avalonia

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -191,6 +191,7 @@ public partial class PackagesPageViewModel : ViewModelBase
         RoleIsUpdateLike = data.PageRole == OperationType.Update;
         NewVersionHeaderVisible = RoleIsUpdateLike;
         ReloadButtonVisible = !DisableReload;
+        ReloadButtonTooltip = CoreTools.Translate("Reload");
         SearchBoxPlaceholder = CoreTools.Translate("Search for packages");
 
         AllPackagesChecked = data.PackagesAreCheckedByDefault;

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -191,7 +191,6 @@ public partial class PackagesPageViewModel : ViewModelBase
         RoleIsUpdateLike = data.PageRole == OperationType.Update;
         NewVersionHeaderVisible = RoleIsUpdateLike;
         ReloadButtonVisible = !DisableReload;
-        ReloadButtonTooltip = CoreTools.Translate("Reload");
         SearchBoxPlaceholder = CoreTools.Translate("Search for packages");
 
         AllPackagesChecked = data.PackagesAreCheckedByDefault;

--- a/src/UniGetUI.Avalonia/Views/Controls/UserAvatarControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/Controls/UserAvatarControl.axaml
@@ -102,11 +102,14 @@
             </Panel>
 
             <!-- Avatar image (shown when logged in) -->
-            <Panel IsVisible="{Binding IsAuthenticated}">
+            <Border IsVisible="{Binding IsAuthenticated}"
+                    Width="32" Height="32"
+                    CornerRadius="100"
+                    ClipToBounds="True">
                 <Image Source="{Binding AvatarBitmap}"
                        Width="32" Height="32"
                        Stretch="UniformToFill"/>
-            </Panel>
+            </Border>
         </Panel>
 
     </Button>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -40,12 +40,12 @@
             </ContentControl>
 
             <!-- Vertical separator (spans all rows) -->
-            <Border Grid.Column="0" Grid.RowSpan="3"
-                    Width="1"
-                    HorizontalAlignment="Right"
-                    automation:AutomationProperties.AccessibilityView="Raw"
-                    Opacity="0.2"
-                    Background="{DynamicResource SystemBaseMediumColor}"/>
+            <!-- <Border Grid.Column="0" Grid.RowSpan="3" -->
+            <!--         Width="1" -->
+            <!--         HorizontalAlignment="Right" -->
+            <!--         automation:AutomationProperties.AccessibilityView="Raw" -->
+            <!--         Opacity="0.2" -->
+            <!--         Background="{DynamicResource SystemBaseMediumColor}"/> -->
 
             <!-- ── Banners + page content ── -->
             <Grid Grid.Column="1" Grid.Row="0" RowDefinitions="Auto,*" Margin="0,10">
@@ -370,13 +370,8 @@
                 </Button>
             </StackPanel>
 
-            <!-- Right column: avatar centred + Linux window buttons on the far right -->
+            <!-- Right column: Linux window buttons on the far right -->
             <Panel Grid.Column="2">
-                <controls:UserAvatarControl x:Name="AvatarControl"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            Height="50"
-                                            Margin="0,10,0,0"/>
 
                 <!-- Linux only: min / max / close (IsVisible set in code-behind) -->
                 <StackPanel x:Name="LinuxWindowButtons"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -39,14 +39,6 @@
                 </ContentControl.DataTemplates>
             </ContentControl>
 
-            <!-- Vertical separator (spans all rows) -->
-            <!-- <Border Grid.Column="0" Grid.RowSpan="3" -->
-            <!--         Width="1" -->
-            <!--         HorizontalAlignment="Right" -->
-            <!--         automation:AutomationProperties.AccessibilityView="Raw" -->
-            <!--         Opacity="0.2" -->
-            <!--         Background="{DynamicResource SystemBaseMediumColor}"/> -->
-
             <!-- ── Banners + page content ── -->
             <Grid Grid.Column="1" Grid.Row="0" RowDefinitions="Auto,*" Margin="0,10">
                 <StackPanel Grid.Row="0"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -159,10 +159,8 @@ public partial class MainWindow : Window
             // macOS: extend into the native title bar area.
             // WindowDecorationMargin.Top drives TitleBarGrid.Height via binding.
             // Traffic lights sit on the left → keep the 65 px HamburgerPanel margin.
-            // Avatar can be a bit taller to fill the deeper title bar.
             ExtendClientAreaToDecorationsHint = true;
             ExtendClientAreaTitleBarHeightHint = -1;
-            AvatarControl.Height = 36;
         }
         else if (OperatingSystem.IsWindows())
         {
@@ -172,8 +170,6 @@ public partial class MainWindow : Window
             TitleBarGrid.ClearValue(HeightProperty);
             TitleBarGrid.Height = 44;
             HamburgerPanel.Margin = new Thickness(10, 0, 8, 0);
-            AvatarControl.Height = 28;
-            AvatarControl.Margin = new Thickness(0);
             LinuxWindowButtons.IsVisible = true;
             MainContentGrid.Margin = new Thickness(0, 44, 0, 0);
             this.GetObservable(WindowStateProperty).Subscribe(state =>
@@ -196,7 +192,6 @@ public partial class MainWindow : Window
             TitleBarGrid.ClearValue(HeightProperty);
             TitleBarGrid.Height = 44;
             HamburgerPanel.Margin = new Thickness(10, 0, 8, 0);
-            AvatarControl.Height = 32;
             LinuxWindowButtons.IsVisible = !isWsl;
             MainContentGrid.Margin = new Thickness(0, 44, 0, 0);
             // Keep maximize icon in sync with window state

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -161,7 +161,7 @@
 
         <!-- Footer items -->
         <StackPanel Grid.Row="1" Margin="8,0,8,12" Spacing="2">
-            <Separator Margin="8,4"/>
+            <controls:UserAvatarControl HorizontalAlignment="Left" Margin="8,4,0,4"/>
 
             <Button Command="{Binding RequestNavigationCommand}"
                     CommandParameter="Settings"

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -215,17 +215,33 @@
                 </StackPanel>
                 <Button.Flyout>
                     <MenuFlyout Placement="RightEdgeAlignedTop">
-                        <MenuItem Header="{t:Translate UniGetUI Log}" Command="{Binding RequestNavigationCommand}" CommandParameter="OwnLog"/>
-                        <MenuItem Header="{t:Translate Package Manager logs}" Command="{Binding RequestNavigationCommand}" CommandParameter="ManagerLog"/>
-                        <MenuItem Header="{t:Translate Operation history}" Command="{Binding RequestNavigationCommand}" CommandParameter="OperationHistory"/>
+                        <MenuItem Header="{t:Translate UniGetUI Log}" Command="{Binding RequestNavigationCommand}" CommandParameter="OwnLog">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/buggy.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{t:Translate Package Manager logs}" Command="{Binding RequestNavigationCommand}" CommandParameter="ManagerLog">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/console.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{t:Translate Operation history}" Command="{Binding RequestNavigationCommand}" CommandParameter="OperationHistory">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/history.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
                         <Separator/>
-                        <MenuItem Header="{Binding VersionLabel}" IsEnabled="False"/>
-                        <MenuItem Header="{t:Translate Release notes}" Command="{Binding RequestNavigationCommand}" CommandParameter="ReleaseNotes"/>
+                        <MenuItem Header="{Binding VersionLabel}" IsEnabled="False">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/info_round.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{t:Translate Release notes}" Command="{Binding RequestNavigationCommand}" CommandParameter="ReleaseNotes">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/megaphone.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
                         <Separator/>
-                        <MenuItem Header="{t:Translate Help}" Command="{Binding RequestNavigationCommand}" CommandParameter="Help"/>
-                        <MenuItem Header="{t:Translate About}" Command="{Binding RequestNavigationCommand}" CommandParameter="About"/>
+                        <MenuItem Header="{t:Translate Help}" Command="{Binding RequestNavigationCommand}" CommandParameter="Help">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/help.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{t:Translate About}" Command="{Binding RequestNavigationCommand}" CommandParameter="About">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/info_round.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
                         <Separator/>
-                        <MenuItem Header="{t:Translate Quit UniGetUI}" Command="{Binding RequestNavigationCommand}" CommandParameter="Quit"/>
+                        <MenuItem Header="{t:Translate Quit UniGetUI}" Command="{Binding RequestNavigationCommand}" CommandParameter="Quit">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/close_round.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
                     </MenuFlyout>
                 </Button.Flyout>
             </Button>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -50,12 +50,12 @@
       </Style>
    </UserControl.Styles>
 
-   <Grid RowDefinitions="Auto,Auto,*" Margin="8,8,8,8">
+   <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="8,8,8,8">
 
         <!-- ==================== HEADER ==================== -->
         <Grid Name="MainHeader"
               Grid.Row="0"
-              ColumnDefinitions="80,*,Auto"
+              ColumnDefinitions="80,*"
               ColumnSpacing="8"
               Margin="0,0,0,4">
 
@@ -87,101 +87,6 @@
                            Text="{Binding Subtitle}"/>
             </StackPanel>
 
-            <!-- Order by + View mode + Reload -->
-            <Grid Grid.Column="2"
-                  RowDefinitions="Auto,Auto"
-                  ColumnDefinitions="Auto,Auto"
-                  RowSpacing="6"
-                  ColumnSpacing="8"
-                  HorizontalAlignment="Right"
-                  VerticalAlignment="Center">
-
-                <!-- Order by -->
-                <StackPanel x:Name="OrderByContainer"
-                            Grid.Row="0" Grid.Column="0"
-                            Orientation="Horizontal"
-                            Spacing="4"
-                            VerticalAlignment="Center">
-                    <TextBlock x:Name="OrderByLabel" Text="{t:Translate Order by:}" VerticalAlignment="Center"/>
-                    <Button x:Name="OrderByButton"
-                            Padding="8,4"
-                            CornerRadius="4"
-                            automation:AutomationProperties.LabeledBy="{Binding #OrderByLabel}">
-                        <StackPanel Orientation="Horizontal" Spacing="6">
-                            <TextBlock Text="{Binding SortFieldName}" VerticalAlignment="Center" FontSize="12"/>
-                            <TextBlock Text="▾" VerticalAlignment="Center" FontSize="10" Opacity="0.7"
-                                       automation:AutomationProperties.AccessibilityView="Raw"/>
-                        </StackPanel>
-                        <Button.Flyout>
-                            <MenuFlyout Placement="BottomEdgeAlignedLeft">
-                                <MenuItem x:Name="OrderByName_Menu"       Header="{t:Translate Name}"        Command="{Binding SortByNameCommand}"/>
-                                <MenuItem x:Name="OrderById_Menu"         Header="{t:Translate Id}"          Command="{Binding SortByIdCommand}"/>
-                                <MenuItem x:Name="OrderByVersion_Menu"    Header="{t:Translate Version}"     Command="{Binding SortByVersionCommand}"/>
-                                <MenuItem x:Name="OrderByNewVersion_Menu" Header="{t:Translate New version}" Command="{Binding SortByNewVersionCommand}"/>
-                                <MenuItem x:Name="OrderBySource_Menu"     Header="{t:Translate Source}"      Command="{Binding SortBySourceCommand}"/>
-                                <Separator/>
-                                <MenuItem x:Name="OrderByAscending_Menu"  Header="{t:Translate Ascendant}"   Command="{Binding SetSortAscendingCommand}"/>
-                                <MenuItem x:Name="OrderByDescending_Menu" Header="{t:Translate Descendant}"  Command="{Binding SetSortDescendingCommand}"/>
-                            </MenuFlyout>
-                        </Button.Flyout>
-                    </Button>
-                </StackPanel>
-
-                <!-- Reload button -->
-                <Button x:Name="ReloadButton"
-                        Grid.Row="0" Grid.Column="1"
-                        Width="22" Height="22"
-                        Padding="0"
-                        CornerRadius="4"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Command="{Binding ReloadCommand}"
-                        ToolTip.Tip="{Binding ReloadButtonTooltip}"
-                        automation:AutomationProperties.Name="{t:Translate Reload}"
-                        automation:AutomationProperties.AcceleratorKey="F5"
-                        IsVisible="{Binding ReloadButtonVisible}">
-                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/reload.svg" Width="16" Height="16"/>
-                </Button>
-
-                <!-- View mode selector -->
-                <StackPanel x:Name="ViewModeContainer"
-                            Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                            Orientation="Horizontal"
-                            Spacing="4"
-                            VerticalAlignment="Center">
-                    <TextBlock x:Name="ViewModeLabel" Text="{t:Translate View mode:}" VerticalAlignment="Center"/>
-                    <ListBox x:Name="ViewModeSelector"
-                             SelectionMode="Single"
-                             SelectedIndex="{Binding ViewModeIndex, Mode=TwoWay}"
-                             Background="Transparent"
-                             BorderThickness="1"
-                             CornerRadius="4"
-                         automation:AutomationProperties.LabeledBy="{Binding #ViewModeLabel}"
-                             Padding="0">
-                        <ListBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel Orientation="Horizontal"/>
-                            </ItemsPanelTemplate>
-                        </ListBox.ItemsPanel>
-                        <!-- List -->
-                        <ListBoxItem x:Name="Selector_List" Padding="6,4" ToolTip.Tip="List"
-                                     automation:AutomationProperties.Name="List">
-                            <TextBlock Text="☰" FontSize="16" automation:AutomationProperties.AccessibilityView="Raw"/>
-                        </ListBoxItem>
-                        <!-- Grid -->
-                        <ListBoxItem x:Name="Selector_Grid" Padding="6,4" ToolTip.Tip="Grid"
-                                     automation:AutomationProperties.Name="Grid">
-                            <TextBlock Text="⊞" FontSize="16" automation:AutomationProperties.AccessibilityView="Raw"/>
-                        </ListBoxItem>
-                        <!-- Icons -->
-                        <ListBoxItem x:Name="Selector_Icons" Padding="6,4" ToolTip.Tip="Icons"
-                                     automation:AutomationProperties.Name="Icons">
-                            <TextBlock Text="⊟" FontSize="16" automation:AutomationProperties.AccessibilityView="Raw"/>
-                        </ListBoxItem>
-                    </ListBox>
-                </StackPanel>
-
-            </Grid>
         </Grid>
 
         <!-- ==================== TOOLBAR ROW ==================== -->
@@ -766,5 +671,78 @@
             </Grid>
         </Grid>
 
+    <!-- ==================== FOOTER STATUS BAR ==================== -->
+    <Border Grid.Row="3" Margin="0,4,0,-8" VerticalAlignment="Center">
+        <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+
+            <!-- Order by -->
+            <StackPanel x:Name="OrderByContainer"
+                        Orientation="Horizontal"
+                        Spacing="4"
+                        VerticalAlignment="Center">
+                <TextBlock x:Name="OrderByLabel" Text="{t:Translate Order by:}" FontSize="13" VerticalAlignment="Center"/>
+                <Button x:Name="OrderByButton"
+                        Padding="10,6"
+                        CornerRadius="4"
+                        Background="Transparent"
+                        BorderThickness="1"
+                        BorderBrush="{DynamicResource AppBorderBrush}"
+                        automation:AutomationProperties.LabeledBy="{Binding #OrderByLabel}">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="{Binding SortFieldName}" VerticalAlignment="Center" FontSize="13"/>
+                        <TextBlock Text="▾" VerticalAlignment="Center" FontSize="19" Opacity="0.7"
+                                   automation:AutomationProperties.AccessibilityView="Raw"/>
+                    </StackPanel>
+                    <Button.Flyout>
+                        <MenuFlyout Placement="TopEdgeAlignedRight">
+                            <MenuItem x:Name="OrderByName_Menu"       Header="{t:Translate Name}"        Command="{Binding SortByNameCommand}"/>
+                            <MenuItem x:Name="OrderById_Menu"         Header="{t:Translate Id}"          Command="{Binding SortByIdCommand}"/>
+                            <MenuItem x:Name="OrderByVersion_Menu"    Header="{t:Translate Version}"     Command="{Binding SortByVersionCommand}"/>
+                            <MenuItem x:Name="OrderByNewVersion_Menu" Header="{t:Translate New version}" Command="{Binding SortByNewVersionCommand}"/>
+                            <MenuItem x:Name="OrderBySource_Menu"     Header="{t:Translate Source}"      Command="{Binding SortBySourceCommand}"/>
+                            <Separator/>
+                            <MenuItem x:Name="OrderByAscending_Menu"  Header="{t:Translate Ascendant}"   Command="{Binding SetSortAscendingCommand}"/>
+                            <MenuItem x:Name="OrderByDescending_Menu" Header="{t:Translate Descendant}"  Command="{Binding SetSortDescendingCommand}"/>
+                        </MenuFlyout>
+                    </Button.Flyout>
+                </Button>
+            </StackPanel>
+
+            <!-- View mode selector -->
+            <StackPanel x:Name="ViewModeContainer"
+                        Orientation="Horizontal"
+                        Spacing="4"
+                        VerticalAlignment="Center"
+                        automation:AutomationProperties.Name="{t:Translate View modes}">
+                <ListBox x:Name="ViewModeSelector"
+                         SelectionMode="Single"
+                         SelectedIndex="{Binding ViewModeIndex, Mode=TwoWay}"
+                         Background="Transparent"
+                         BorderThickness="1"
+                         BorderBrush="{DynamicResource AppBorderBrush}"
+                         CornerRadius="4"
+                         Padding="0">
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal"/>
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                    <ListBoxItem x:Name="Selector_List" Padding="10,6" ToolTip.Tip="List"
+                                 automation:AutomationProperties.Name="List">
+                        <TextBlock Text="☰" FontSize="19" automation:AutomationProperties.AccessibilityView="Raw"/>
+                    </ListBoxItem>
+                    <ListBoxItem x:Name="Selector_Grid" Padding="10,6" ToolTip.Tip="Grid"
+                                 automation:AutomationProperties.Name="Grid">
+                        <TextBlock Text="⊞" FontSize="19" automation:AutomationProperties.AccessibilityView="Raw"/>
+                    </ListBoxItem>
+                    <ListBoxItem x:Name="Selector_Icons" Padding="10,6" ToolTip.Tip="Icons"
+                                 automation:AutomationProperties.Name="Icons">
+                        <TextBlock Text="⊟" FontSize="19" automation:AutomationProperties.AccessibilityView="Raw"/>
+                    </ListBoxItem>
+                </ListBox>
+            </StackPanel>
+
+        </StackPanel>
+    </Border>
     </Grid>
 </UserControl>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -68,7 +68,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
         if (!ViewModel.DisableReload)
         {
             var reloadBtn = ViewModel.AddToolbarButton("reload", CoreTools.Translate("Reload"),
-                () => ViewModel.TriggerReload());
+                ViewModel.TriggerReload);
             reloadBtn.Bind(ToolTip.TipProperty,
                 new global::Avalonia.Data.Binding(nameof(PackagesPageViewModel.ReloadButtonTooltip)) { Source = ViewModel });
             ViewModel.AddToolbarSeparator();

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -64,6 +64,16 @@ public abstract partial class AbstractPackagesPage : UserControl,
         SyncFiltersButtonName();
         SyncOrderByButtonName();
 
+        // Reload button added before subclass toolbar items (mirrors WinUI AbstractPackagesPage)
+        if (!ViewModel.DisableReload)
+        {
+            var reloadBtn = ViewModel.AddToolbarButton("reload", CoreTools.Translate("Reload"),
+                () => ViewModel.TriggerReload());
+            reloadBtn.Bind(ToolTip.TipProperty,
+                new global::Avalonia.Data.Binding(nameof(PackagesPageViewModel.ReloadButtonTooltip)) { Source = ViewModel });
+            ViewModel.AddToolbarSeparator();
+        }
+
         // Build the toolbar now that both AXAML controls and the ViewModel are ready
         GenerateToolBar(ViewModel);
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/DiscoverSoftwarePage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/DiscoverSoftwarePage.cs
@@ -78,9 +78,6 @@ public class DiscoverSoftwarePage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("add_to", CoreTools.Translate("Add selection to bundle"),
             () => _ = ExportSelectionToBundleAsync(vm));
-        ViewModel.AddToolbarSeparator();
-        ViewModel.AddToolbarButton("help", CoreTools.Translate("Help"),
-            () => vm.RequestHelpCommand.Execute(null));
     }
 
     // ─── Context menu ─────────────────────────────────────────────────────────

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
@@ -124,9 +124,6 @@ public class InstalledPackagesPage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("add_to", CoreTools.Translate("Add selection to bundle"),
             () => _ = ExportSelectionToBundleAsync(vm));
-        ViewModel.AddToolbarSeparator();
-        ViewModel.AddToolbarButton("help", CoreTools.Translate("Help"),
-            () => vm.RequestHelpCommand.Execute(null));
     }
 
     // ─── Context menu ─────────────────────────────────────────────────────────

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
@@ -112,9 +112,6 @@ public class PackageBundlesPage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("info_round", CoreTools.Translate("Package details"),
             () => _ = ShowDetailsForPackage(SelectedItem), showLabel: false);
-        ViewModel.AddToolbarSeparator();
-        ViewModel.AddToolbarButton("help", CoreTools.Translate("Help"),
-            () => vm.RequestHelpCommand.Execute(null));
     }
 
     private static IReadOnlyList<IPackage> GetCheckedNonInstalledPackages(PackagesPageViewModel vm)

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -102,9 +102,6 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         });
         ViewModel.AddToolbarButton("clipboard_list", CoreTools.Translate("Manage ignored updates"),
             () => vm.RequestManageIgnoredCommand.Execute(null));
-        ViewModel.AddToolbarSeparator();
-        ViewModel.AddToolbarButton("help", CoreTools.Translate("Help"),
-            () => vm.RequestHelpCommand.Execute(null));
     }
 
     // ─── Context menu ─────────────────────────────────────────────────────────

--- a/src/UniGetUI/MainWindow.xaml
+++ b/src/UniGetUI/MainWindow.xaml
@@ -6,7 +6,6 @@
   xmlns:animations="using:CommunityToolkit.WinUI.Animations"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  xmlns:services="using:UniGetUI.Services"
   xmlns:widgets="using:UniGetUI.Interface.Widgets"
   Title="UniGetUI"
   mc:Ignorable="d"
@@ -52,9 +51,6 @@
           QueryIcon="Find"
         />
       </TitleBar.Content>
-      <TitleBar.RightHeader>
-        <services:UserAvatar Margin="0,0,0,0" />
-      </TitleBar.RightHeader>
     </TitleBar>
     <StackPanel Grid.Row="1" Margin="0" Padding="0" BorderThickness="0" Spacing="0">
       <InfoBar

--- a/src/UniGetUI/Pages/MainView.xaml
+++ b/src/UniGetUI/Pages/MainView.xaml
@@ -12,6 +12,7 @@
   xmlns:operationWidgets="using:UniGetUI.Controls.OperationWidgets"
   xmlns:operations="using:UniGetUI.PackageOperations"
   xmlns:pages="using:UniGetUI.Interface"
+  xmlns:services="using:UniGetUI.Services"
   xmlns:widgets="using:UniGetUI.Interface.Widgets"
   MinWidth="200"
   MinHeight="200"
@@ -367,6 +368,9 @@
         Text="More"
       />
     </NavigationView.FooterMenuItems>
+    <NavigationView.PaneFooter>
+      <services:UserAvatar Margin="12,4,12,8" />
+    </NavigationView.PaneFooter>
 
     <Grid Name="ContentGrid" Grid.Row="0" Grid.Column="1" Margin="8,8,8,8" RowSpacing="0">
       <Grid.ColumnDefinitions>

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
@@ -493,6 +493,7 @@
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto" />
       <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="*" />
@@ -505,7 +506,6 @@
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="80" />
         <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto" />
@@ -545,101 +545,7 @@
         />
       </StackPanel>
 
-      <Grid
-        Grid.Row="0"
-        Grid.Column="2"
-        HorizontalAlignment="Right"
-        VerticalAlignment="Center"
-        ColumnSpacing="8"
-        RowSpacing="8"
-      >
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition Height="Auto" />
-          <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <StackPanel
-          x:Name="OrderByContainer"
-          Grid.Column="0"
-          VerticalAlignment="Center"
-          Orientation="Horizontal"
-          Spacing="4"
-        >
-          <widgets:TranslatedTextBlock VerticalAlignment="Center" Text="Order by:" />
-          <DropDownButton x:Name="OrderByButton">
-            <DropDownButton.Flyout>
-              <widgets:BetterMenu Placement="Bottom">
-                <widgets:BetterToggleMenuItem x:Name="OrderByName_Menu" Text="Name" />
-                <widgets:BetterToggleMenuItem x:Name="OrderById_Menu" Text="Id" />
-                <widgets:BetterToggleMenuItem x:Name="OrderByVer_Menu" Text="Version" />
-                <widgets:BetterToggleMenuItem
-                  x:Name="OrderByNewVer_Menu"
-                  Text="New version"
-                  Visibility="{x:Bind RoleIsUpdateLike}"
-                />
-                <widgets:BetterToggleMenuItem x:Name="OrderBySrc_Menu" Text="Source" />
-                <MenuFlyoutSeparator />
-                <widgets:BetterToggleMenuItem x:Name="OrderAsc_Menu" Text="Ascendant" />
-                <widgets:BetterToggleMenuItem x:Name="OrderDesc_Menu" Text="Descendant" />
-              </widgets:BetterMenu>
-            </DropDownButton.Flyout>
-          </DropDownButton>
-        </StackPanel>
-        <StackPanel
-          x:Name="ViewModeContainer"
-          Grid.Row="1"
-          Grid.Column="0"
-          Grid.ColumnSpan="2"
-          VerticalAlignment="Center"
-          Orientation="Horizontal"
-          Spacing="4"
-          AutomationProperties.Name="View modes"
-          AutomationProperties.LocalizedControlType="grouping"
-        >
-          <widgets:TranslatedTextBlock VerticalAlignment="Center" Text="View mode:" />
-          <Toolkit:Segmented
-            x:Name="ViewModeSelector"
-            SelectionChanged="ViewModeSelector_SelectionChanged"
-            SelectionMode="Single"
-          >
-            <Toolkit:SegmentedItem x:Name="Selector_List" AutomationProperties.Name="List view">
-              <Toolkit:SegmentedItem.Icon>
-                <FontIcon Glyph="&#xE8FD;" />
-              </Toolkit:SegmentedItem.Icon>
-            </Toolkit:SegmentedItem>
-            <Toolkit:SegmentedItem x:Name="Selector_Grid" AutomationProperties.Name="Grid view">
-              <Toolkit:SegmentedItem.Icon>
-                <FontIcon Glyph="&#xF168;" />
-              </Toolkit:SegmentedItem.Icon>
-            </Toolkit:SegmentedItem>
-            <Toolkit:SegmentedItem x:Name="Selector_Icons" AutomationProperties.Name="Icons view">
-              <Toolkit:SegmentedItem.Icon>
-                <FontIcon Glyph="&#xF0E2;" />
-              </Toolkit:SegmentedItem.Icon>
-            </Toolkit:SegmentedItem>
-          </Toolkit:Segmented>
-        </StackPanel>
-        <Button
-          x:Name="ReloadButton"
-          Grid.Column="1"
-          Width="32"
-          Height="32"
-          Padding="0"
-          HorizontalAlignment="Right"
-          VerticalAlignment="Center"
-          x:FieldModifier="protected"
-          AutomationProperties.HelpText="Reload packages"
-          CornerRadius="4"
-        >
-          <FontIcon FontSize="16" Glyph="&#xE72C;" />
-        </Button>
-      </Grid>
-
-      <Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3">
+      <Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="Auto" />
@@ -751,7 +657,7 @@
 
     <SplitView
       Name="FilteringPanel"
-      Grid.Row="2"
+      Grid.Row="1"
       Grid.Column="1"
       BorderThickness="0"
       CornerRadius="0,0,0,0"
@@ -1295,5 +1201,74 @@
         </Grid>
       </Grid>
     </SplitView>
+
+    <!--  FOOTER STATUS BAR  -->
+    <Border
+      Grid.Row="2"
+      Grid.Column="1"
+      Padding="4,3,4,3"
+      BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+      BorderThickness="0,1,0,0"
+    >
+      <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+        <StackPanel
+          x:Name="OrderByContainer"
+          VerticalAlignment="Center"
+          Orientation="Horizontal"
+          Spacing="4"
+        >
+          <widgets:TranslatedTextBlock FontSize="12" VerticalAlignment="Center" Text="Order by:" />
+          <DropDownButton x:Name="OrderByButton" FontSize="12">
+            <DropDownButton.Flyout>
+              <widgets:BetterMenu Placement="Top">
+                <widgets:BetterToggleMenuItem x:Name="OrderByName_Menu" Text="Name" />
+                <widgets:BetterToggleMenuItem x:Name="OrderById_Menu" Text="Id" />
+                <widgets:BetterToggleMenuItem x:Name="OrderByVer_Menu" Text="Version" />
+                <widgets:BetterToggleMenuItem
+                  x:Name="OrderByNewVer_Menu"
+                  Text="New version"
+                  Visibility="{x:Bind RoleIsUpdateLike}"
+                />
+                <widgets:BetterToggleMenuItem x:Name="OrderBySrc_Menu" Text="Source" />
+                <MenuFlyoutSeparator />
+                <widgets:BetterToggleMenuItem x:Name="OrderAsc_Menu" Text="Ascendant" />
+                <widgets:BetterToggleMenuItem x:Name="OrderDesc_Menu" Text="Descendant" />
+              </widgets:BetterMenu>
+            </DropDownButton.Flyout>
+          </DropDownButton>
+        </StackPanel>
+        <Border Width="1" Height="14" Background="{ThemeResource CardStrokeColorDefaultBrush}" />
+        <StackPanel
+          x:Name="ViewModeContainer"
+          VerticalAlignment="Center"
+          Orientation="Horizontal"
+          Spacing="4"
+          AutomationProperties.Name="View modes"
+          AutomationProperties.LocalizedControlType="grouping"
+        >
+          <Toolkit:Segmented
+            x:Name="ViewModeSelector"
+            SelectionChanged="ViewModeSelector_SelectionChanged"
+            SelectionMode="Single"
+          >
+            <Toolkit:SegmentedItem x:Name="Selector_List" AutomationProperties.Name="List view">
+              <Toolkit:SegmentedItem.Icon>
+                <FontIcon Glyph="&#xE8FD;" />
+              </Toolkit:SegmentedItem.Icon>
+            </Toolkit:SegmentedItem>
+            <Toolkit:SegmentedItem x:Name="Selector_Grid" AutomationProperties.Name="Grid view">
+              <Toolkit:SegmentedItem.Icon>
+                <FontIcon Glyph="&#xF168;" />
+              </Toolkit:SegmentedItem.Icon>
+            </Toolkit:SegmentedItem>
+            <Toolkit:SegmentedItem x:Name="Selector_Icons" AutomationProperties.Name="Icons view">
+              <Toolkit:SegmentedItem.Icon>
+                <FontIcon Glyph="&#xF0E2;" />
+              </Toolkit:SegmentedItem.Icon>
+            </Toolkit:SegmentedItem>
+          </Toolkit:Segmented>
+        </StackPanel>
+      </StackPanel>
+    </Border>
   </Grid>
 </Page>

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -162,6 +162,7 @@ namespace UniGetUI.Interface
         protected readonly bool DISABLE_RELOAD;
         protected readonly string PAGE_NAME;
         public readonly bool RoleIsUpdateLike;
+        protected AppBarButton ReloadButton = new();
         protected DateTime LastPackageLoadTime { get; private set; }
         protected readonly OperationType PAGE_ROLE;
 
@@ -426,6 +427,11 @@ namespace UniGetUI.Interface
 
             OrderAsc_Menu.Click += (_, _) => SortPackagesBy(ascendent: true);
             OrderDesc_Menu.Click += (_, _) => SortPackagesBy(ascendent: false);
+
+            ReloadButton.Icon = new LocalIcon(IconType.Reload);
+            ReloadButton.Label = CoreTools.Translate("Reload");
+            ToolBar.PrimaryCommands.Add(ReloadButton);
+            ToolBar.PrimaryCommands.Add(new AppBarSeparator());
 
             GenerateToolBar();
             var menu = GenerateContextMenu();

--- a/src/UniGetUI/Pages/SoftwarePages/DiscoverSoftwarePage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/DiscoverSoftwarePage.cs
@@ -181,16 +181,12 @@ namespace UniGetUI.Interface.SoftwarePages
 
             AppBarButton ExportSelection = new();
 
-            AppBarButton HelpButton = new();
-
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(InstallationSettings);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(PackageDetails);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(ExportSelection);
-            ToolBar.PrimaryCommands.Add(new AppBarSeparator());
-            ToolBar.PrimaryCommands.Add(HelpButton);
 
             Dictionary<DependencyObject, string> Labels = new()
             { // Entries with a trailing space are collapsed
@@ -202,7 +198,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { InstallationSettings, CoreTools.Translate("Install options") },
                 { PackageDetails, " " + CoreTools.Translate("Package details") },
                 { ExportSelection, CoreTools.Translate("Add selection to bundle") },
-                { HelpButton, CoreTools.Translate("Help") },
             };
 
             Dictionary<DependencyObject, IconType> Icons = new()
@@ -214,7 +209,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { InstallInteractive, IconType.Interactive },
                 { PackageDetails, IconType.Info_Round },
                 { ExportSelection, IconType.AddTo },
-                { HelpButton, IconType.Help },
             };
 
             ApplyTextAndIconsToToolbar(Labels, Icons);
@@ -222,7 +216,6 @@ namespace UniGetUI.Interface.SoftwarePages
             PackageDetails.Click += (_, _) =>
                 ShowDetailsForPackage(SelectedItem, TEL_InstallReferral.DIRECT_SEARCH);
             ExportSelection.Click += ExportSelection_Click;
-            HelpButton.Click += (_, _) => MainApp.Instance.MainWindow.NavigationPage.ShowHelp();
             InstallationSettings.Click += (_, _) =>
                 _ = ShowInstallationOptionsForPackage(SelectedItem);
 

--- a/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/InstalledPackagesPage.cs
@@ -207,8 +207,6 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton ManageIgnored = new();
             AppBarButton ExportSelection = new();
 
-            AppBarButton HelpButton = new();
-
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(InstallationSettings);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
@@ -218,8 +216,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ToolBar.PrimaryCommands.Add(ManageIgnored);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(ExportSelection);
-            ToolBar.PrimaryCommands.Add(new AppBarSeparator());
-            ToolBar.PrimaryCommands.Add(HelpButton);
 
             Dictionary<DependencyObject, string> Labels = new()
             { // Entries with a trailing space are collapsed
@@ -232,7 +228,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { IgnoreSelected, CoreTools.Translate("Ignore selected packages") },
                 { ManageIgnored, CoreTools.Translate("Manage ignored updates") },
                 { ExportSelection, CoreTools.Translate("Add selection to bundle") },
-                { HelpButton, CoreTools.Translate("Help") },
             };
 
             Dictionary<DependencyObject, IconType> Icons = new()
@@ -245,7 +240,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { IgnoreSelected, IconType.Pin },
                 { ManageIgnored, IconType.ClipboardList },
                 { ExportSelection, IconType.AddTo },
-                { HelpButton, IconType.Help },
             };
 
             ApplyTextAndIconsToToolbar(Labels, Icons);
@@ -254,7 +248,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 ShowDetailsForPackage(SelectedItem, TEL_InstallReferral.ALREADY_INSTALLED);
 
             ExportSelection.Click += ExportSelection_Click;
-            HelpButton.Click += (_, _) => MainApp.Instance.MainWindow.NavigationPage.ShowHelp();
             InstallationSettings.Click += (_, _) =>
                 _ = ShowInstallationOptionsForPackage(SelectedItem);
             ManageIgnored.Click += async (_, _) => await DialogHelper.ManageIgnoredUpdates();

--- a/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
@@ -203,7 +203,6 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton ToBatchScript = new();
             AppBarButton AddPackagesToBundle = new();
             AppBarButton PackageDetails = new();
-            AppBarButton HelpButton = new();
 
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(NewBundle);
@@ -216,8 +215,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ToolBar.PrimaryCommands.Add(RemoveSelected);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(PackageDetails);
-            ToolBar.PrimaryCommands.Add(new AppBarSeparator());
-            ToolBar.PrimaryCommands.Add(HelpButton);
 
             Dictionary<DependencyObject, string> Labels = new()
             { // Entries with a trailing space are collapsed
@@ -233,7 +230,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { SaveBundle, CoreTools.Translate("Save as") },
                 { AddPackagesToBundle, CoreTools.Translate("Add packages to bundle") },
                 { PackageDetails, " " + CoreTools.Translate("Package details") },
-                { HelpButton, CoreTools.Translate("Help") },
             };
 
             Dictionary<DependencyObject, IconType> Icons = new()
@@ -249,7 +245,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { SaveBundle, IconType.SaveAs },
                 { AddPackagesToBundle, IconType.AddTo },
                 { PackageDetails, IconType.Info_Round },
-                { HelpButton, IconType.Help },
             };
 
             ApplyTextAndIconsToToolbar(Labels, Icons);
@@ -278,10 +273,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 );
             };
 
-            HelpButton.Click += (_, _) =>
-            {
-                MainApp.Instance.MainWindow.NavigationPage.ShowHelp();
-            };
             NewBundle.Click += async (s, e) => await AskForNewBundle();
 
             RemoveSelected.Click += (_, _) =>

--- a/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
@@ -270,8 +270,6 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton IgnoreSelected = new();
             AppBarButton ManageIgnored = new();
 
-            AppBarButton HelpButton = new();
-
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(InstallationSettings);
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
@@ -279,8 +277,6 @@ namespace UniGetUI.Interface.SoftwarePages
             ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(IgnoreSelected);
             ToolBar.PrimaryCommands.Add(ManageIgnored);
-            ToolBar.PrimaryCommands.Add(new AppBarSeparator());
-            ToolBar.PrimaryCommands.Add(HelpButton);
 
             Dictionary<DependencyObject, string> Labels = new()
             { // Entries with a leading space are collapsed
@@ -294,7 +290,6 @@ namespace UniGetUI.Interface.SoftwarePages
                 { PackageDetails, " " + CoreTools.Translate("Package details") },
                 { IgnoreSelected, CoreTools.Translate("Ignore selected packages") },
                 { ManageIgnored, CoreTools.Translate("Manage ignored updates") },
-                { HelpButton, CoreTools.Translate("Help") },
             };
 
             Dictionary<DependencyObject, IconType> Icons = new()
@@ -308,14 +303,12 @@ namespace UniGetUI.Interface.SoftwarePages
                 { PackageDetails, IconType.Info_Round },
                 { IgnoreSelected, IconType.Pin },
                 { ManageIgnored, IconType.ClipboardList },
-                { HelpButton, IconType.Help },
             };
 
             ApplyTextAndIconsToToolbar(Labels, Icons);
 
             PackageDetails.Click += (_, _) =>
                 ShowDetailsForPackage(SelectedItem, TEL_InstallReferral.ALREADY_INSTALLED);
-            HelpButton.Click += (_, _) => MainApp.Instance.MainWindow.NavigationPage.ShowHelp();
             InstallationSettings.Click += (_, _) =>
                 _ = ShowInstallationOptionsForPackage(SelectedItem);
             ManageIgnored.Click += async (_, _) => await DialogHelper.ManageIgnoredUpdates();


### PR DESCRIPTION
This pull request makes several UI improvements to the application, focusing on the layout and controls of the packages page, sidebar, and main window. 

**Packages Page Layout and Controls:**
- Moved the "Order by" and "View mode" controls from the header to a new footer status bar, improving clarity and freeing up header space.
- The "Reload" button is now added programmatically to the toolbar, with its tooltip text bound to a translatable resource.

**Sidebar Improvements:**
- The user avatar has been moved from the main window's title bar to the sidebar's footer for a more standard navigation experience.
- All sidebar menu items now feature clear, consistent SVG icons, improving visual navigation and accessibility.

**Main Window and Avatar Handling:**
- The avatar display control has been updated to use a circular border for a modern look.

**Other UI Tweaks:**
- Minor toolbar adjustments on the Discover Software page, such as removing a duplicate help button.