### PR TITLE
Fix translation issues

### DIFF
--- a/src/Languages/lang_ca.json
+++ b/src/Languages/lang_ca.json
@@ -66,6 +66,8 @@
   "Version to install:": "Versió a instal·lar:",
   "Architecture to install:": "Arquitectura a instal·lar:",
   "Installation scope:": "Entorn d'instal·lació:",
+  "User | Local": "Usuari | Local",
+  "Machine | Global": "Màquina | Global",
   "Install location:": "Ubicació d'instal·lació:",
   "Select": "Sel·lecciona",
   "Reset": "Reseteja",

--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -66,6 +66,8 @@
   "Version to install:": "Version to install:",
   "Architecture to install:": "Architecture to install:",
   "Installation scope:": "Installation scope:",
+  "User | Local": "User | Local",
+  "Machine | Global": "Machine | Global",
   "Install location:": "Install location:",
   "Select": "Select",
   "Reset": "Reset",


### PR DESCRIPTION
"User | Local" and "Machine | Global" were only ever added to lang_ca.json and never to lang_en.json. The translation sync script in #4677 correctly pruned them as orphaned keys, which broke the test