### PR TITLE
Avalonia: Updated packages now auto-remove from the updates list

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -354,11 +354,13 @@ public partial class PackagesPageViewModel : ViewModelBase
         {
             foreach (var pkg in e.AddedPackages)
             {
-                if (_wrappedPackages.Any(w => w.Package.Equals(pkg))) continue;
+                if (_wrappedPackages.Any(w => w.Package.GetVersionedHash() == pkg.GetVersionedHash())) continue;
                 _wrappedPackages.Add(new PackageWrapper(pkg, this));
                 AddPackageToSourcesList(pkg);
             }
-            var toRemove = _wrappedPackages.Where(w => e.RemovedPackages.Contains(w.Package)).ToList();
+            var toRemove = _wrappedPackages
+                .Where(w => e.RemovedPackages.Any(r => r.GetVersionedHash() == w.Package.GetVersionedHash()))
+                .ToList();
             foreach (var wrapper in toRemove) { wrapper.Dispose(); _wrappedPackages.Remove(wrapper); }
         }
         else


### PR DESCRIPTION
Previously, successfully updated packages remained in the Software Updates list until the user manually pressed Reload.

### Root cause
Package.Equals(IPackage? other) compares this._versionedHash (hashed with version) against other.GetHash() (hashed without version). Since these are hashed from different input strings, the result is never equal — not even when comparing an object to itself. This caused the Contains check in Loader_PackagesChanged to always return false, so the procedural removal of packages from _wrappedPackages was silently a no-op.

###  Fix
Replace the broken Equals/Contains calls in PackagesPageViewModel.Loader_PackagesChanged with direct GetVersionedHash() equality on both sides. The flow now works end-to-end: UpdatePackageOperation.HandleSuccess → UpgradablePackagesLoader.Remove → PackagesChanged event → wrapper removed from _wrappedPackages → FilterPackages redraws the list without the updated entry.

fix issue #4696