### PR TITLE
Fix Pinget detection and Avalonia WinGet settings

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -23,9 +23,51 @@
         <ApplicationManifest Condition="$([MSBuild]::IsOSPlatform('Windows'))">app.manifest</ApplicationManifest>
     </PropertyGroup>
 
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <PingetCliProject>$(MSBuildThisFileDirectory)..\UniGetUI.Pinget.Cli\UniGetUI.Pinget.Cli.csproj</PingetCliProject>
+        <PingetCliRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</PingetCliRuntimeIdentifier>
+        <PingetCliRuntimeIdentifier Condition="'$(PingetCliRuntimeIdentifier)' == '' and '$(Platform)' == 'arm64'">win-arm64</PingetCliRuntimeIdentifier>
+        <PingetCliRuntimeIdentifier Condition="'$(PingetCliRuntimeIdentifier)' == ''">win-x64</PingetCliRuntimeIdentifier>
+        <PingetCliPublishDir>$(MSBuildProjectDirectory)\obj\$(Platform)\$(Configuration)\BundledPinget\$(PingetCliRuntimeIdentifier)\</PingetCliPublishDir>
+        <PingetCliExecutablePath>$(PingetCliPublishDir)pinget.exe</PingetCliExecutablePath>
+        <PingetCliNativeSqlitePath>$(PingetCliPublishDir)e_sqlite3.dll</PingetCliNativeSqlitePath>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(EnableAvaloniaDiagnostics)' == 'true'">
         <DefineConstants>$(DefineConstants);AVALONIA_DIAGNOSTICS_ENABLED</DefineConstants>
     </PropertyGroup>
+
+    <Target
+        Name="PublishBundledPingetCli"
+        AfterTargets="Build;Publish"
+        Condition="'$(DesignTimeBuild)' != 'true' and $([MSBuild]::IsOSPlatform('Windows'))"
+    >
+        <MSBuild
+            Projects="$(PingetCliProject)"
+            Targets="Restore;Publish"
+            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=false;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
+        />
+        <ItemGroup>
+            <PingetCliOutputFiles Include="$(PingetCliExecutablePath)" Condition="Exists('$(PingetCliExecutablePath)')" />
+            <PingetCliOutputFiles Include="$(PingetCliNativeSqlitePath)" Condition="Exists('$(PingetCliNativeSqlitePath)')" />
+            <PingetCliOutputFiles Include="$(TargetDir)runtimes\$(PingetCliRuntimeIdentifier)\native\e_sqlite3.dll" Condition="!Exists('$(PingetCliNativeSqlitePath)') and Exists('$(TargetDir)runtimes\$(PingetCliRuntimeIdentifier)\native\e_sqlite3.dll')" />
+            <PingetCliPublishOutputFiles Include="$(PingetCliExecutablePath)" Condition="Exists('$(PingetCliExecutablePath)')" />
+            <PingetCliPublishOutputFiles Include="$(PingetCliNativeSqlitePath)" Condition="Exists('$(PingetCliNativeSqlitePath)')" />
+            <PingetCliPublishOutputFiles Include="$(PublishDir)runtimes\$(PingetCliRuntimeIdentifier)\native\e_sqlite3.dll" Condition="!Exists('$(PingetCliNativeSqlitePath)') and Exists('$(PublishDir)runtimes\$(PingetCliRuntimeIdentifier)\native\e_sqlite3.dll')" />
+        </ItemGroup>
+        <Copy
+            SourceFiles="@(PingetCliOutputFiles)"
+            DestinationFolder="$(TargetDir)"
+            SkipUnchangedFiles="true"
+            Condition="'$(TargetDir)' != ''"
+        />
+        <Copy
+            SourceFiles="@(PingetCliPublishOutputFiles)"
+            DestinationFolder="$(PublishDir)"
+            SkipUnchangedFiles="true"
+            Condition="'$(PublishDir)' != '' and Exists('$(PublishDir)')"
+        />
+    </Target>
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.0-rc1" />

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -160,6 +160,7 @@ public partial class PackagesPageViewModel : ViewModelBase
     protected ConcurrentDictionary<IPackageManager, SourceTreeNode> RootNodeForManager = new();
     protected ConcurrentDictionary<IManagerSource, SourceTreeNode> NodesForSources = new();
     private readonly SourceTreeNode _localPackagesNode = new() { PackageName = "local" };
+    private bool _isSynchronizingSourceSelection;
 
     // ─── Events (replace abstract methods) ───────────────────────────────────
     public event Action<ReloadReason>? PackagesLoaded;
@@ -457,14 +458,17 @@ public partial class PackagesPageViewModel : ViewModelBase
             _ => pkg => FilterHelpers.NameOrIdContains(pkg, query, filters),
         };
 
-        var selectedSources = GetSelectedSourceNodes();
+        var (visibleSources, visibleManagers) = GetSelectedSourceFilters();
         Func<IPackage, bool> sourceFilter = SourceNodes.Count == 0
             ? _ => true   // sources not yet loaded — show everything
-            : selectedSources.Count == 0
+            : visibleSources.Count == 0 && visibleManagers.Count == 0
                 ? _ => false  // sources loaded but none selected — show nothing
-                : pkg => selectedSources.Any(n =>
-                    n.PackageName.TrimEnd('.', ' ') == pkg.Source.Manager.DisplayName
-                    || n.PackageName.TrimEnd('.', ' ') == pkg.Source.Name);
+                : pkg =>
+                    visibleSources.Contains(pkg.Source)
+                    || (
+                        !pkg.Manager.Capabilities.SupportsCustomSources
+                        && visibleManagers.Contains(pkg.Manager)
+                    );
 
         var results = FilteredPackages.ApplyToList(
             _wrappedPackages.Where(w => matchFunc(w.Package) && sourceFilter(w.Package))
@@ -597,11 +601,12 @@ public partial class PackagesPageViewModel : ViewModelBase
                 Version = package.VersionString,
                 Source = package.Source.Name
             };
-            item.PropertyChanged += OnRootSourceNodePropertyChanged;
             NodesForSources.TryAdd(source, item);
 
             if (source.IsVirtualManager)
             {
+                item.IsSelected = _localPackagesNode.IsSelected;
+                item.PropertyChanged += OnRootSourceNodePropertyChanged;
                 _localPackagesNode.Children.Add(item);
                 if (!GetAllSourceNodes().Contains(_localPackagesNode))
                 {
@@ -611,7 +616,10 @@ public partial class PackagesPageViewModel : ViewModelBase
             }
             else
             {
-                RootNodeForManager[source.Manager].Children.Add(item);
+                var rootNode = RootNodeForManager[source.Manager];
+                item.IsSelected = rootNode.IsSelected;
+                item.PropertyChanged += OnRootSourceNodePropertyChanged;
+                rootNode.Children.Add(item);
             }
         }
     }
@@ -641,9 +649,65 @@ public partial class PackagesPageViewModel : ViewModelBase
     private void OnRootSourceNodePropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(SourceTreeNode.IsSelected))
+        {
+            if (sender is SourceTreeNode node && SourceNodes.Contains(node))
+            {
+                _isSynchronizingSourceSelection = true;
+                try
+                {
+                    foreach (var child in node.Children)
+                    {
+                        child.IsSelected = node.IsSelected;
+                    }
+                }
+                finally
+                {
+                    _isSynchronizingSourceSelection = false;
+                }
+            }
+
+            if (_isSynchronizingSourceSelection)
+                return;
+
             FilterPackages();
+        }
     }
     private List<SourceTreeNode> GetAllSourceNodes() => SourceNodes.ToList();
+
+    private (List<IManagerSource> Sources, List<IPackageManager> Managers) GetSelectedSourceFilters()
+    {
+        var visibleSources = new List<IManagerSource>();
+        var visibleManagers = new List<IPackageManager>();
+
+        foreach (var node in GetSelectedSourceNodes())
+        {
+            var source = NodesForSources.FirstOrDefault(x => ReferenceEquals(x.Value, node)).Key;
+            if (source is not null)
+            {
+                if (!visibleSources.Contains(source))
+                    visibleSources.Add(source);
+                continue;
+            }
+
+            var manager = RootNodeForManager.FirstOrDefault(x => ReferenceEquals(x.Value, node)).Key;
+            if (manager is null)
+                continue;
+
+            if (!visibleManagers.Contains(manager))
+                visibleManagers.Add(manager);
+
+            if (!manager.Capabilities.SupportsCustomSources || node.Children.Count > 0)
+                continue;
+
+            foreach (IManagerSource managerSource in manager.SourcesHelper.Factory.GetAvailableSources())
+            {
+                if (!visibleSources.Contains(managerSource))
+                    visibleSources.Add(managerSource);
+            }
+        }
+
+        return (visibleSources, visibleManagers);
+    }
 
     private List<SourceTreeNode> GetSelectedSourceNodes()
     {

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml.cs
@@ -355,17 +355,54 @@ public sealed partial class PackageManagerPage : UserControl, ISettingsPage
 
         switch (manager.Name)
         {
-            case "WinGet":
+            case "Winget":
                 disableNotifsCard.CornerRadius = new CornerRadius(8, 8, 0, 0);
                 disableNotifsCard.BorderThickness = new Thickness(1, 1, 1, 0);
                 ExtraControls.Children.Add(disableNotifsCard);
+
+                var wingetCliToolPreference = new ComboboxCard
+                {
+                    Text = CoreTools.Translate("WinGet command-line tool"),
+                    Description = CoreTools.Translate(
+                        "Choose which command-line tool UniGetUI uses for WinGet operations when the COM API is not used"
+                    ),
+                    SettingName = CoreSettings.K.WinGetCliToolPreference,
+                    CornerRadius = new CornerRadius(0),
+                    BorderThickness = new Thickness(1, 0, 1, 1),
+                };
+                wingetCliToolPreference.AddItem("Default", "default");
+                wingetCliToolPreference.AddItem("WinGet", "winget", false);
+                wingetCliToolPreference.AddItem("Pinget", "pinget", false);
+                wingetCliToolPreference.ShowAddedItems();
+                wingetCliToolPreference.ValueChanged += (_, _) =>
+                    _ = ViewModel.ReloadManagerCommand.ExecuteAsync(null);
+                ExtraControls.Children.Add(wingetCliToolPreference);
+
+                var wingetComApiPolicy = new ComboboxCard
+                {
+                    Text = CoreTools.Translate("WinGet COM API"),
+                    Description = CoreTools.Translate(
+                        "Choose whether UniGetUI can use the WinGet COM API before falling back to the command-line tool"
+                    ),
+                    SettingName = CoreSettings.K.WinGetComApiPolicy,
+                    CornerRadius = new CornerRadius(0),
+                    BorderThickness = new Thickness(1, 0, 1, 1),
+                };
+                wingetComApiPolicy.AddItem("Default", "default");
+                wingetComApiPolicy.AddItem("Enabled", "enabled");
+                wingetComApiPolicy.AddItem("Disabled", "disabled");
+                wingetComApiPolicy.ShowAddedItems();
+                wingetComApiPolicy.ValueChanged += (_, _) =>
+                    _ = ViewModel.ReloadManagerCommand.ExecuteAsync(null);
+                ExtraControls.Children.Add(wingetComApiPolicy);
 
                 var wingetResetBtn = new ButtonCard
                 {
                     Text = CoreTools.Translate("Reset WinGet")
                         + $" ({CoreTools.Translate("This may help if no packages are listed")})",
                     ButtonText = CoreTools.AutoTranslated("Reset"),
-                    CornerRadius = new CornerRadius(0, 0, 8, 8),
+                    CornerRadius = new CornerRadius(0),
+                    BorderThickness = new Thickness(1, 0, 1, 1),
                 };
                 wingetResetBtn.Click += (_, _) => _ = AvaloniaPackageOperationHelper.HandleBrokenWinGetAsync();
                 ExtraControls.Children.Add(wingetResetBtn);
@@ -374,7 +411,7 @@ public sealed partial class PackageManagerPage : UserControl, ISettingsPage
                 {
                     Text = CoreTools.Translate("Force install location parameter when updating packages with custom locations"),
                     SettingName = CoreSettings.K.WinGetForceLocationOnUpdate,
-                    CornerRadius = new CornerRadius(0),
+                    CornerRadius = new CornerRadius(0, 0, 8, 8),
                     BorderThickness = new Thickness(1, 0, 1, 1),
                 });
 

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -22,6 +22,8 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
     {
         internal const string CliToolPreferenceEnvironmentVariable = "UNIGETUI_WINGET_CLI";
         internal const string ComApiPolicyEnvironmentVariable = "UNIGETUI_WINGET_COM";
+        private const string SystemWinGetExecutableName = "winget.exe";
+        private const string PingetExecutableName = "pinget.exe";
 
         public static string[] FALSE_PACKAGE_NAMES = ["", "e(s)", "have", "the", "Id"];
         public static string[] FALSE_PACKAGE_IDS =
@@ -274,24 +276,38 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             WinGetCliToolPreference cliToolPreference = WinGetCliToolPreference.Default
         )
         {
-            IReadOnlyList<string> systemWinGetCandidates = findExecutables("winget.exe");
-            bool bundledPingetExists = fileExists(bundledPingetPath);
+            List<string> candidates = [];
 
-            List<string> candidates = cliToolPreference switch
+            if (cliToolPreference is not WinGetCliToolPreference.BundledPinget)
             {
-                WinGetCliToolPreference.BundledPinget => bundledPingetExists
-                    ? [bundledPingetPath]
-                    : [],
-                WinGetCliToolPreference.SystemWinGet => [.. systemWinGetCandidates],
-                _ => [.. systemWinGetCandidates],
-            };
+                candidates.AddRange(findExecutables(SystemWinGetExecutableName));
+            }
 
-            if (cliToolPreference is WinGetCliToolPreference.Default && bundledPingetExists)
+            if (cliToolPreference is not WinGetCliToolPreference.SystemWinGet)
             {
-                candidates.Add(bundledPingetPath);
+                candidates.AddRange(
+                    FindPingetExecutableFiles(findExecutables, fileExists, bundledPingetPath)
+                );
             }
 
             return candidates.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+
+        private static IEnumerable<string> FindPingetExecutableFiles(
+            Func<string, IReadOnlyList<string>> findExecutables,
+            Func<string, bool> fileExists,
+            string bundledPingetPath
+        )
+        {
+            if (fileExists(bundledPingetPath))
+            {
+                yield return bundledPingetPath;
+            }
+
+            foreach (string pingetExecutablePath in findExecutables(PingetExecutableName))
+            {
+                yield return pingetExecutablePath;
+            }
         }
 
         internal static string GetBundledPingetExecutablePath()
@@ -326,7 +342,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
             if (SelectedCliToolKind == WinGetCliToolKind.BundledPinget)
             {
-                Logger.Warn("Using bundled Pinget CLI tool.");
+                Logger.Warn("Using Pinget CLI tool.");
                 WinGetHelper.Instance = new PingetCliHelper(this, path);
                 return;
             }
@@ -473,15 +489,29 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                 : value.Trim().Replace("-", "").Replace("_", "").ToLowerInvariant();
         }
 
-        private static WinGetCliToolKind GetCliToolKind(string executablePath)
+        internal static WinGetCliToolKind GetCliToolKind(string executablePath)
         {
-            return Path.GetFullPath(executablePath)
+            return IsPingetExecutablePath(executablePath)
+                ? WinGetCliToolKind.BundledPinget
+                : WinGetCliToolKind.SystemWinGet;
+        }
+
+        private static bool IsPingetExecutablePath(string executablePath)
+        {
+            if (string.IsNullOrWhiteSpace(executablePath))
+            {
+                return false;
+            }
+
+            return Path.GetFileName(executablePath).Equals(
+                    PingetExecutableName,
+                    StringComparison.OrdinalIgnoreCase
+                )
+                || Path.GetFullPath(executablePath)
                     .Equals(
                         Path.GetFullPath(GetBundledPingetExecutablePath()),
                         StringComparison.OrdinalIgnoreCase
-                    )
-                ? WinGetCliToolKind.BundledPinget
-                : WinGetCliToolKind.SystemWinGet;
+                    );
         }
 
         protected override void _loadManagerVersion(out string version)
@@ -514,7 +544,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
             string rawVersion = process.StandardOutput.ReadToEnd().Trim();
             version = usesPingetHelper
-                ? $"Bundled Pinget CLI Version: {rawVersion}"
+                ? $"Pinget CLI Version: {rawVersion}"
                 : $"System WinGet (CLI) Version: {rawVersion}";
 
             if (usesPingetHelper)

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -205,6 +205,30 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void FindCandidateExecutableFilesCanUsePathPingetWithoutSystemWinGetFallback()
+    {
+        const string bundledPinget = @"C:\Program Files\UniGetUI\pinget.exe";
+        const string pathPinget = @"C:\Tools\pinget.exe";
+
+        var candidates = WinGet.FindCandidateExecutableFiles(
+            static executableName =>
+                executableName switch
+                {
+                    "winget.exe" => throw new InvalidOperationException(
+                        "System WinGet should not be queried in Pinget mode."
+                    ),
+                    "pinget.exe" => [pathPinget],
+                    _ => [],
+                },
+            static _ => false,
+            bundledPinget,
+            WinGetCliToolPreference.BundledPinget
+        );
+
+        Assert.Equal([pathPinget], candidates);
+    }
+
+    [Fact]
     public void FindCandidateExecutableFilesReturnsEmptyWhenNoCliToolExists()
     {
         var candidates = WinGet.FindCandidateExecutableFiles(
@@ -290,6 +314,18 @@ public sealed class WinGetManagerTests : IDisposable
         );
 
         Assert.Equal((WinGetCliToolPreference)expectedPreference, preference);
+    }
+
+    [Theory]
+    [InlineData(@"C:\Program Files\UniGetUI\pinget.exe", 1)]
+    [InlineData(@"C:\Tools\pinget.exe", 1)]
+    [InlineData(@"C:\WindowsApps\winget.exe", 0)]
+    public void GetCliToolKindRecognizesPingetExecutableName(
+        string executablePath,
+        int expectedKind
+    )
+    {
+        Assert.Equal((WinGetCliToolKind)expectedKind, WinGet.GetCliToolKind(executablePath));
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Report WinGet as found when the WinGet CLI preference is set to Pinget and pinget.exe is available
- Add the missing Avalonia WinGet command-line tool and COM API settings
- Bundle Pinget and its native SQLite dependency with the Avalonia local dev build
- Make Avalonia installed-package source filters use source identities so WinGet local/subsources filter correctly

## Validation
- dotnet test src\UniGetUI.PackageEngine.Tests\UniGetUI.PackageEngine.Tests.csproj --framework net10.0-windows10.0.26100.0 --filter "FullyQualifiedName~FindCandidateExecutableFilesCanUsePathPingetWithoutSystemWinGetFallback|FullyQualifiedName~GetCliToolKindRecognizesPingetExecutableName" --verbosity normal --nologo
- dotnet test src\UniGetUI.PackageEngine.Tests\UniGetUI.PackageEngine.Tests.csproj --framework net10.0-windows10.0.26100.0 --verbosity q --nologo
- dotnet build src\UniGetUI.Avalonia\UniGetUI.Avalonia.csproj /p:Configuration=Debug /p:Platform=x64 --verbosity minimal --nologo
- dotnet build src\UniGetUI\UniGetUI.csproj /p:Configuration=Debug /p:Platform=x64 --verbosity minimal --nologo
- pinget.exe upgrade --include-unknown --output json from the Avalonia Debug output
