### PR TITLE
Remove Korean translator entries

### DIFF
--- a/src/Languages/Data/Translators.json
+++ b/src/Languages/Data/Translators.json
@@ -492,26 +492,6 @@
   ],
   "ko": [
     {
-      "name": "jihoon416",
-      "link": "https://github.com/jihoon416"
-    },
-    {
-      "name": "minbert",
-      "link": "https://github.com/minbert"
-    },
-    {
-      "name": "MuscularPuky",
-      "link": "https://github.com/MuscularPuky"
-    },
-    {
-      "name": "shblue21",
-      "link": "https://github.com/shblue21"
-    },
-    {
-      "name": "thejjw",
-      "link": "https://github.com/thejjw"
-    },
-    {
       "name": "VenusGirl",
       "link": "https://github.com/VenusGirl"
     }


### PR DESCRIPTION
Removed several translator entries fojihoon416, minbert, musicalPuky, shblue21, and thejjw are other app developers who have nothing to do with the UnigetUI translation project, a list that was mistakenly included by a previous developer. The full translator of the original is the exclusive translation of VenusGirl. So I set it right away.r Korean language.
