### PR TITLE
update Devolutions.UniGetUI.Elevator to 2.6.1.3

### DIFF
--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -188,12 +188,7 @@
         <PackageReference Include="YamlDotNet" Version="17.0.1" />
         <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
         <PackageReference Include="Octokit" Version="14.0.0" />
-        <PackageReference
-            Include="Devolutions.UniGetUI.Elevator"
-            Version="2.6.1.2"
-            GeneratePathProperty="true"
-            ExcludeAssets="build;buildTransitive"
-        />
+        <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive" />
 
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>


### PR DESCRIPTION
This pull request updates a package dependency in the `UniGetUI` project file. The only change is upgrading the `Devolutions.UniGetUI.Elevator` package from version `2.6.1.2` to `2.6.1.3`. 
