### PR TITLE
Fix bundled Pinget lookup for WinGet downloads

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -312,7 +312,26 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
         internal static string GetBundledPingetExecutablePath()
         {
-            return Path.Join(CoreData.UniGetUIExecutableDirectory, "pinget.exe");
+            return GetBundledPingetExecutablePath(CoreData.UniGetUIExecutableDirectory, File.Exists);
+        }
+
+        internal static string GetBundledPingetExecutablePath(
+            string executableDirectory,
+            Func<string, bool> fileExists
+        )
+        {
+            string rootPingetPath = Path.Join(executableDirectory, PingetExecutableName);
+            if (fileExists(rootPingetPath))
+            {
+                return rootPingetPath;
+            }
+
+            string avaloniaPingetPath = Path.Join(
+                executableDirectory,
+                "Avalonia",
+                PingetExecutableName
+            );
+            return fileExists(avaloniaPingetPath) ? avaloniaPingetPath : rootPingetPath;
         }
 
         internal IWinGetManagerHelper CreateCliHelperForSelectedCliTool()

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -144,6 +144,46 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void GetBundledPingetExecutablePathPrefersRootExecutable()
+    {
+        const string installDir = @"C:\Program Files\UniGetUI";
+        string rootPinget = Path.Join(installDir, "pinget.exe");
+        string avaloniaPinget = Path.Join(installDir, "Avalonia", "pinget.exe");
+
+        string path = WinGet.GetBundledPingetExecutablePath(
+            installDir,
+            filePath => filePath == rootPinget || filePath == avaloniaPinget
+        );
+
+        Assert.Equal(rootPinget, path);
+    }
+
+    [Fact]
+    public void GetBundledPingetExecutablePathFallsBackToAvaloniaExecutable()
+    {
+        const string installDir = @"C:\Program Files\UniGetUI";
+        string avaloniaPinget = Path.Join(installDir, "Avalonia", "pinget.exe");
+
+        string path = WinGet.GetBundledPingetExecutablePath(
+            installDir,
+            filePath => filePath == avaloniaPinget
+        );
+
+        Assert.Equal(avaloniaPinget, path);
+    }
+
+    [Fact]
+    public void GetBundledPingetExecutablePathReturnsRootPathWhenNoExecutableExists()
+    {
+        const string installDir = @"C:\Program Files\UniGetUI";
+        string rootPinget = Path.Join(installDir, "pinget.exe");
+
+        string path = WinGet.GetBundledPingetExecutablePath(installDir, static _ => false);
+
+        Assert.Equal(rootPinget, path);
+    }
+
+    [Fact]
     public void FindCandidateExecutableFilesPrefersSystemWinGetBeforeBundledPinget()
     {
         const string systemWinGet = @"C:\WindowsApps\winget.exe";


### PR DESCRIPTION
## Summary
- Allow the WinGet manager to find bundled `pinget.exe` from the root install directory or the `Avalonia` subdirectory.
- Preserve the root `pinget.exe` path as the preferred/default location.
- Add WinGet manager tests for root preference, Avalonia fallback, and missing-file default behavior.

Fixes #4700

## Testing
- `dotnet test src\UniGetUI.PackageEngine.Tests\UniGetUI.PackageEngine.Tests.csproj --verbosity minimal --nologo /p:Platform=x64`
- Dry-run Build and Release workflow: https://github.com/Devolutions/UniGetUI/actions/runs/25452628780