### PR TITLE
Fix color issues for operation output and theme switching

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Windows.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Windows.axaml
@@ -39,6 +39,8 @@
                     <SolidColorBrush x:Key="StatusErrorForeground"       Color="#ef9a9a"/>
                     <!-- Setting warning subtext -->
                     <SolidColorBrush x:Key="SettingWarningTextForeground" Color="#ffc107"/>
+                    <!-- Operation log output text -->
+                    <SolidColorBrush x:Key="LogOutputVerboseForeground"   Color="#9D9D9D"/>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
                     <!-- Settings cards -->
@@ -76,6 +78,8 @@
                     <SolidColorBrush x:Key="StatusErrorForeground"       Color="#c62828"/>
                     <!-- Setting warning subtext -->
                     <SolidColorBrush x:Key="SettingWarningTextForeground" Color="#a05c00"/>
+                    <!-- Operation log output text -->
+                    <SolidColorBrush x:Key="LogOutputVerboseForeground"   Color="#5C5C5C"/>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
@@ -1,5 +1,7 @@
 using System.Collections.ObjectModel;
+using Avalonia;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using UniGetUI.Avalonia.ViewModels.Pages.LogPages;
@@ -12,12 +14,17 @@ public partial class OperationOutputViewModel : ObservableObject
     [ObservableProperty] private string _title = "";
     public ObservableCollection<LogLineItem> OutputLines { get; } = new();
 
-    private static readonly IBrush _errorBrush = new SolidColorBrush(Color.Parse("#FF6B6B"));
-    private static readonly IBrush _debugBrush = new SolidColorBrush(Color.Parse("#888888"));
-    private static readonly IBrush _normalBrush = Brushes.White;
+    private readonly IBrush _errorBrush;
+    private readonly IBrush _debugBrush;
+    private readonly IBrush _normalBrush;
 
     public OperationOutputViewModel(AbstractOperation operation)
     {
+        var theme = Application.Current?.ActualThemeVariant ?? ThemeVariant.Default;
+        _errorBrush = LookupBrush("StatusErrorForeground", theme, new SolidColorBrush(Color.Parse("#c62828")));
+        _debugBrush = LookupBrush("LogOutputVerboseForeground", theme, new SolidColorBrush(Color.Parse("#767676")));
+        _normalBrush = LookupBrush("SystemControlForegroundBaseHighBrush", theme, Brushes.White);
+
         Title = operation.Metadata.Title;
 
         foreach (var (text, type) in operation.GetOutput())
@@ -25,6 +32,13 @@ public partial class OperationOutputViewModel : ObservableObject
 
         operation.LogLineAdded += (_, ev) =>
             Dispatcher.UIThread.Post(() => OutputLines.Add(MakeLine(ev.Item1, ev.Item2)));
+    }
+
+    private static IBrush LookupBrush(string key, ThemeVariant theme, IBrush fallback)
+    {
+        if (Application.Current?.TryGetResource(key, theme, out var resource) == true && resource is IBrush brush)
+            return brush;
+        return fallback;
     }
 
     private LogLineItem MakeLine(string text, AbstractOperation.LineType type)

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
@@ -289,7 +289,6 @@ public sealed partial class OperationViewModel : ViewModelBase
                 Path = $"avares://UniGetUI.Avalonia/Assets/Symbols/{svgName}",
                 Width = 16,
                 Height = 16,
-                Foreground = Brushes.White,
             },
         };
 

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
@@ -6,6 +6,25 @@
              xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
              x:DataType="vm:InfoBarViewModel">
 
+    <UserControl.Styles>
+        <Style Selector="Border.severity-success">
+            <Setter Property="Background"   Value="{DynamicResource StatusSuccessBackground}"/>
+            <Setter Property="BorderBrush"  Value="{DynamicResource StatusSuccessBorderBrush}"/>
+        </Style>
+        <Style Selector="Border.severity-error">
+            <Setter Property="Background"   Value="{DynamicResource StatusErrorBackground}"/>
+            <Setter Property="BorderBrush"  Value="{DynamicResource StatusErrorBorderBrush}"/>
+        </Style>
+        <Style Selector="Border.severity-warning">
+            <Setter Property="Background"   Value="{DynamicResource WarningBannerBackground}"/>
+            <Setter Property="BorderBrush"  Value="{DynamicResource WarningBannerBorderBrush}"/>
+        </Style>
+        <Style Selector="Border.severity-info">
+            <Setter Property="Background"   Value="{DynamicResource StatusInfoBackground}"/>
+            <Setter Property="BorderBrush"  Value="{DynamicResource StatusInfoBorderBrush}"/>
+        </Style>
+    </UserControl.Styles>
+
     <Border x:Name="BodyBorder"
             IsVisible="{Binding IsOpen}"
             BorderThickness="0,1,0,1"

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
@@ -43,7 +43,14 @@ public partial class InfoBar : UserControl
 
     private void ApplySeverity(InfoBarSeverity severity)
     {
-        // Update strip colour
+        // Background + border: swap a single CSS class — DynamicResource in the style
+        // handles theme changes automatically without any event subscription.
+        BodyBorder.Classes.Set("severity-success", severity == InfoBarSeverity.Success);
+        BodyBorder.Classes.Set("severity-error", severity == InfoBarSeverity.Error);
+        BodyBorder.Classes.Set("severity-warning", severity == InfoBarSeverity.Warning);
+        BodyBorder.Classes.Set("severity-info", severity == InfoBarSeverity.Informational);
+
+        // Strip colour (solid, not theme-sensitive)
         var stripColor = severity switch
         {
             InfoBarSeverity.Warning => Color.Parse("#F7A800"),
@@ -53,29 +60,7 @@ public partial class InfoBar : UserControl
         };
         SeverityStrip.Background = new SolidColorBrush(stripColor);
 
-        // Update body background/border from theme resources
-        string bgKey = severity switch
-        {
-            InfoBarSeverity.Warning => "WarningBannerBackground",
-            InfoBarSeverity.Error => "StatusErrorBackground",
-            InfoBarSeverity.Success => "StatusSuccessBackground",
-            _ => "StatusInfoBackground",
-        };
-        string borderKey = severity switch
-        {
-            InfoBarSeverity.Warning => "WarningBannerBorderBrush",
-            InfoBarSeverity.Error => "StatusErrorBorderBrush",
-            InfoBarSeverity.Success => "StatusSuccessBorderBrush",
-            _ => "StatusInfoBorderBrush",
-        };
-
-        var theme = Application.Current?.ActualThemeVariant;
-        if (Application.Current?.TryGetResource(bgKey, theme, out var bg) == true && bg is IBrush bgBrush)
-            BodyBorder.Background = bgBrush;
-        if (Application.Current?.TryGetResource(borderKey, theme, out var border) == true && border is IBrush borderBrush)
-            BodyBorder.BorderBrush = borderBrush;
-
-        // Update icon
+        // Icon shape
         SeverityIcon.Data = Geometry.Parse(severity switch
         {
             InfoBarSeverity.Warning => WarningPath,
@@ -84,14 +69,7 @@ public partial class InfoBar : UserControl
             _ => InfoPath,
         });
 
-        // Icon foreground
-        var iconColor = severity switch
-        {
-            InfoBarSeverity.Warning => Color.Parse("#F7A800"),
-            InfoBarSeverity.Error => Color.Parse("#C42B1C"),
-            InfoBarSeverity.Success => Color.Parse("#107C10"),
-            _ => Color.Parse("#0078D4"),
-        };
-        SeverityIcon.Foreground = new SolidColorBrush(iconColor);
+        // Icon foreground (solid, not theme-sensitive)
+        SeverityIcon.Foreground = new SolidColorBrush(stripColor);
     }
 }

--- a/src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs
@@ -5,8 +5,10 @@ using System.Xml.Linq;
 using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.Styling;
 
 namespace UniGetUI.Avalonia.Views.Controls;
 
@@ -35,6 +37,7 @@ public class SvgIcon : Control
         set => SetValue(PathProperty, value);
     }
 
+    private IBrush? _localForeground;
     public IBrush? Foreground
     {
         get => GetValue(ForegroundProperty);
@@ -50,12 +53,34 @@ public class SvgIcon : Control
         AffectsMeasure<SvgIcon>(PathProperty);
     }
 
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        if (Application.Current is { } app)
+            app.ActualThemeVariantChanged += OnThemeChanged;
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        if (Application.Current is { } app)
+            app.ActualThemeVariantChanged -= OnThemeChanged;
+    }
+
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-        if (change.Property == PathProperty)
+        if (change.Property == ForegroundProperty)
+        {
+            _localForeground = change.Priority < BindingPriority.Style
+                ? change.NewValue as IBrush
+                : null;
+        }
+        else if (change.Property == PathProperty)
             LoadSvg(change.NewValue as string);
     }
+
+    private void OnThemeChanged(object? sender, EventArgs e) => InvalidateVisual();
 
     private void LoadSvg(string? uri)
     {
@@ -134,6 +159,14 @@ public class SvgIcon : Control
         InvalidateVisual();
     }
 
+    private static readonly IBrush _darkFg = new SolidColorBrush(Color.Parse("#E8E8E8"));
+    private static readonly IBrush _lightFg = new SolidColorBrush(Color.Parse("#1E1E1E"));
+
+    private static IBrush LookupThemeForeground() =>
+        Application.Current?.ActualThemeVariant == ThemeVariant.Dark
+            ? _darkFg
+            : _lightFg;
+
     protected override Size MeasureOverride(Size availableSize)
     {
         double w = double.IsInfinity(availableSize.Width) ? _viewBoxWidth : availableSize.Width;
@@ -146,6 +179,7 @@ public class SvgIcon : Control
         if (_geometries.Count == 0) return;
 
         IBrush brush = Foreground ?? Brushes.Black;
+        IBrush brush = _localForeground ?? LookupThemeForeground();
 
         double scaleX = Bounds.Width / _viewBoxWidth;
         double scaleY = Bounds.Height / _viewBoxHeight;

--- a/src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs
@@ -178,7 +178,6 @@ public class SvgIcon : Control
     {
         if (_geometries.Count == 0) return;
 
-        IBrush brush = Foreground ?? Brushes.Black;
         IBrush brush = _localForeground ?? LookupThemeForeground();
 
         double scaleX = Bounds.Width / _viewBoxWidth;

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -211,7 +211,7 @@
                                                             <StackPanel Orientation="Horizontal" Spacing="4">
                                                                 <controls:SvgIcon Path="{Binding IconPath}"
                                                                                   Width="12" Height="12"
-                                                                                  Foreground="White"/>
+                                                                                  Foreground="{DynamicResource AppIconForeground}"/>
                                                                 <TextBlock Text="{Binding Label}"
                                                                            FontSize="10"
                                                                            Opacity="0.8"/>


### PR DESCRIPTION
This pull request introduces several improvements to theming and dynamic resource usage for UI elements, with a focus on making colors and styles adapt automatically to the current theme. The changes primarily affect how foreground and background colors are applied to log output, icons, and info bars, increasing consistency and maintainability across light and dark themes.

**Theming and dynamic resource improvements:**

* The `OperationOutputViewModel` now uses theme-aware brushes for log output lines, looking up resources like `StatusErrorForeground` and `LogOutputVerboseForeground` instead of hardcoded colors. This ensures log output colors adapt to the current theme. (issue #4681)
* The `SvgIcon` control has been updated to automatically select an appropriate foreground color based on the current theme unless explicitly set, and now listens for theme changes to update its appearance dynamically. 
* The main window now uses a dynamic resource for icon foregrounds (`AppIconForeground`) instead of a hardcoded color, improving theme consistency.

**InfoBar styling simplification:**

* InfoBar background and border colors are now set using style classes and dynamic resources, rather than being updated manually in code. This makes theme changes seamless and reduces code complexity. [

**Code cleanup:**

* Removes an unnecessary hardcoded foreground color in the `OperationViewModel` menu icon, allowing it to inherit the correct color from the theme.