### PR TITLE
Fix build issues macos

### DIFF
--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -184,7 +184,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
                     Manager.Name,
                     CoreTools.MakeValidFileName(Id)
                 );
-                return path is null ? null : new Uri("file:///" + path);
+                return path is null ? null : new Uri((path.StartsWith('/') ? "file://" : "file:///") + path);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This pull request makes a small update to the `GetIconUrl` method in `Package.cs` to improve how file URIs are constructed. The change ensures that the correct URI prefix is used depending on whether the path starts with a slash.
