### PR TITLE
Batch package telemetry events into a single OpenSearch bulk request

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -12,6 +12,7 @@ using UniGetUI.Interface;
 using UniGetUI.Interface.Telemetry;
 using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Classes.Manager.Classes;
+using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.Infrastructure;
 
@@ -112,6 +113,7 @@ internal static class AvaloniaBootstrapper
         TelemetryHandler.Configure(
             Secrets.GetOpenSearchUsername(),
             Secrets.GetOpenSearchPassword());
+        AbstractOperation.QueueDrained += (_, _) => _ = TelemetryHandler.FlushPackageEventsAsync();
         _ = TelemetryHandler.InitializeAsync()
             .ContinueWith(
                 t => Logger.Error(t.Exception!),

--- a/src/UniGetUI.Interface.Telemetry.Tests/TelemetryHandlerTests.cs
+++ b/src/UniGetUI.Interface.Telemetry.Tests/TelemetryHandlerTests.cs
@@ -169,10 +169,13 @@ public sealed class TelemetryHandlerTests : IDisposable
             );
         });
 
-        using var json = JsonDocument.Parse(captured.Body);
+        // Body is NDJSON: {"index":{}}\n{event}\n
+        string[] lines = captured.Body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        using var json = JsonDocument.Parse(lines[1]);
         JsonElement root = json.RootElement;
 
-        Assert.Contains("package_events", captured.RequestUri.AbsoluteUri);
+        Assert.Contains("package_events/_bulk", captured.RequestUri.AbsoluteUri);
         Assert.Equal("install", root.GetProperty("operation").GetString());
         Assert.Equal(package.Id, root.GetProperty("packageId").GetString());
         Assert.Equal(package.Manager.Name, root.GetProperty("managerName").GetString());
@@ -202,12 +205,51 @@ public sealed class TelemetryHandlerTests : IDisposable
             TelemetryHandler.PackageDetails(package, "DIRECT_LINK");
         });
 
-        using var json = JsonDocument.Parse(captured.Body);
+        // Body is NDJSON: {"index":{}}\n{event}\n
+        string[] lines = captured.Body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        using var json = JsonDocument.Parse(lines[1]);
         JsonElement root = json.RootElement;
 
         Assert.Equal("details", root.GetProperty("operation").GetString());
         Assert.Equal("DIRECT_LINK", root.GetProperty("eventSource").GetString());
         Assert.False(root.TryGetProperty("operationResult", out _));
+    }
+
+    [Fact]
+    public async Task UpdatePackages_BatchesManyEventsIntoOneBulkRequest()
+    {
+        TelemetryHandler.Configure("telemetry-user", "telemetry-pass");
+
+        int requestCount = 0;
+        string lastBody = string.Empty;
+        TaskCompletionSource<string> completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        TelemetryHandler.TestSendAsyncOverride = async request =>
+        {
+            Interlocked.Increment(ref requestCount);
+            lastBody = request.Content is null ? string.Empty : await request.Content.ReadAsStringAsync();
+            completionSource.TrySetResult(lastBody);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        };
+
+        var packages = Enumerable.Range(1, 5).Select(i => new Package(
+            $"Package {i}", $"pkg.{i}", "1.0", new NullSource("src"), NullPackageManager.Instance
+        )).ToArray();
+
+        foreach (var pkg in packages)
+            TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
+
+        await TelemetryHandler.FlushPackageEventsAsync();
+        string body = await completionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, requestCount);
+
+        // NDJSON body must have 2 lines per event: action + document
+        string[] lines = body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(10, lines.Length); // 5 events × 2 lines
+        for (int i = 0; i < lines.Length; i += 2)
+            Assert.Equal("{\"index\":{}}", lines[i]);
     }
 
     [Fact]
@@ -266,7 +308,7 @@ public sealed class TelemetryHandlerTests : IDisposable
         CaptureRequestAsync(() =>
         {
             trigger();
-            return Task.CompletedTask;
+            return TelemetryHandler.FlushPackageEventsAsync();
         });
 
     private static async Task<IReadOnlyList<CapturedRequest>> CaptureRequestsAsync(

--- a/src/UniGetUI.Interface.Telemetry/TelemetryHandler.cs
+++ b/src/UniGetUI.Interface.Telemetry/TelemetryHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -72,6 +73,8 @@ public static class TelemetryHandler
 #endif
 
     private static readonly HttpClient _httpClient = CreateHttpClient();
+
+    private static readonly ConcurrentQueue<UniGetUIPackageEvent> _pendingPackageEvents = new();
 
     private static HttpClient CreateHttpClient()
     {
@@ -181,6 +184,7 @@ public static class TelemetryHandler
         _openSearchPassword = "";
         _credentialsWarningLogged = false;
         TestSendAsyncOverride = null;
+        while (_pendingPackageEvents.TryDequeue(out _)) { }
     }
 
     // -------------------------------------------------------------------------
@@ -189,57 +193,107 @@ public static class TelemetryHandler
         IPackage package,
         TEL_OP_RESULT status,
         TEL_InstallReferral source
-    ) => _ = TrackPackageEventAsync(package, "install", status, source.ToString());
+    ) => EnqueuePackageEvent(package, "install", status, source.ToString());
 
     public static void UpdatePackage(IPackage package, TEL_OP_RESULT status) =>
-        _ = TrackPackageEventAsync(package, "update", status);
+        EnqueuePackageEvent(package, "update", status);
 
     public static void DownloadPackage(
         IPackage package,
         TEL_OP_RESULT status,
         TEL_InstallReferral source
-    ) => _ = TrackPackageEventAsync(package, "download", status, source.ToString());
+    ) => EnqueuePackageEvent(package, "download", status, source.ToString());
 
     public static void UninstallPackage(IPackage package, TEL_OP_RESULT status) =>
-        _ = TrackPackageEventAsync(package, "uninstall", status);
+        EnqueuePackageEvent(package, "uninstall", status);
 
     public static void PackageDetails(IPackage package, string eventSource) =>
-        _ = TrackPackageEventAsync(package, "details", eventSource: eventSource);
+        EnqueuePackageEvent(package, "details", eventSource: eventSource);
 
-    private static async Task TrackPackageEventAsync(
+    private static void EnqueuePackageEvent(
         IPackage package,
         string operation,
         TEL_OP_RESULT? result = null,
         string? eventSource = null)
     {
+        if (result is null && eventSource is null)
+            throw new ArgumentException("result and eventSource cannot both be null");
+        if (Settings.Get(Settings.K.DisableTelemetry))
+            return;
+
+        _pendingPackageEvents.Enqueue(new UniGetUIPackageEvent
+        {
+            InstallID = GetRandomizedId(),
+            Locale = LanguageEngine.SelectedLocale,
+            Application = BuildApplicationInfo(),
+            Platform = BuildPlatformInfo(),
+            Operation = operation,
+            PackageId = package.Id,
+            ManagerName = package.Manager.Name,
+            SourceName = package.Source.Name,
+            OperationResult = result?.ToString(),
+            EventSource = eventSource,
+        });
+    }
+
+    /// <summary>
+    /// Drains the pending package-event queue and sends everything in a single
+    /// bulk request. Called from QueueDrained event subscribers and on app shutdown.
+    /// </summary>
+    public static async Task FlushPackageEventsAsync()
+    {
+        if (_pendingPackageEvents.IsEmpty)
+            return;
+
+        var batch = new List<UniGetUIPackageEvent>();
+        while (_pendingPackageEvents.TryDequeue(out UniGetUIPackageEvent? ev))
+            batch.Add(ev);
+
+        if (batch.Count > 0)
+            await PostBulkPackageEventsAsync(batch);
+    }
+
+    private static async Task PostBulkPackageEventsAsync(IReadOnlyList<UniGetUIPackageEvent> events)
+    {
+        if (!CredentialsConfigured())
+            return;
+
         try
         {
-            if (result is null && eventSource is null)
-                throw new ArgumentException("result and eventSource cannot both be null");
-            if (Settings.Get(Settings.K.DisableTelemetry))
-                return;
-
             await CoreTools.WaitForInternetConnection();
 
-            var ev = new UniGetUIPackageEvent
-            {
-                InstallID = GetRandomizedId(),
-                Locale = LanguageEngine.SelectedLocale,
-                Application = BuildApplicationInfo(),
-                Platform = BuildPlatformInfo(),
-                Operation = operation,
-                PackageId = package.Id,
-                ManagerName = package.Manager.Name,
-                SourceName = package.Source.Name,
-                OperationResult = result?.ToString(),
-                EventSource = eventSource,
-            };
+            string fullIndex = IndexPrefix + IndexPackage;
 
-            await PostToOpenSearchAsync(IndexPackage, ev, TelemetrySerializerContext.Trimming.UniGetUIPackageEvent);
+            var sb = new StringBuilder();
+            foreach (UniGetUIPackageEvent ev in events)
+            {
+                sb.Append("{\"index\":{}}\n");
+                sb.Append(JsonSerializer.Serialize(ev, TelemetrySerializerContext.BulkTrimming.UniGetUIPackageEvent));
+                sb.Append('\n');
+            }
+
+            string credentials = Convert.ToBase64String(
+                Encoding.UTF8.GetBytes($"{_openSearchUsername}:{_openSearchPassword}"));
+
+            using var content = new StringContent(sb.ToString(), Encoding.UTF8, "application/x-ndjson");
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{OpenSearchUrl}/{fullIndex}/_bulk")
+            {
+                Content = content,
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+            HttpResponseMessage response = TestSendAsyncOverride is { } sendAsync
+                ? await sendAsync(request)
+                : await _httpClient.SendAsync(request);
+
+            if (response.IsSuccessStatusCode)
+                Logger.Debug($"[Telemetry] Sent {events.Count} package event(s) to {fullIndex} (bulk)");
+            else
+                Logger.Warn($"[Telemetry] Bulk {fullIndex} returned {(int)response.StatusCode}");
         }
         catch (Exception ex)
         {
-            Logger.Error($"[Telemetry] Hard crash in TrackPackageEventAsync ({operation})");
+            Logger.Error("[Telemetry] Hard crash posting bulk package events");
             Logger.Error(ex);
         }
     }
@@ -373,5 +427,14 @@ internal partial class TelemetrySerializerContext : JsonSerializerContext
         new(new JsonSerializerOptions(SerializationHelpers.DefaultOptions)
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        });
+
+    // Compact (non-indented) variant required for NDJSON bulk payloads:
+    // OpenSearch _bulk API requires each document to be on a single line.
+    internal static readonly TelemetrySerializerContext BulkTrimming =
+        new(new JsonSerializerOptions(SerializationHelpers.DefaultOptions)
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false,
         });
 }

--- a/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
@@ -243,6 +243,11 @@ public abstract partial class AbstractOperation : IDisposable
                 LineType.ProgressIndicator
             );
         }
+        finally
+        {
+            if (OperationQueue.Count == 0)
+                QueueDrained?.Invoke(null, EventArgs.Empty);
+        }
     }
 
     private async Task<OperationVeredict> _runOperation()

--- a/src/UniGetUI.PackageEngine.Operations/AbstractOperation_Auxiliaries.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractOperation_Auxiliaries.cs
@@ -5,6 +5,12 @@ public abstract partial class AbstractOperation
     public static readonly List<AbstractOperation> OperationQueue = [];
     public static int MAX_OPERATIONS;
 
+    /// <summary>
+    /// Raised on the thread that completed the last operation in <see cref="OperationQueue"/>.
+    /// Subscribers should not do heavy work here — fire-and-forget async is fine.
+    /// </summary>
+    public static event EventHandler<EventArgs>? QueueDrained;
+
     public static class RetryMode
     {
         public const string NoRetry = "";

--- a/src/UniGetUI/App.xaml.cs
+++ b/src/UniGetUI/App.xaml.cs
@@ -17,6 +17,7 @@ using UniGetUI.Interface.Telemetry;
 using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Classes.Manager.Classes;
 using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageOperations;
 using UniGetUI.Pages.DialogPages;
 using UniGetUI.Services;
 using Windows.ApplicationModel.Activation;
@@ -384,6 +385,7 @@ namespace UniGetUI
                 TelemetryHandler.Configure(
                     Secrets.GetOpenSearchUsername(),
                     Secrets.GetOpenSearchPassword());
+                AbstractOperation.QueueDrained += (_, _) => _ = TelemetryHandler.FlushPackageEventsAsync();
                 _ = TelemetryHandler.InitializeAsync();
                 _ = IconDatabase.Instance.LoadIconAndScreenshotsDatabaseAsync();
 


### PR DESCRIPTION
-  Package telemetry events (install, update, uninstall, download, details) are now queued in-memory and flushed as a single /_bulk NDJSON request instead of one HTTP request per event.

- Flush is triggered by a new AbstractOperation.QueueDrained static event, which fires whenever the last running operation exits its queue. This means a burst of 30 package updates produces exactly one HTTP request, fired as soon as the last operation finishes — no fixed timer.

- Added TelemetrySerializerContext.BulkTrimming (compact, non-indented JSON) required by the OpenSearch bulk API.
- FlushPackageEventsAsync() is public for explicit calls from tests.
- QueueDrained is wired in both the Avalonia and WinUI bootstrappers.
