### PR TITLE
fix elevator in avalonia not working

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -219,8 +219,10 @@ internal static class AvaloniaBootstrapper
             Logger.Warn($"Using system GSudo since UniGetUI Elevator is not available in DEBUG builds");
             CoreData.ElevatorPath = (await CoreTools.WhichAsync("gsudo.exe")).Item2;
 #else
+            string installRoot = Path.GetDirectoryName(CoreData.UniGetUIExecutableDirectory)
+                ?? CoreData.UniGetUIExecutableDirectory;
             CoreData.ElevatorPath = Path.Join(
-                CoreData.UniGetUIExecutableDirectory,
+                installRoot,
                 "Assets",
                 "Utilities",
                 "UniGetUI Elevator.exe"


### PR DESCRIPTION
The Avalonia binary is installed in an Avalonia\ subdirectory of the install root, but Assets\Utilities\UniGetUI Elevator.exe lives at the install root. CoreData.UniGetUIExecutableDirectory resolves to the Avalonia\ directory, causing the elevator to be looked up at Avalonia\Assets\Utilities\UniGetUI Elevator.exe — a path that doesn't exist.

Fix: walk up one directory from the Avalonia exe directory to reach the install root before building the elevator path. Mac, Linux and the classic WinUI build are unaffected.

Fixes #4697


