### PR TITLE
Fix RPM install failure on Fedora 38+ due to liblttng-ust.so.0 dependency 

### DIFF
--- a/scripts/package-linux.ps1
+++ b/scripts/package-linux.ps1
@@ -236,6 +236,11 @@ Summary:    $Description
 License:    GPL-3.0-or-later
 URL:        $Url
 
+# The self-contained .NET runtime links against liblttng-ust.so.0, which was
+# renamed to .so.1 in newer distros (Fedora 38+). Exclude it so the package
+# installs on both old and new releases; .NET ships its own tracing fallback.
+%global __requires_exclude ^liblttng-ust\\.so
+
 %description
 $Description
 

--- a/scripts/package-linux.ps1
+++ b/scripts/package-linux.ps1
@@ -239,7 +239,7 @@ URL:        $Url
 # The self-contained .NET runtime links against liblttng-ust.so.0, which was
 # renamed to .so.1 in newer distros (Fedora 38+). Exclude it so the package
 # installs on both old and new releases; .NET ships its own tracing fallback.
-%global __requires_exclude ^liblttng-ust\\.so
+%global __requires_exclude ^liblttng-ust\.so
 
 %description
 $Description


### PR DESCRIPTION
fix for issue #4676

 ## Problem
Fedora 38 renamed `liblttng-ust` from `.so.0` to `.so.1`. The self-contained .NET runtime bundles pre-built native binaries that reference `liblttng-ust.so.0`, which `rpmbuild`'s automatic dependency scanner picks up and declares as a hard RPM install requirement.

 ## Fix
Add `%global __requires_exclude ^liblttng-ust\.so` to the generated RPM spec. This drops the auto-detected requirement from the package metadata so the package installs on both older and newer Fedora releases.

This has no effect on runtime behavior: .NET loads LTTng via `dlopen`, not a hard ELF link, so the runtime gracefully skips tracing when `.so.0` is absent. On older distros where `.so.0` is present, it is still found and used by the dynamic linker as before.