### PR TITLE
Avalonia: Add support for the system tray on non-windows machine

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
@@ -1,9 +1,8 @@
-using System.Runtime.Versioning;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform;
+using Avalonia.Styling;
 using Avalonia.Threading;
-using Microsoft.Win32;
 using UniGetUI.Avalonia.Views;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
@@ -14,13 +13,12 @@ using UniGetUI.PackageEngine.PackageLoader;
 
 namespace UniGetUI.Avalonia.Infrastructure;
 
-[SupportedOSPlatform("windows")]
-internal sealed class WindowsTrayService : IDisposable
+internal sealed class TrayService : IDisposable
 {
     private readonly TrayIcon _trayIcon;
     private string _lastIconUri = "";
 
-    public WindowsTrayService(MainWindow owner)
+    public TrayService(MainWindow owner)
     {
         _trayIcon = new TrayIcon
         {
@@ -96,12 +94,13 @@ internal sealed class WindowsTrayService : IDisposable
         }
     }
 
-    // Windows reads SystemUsesLightTheme to pick dark vs light taskbar icons.
     private static bool IsTaskbarLight()
     {
+#if WINDOWS
+        // On Windows, read the registry to match the taskbar background colour.
         try
         {
-            using var key = Registry.CurrentUser.OpenSubKey(
+            using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(
                 @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
             return key?.GetValue("SystemUsesLightTheme") is int v && v > 0;
         }
@@ -109,6 +108,11 @@ internal sealed class WindowsTrayService : IDisposable
         {
             return false;
         }
+#else
+        // On Linux (and other platforms), mirror the app's active theme variant so
+        // the icon remains legible regardless of the desktop colour scheme.
+        return Application.Current?.ActualThemeVariant == ThemeVariant.Light;
+#endif
     }
 
     private static NativeMenu BuildMenu(MainWindow owner)

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -131,7 +131,7 @@
       <Compile Include="Infrastructure\AvaloniaOperationRegistry.cs" />
       <Compile Include="Infrastructure\AppRestartHelper.cs" />
       <Compile Include="Infrastructure\WindowsAppNotificationBridge.cs" />
-      <Compile Include="Infrastructure\WindowsTrayService.cs" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+      <Compile Include="Infrastructure\TrayService.cs" />
       <Compile Include="Infrastructure\MacOsNotificationBridge.cs" />
       <Compile Include="Infrastructure\Secrets.cs" />
       <Compile Include="Infrastructure\AsyncCommand.cs" />

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/NotificationsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/NotificationsViewModel.cs
@@ -10,8 +10,8 @@ public partial class NotificationsViewModel : ViewModelBase
     [ObservableProperty] private bool _isSystemTrayEnabled;
     [ObservableProperty] private bool _isNotificationsEnabled;
 
-    /// <summary>True when the system-tray-disabled warning should be shown (Windows only).</summary>
-    public bool IsSystemTrayWarningVisible => OperatingSystem.IsWindows() && !IsSystemTrayEnabled;
+    /// <summary>True when the system-tray-disabled warning should be shown.</summary>
+    public bool IsSystemTrayWarningVisible => !IsSystemTrayEnabled;
 
     public NotificationsViewModel()
     {

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -48,7 +48,7 @@ public partial class MainWindow : Window
     private const uint SWP_FRAMECHANGED = 0x0020;
 
     private bool _focusSidebarSelectionOnNextPageChange;
-    private WindowsTrayService? _trayService;
+    private TrayService? _trayService;
     private bool _allowClose;
     private NativeMethods.RECT? _windowsRestoreBoundsBeforeManualMaximize;
 
@@ -73,16 +73,13 @@ public partial class MainWindow : Window
         KeyDown += Window_KeyDown;
         ViewModel.CurrentPageChanged += OnCurrentPageChanged;
 
-        if (OperatingSystem.IsWindows())
-        {
-            _trayService = new WindowsTrayService(this);
-            _trayService.UpdateStatus();
-        }
+        _trayService = new TrayService(this);
+        _trayService.UpdateStatus();
     }
 
     protected override void OnClosing(WindowClosingEventArgs e)
     {
-        if (!_allowClose && OperatingSystem.IsWindows() && !Settings.Get(Settings.K.DisableSystemTray))
+        if (!_allowClose && !Settings.Get(Settings.K.DisableSystemTray))
         {
             e.Cancel = true;
             Hide();
@@ -90,11 +87,8 @@ public partial class MainWindow : Window
         }
 
         AvaloniaAutoUpdater.ReleaseLockForAutoupdate_Window = true;
-        if (OperatingSystem.IsWindows())
-        {
-            _trayService?.Dispose();
-            _trayService = null;
-        }
+        _trayService?.Dispose();
+        _trayService = null;
         base.OnClosing(e);
     }
 
@@ -532,11 +526,7 @@ public partial class MainWindow : Window
         ViewModel.ErrorBanner.IsOpen = true;
     }
 
-    public void UpdateSystemTrayStatus()
-    {
-        if (OperatingSystem.IsWindows())
-            _trayService?.UpdateStatus();
-    }
+    public void UpdateSystemTrayStatus() => _trayService?.UpdateStatus();
 
     public void ShowRuntimeNotification(string title, string message, RuntimeNotificationLevel level) =>
         ShowBanner(title, message, level);

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
@@ -33,7 +33,7 @@
                                    StateChangedCommand="{Binding ShowRestartRequiredCommand}"
                                    CornerRadius="8"/>
 
-             <StackPanel x:Name="SystemTraySection" Orientation="Vertical" IsVisible="{Binding IsWindows}">
+             <StackPanel x:Name="SystemTraySection" Orientation="Vertical">
                 <settings:TranslatedTextBlock Text="UniGetUI on the background and system tray"
                                               FontWeight="SemiBold"
                                               Margin="44,32,4,8"
@@ -46,6 +46,7 @@
                 <settings:ButtonCard x:Name="EditAutostartSettings"
                                      CornerRadius="0,0,8,8"
                                      BorderThickness="1,0,1,1"
+                                     IsVisible="{Binding IsWindows}"
                                      Text="{t:Translate Manage UniGetUI autostart behaviour}"
                                      ButtonText="{t:Translate Open}"
                                      Command="{Binding EditAutostartSettingsCommand}"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml.cs
@@ -20,9 +20,6 @@ public sealed partial class Interface_P : UserControl, ISettingsPage
         DataContext = new Interface_PViewModel();
         InitializeComponent();
 
-        if (OperatingSystem.IsMacOS())
-            SystemTraySection.IsVisible = false;
-
         VM.RestartRequired += (s, e) => RestartRequired?.Invoke(s, e);
         _ = VM.LoadIconCacheSize();
 


### PR DESCRIPTION
This pull request refactors and generalizes the system tray integration to support platforms beyond Windows, consolidating platform-specific logic and improving cross-platform compatibility. The main changes include renaming and updating the tray service, removing unnecessary platform checks, and adjusting the UI and view models to reflect the new, platform-agnostic approach.

**Tray Service Refactor and Platform Abstraction:**

* Renamed `WindowsTrayService` to `TrayService`, removed the Windows-specific attribute, and updated instantiations and references throughout the codebase to use the new, platform-agnostic service. (`src/UniGetUI.Avalonia/Infrastructure/TrayService.cs`, `src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs`, `src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj`) 
* Moved platform-specific logic for detecting the taskbar theme into `TrayService` using preprocessor directives, enabling correct icon theming on both Windows and other platforms. (`src/UniGetUI.Avalonia/Infrastructure/TrayService.cs`)

**UI and ViewModel Adjustments:**

* Removed Windows-only visibility conditions from the system tray settings UI, making the section visible on all platforms, but kept the autostart management button visible only on Windows. (`src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml`, `src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml.cs`) 
* Simplified the logic for displaying the system tray warning in the `NotificationsViewModel`, removing the Windows-only check. (`src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/NotificationsViewModel.cs`)

**Code Simplification:**

* Removed redundant platform checks in tray service initialization, status updates, and disposal, further streamlining the codebase. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs`)

#4704