### PR TITLE
show "UniGetUI" in menu bar instead of "Avalonia Application"

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml
+++ b/src/UniGetUI.Avalonia/App.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="UniGetUI.Avalonia.App"
              xmlns:avaloniaApplication1="clr-namespace:UniGetUI.Avalonia"
+             Name="UniGetUI"
              RequestedThemeVariant="Default">
 
     <Application.DataTemplates>


### PR DESCRIPTION
This pull request makes a small update to the `App.axaml` file by adding a `Name` attribute to the application definition. This change helps identify the application instance in the XAML markup.

* Added `Name="UniGetUI"` attribute to the root `Application` element in `App.axaml`.
