### PR TITLE
Fix: skip version comparison for unparseable hash-based versions

### DIFF
--- a/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
+++ b/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
@@ -317,6 +317,13 @@ namespace UniGetUI.Core.Tools.Tests
             Assert.Equal(i4, v.Remainder);
         }
 
+        [Fact]
+        public void TestGetVersionStringAsFloat_WithNonNumericVersion_ReturnsNull()
+        {
+            CoreTools.Version v = CoreTools.VersionStringToStruct("10c8e557");
+            Assert.Equal(CoreTools.Version.Null, v);
+        }
+
         [Theory]
         [InlineData("2026.1.0", "2026.1.0")]
         [InlineData("2026.1.0.0", "2026.1.0")]

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -236,6 +236,7 @@ namespace UniGetUI.Core.Tools
                     p.StartInfo.ArgumentList.Add(path);
                     p.StartInfo.UseShellExecute = false;
                 }
+
                 p.StartInfo.CreateNoWindow = true;
                 p.Start();
                 await p.WaitForExitAsync();
@@ -310,22 +311,22 @@ namespace UniGetUI.Core.Tools
                 if (
                     response.StatusCode
                     is HttpStatusCode.Moved
-                        or HttpStatusCode.Redirect
-                        or HttpStatusCode.RedirectMethod
-                        or HttpStatusCode.TemporaryRedirect
-                        or HttpStatusCode.PermanentRedirect
+                    or HttpStatusCode.Redirect
+                    or HttpStatusCode.RedirectMethod
+                    or HttpStatusCode.TemporaryRedirect
+                    or HttpStatusCode.PermanentRedirect
                 )
                 {
                     return GetFileName(
                         response.Headers.Location
-                            ?? throw new HttpRequestException(
-                                "A redirect code was returned but no new location was given"
-                            )
+                        ?? throw new HttpRequestException(
+                            "A redirect code was returned but no new location was given"
+                        )
                     );
                 }
 
                 return response.Content.Headers.ContentDisposition?.FileName
-                    ?? Path.GetFileName(url.LocalPath);
+                       ?? Path.GetFileName(url.LocalPath);
             }
             catch (Exception e)
             {
@@ -404,19 +405,47 @@ namespace UniGetUI.Core.Tools
         /// <summary>
         /// Converts a string into a double floating-point number.
         /// </summary>
-        /// <param name="Version">Any string</param>
+        /// <param name="version">Any string</param>
         /// <returns>The best approximation of the string as a Version</returns>
-        public static Version VersionStringToStruct(string Version)
+        public static Version VersionStringToStruct(string version)
         {
             try
             {
                 char[] separators = ['.', '-', '/', '#'];
                 string[] versionItems = ["", "", "", ""];
 
+                string[] segments = version.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var segment in segments)
+                {
+                    bool seenDigit = false;
+                    bool seenLetterAfterDigit = false;
+                    bool seenDigitAfterLetter = false;
+                    foreach (char c in segment)
+                    {
+                        if (char.IsDigit(c))
+                        {
+                            if (seenLetterAfterDigit)
+                                seenDigitAfterLetter = true;
+                            seenDigit = true;
+                        }
+                        else if (char.IsLetter(c) && seenDigit)
+                        {
+                            seenLetterAfterDigit = true;
+                        }
+                    }
+
+                    if (seenDigit && seenLetterAfterDigit && seenDigitAfterLetter)
+                    {
+                        Logger.Warn(
+                            $"Version string {version} appears to contain non-numeric characters within a numeric segment and will be treated as unknown");
+                        return CoreTools.Version.Null;
+                    }
+                }
+
                 int dotCount = 0;
                 bool first = true;
 
-                foreach (char c in Version)
+                foreach (char c in version)
                 {
                     if (char.IsDigit(c))
                         versionItems[dotCount] += c;
@@ -438,7 +467,7 @@ namespace UniGetUI.Core.Tools
             }
             catch
             {
-                Logger.Warn($"Failed to parse version {Version} to float");
+                Logger.Warn($"Failed to parse version {version} to float");
                 return CoreTools.Version.Null;
             }
         }
@@ -862,12 +891,7 @@ namespace UniGetUI.Core.Tools
 
                 var p = new Process()
                 {
-                    StartInfo = new()
-                    {
-                        FileName = path,
-                        UseShellExecute = true,
-                        CreateNoWindow = true,
-                    },
+                    StartInfo = new() { FileName = path, UseShellExecute = true, CreateNoWindow = true, },
                 };
                 p.Start();
             }
@@ -993,8 +1017,8 @@ namespace UniGetUI.Core.Tools
         private static IReadOnlyList<string> GetWindowsExecutableExtensions()
         {
             List<string> extensions = (
-                Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD"
-            )
+                    Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD"
+                )
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
                 .Select(extension => extension.Trim())
                 .Where(extension => !string.IsNullOrWhiteSpace(extension))
@@ -1073,15 +1097,15 @@ namespace UniGetUI.Core.Tools
 
             string separator = Path.PathSeparator.ToString();
             string pathValue =
-                (
-                    Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User)
-                    ?? string.Empty
-                ) + separator;
+            (
+                Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User)
+                ?? string.Empty
+            ) + separator;
             pathValue +=
-                (
-                    Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine)
-                    ?? string.Empty
-                ) + separator;
+            (
+                Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine)
+                ?? string.Empty
+            ) + separator;
             pathValue +=
                 Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process)
                 ?? string.Empty;

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -294,6 +294,11 @@ namespace UniGetUI.PackageEngine.PackageClasses
         {
             foreach (var p in GetInstalledPackages())
             {
+                if (p.NormalizedVersion == CoreTools.Version.Null || this.NormalizedNewVersion == CoreTools.Version.Null)
+                {
+                    continue;
+                }
+
                 if (p.NormalizedVersion >= this.NormalizedNewVersion)
                 {
                     return true;

--- a/src/UniGetUI.PackageEngine.Tests/NpmManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NpmManagerTests.cs
@@ -16,7 +16,7 @@ public sealed class NpmManagerTests
         var manager = new Npm();
 
         var packages = Npm.ParseSearchOutput(
-            PackageEngineFixtureFiles.ReadAllText(@"Npm\search-array-with-warning.txt"),
+            File.ReadAllText(PackageEngineFixtureFiles.GetPath(Path.Combine("Npm", "search-array-with-warning.txt"))),
             manager.DefaultSource,
             manager
         );
@@ -37,7 +37,7 @@ public sealed class NpmManagerTests
         var manager = new Npm();
 
         var packages = Npm.ParseSearchOutput(
-            PackageEngineFixtureFiles.ReadAllText(@"Npm\search-ndjson.txt"),
+            File.ReadAllText(PackageEngineFixtureFiles.GetPath(Path.Combine("Npm", "search-ndjson.txt"))),
             manager.DefaultSource,
             manager
         );
@@ -56,7 +56,7 @@ public sealed class NpmManagerTests
         var manager = new Npm();
 
         var packages = Npm.ParseAvailableUpdatesOutput(
-            PackageEngineFixtureFiles.ReadAllText(@"Npm\outdated.json"),
+            File.ReadAllText(PackageEngineFixtureFiles.GetPath(Path.Combine("Npm", "outdated.json"))),
             manager.DefaultSource,
             manager,
             new OverridenInstallationOptions(PackageScope.Global)
@@ -76,7 +76,7 @@ public sealed class NpmManagerTests
         var manager = new Npm();
 
         var packages = Npm.ParseInstalledPackagesOutput(
-            PackageEngineFixtureFiles.ReadAllText(@"Npm\installed.json"),
+            File.ReadAllText(PackageEngineFixtureFiles.GetPath(Path.Combine("Npm", "installed.json"))),
             manager.DefaultSource,
             manager,
             new OverridenInstallationOptions(PackageScope.Local)

--- a/src/UniGetUI.PackageEngine.Tests/PackageTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageTests.cs
@@ -1,0 +1,68 @@
+using UniGetUI.Core.Data;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.PackageEngine.PackageLoader;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Builders;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class NewerVersionIsInstalledTests : IDisposable
+{
+    private readonly string _testRoot;
+
+    public NewerVersionIsInstalledTests()
+    {
+        _testRoot = Path.Combine(
+            Path.GetTempPath(),
+            nameof(NewerVersionIsInstalledTests),
+            Guid.NewGuid().ToString("N")
+        );
+        CoreData.TEST_DataDirectoryOverride = Path.Combine(_testRoot, "Data");
+        SecureSettings.TEST_SecureSettingsRootOverride = Path.Combine(_testRoot, "SecureSettings");
+        Directory.CreateDirectory(CoreData.UniGetUIUserConfigurationDirectory);
+        Settings.ResetSettings();
+    }
+
+    public void Dispose()
+    {
+        Settings.ResetSettings();
+        CoreData.TEST_DataDirectoryOverride = null;
+        SecureSettings.TEST_SecureSettingsRootOverride = null;
+        if (Directory.Exists(_testRoot))
+            Directory.Delete(_testRoot, recursive: true);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "2.0.0", false)]
+    [InlineData("2.0.0", "2.0.0", true)]
+    [InlineData("3.0.0", "2.0.0", true)]
+    [InlineData("10c8e557", "8b640eef", false)]
+    [InlineData("10c8e557", "2.0.0", false)]
+    [InlineData("2.0.0", "8b640eef", false)]
+    [InlineData("", "2.0.0", false)]
+    [InlineData("1.0.0;3.0.0", "2.0.0", true)]
+    public async Task NewerVersionIsInstalled_ReturnsExpectedResult(string installedVersions, string newVersion, bool expected)
+    {
+        var manager = new PackageManagerBuilder().Build();
+        InitializeLoaders();
+
+        foreach (var v in installedVersions.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            await InstalledPackagesLoader.Instance.AddForeign(
+                new PackageBuilder().WithManager(manager).WithId("Contoso.Tool").WithVersion(v.Trim()).Build()
+            );
+        }
+
+        var update = new PackageBuilder()
+            .WithManager(manager).WithId("Contoso.Tool").WithVersion("1.0.0").WithNewVersion(newVersion).Build();
+
+        Assert.Equal(expected, update.NewerVersionIsInstalled());
+    }
+
+    private static void InitializeLoaders()
+    {
+        _ = new DiscoverablePackagesLoader([]);
+        _ = new UpgradablePackagesLoader([]);
+        _ = new InstalledPackagesLoader([]);
+    }
+}

--- a/src/UniGetUI.PackageEngine.Tests/PipManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PipManagerTests.cs
@@ -50,6 +50,7 @@ public sealed class PipManagerTests : IDisposable
     public void SearchHelpersParseSimpleIndexAndRankPrefixMatchesFirst()
     {
         var names = Pip.ParseSimpleIndexProjectNames(
+
             PackageEngineFixtureFiles.ReadAllText(Path.Combine("Pip", "simple-index.json"))
         );
 


### PR DESCRIPTION
VersionStringToStruct silently concatenates digits across non-digit characters, causing snap commit hashes like 10c8e557 to be parsed as 108557.0.0.0. NewerVersionIsInstalled then incorrectly filters out valid updates when both installed and new versions are hashes.

- Tools.cs: detect letters between digits in version segments and return Version.Null for hash-like strings
- Package.cs: skip version comparison when either version is Null
- Tests: add VersionStringToStruct test for hash input and 8 NewerVersionIsInstalled scenarios covering semver, hash, and mixed version comparisons
- Tests: use Path.Concatenate to construct fixtures paths as \ is not a valid path separator on POSIX systems, causing tests to fail
