### PR TITLE
fix for Portable package being deleted when updating

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -334,6 +334,14 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
                     continue;
                 }
 
+                if (nativePackage.DefaultInstallVersion.PackageCatalog?.Info is null)
+                {
+                    Logger.Warn(
+                        $"WinGet package {nativePackage.Id} has a DefaultInstallVersion with null PackageCatalog or Info, skipping"
+                    );
+                    continue;
+                }
+
                 IManagerSource source;
                 source = Manager.SourcesHelper.Factory.GetSourceOrDefault(
                     nativePackage.DefaultInstallVersion.PackageCatalog.Info.Name

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -1,4 +1,5 @@
 using Microsoft.Management.Deployment;
+using Microsoft.Win32;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -89,11 +90,17 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             }
             parameters.Add("--include-unknown");
 
-            if (
-                Settings.Get(Settings.K.WinGetForceLocationOnUpdate)
-                && options.CustomInstallLocation != ""
-            )
-                parameters.AddRange(["--location", $"\"{options.CustomInstallLocation}\""]);
+            if (options.CustomInstallLocation != "")
+            {
+                if (Settings.Get(Settings.K.WinGetForceLocationOnUpdate))
+                    parameters.AddRange(["--location", $"\"{options.CustomInstallLocation}\""]);
+            }
+            else
+            {
+                var detectedLocation = TryGetPortableInstallLocation(package);
+                if (detectedLocation is not null)
+                    parameters.AddRange(["--location", $"\"{detectedLocation}\""]);
+            }
         }
         else if (operation is OperationType.Install)
         {
@@ -329,5 +336,69 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
         if (val is null || val == "")
             val = "Unknown";
         return val;
+    }
+
+    /// <summary>
+    /// For portable WinGet packages, reads the current install location from the Windows registry
+    /// ARP entry (written by WinGet at install time). Returns null if the package is not portable
+    /// or the location cannot be determined.
+    /// </summary>
+    private static string? TryGetPortableInstallLocation(IPackage package)
+    {
+        try
+        {
+            foreach (
+                var hive in new RegistryKey[] { Registry.CurrentUser, Registry.LocalMachine }
+            )
+            {
+                using var uninstallKey = hive.OpenSubKey(
+                    @"Software\Microsoft\Windows\CurrentVersion\Uninstall"
+                );
+                if (uninstallKey is null)
+                    continue;
+
+                foreach (var name in uninstallKey.GetSubKeyNames())
+                {
+                    using var entry = uninstallKey.OpenSubKey(name);
+                    if (entry is null)
+                        continue;
+
+                    if (
+                        entry.GetValue("WinGetPackageIdentifier") is not string pkgId
+                        || !string.Equals(pkgId, package.Id, StringComparison.OrdinalIgnoreCase)
+                    )
+                        continue;
+
+                    if (
+                        entry.GetValue("WinGetInstallerType") is not string installerType
+                        || !string.Equals(
+                            installerType,
+                            "portable",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                        return null;
+
+                    if (
+                        entry.GetValue("InstallLocation") is string location
+                        && location.Length > 0
+                    )
+                    {
+                        Logger.Info(
+                            $"Auto-detected portable install location for {package.Id}: {location}"
+                        );
+                        return location;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(
+                $"Failed to auto-detect portable install location for {package.Id}: {ex.Message}"
+            );
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
issue #4693

### Problem
When a WinGet portable package is installed to a custom path (e.g. winget install <id> --location "C:\MyTools\app"), triggering an update through UniGetUI would delete the files from the custom directory and reinstall to WinGet's default packages location. This left users' custom installations wiped with no warning.

### Solution

When building the winget upgrade command, if the user hasn't set a CustomInstallLocation, the new TryGetPortableInstallLocation method is called. It scans the Windows registry ARP entries for an entry whose WinGetPackageIdentifier matches the package ID and whose WinGetInstallerType is portable. If found, it reads the InstallLocation value — which WinGet writes at install time — and passes it as --location to the upgrade command.
