### PR TITLE
Enhance update functionality and logging

### DIFF
--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -109,6 +109,7 @@ procedure KillRunningApps;
 begin
     TaskKill('WingetUI.exe');
     TaskKill('UniGetUI.exe');
+    TaskKill('UniGetUI.Avalonia.exe');
 end;
 
 function CmdLineParamExists(const Value: string): Boolean;
@@ -236,3 +237,4 @@ Filename: "{app}\{#MyAppExeName}"; Parameters: "--migrate-wingetui-to-unigetui";
 ; Filename: "{app}\{#MyAppExeName}"; Parameters: "--uninstall-unigetui"; Flags: skipifdoesntexist runhidden;
 Filename: {sys}\taskkill.exe; Parameters: "/f /im WingetUI.exe"; Flags: skipifdoesntexist runhidden; RunOnceId: "KillWingetUI"
 Filename: {sys}\taskkill.exe; Parameters: "/f /im UniGetUI.exe"; Flags: skipifdoesntexist runhidden; RunOnceId: "KillUniGetUI"
+Filename: {sys}\taskkill.exe; Parameters: "/f /im UniGetUI.Avalonia.exe"; Flags: skipifdoesntexist runhidden; RunOnceId: "KillUniGetUIAvalonia"

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -870,7 +870,7 @@ internal static partial class AvaloniaAutoUpdater
             Process.Start(new ProcessStartInfo
             {
                 FileName = "/bin/sh",
-                ArgumentList = { "-c", $"sleep 1 && \"{runningApp}\" >/dev/null 2>&1 &" },
+                ArgumentList = { "-c", "sleep 1 && \"$1\" >/dev/null 2>&1 &", "sh", runningApp },
                 UseShellExecute = false,
                 CreateNoWindow = true,
             });

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -9,6 +9,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using Microsoft.Win32;
+using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.Avalonia.Views;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
@@ -64,6 +65,25 @@ internal static partial class AvaloniaAutoUpdater
     /// </summary>
     public static event Action<string>? UpdateAvailable;
 
+    /// <summary>
+    /// Fired on the UI thread to surface progress/result of an update check or
+    /// install attempt to the UI banner.  Mirrors the verbose feedback the WinUI
+    /// AutoUpdater shows in its <c>InfoBar</c>.
+    /// </summary>
+    public static event Action<UpdateStatusInfo>? StatusChanged;
+
+    public sealed record UpdateStatusInfo(
+        string Title,
+        string Message,
+        InfoBarSeverity Severity,
+        bool IsClosable);
+
+    private static void RaiseStatus(string title, string message, InfoBarSeverity severity, bool isClosable)
+    {
+        var info = new UpdateStatusInfo(title, message, severity, isClosable);
+        Dispatcher.UIThread.Post(() => StatusChanged?.Invoke(info));
+    }
+
     private static volatile bool _installRequested;
     private static string? _pendingInstallerPath;
 
@@ -112,12 +132,22 @@ internal static partial class AvaloniaAutoUpdater
     }
 
     // ------------------------------------------------------------------ core logic
-    internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false)
+    internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false, bool verbose = false)
     {
         UpdaterOverrides overrides = LoadUpdaterOverrides();
+        bool wasCheckingForUpdates = true;
 
         try
         {
+            if (verbose)
+            {
+                RaiseStatus(
+                    CoreTools.Translate("We are checking for updates."),
+                    CoreTools.Translate("Please wait"),
+                    InfoBarSeverity.Informational,
+                    isClosable: false);
+            }
+
             UpdateCandidate candidate = await GetUpdateCandidateAsync(overrides);
             Logger.Info(
                 $"Auto-updater source '{candidate.SourceName}' returned version {candidate.VersionName} (upgradable={candidate.IsUpgradable})"
@@ -125,9 +155,18 @@ internal static partial class AvaloniaAutoUpdater
 
             if (!candidate.IsUpgradable)
             {
+                if (verbose)
+                {
+                    RaiseStatus(
+                        CoreTools.Translate("Great! You are on the latest version."),
+                        CoreTools.Translate("There are no new UniGetUI versions to be installed"),
+                        InfoBarSeverity.Success,
+                        isClosable: true);
+                }
                 return true;
             }
 
+            wasCheckingForUpdates = false;
             Logger.Info($"Update to UniGetUI {candidate.VersionName} is available.");
 
             string installerPath = Path.Join(CoreData.UniGetUIDataDirectory, "UniGetUI Updater.exe");
@@ -146,6 +185,14 @@ internal static partial class AvaloniaAutoUpdater
             // Delete invalid/outdated cached copy
             try { File.Delete(installerPath); } catch { }
 
+            RaiseStatus(
+                CoreTools.Translate(
+                    "UniGetUI version {0} is being downloaded.",
+                    candidate.VersionName.ToString(CultureInfo.InvariantCulture)),
+                CoreTools.Translate("This may take a minute or two"),
+                InfoBarSeverity.Informational,
+                isClosable: false);
+
             Logger.Info("Downloading installer...");
             await DownloadInstallerAsync(candidate.InstallerDownloadUrl, installerPath, overrides);
 
@@ -159,12 +206,25 @@ internal static partial class AvaloniaAutoUpdater
             }
 
             Logger.Error("Installer authenticity could not be verified. Aborting update.");
+            RaiseStatus(
+                CoreTools.Translate("The installer authenticity could not be verified."),
+                CoreTools.Translate("The update process has been aborted."),
+                InfoBarSeverity.Error,
+                isClosable: true);
             return false;
         }
         catch (Exception ex)
         {
             Logger.Error("An error occurred while checking for updates:");
             Logger.Error(ex);
+            if (verbose || !wasCheckingForUpdates)
+            {
+                RaiseStatus(
+                    CoreTools.Translate("An error occurred when checking for updates: "),
+                    ex.Message,
+                    InfoBarSeverity.Error,
+                    isClosable: true);
+            }
             return false;
         }
     }
@@ -225,6 +285,11 @@ internal static partial class AvaloniaAutoUpdater
         if (!started)
         {
             Logger.Error("Failed to start installer process.");
+            RaiseStatus(
+                CoreTools.Translate("Something went wrong while launching the updater."),
+                CoreTools.Translate("Please try again later"),
+                InfoBarSeverity.Error,
+                isClosable: true);
             return;
         }
 

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Avalonia.Threading;
@@ -73,13 +74,245 @@ internal static partial class AvaloniaAutoUpdater
         string Title,
         string Message,
         InfoBarSeverity Severity,
-        bool IsClosable);
+        bool IsClosable,
+        string? ActionButtonText = null,
+        Action? ActionButtonAction = null);
 
-    private static void RaiseStatus(string title, string message, InfoBarSeverity severity, bool isClosable)
+    private static void RaiseStatus(
+        string title,
+        string message,
+        InfoBarSeverity severity,
+        bool isClosable,
+        string? actionButtonText = null,
+        Action? actionButtonAction = null)
     {
-        var info = new UpdateStatusInfo(title, message, severity, isClosable);
+        var info = new UpdateStatusInfo(title, message, severity, isClosable, actionButtonText, actionButtonAction);
         Dispatcher.UIThread.Post(() => StatusChanged?.Invoke(info));
     }
+
+    // ------------------------------------------------------------------ per-attempt log
+    // Captures auto-updater log entries for the current update attempt. We keep a
+    // dedicated buffer (in addition to the global session log) so the "View log"
+    // banner button can show the user only the entries relevant to their failed
+    // update, instead of dumping the entire noisy session log.
+    private static readonly Lock _updateLogLock = new();
+    private static StringBuilder? _updateLogBuilder;
+    private static readonly string _updateLogPath = Path.Combine(
+        Path.GetTempPath(),
+        "UniGetUI",
+        "last-update-attempt.log"
+    );
+
+    private static void ResetUpdateLog(bool manualCheck, bool autoLaunch)
+    {
+        lock (_updateLogLock)
+        {
+            _updateLogBuilder = new StringBuilder()
+                .AppendLine($"=== UniGetUI update attempt started at {DateTime.Now:yyyy-MM-dd HH:mm:ss} ===")
+                .AppendLine($"Current version: {CoreData.VersionName} (build {CoreData.BuildNumber})")
+                .AppendLine($"Manual check: {manualCheck}")
+                .AppendLine($"Auto-launch: {autoLaunch}")
+                .AppendLine($"Process architecture: {RuntimeInformation.ProcessArchitecture}")
+                .AppendLine();
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    private static void AppendToUpdateLog(string severity, string message)
+    {
+        lock (_updateLogLock)
+        {
+            if (_updateLogBuilder is null) return;
+            _updateLogBuilder.AppendLine($"[{DateTime.Now:HH:mm:ss}] [{severity}] {message}");
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    // Persists the current buffer to _updateLogPath. Caller MUST hold _updateLogLock.
+    // Failures are silently swallowed — a missing log file should never break the
+    // update flow itself.
+    private static void FlushUpdateLogToDiskNoLock()
+    {
+        if (_updateLogBuilder is null) return;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_updateLogPath)!);
+            File.WriteAllText(_updateLogPath, _updateLogBuilder.ToString());
+        }
+        catch { /* see comment above */ }
+    }
+
+    private const string AttemptFinishedMarker = "=== Attempt finished:";
+
+    // Appends a structured line indicating the update flow reached a terminal state.
+    // The presence/absence of this marker on disk lets a subsequent app launch tell
+    // whether the previous attempt completed cleanly or was killed mid-flow (e.g.,
+    // by the installer terminating us during file replacement).
+    private static void MarkAttemptFinished(string outcome)
+    {
+        lock (_updateLogLock)
+        {
+            if (_updateLogBuilder is null) return;
+            _updateLogBuilder
+                .AppendLine()
+                .AppendLine($"{AttemptFinishedMarker} {outcome} at {DateTime.Now:yyyy-MM-dd HH:mm:ss} ===");
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    private static void RecordTargetVersion(string version)
+    {
+        lock (_updateLogLock)
+        {
+            _updateLogBuilder?.AppendLine($"Target version: {version}");
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    /// <summary>
+    /// On app startup, detects an interrupted update attempt — the log file
+    /// from the previous attempt has no <see cref="AttemptFinishedMarker"/>,
+    /// indicating the app was killed mid-flow (almost always because the
+    /// installer terminated us during file replacement).
+    ///
+    /// If the running version equals the target version we recorded, the
+    /// install succeeded and we are now the new version — silently appends
+    /// a marker so we don't re-prompt next time.
+    ///
+    /// Otherwise, surfaces a Warning banner with a "View log" button so the
+    /// user can investigate what happened.
+    /// </summary>
+    public static void CheckForOrphanedUpdateAttempt()
+    {
+        try
+        {
+            if (!File.Exists(_updateLogPath)) return;
+
+            var info = new FileInfo(_updateLogPath);
+            if ((DateTime.Now - info.LastWriteTime).TotalMinutes > 10)
+                return;
+
+            string content = File.ReadAllText(_updateLogPath);
+            if (content.Contains(AttemptFinishedMarker))
+                return;
+
+            string currentVer = CoreData.VersionName;
+            string? targetVer = null;
+            foreach (string line in content.Split('\n'))
+            {
+                if (line.StartsWith("Target version: "))
+                {
+                    targetVer = line["Target version: ".Length..].Trim();
+                    break;
+                }
+            }
+
+            if (targetVer is not null && targetVer == currentVer)
+            {
+                Logger.Info($"Previous update attempt killed mid-flow but install succeeded (running version {currentVer} matches target). Marking as finished.");
+                try
+                {
+                    File.AppendAllText(
+                        _updateLogPath,
+                        $"{Environment.NewLine}{AttemptFinishedMarker} installer succeeded (detected on next launch — running version is {currentVer}) at {DateTime.Now:yyyy-MM-dd HH:mm:ss} ==={Environment.NewLine}");
+                }
+                catch { /* swallow */ }
+                return;
+            }
+
+            Logger.Warn($"Detected interrupted update attempt. Running={currentVer}, Target={targetVer ?? "(unknown)"}");
+
+            RaiseStatus(
+                CoreTools.Translate("Your last update attempt did not complete."),
+                CoreTools.Translate("UniGetUI could not confirm whether the update succeeded. Open the log to see what happened."),
+                InfoBarSeverity.Warning,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Could not check for orphaned update attempt: {ex.Message}");
+        }
+    }
+
+    private static void LogUpdateInfo(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Info(message, caller);
+        AppendToUpdateLog("INFO ", message);
+    }
+
+    private static void LogUpdateWarn(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Warn(message, caller);
+        AppendToUpdateLog("WARN ", message);
+    }
+
+    private static void LogUpdateWarn(Exception ex, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Warn(ex, caller);
+        AppendToUpdateLog("WARN ", ex.ToString());
+    }
+
+    private static void LogUpdateError(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Error(message, caller);
+        AppendToUpdateLog("ERROR", message);
+    }
+
+    private static void LogUpdateError(Exception ex, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Error(ex, caller);
+        AppendToUpdateLog("ERROR", ex.ToString());
+    }
+
+    private static void LogUpdateDebug(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Debug(message, caller);
+        AppendToUpdateLog("DEBUG", message);
+    }
+
+    private static void OpenUpdateLog()
+    {
+        // The buffer is flushed to disk on every append/reset, so the file should
+        // already be current. Only fall back to the full session log if no flow
+        // has ever run (button shouldn't appear in that case, but be defensive).
+        string pathToOpen = File.Exists(_updateLogPath)
+            ? _updateLogPath
+            : Logger.GetSessionLogPath();
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = pathToOpen,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Could not open log file '{pathToOpen}': {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Translates an Inno Setup installer exit code into a short human-readable
+    /// reason. The codes come from the Inno Setup documentation
+    /// (https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes).
+    /// </summary>
+    private static string DescribeInstallerExitCode(int code) => code switch
+    {
+        0 => CoreTools.Translate("The installer reported success but did not restart UniGetUI."),
+        1 => CoreTools.Translate("The installer failed to initialize."),
+        2 => CoreTools.Translate("Setup was canceled before installation began."),
+        3 => CoreTools.Translate("A fatal error occurred during the preparation phase."),
+        4 => CoreTools.Translate("A fatal error occurred during installation."),
+        5 => CoreTools.Translate("Installation was canceled while in progress."),
+        6 => CoreTools.Translate("The installer was terminated by another process."),
+        7 => CoreTools.Translate("The preparation phase determined the installation cannot proceed."),
+        8 => CoreTools.Translate("The installer could not start. UniGetUI may already be running, or you do not have permission to install."),
+        _ => CoreTools.Translate("Unexpected installer error."),
+    };
 
     private static volatile bool _installRequested;
     private static string? _pendingInstallerPath;
@@ -103,14 +336,14 @@ internal static partial class AvaloniaAutoUpdater
     /// </summary>
     public static void TriggerInstall()
     {
-        Logger.Info("Auto-updater: TriggerInstall invoked (user clicked Update now).");
+        LogUpdateInfo("Auto-updater: TriggerInstall invoked (user clicked Update now).");
         _installRequested = true;
     }
     public static async Task UpdateCheckLoopAsync()
     {
         if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
         {
-            Logger.Warn("Auto-updater: disabled by user setting, skipping.");
+            LogUpdateWarn("Auto-updater: disabled by user setting, skipping.");
             return;
         }
 
@@ -121,7 +354,7 @@ internal static partial class AvaloniaAutoUpdater
         {
             if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
             {
-                Logger.Warn("Auto-updater: disabled by user setting, stopping loop.");
+                LogUpdateWarn("Auto-updater: disabled by user setting, stopping loop.");
                 return;
             }
 
@@ -135,6 +368,7 @@ internal static partial class AvaloniaAutoUpdater
     // ------------------------------------------------------------------ core logic
     internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false, bool manualCheck = false)
     {
+        ResetUpdateLog(manualCheck, autoLaunch);
         UpdaterOverrides overrides = LoadUpdaterOverrides();
         bool wasCheckingForUpdates = true;
 
@@ -150,7 +384,7 @@ internal static partial class AvaloniaAutoUpdater
             }
 
             UpdateCandidate candidate = await GetUpdateCandidateAsync(overrides);
-            Logger.Info(
+            LogUpdateInfo(
                 $"Auto-updater source '{candidate.SourceName}' returned version {candidate.VersionName} (upgradable={candidate.IsUpgradable})"
             );
 
@@ -164,11 +398,13 @@ internal static partial class AvaloniaAutoUpdater
                         InfoBarSeverity.Success,
                         isClosable: true);
                 }
+                MarkAttemptFinished("no update available");
                 return true;
             }
 
             wasCheckingForUpdates = false;
-            Logger.Info($"Update to UniGetUI {candidate.VersionName} is available.");
+            RecordTargetVersion(candidate.VersionName);
+            LogUpdateInfo($"Update to UniGetUI {candidate.VersionName} is available.");
 
             string installerPath = Path.Join(CoreData.UniGetUIDataDirectory, "UniGetUI Updater.exe");
 
@@ -179,7 +415,7 @@ internal static partial class AvaloniaAutoUpdater
                 && CheckInstallerSignerThumbprint(installerPath, overrides)
             )
             {
-                Logger.Info("Cached valid installer found, preparing to launch...");
+                LogUpdateInfo("Cached valid installer found, preparing to launch...");
                 return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch, manualCheck);
             }
 
@@ -194,7 +430,7 @@ internal static partial class AvaloniaAutoUpdater
                 InfoBarSeverity.Informational,
                 isClosable: false);
 
-            Logger.Info("Downloading installer...");
+            LogUpdateInfo("Downloading installer...");
             await DownloadInstallerAsync(candidate.InstallerDownloadUrl, installerPath, overrides);
 
             if (
@@ -202,30 +438,36 @@ internal static partial class AvaloniaAutoUpdater
                 && CheckInstallerSignerThumbprint(installerPath, overrides)
             )
             {
-                Logger.Info("Downloaded installer is valid, preparing to launch...");
+                LogUpdateInfo("Downloaded installer is valid, preparing to launch...");
                 return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch, manualCheck);
             }
 
-            Logger.Error("Installer authenticity could not be verified. Aborting update.");
+            LogUpdateError("Installer authenticity could not be verified. Aborting update.");
             RaiseStatus(
                 CoreTools.Translate("The installer authenticity could not be verified."),
                 CoreTools.Translate("The update process has been aborted."),
                 InfoBarSeverity.Error,
-                isClosable: true);
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished("authenticity verification failed");
             return false;
         }
         catch (Exception ex)
         {
-            Logger.Error("An error occurred while checking for updates:");
-            Logger.Error(ex);
+            LogUpdateError("An error occurred while checking for updates:");
+            LogUpdateError(ex);
             if (manualCheck || !wasCheckingForUpdates)
             {
                 RaiseStatus(
                     CoreTools.Translate("An error occurred when checking for updates: "),
                     ex.Message,
                     InfoBarSeverity.Error,
-                    isClosable: true);
+                    isClosable: true,
+                    actionButtonText: CoreTools.Translate("View log"),
+                    actionButtonAction: OpenUpdateLog);
             }
+            MarkAttemptFinished($"exception: {ex.Message}");
             return false;
         }
     }
@@ -258,20 +500,21 @@ internal static partial class AvaloniaAutoUpdater
         {
             if (!manualCheck && Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
             {
-                Logger.Warn("Auto-updater: disabled while waiting for user \u2014 aborting.");
+                LogUpdateWarn("Auto-updater: disabled while waiting for user \u2014 aborting.");
+                MarkAttemptFinished("aborted - auto-update disabled while waiting");
                 return true;
             }
             await Task.Delay(500);
         }
 
-        Logger.Info("Installing update \u2014 launching installer.");
+        LogUpdateInfo("Installing update \u2014 launching installer.");
         await LaunchInstallerAsync(installerPath);
         return true;
     }
 
     private static async Task LaunchInstallerAsync(string installerLocation)
     {
-        Logger.Info($"Launching installer: {installerLocation}");
+        LogUpdateInfo($"Launching installer: {installerLocation}");
         using Process p = new()
         {
             StartInfo = new ProcessStartInfo
@@ -290,28 +533,34 @@ internal static partial class AvaloniaAutoUpdater
         }
         catch (Exception ex)
         {
-            Logger.Error("Process.Start threw while launching the installer:");
-            Logger.Error(ex);
+            LogUpdateError("Process.Start threw while launching the installer:");
+            LogUpdateError(ex);
             RaiseStatus(
-                CoreTools.Translate("Something went wrong while launching the updater."),
+                CoreTools.Translate("The updater could not be launched."),
                 ex.Message,
                 InfoBarSeverity.Error,
-                isClosable: true);
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished($"installer launch threw: {ex.Message}");
             return;
         }
 
         if (!started)
         {
-            Logger.Error("Failed to start installer process (Process.Start returned false).");
+            LogUpdateError("Failed to start installer process (Process.Start returned false).");
             RaiseStatus(
-                CoreTools.Translate("Something went wrong while launching the updater."),
-                CoreTools.Translate("Please try again later"),
+                CoreTools.Translate("The updater could not be launched."),
+                CoreTools.Translate("The operating system did not start the installer process."),
                 InfoBarSeverity.Error,
-                isClosable: true);
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished("Process.Start returned false");
             return;
         }
 
-        Logger.Info($"Installer process started (PID {p.Id}). The installer is expected to terminate UniGetUI before file replacement.");
+        LogUpdateInfo($"Installer process started (PID {p.Id}). The installer is expected to terminate UniGetUI before file replacement.");
 
         RaiseStatus(
             CoreTools.Translate("UniGetUI is being updated..."),
@@ -321,13 +570,42 @@ internal static partial class AvaloniaAutoUpdater
 
         await p.WaitForExitAsync();
 
-        // If we reach here, the installer exited without terminating us \u2014 surface that
-        // to the user the same way WinUI does.
+        // If we reach here, the installer exited without terminating this process.
+        // Distinguish two cases:
+        //   - Exit code 0: installer succeeded; the new version IS installed at the
+        //     install location, but the running copy was not replaced (almost always
+        //     because UniGetUI is running from outside the install location — typically
+        //     a development build). This is not really an error.
+        //   - Any other code: installer reported a failure; the update did not apply.
+        int exitCode = p.ExitCode;
+        string reason = DescribeInstallerExitCode(exitCode);
+
+        if (exitCode == 0)
+        {
+            string runningPath = Environment.ProcessPath ?? "(unknown)";
+            LogUpdateWarn($"Installer reported success (exit code 0) but did not replace this running copy. Running from: {runningPath}");
+
+            RaiseStatus(
+                CoreTools.Translate("Update installed."),
+                CoreTools.Translate("UniGetUI was updated successfully, but this running copy was not replaced. This usually means you are running a development build. Close this copy and start the newly-installed version to finish."),
+                InfoBarSeverity.Warning,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished("installer succeeded but did not replace running copy");
+            return;
+        }
+
+        LogUpdateError($"Installer exited with code {exitCode} ({reason}) without restarting UniGetUI.");
+
         RaiseStatus(
-            CoreTools.Translate("Something went wrong while launching the updater."),
-            CoreTools.Translate("Please try again later"),
+            CoreTools.Translate("The update could not be applied."),
+            CoreTools.Translate("Installer exit code {0}: {1}", exitCode, reason),
             InfoBarSeverity.Error,
-            isClosable: true);
+            isClosable: true,
+            actionButtonText: CoreTools.Translate("View log"),
+            actionButtonAction: OpenUpdateLog);
+        MarkAttemptFinished($"installer failed with code {exitCode}");
     }
 
     // ------------------------------------------------------------------ update check sources
@@ -338,7 +616,7 @@ internal static partial class AvaloniaAutoUpdater
 
     private static async Task<UpdateCandidate> CheckFromProductInfoAsync(UpdaterOverrides overrides)
     {
-        Logger.Debug($"Checking updates via ProductInfo: {overrides.ProductInfoUrl}");
+        LogUpdateDebug($"Checking updates via ProductInfo: {overrides.ProductInfoUrl}");
 
         if (!IsSourceUrlAllowed(overrides.ProductInfoUrl, overrides.AllowUnsafeUrls))
         {
@@ -396,7 +674,7 @@ internal static partial class AvaloniaAutoUpdater
         Version available = ParseVersionOrFallback(channel.Version, new Version(0, 0, 0, 0));
         bool upgradable = available > current;
 
-        Logger.Debug(
+        LogUpdateDebug(
             $"ProductInfo check: current={current}, available={available}, upgradable={upgradable}"
         );
 
@@ -411,7 +689,7 @@ internal static partial class AvaloniaAutoUpdater
     {
         if (overrides.SkipHashValidation)
         {
-            Logger.Warn("Registry override: skipping hash validation.");
+            LogUpdateWarn("Registry override: skipping hash validation.");
             return true;
         }
 
@@ -422,11 +700,11 @@ internal static partial class AvaloniaAutoUpdater
 
         if (actual == expectedHash.ToLowerInvariant())
         {
-            Logger.Debug($"Hash match: {actual}");
+            LogUpdateDebug($"Hash match: {actual}");
             return true;
         }
 
-        Logger.Warn($"Hash mismatch. Expected: {expectedHash}  Got: {actual}");
+        LogUpdateWarn($"Hash mismatch. Expected: {expectedHash}  Got: {actual}");
         return false;
     }
 
@@ -434,7 +712,7 @@ internal static partial class AvaloniaAutoUpdater
     {
         if (overrides.SkipSignerThumbprintCheck)
         {
-            Logger.Warn("Registry override: skipping signer thumbprint validation.");
+            LogUpdateWarn("Registry override: skipping signer thumbprint validation.");
             return true;
         }
 
@@ -448,23 +726,23 @@ internal static partial class AvaloniaAutoUpdater
 
             if (string.IsNullOrWhiteSpace(thumbprint))
             {
-                Logger.Warn($"Could not read signer thumbprint for '{path}'");
+                LogUpdateWarn($"Could not read signer thumbprint for '{path}'");
                 return false;
             }
 
             if (DEVOLUTIONS_CERT_THUMBPRINTS.Contains(thumbprint, StringComparer.OrdinalIgnoreCase))
             {
-                Logger.Debug($"Installer signer thumbprint is trusted: {thumbprint}");
+                LogUpdateDebug($"Installer signer thumbprint is trusted: {thumbprint}");
                 return true;
             }
 
-            Logger.Warn($"Installer signer thumbprint is NOT trusted: {thumbprint}");
+            LogUpdateWarn($"Installer signer thumbprint is NOT trusted: {thumbprint}");
             return false;
         }
         catch (Exception ex)
         {
-            Logger.Warn("Could not validate installer signer thumbprint.");
-            Logger.Warn(ex);
+            LogUpdateWarn("Could not validate installer signer thumbprint.");
+            LogUpdateWarn(ex);
             return false;
         }
     }
@@ -480,7 +758,7 @@ internal static partial class AvaloniaAutoUpdater
             throw new InvalidOperationException($"Download URL is not allowed: {url}");
         }
 
-        Logger.Debug($"Downloading installer from {url}");
+        LogUpdateDebug($"Downloading installer from {url}");
         using HttpClient client = new(CreateHttpClientHandler(overrides));
         client.Timeout = TimeSpan.FromSeconds(600);
         client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
@@ -491,7 +769,7 @@ internal static partial class AvaloniaAutoUpdater
         using FileStream fs = new(destination, FileMode.OpenOrCreate);
         await response.Content.CopyToAsync(fs);
 
-        Logger.Debug("Installer download complete.");
+        LogUpdateDebug("Installer download complete.");
     }
 
     // ------------------------------------------------------------------ HTTP client
@@ -500,7 +778,7 @@ internal static partial class AvaloniaAutoUpdater
         var handler = new HttpClientHandler();
         if (overrides.DisableTlsValidation)
         {
-            Logger.Warn("Registry override: TLS certificate validation is disabled for updater requests.");
+            LogUpdateWarn("Registry override: TLS certificate validation is disabled for updater requests.");
             handler.ServerCertificateCustomValidationCallback = static (_, _, _, _) => true;
         }
         return handler;
@@ -516,7 +794,7 @@ internal static partial class AvaloniaAutoUpdater
 
         if (allowUnsafe)
         {
-            Logger.Warn($"Registry override: allowing potentially unsafe URL {url}");
+            LogUpdateWarn($"Registry override: allowing potentially unsafe URL {url}");
             return true;
         }
 
@@ -558,7 +836,7 @@ internal static partial class AvaloniaAutoUpdater
             return CoreTools.NormalizeVersionForComparison(parsed);
         }
 
-        Logger.Warn($"Could not parse version '{raw}', using fallback '{fallback}'");
+        LogUpdateWarn($"Could not parse version '{raw}', using fallback '{fallback}'");
         return fallback;
     }
 
@@ -574,7 +852,7 @@ internal static partial class AvaloniaAutoUpdater
 #if DEBUG
         if (key is not null)
         {
-            Logger.Info($"Updater registry overrides loaded from HKLM\\{REGISTRY_PATH}");
+            LogUpdateInfo($"Updater registry overrides loaded from HKLM\\{REGISTRY_PATH}");
         }
 
         return new UpdaterOverrides(
@@ -614,7 +892,7 @@ internal static partial class AvaloniaAutoUpdater
         {
             if (key.GetValue(valueName) is not null)
             {
-                Logger.Warn(
+                LogUpdateWarn(
                     $"Release build is ignoring updater registry value HKLM\\{REGISTRY_PATH}\\{valueName}."
                 );
             }

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -41,6 +41,11 @@ internal static partial class AvaloniaAutoUpdater
         "50f753333811ff11f1920274afde3ffd4468b210",
     ];
 
+    private static readonly string[] DEVOLUTIONS_MAC_DEVELOPER_IDS =
+    [
+        "N592S9ASDB",
+    ];
+
 #if !DEBUG
     private static readonly string[] RELEASE_IGNORED_REGISTRY_VALUES =
     [
@@ -369,6 +374,22 @@ internal static partial class AvaloniaAutoUpdater
     internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false, bool manualCheck = false)
     {
         ResetUpdateLog(manualCheck, autoLaunch);
+
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
+        {
+            LogUpdateWarn("Auto-updater is not yet supported on this platform.");
+            if (manualCheck)
+            {
+                RaiseStatus(
+                    CoreTools.Translate("Updates are not yet supported on this platform."),
+                    CoreTools.Translate("Please update UniGetUI manually."),
+                    InfoBarSeverity.Warning,
+                    isClosable: true);
+            }
+            MarkAttemptFinished("platform not supported");
+            return false;
+        }
+
         UpdaterOverrides overrides = LoadUpdaterOverrides();
         bool wasCheckingForUpdates = true;
 
@@ -406,7 +427,18 @@ internal static partial class AvaloniaAutoUpdater
             RecordTargetVersion(candidate.VersionName);
             LogUpdateInfo($"Update to UniGetUI {candidate.VersionName} is available.");
 
-            string installerPath = Path.Join(CoreData.UniGetUIDataDirectory, "UniGetUI Updater.exe");
+            // Linux artifact format is undecided (.deb / .rpm / .AppImage / .tar.gz) —
+            // when adding Linux support, extend this branch and the matching arms in
+            // SelectInstallerFile, CheckInstallerSignerThumbprint, and LaunchInstallerAsync.
+            string installerName;
+            if (OperatingSystem.IsWindows())
+                installerName = "UniGetUI Updater.exe";
+            else if (OperatingSystem.IsMacOS())
+                installerName = "UniGetUI Updater.pkg";
+            else
+                throw new PlatformNotSupportedException(
+                    "Auto-updater is not yet supported on this platform.");
+            string installerPath = Path.Join(CoreData.UniGetUIDataDirectory, installerName);
 
             // Try cached installer first
             if (
@@ -451,6 +483,23 @@ internal static partial class AvaloniaAutoUpdater
                 actionButtonText: CoreTools.Translate("View log"),
                 actionButtonAction: OpenUpdateLog);
             MarkAttemptFinished("authenticity verification failed");
+            return false;
+        }
+        catch (PlatformArtifactMissingException ex)
+        {
+            // A newer version exists in productinfo but no installer artifact is
+            // published for the current OS/arch yet. Surface this as a friendly
+            // "manual update required" notice rather than a generic error.
+            LogUpdateWarn(ex.Message);
+            if (manualCheck)
+            {
+                RaiseStatus(
+                    CoreTools.Translate("Auto-update is not yet available on this platform."),
+                    CoreTools.Translate("Please update UniGetUI manually."),
+                    InfoBarSeverity.Warning,
+                    isClosable: true);
+            }
+            MarkAttemptFinished("platform artifact missing");
             return false;
         }
         catch (Exception ex)
@@ -514,6 +563,12 @@ internal static partial class AvaloniaAutoUpdater
 
     private static async Task LaunchInstallerAsync(string installerLocation)
     {
+        if (OperatingSystem.IsMacOS())
+        {
+            await LaunchMacInstallerAsync(installerLocation);
+            return;
+        }
+
         LogUpdateInfo($"Launching installer: {installerLocation}");
         using Process p = new()
         {
@@ -606,6 +661,154 @@ internal static partial class AvaloniaAutoUpdater
             actionButtonText: CoreTools.Translate("View log"),
             actionButtonAction: OpenUpdateLog);
         MarkAttemptFinished($"installer failed with code {exitCode}");
+    }
+
+    private static async Task LaunchMacInstallerAsync(string installerLocation)
+    {
+        LogUpdateInfo($"Launching macOS installer: {installerLocation}");
+
+        // Escape for inclusion in the AppleScript string literal.
+        string scriptPath = installerLocation.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        string appleScript =
+            $"do shell script \"/usr/sbin/installer -pkg \\\"{scriptPath}\\\" -target /\" with administrator privileges";
+
+        using Process p = new()
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "/usr/bin/osascript",
+                ArgumentList = { "-e", appleScript },
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+
+        bool started;
+        try
+        {
+            started = p.Start();
+        }
+        catch (Exception ex)
+        {
+            LogUpdateError("osascript threw while launching the macOS installer:");
+            LogUpdateError(ex);
+            RaiseStatus(
+                CoreTools.Translate("The updater could not be launched."),
+                ex.Message,
+                InfoBarSeverity.Error,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished($"installer launch threw: {ex.Message}");
+            return;
+        }
+
+        if (!started)
+        {
+            LogUpdateError("Failed to start osascript process (Process.Start returned false).");
+            RaiseStatus(
+                CoreTools.Translate("The updater could not be launched."),
+                CoreTools.Translate("The operating system did not start the installer process."),
+                InfoBarSeverity.Error,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished("Process.Start returned false");
+            return;
+        }
+
+        RaiseStatus(
+            CoreTools.Translate("UniGetUI is being updated..."),
+            CoreTools.Translate("This may take a minute or two"),
+            InfoBarSeverity.Informational,
+            isClosable: false);
+
+        string stderr = await p.StandardError.ReadToEndAsync();
+        await p.WaitForExitAsync();
+        int exitCode = p.ExitCode;
+
+        if (exitCode != 0)
+        {
+            // osascript exits 1 with stderr "User canceled." when the user dismisses
+            // the admin authentication prompt. Treat that as a normal cancellation.
+            bool userCancelled = stderr.Contains("User canceled", StringComparison.OrdinalIgnoreCase)
+                                 || stderr.Contains("(-128)");
+            string trimmed = stderr.Trim();
+            LogUpdateError(
+                userCancelled
+                    ? "macOS installer cancelled at the authentication prompt."
+                    : $"macOS installer failed (exit {exitCode}): {trimmed}"
+            );
+
+            RaiseStatus(
+                userCancelled
+                    ? CoreTools.Translate("Update cancelled.")
+                    : CoreTools.Translate("The update could not be applied."),
+                userCancelled
+                    ? CoreTools.Translate("Authentication was cancelled.")
+                    : (string.IsNullOrWhiteSpace(trimmed)
+                        ? CoreTools.Translate("Installer exit code {0}", exitCode)
+                        : trimmed),
+                userCancelled ? InfoBarSeverity.Warning : InfoBarSeverity.Error,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished(
+                userCancelled
+                    ? "user cancelled authentication"
+                    : $"installer failed with code {exitCode}"
+            );
+            return;
+        }
+
+        LogUpdateInfo("macOS installer completed successfully.");
+
+        const string installedApp = "/Applications/UniGetUI.app";
+        if (!Directory.Exists(installedApp))
+        {
+            string runningPath = Environment.ProcessPath ?? "(unknown)";
+            LogUpdateWarn(
+                $"Installer reported success but {installedApp} was not found. Running from: {runningPath}"
+            );
+            RaiseStatus(
+                CoreTools.Translate("Update installed."),
+                CoreTools.Translate("UniGetUI was updated successfully, but this running copy was not replaced. This usually means you are running a development build. Close this copy and start the newly-installed version to finish."),
+                InfoBarSeverity.Warning,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished("installer succeeded but did not replace running copy");
+            return;
+        }
+
+        LogUpdateInfo($"Relaunching {installedApp} and exiting current process.");
+
+        // Detach a tiny shell that waits a moment, then opens a *new* instance of the
+        // freshly-installed app. The brief sleep gives this process time to exit so
+        // `open -na` doesn't race against our termination.
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "/bin/sh",
+                ArgumentList = { "-c", $"sleep 1 && /usr/bin/open -na \"{installedApp}\"" },
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            LogUpdateWarn("Could not schedule relaunch of new app instance:");
+            LogUpdateWarn(ex);
+        }
+
+        MarkAttemptFinished("macOS installer succeeded; relaunching");
+
+        // Match the Windows flow: the installer terminates the running copy. On macOS
+        // we do that ourselves so the relaunch picks up the freshly-installed bundle.
+        Environment.Exit(0);
     }
 
     // ------------------------------------------------------------------ update check sources
@@ -716,6 +919,17 @@ internal static partial class AvaloniaAutoUpdater
             return true;
         }
 
+        if (OperatingSystem.IsMacOS())
+        {
+            return CheckMacInstallerSignature(path);
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            LogUpdateWarn("Skipping installer signature validation on unsupported platform.");
+            return true;
+        }
+
         try
         {
 #pragma warning disable SYSLIB0057
@@ -742,6 +956,63 @@ internal static partial class AvaloniaAutoUpdater
         catch (Exception ex)
         {
             LogUpdateWarn("Could not validate installer signer thumbprint.");
+            LogUpdateWarn(ex);
+            return false;
+        }
+    }
+
+    private static bool CheckMacInstallerSignature(string path)
+    {
+        if (DEVOLUTIONS_MAC_DEVELOPER_IDS.Length == 0)
+        {
+            LogUpdateWarn(
+                "No Devolutions macOS Developer Team IDs configured — skipping .pkg signature validation."
+            );
+            return true;
+        }
+
+        try
+        {
+            using Process p = new()
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/usr/sbin/pkgutil",
+                    ArgumentList = { "--check-signature", path },
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                },
+            };
+            p.Start();
+            string stdout = p.StandardOutput.ReadToEnd();
+            string stderr = p.StandardError.ReadToEnd();
+            p.WaitForExit();
+
+            if (p.ExitCode != 0)
+            {
+                LogUpdateWarn(
+                    $"pkgutil --check-signature exited {p.ExitCode}; signature could not be verified. {stderr.Trim()}"
+                );
+                return false;
+            }
+
+            foreach (string teamId in DEVOLUTIONS_MAC_DEVELOPER_IDS)
+            {
+                if (stdout.Contains($"({teamId})", StringComparison.OrdinalIgnoreCase))
+                {
+                    LogUpdateDebug($"Installer is signed by trusted Developer Team ID {teamId}.");
+                    return true;
+                }
+            }
+
+            LogUpdateWarn("Installer signature does not match any trusted Devolutions Developer Team ID.");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            LogUpdateWarn("Could not validate installer signature via pkgutil.");
             LogUpdateWarn(ex);
             return false;
         }
@@ -817,6 +1088,18 @@ internal static partial class AvaloniaAutoUpdater
             _ => "x64",
         };
 
+        if (OperatingSystem.IsMacOS())
+        {
+            ProductInfoFile? mac =
+                files.FirstOrDefault(f => f.Type.Equals("pkg", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase))
+                ?? files.FirstOrDefault(f => f.Type.Equals("pkg", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals("universal", StringComparison.OrdinalIgnoreCase))
+                ?? files.FirstOrDefault(f => f.Type.Equals("pkg", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals("Any", StringComparison.OrdinalIgnoreCase));
+
+            return mac ?? throw new PlatformArtifactMissingException(
+                $"No compatible macOS installer (.pkg) found in productinfo for architecture '{arch}'"
+            );
+        }
+
         ProductInfoFile? match =
             files.FirstOrDefault(f => f.Type.Equals("exe", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase))
             ?? files.FirstOrDefault(f => f.Type.Equals("exe", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals("Any", StringComparison.OrdinalIgnoreCase))
@@ -846,6 +1129,18 @@ internal static partial class AvaloniaAutoUpdater
     // ------------------------------------------------------------------ registry
     private static UpdaterOverrides LoadUpdaterOverrides()
     {
+        if (!OperatingSystem.IsWindows())
+        {
+            return new UpdaterOverrides(
+                DEFAULT_PRODUCTINFO_URL,
+                DEFAULT_PRODUCTINFO_KEY,
+                false,
+                false,
+                false,
+                false
+            );
+        }
+
 #pragma warning disable CA1416
         using RegistryKey? key = Registry.LocalMachine.OpenSubKey(REGISTRY_PATH);
 
@@ -927,6 +1222,8 @@ internal static partial class AvaloniaAutoUpdater
 #endif
 
     // ------------------------------------------------------------------ data types
+    private sealed class PlatformArtifactMissingException(string message) : Exception(message);
+
     private sealed record UpdateCandidate(
         bool IsUpgradable,
         string VersionName,

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -5,12 +5,9 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Avalonia;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using Microsoft.Win32;
 using UniGetUI.Avalonia.ViewModels;
-using UniGetUI.Avalonia.Views;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
@@ -104,7 +101,11 @@ internal static partial class AvaloniaAutoUpdater
     /// <summary>
     /// Called by the user when they click "Update now" in the update banner.
     /// </summary>
-    public static void TriggerInstall() => _installRequested = true;
+    public static void TriggerInstall()
+    {
+        Logger.Info("Auto-updater: TriggerInstall invoked (user clicked Update now).");
+        _installRequested = true;
+    }
     public static async Task UpdateCheckLoopAsync()
     {
         if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
@@ -132,14 +133,14 @@ internal static partial class AvaloniaAutoUpdater
     }
 
     // ------------------------------------------------------------------ core logic
-    internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false, bool verbose = false)
+    internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false, bool manualCheck = false)
     {
         UpdaterOverrides overrides = LoadUpdaterOverrides();
         bool wasCheckingForUpdates = true;
 
         try
         {
-            if (verbose)
+            if (manualCheck)
             {
                 RaiseStatus(
                     CoreTools.Translate("We are checking for updates."),
@@ -155,7 +156,7 @@ internal static partial class AvaloniaAutoUpdater
 
             if (!candidate.IsUpgradable)
             {
-                if (verbose)
+                if (manualCheck)
                 {
                     RaiseStatus(
                         CoreTools.Translate("Great! You are on the latest version."),
@@ -179,7 +180,7 @@ internal static partial class AvaloniaAutoUpdater
             )
             {
                 Logger.Info("Cached valid installer found, preparing to launch...");
-                return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch);
+                return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch, manualCheck);
             }
 
             // Delete invalid/outdated cached copy
@@ -202,7 +203,7 @@ internal static partial class AvaloniaAutoUpdater
             )
             {
                 Logger.Info("Downloaded installer is valid, preparing to launch...");
-                return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch);
+                return await PrepareAndLaunchAsync(installerPath, candidate.VersionName, autoLaunch, manualCheck);
             }
 
             Logger.Error("Installer authenticity could not be verified. Aborting update.");
@@ -217,7 +218,7 @@ internal static partial class AvaloniaAutoUpdater
         {
             Logger.Error("An error occurred while checking for updates:");
             Logger.Error(ex);
-            if (verbose || !wasCheckingForUpdates)
+            if (manualCheck || !wasCheckingForUpdates)
             {
                 RaiseStatus(
                     CoreTools.Translate("An error occurred when checking for updates: "),
@@ -233,7 +234,8 @@ internal static partial class AvaloniaAutoUpdater
     private static async Task<bool> PrepareAndLaunchAsync(
         string installerPath,
         string versionName,
-        bool autoLaunch)
+        bool autoLaunch,
+        bool manualCheck)
     {
         _pendingInstallerPath = installerPath;
         _installRequested = false;
@@ -254,7 +256,7 @@ internal static partial class AvaloniaAutoUpdater
         // Wait until user requests install, clicks the toast, or the window is being closed
         while (!_installRequested && !ReleaseLockForAutoupdate_Window && !ReleaseLockForAutoupdate_Notification)
         {
-            if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
+            if (!manualCheck && Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
             {
                 Logger.Warn("Auto-updater: disabled while waiting for user \u2014 aborting.");
                 return true;
@@ -262,12 +264,12 @@ internal static partial class AvaloniaAutoUpdater
             await Task.Delay(500);
         }
 
-        Logger.Info("Installing update \u2014 launching installer and quitting.");
-        await LaunchInstallerAndQuitAsync(installerPath);
+        Logger.Info("Installing update \u2014 launching installer.");
+        await LaunchInstallerAsync(installerPath);
         return true;
     }
 
-    private static async Task LaunchInstallerAndQuitAsync(string installerLocation)
+    private static async Task LaunchInstallerAsync(string installerLocation)
     {
         Logger.Info($"Launching installer: {installerLocation}");
         using Process p = new()
@@ -281,10 +283,26 @@ internal static partial class AvaloniaAutoUpdater
             },
         };
 
-        bool started = p.Start();
+        bool started;
+        try
+        {
+            started = p.Start();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Process.Start threw while launching the installer:");
+            Logger.Error(ex);
+            RaiseStatus(
+                CoreTools.Translate("Something went wrong while launching the updater."),
+                ex.Message,
+                InfoBarSeverity.Error,
+                isClosable: true);
+            return;
+        }
+
         if (!started)
         {
-            Logger.Error("Failed to start installer process.");
+            Logger.Error("Failed to start installer process (Process.Start returned false).");
             RaiseStatus(
                 CoreTools.Translate("Something went wrong while launching the updater."),
                 CoreTools.Translate("Please try again later"),
@@ -293,23 +311,23 @@ internal static partial class AvaloniaAutoUpdater
             return;
         }
 
-        // Quit the app on the UI thread
-        Dispatcher.UIThread.Post(() =>
-        {
-            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
-            {
-                if (lifetime.MainWindow is MainWindow mw)
-                {
-                    mw.QuitApplication();
-                }
-                else
-                {
-                    lifetime.Shutdown();
-                }
-            }
-        });
+        Logger.Info($"Installer process started (PID {p.Id}). The installer is expected to terminate UniGetUI before file replacement.");
+
+        RaiseStatus(
+            CoreTools.Translate("UniGetUI is being updated..."),
+            CoreTools.Translate("This may take a minute or two"),
+            InfoBarSeverity.Informational,
+            isClosable: false);
 
         await p.WaitForExitAsync();
+
+        // If we reach here, the installer exited without terminating us \u2014 surface that
+        // to the user the same way WinUI does.
+        RaiseStatus(
+            CoreTools.Translate("Something went wrong while launching the updater."),
+            CoreTools.Translate("Please try again later"),
+            InfoBarSeverity.Error,
+            isClosable: true);
     }
 
     // ------------------------------------------------------------------ update check sources

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -374,22 +375,6 @@ internal static partial class AvaloniaAutoUpdater
     internal static async Task<bool> CheckAndInstallUpdatesAsync(bool autoLaunch = false, bool manualCheck = false)
     {
         ResetUpdateLog(manualCheck, autoLaunch);
-
-        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
-        {
-            LogUpdateWarn("Auto-updater is not yet supported on this platform.");
-            if (manualCheck)
-            {
-                RaiseStatus(
-                    CoreTools.Translate("Updates are not yet supported on this platform."),
-                    CoreTools.Translate("Please update UniGetUI manually."),
-                    InfoBarSeverity.Warning,
-                    isClosable: true);
-            }
-            MarkAttemptFinished("platform not supported");
-            return false;
-        }
-
         UpdaterOverrides overrides = LoadUpdaterOverrides();
         bool wasCheckingForUpdates = true;
 
@@ -427,17 +412,13 @@ internal static partial class AvaloniaAutoUpdater
             RecordTargetVersion(candidate.VersionName);
             LogUpdateInfo($"Update to UniGetUI {candidate.VersionName} is available.");
 
-            // Linux artifact format is undecided (.deb / .rpm / .AppImage / .tar.gz) —
-            // when adding Linux support, extend this branch and the matching arms in
-            // SelectInstallerFile, CheckInstallerSignerThumbprint, and LaunchInstallerAsync.
             string installerName;
             if (OperatingSystem.IsWindows())
                 installerName = "UniGetUI Updater.exe";
             else if (OperatingSystem.IsMacOS())
                 installerName = "UniGetUI Updater.pkg";
             else
-                throw new PlatformNotSupportedException(
-                    "Auto-updater is not yet supported on this platform.");
+                installerName = "UniGetUI Updater.AppImage";
             string installerPath = Path.Join(CoreData.UniGetUIDataDirectory, installerName);
 
             // Try cached installer first
@@ -566,6 +547,12 @@ internal static partial class AvaloniaAutoUpdater
         if (OperatingSystem.IsMacOS())
         {
             await LaunchMacInstallerAsync(installerLocation);
+            return;
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            LaunchLinuxInstaller(installerLocation);
             return;
         }
 
@@ -811,6 +798,93 @@ internal static partial class AvaloniaAutoUpdater
         Environment.Exit(0);
     }
 
+    [SupportedOSPlatform("linux")]
+    private static void LaunchLinuxInstaller(string installerLocation)
+    {
+        LogUpdateInfo($"Applying Linux AppImage update from: {installerLocation}");
+
+        // The AppImage runtime sets APPIMAGE to the on-disk path of the running
+        // .AppImage file. Without it we have no reliable way to know which file
+        // to replace (e.g., when running from `dotnet run` during development).
+        string? runningApp = Environment.GetEnvironmentVariable("APPIMAGE");
+        if (string.IsNullOrEmpty(runningApp) || !File.Exists(runningApp))
+        {
+            LogUpdateWarn(
+                $"APPIMAGE env var is not set or points to a missing file (got '{runningApp}'). "
+                + "UniGetUI does not appear to be running from an AppImage; the running copy "
+                + "cannot be replaced automatically."
+            );
+            RaiseStatus(
+                CoreTools.Translate("Update installed."),
+                CoreTools.Translate("UniGetUI was updated successfully, but this running copy was not replaced. This usually means you are running a development build. Close this copy and start the newly-installed version to finish."),
+                InfoBarSeverity.Warning,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished("not running from an AppImage; running copy not replaced");
+            return;
+        }
+
+        try
+        {
+            // Replace the running AppImage on disk. Linux allows renaming over a
+            // currently-executing file: the running process keeps its inode mapped,
+            // and future launches resolve the path to the new file.
+            File.Move(installerLocation, runningApp, overwrite: true);
+
+            File.SetUnixFileMode(
+                runningApp,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute
+            );
+        }
+        catch (Exception ex)
+        {
+            LogUpdateError("Failed to replace the running AppImage:");
+            LogUpdateError(ex);
+            RaiseStatus(
+                CoreTools.Translate("The update could not be applied."),
+                ex.Message,
+                InfoBarSeverity.Error,
+                isClosable: true,
+                actionButtonText: CoreTools.Translate("View log"),
+                actionButtonAction: OpenUpdateLog);
+            MarkAttemptFinished($"AppImage replacement failed: {ex.Message}");
+            return;
+        }
+
+        LogUpdateInfo($"Replaced {runningApp}; relaunching new AppImage and exiting current process.");
+
+        RaiseStatus(
+            CoreTools.Translate("UniGetUI is being updated..."),
+            CoreTools.Translate("This may take a minute or two"),
+            InfoBarSeverity.Informational,
+            isClosable: false);
+
+        // Detach a shell that waits a moment, then runs the new AppImage. The brief
+        // sleep gives this process time to exit so the relaunched instance starts
+        // cleanly without lingering shared resources.
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "/bin/sh",
+                ArgumentList = { "-c", $"sleep 1 && \"{runningApp}\" >/dev/null 2>&1 &" },
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            LogUpdateWarn("Could not schedule relaunch of new AppImage:");
+            LogUpdateWarn(ex);
+        }
+
+        MarkAttemptFinished("Linux AppImage replaced; relaunching");
+        Environment.Exit(0);
+    }
+
     // ------------------------------------------------------------------ update check sources
     private static async Task<UpdateCandidate> GetUpdateCandidateAsync(UpdaterOverrides overrides)
     {
@@ -922,6 +996,17 @@ internal static partial class AvaloniaAutoUpdater
         if (OperatingSystem.IsMacOS())
         {
             return CheckMacInstallerSignature(path);
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            // AppImage has no built-in signing format equivalent to Authenticode/.pkg.
+            // Hash validation (verified separately, against the productinfo.json fetched
+            // over HTTPS from a trusted host) provides the integrity guarantee. A future
+            // extension could verify a detached GPG signature published alongside the
+            // .AppImage in productinfo.
+            LogUpdateWarn("Linux .AppImage signature validation is not implemented — relying on hash check.");
+            return true;
         }
 
         if (!OperatingSystem.IsWindows())
@@ -1097,6 +1182,18 @@ internal static partial class AvaloniaAutoUpdater
 
             return mac ?? throw new PlatformArtifactMissingException(
                 $"No compatible macOS installer (.pkg) found in productinfo for architecture '{arch}'"
+            );
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            ProductInfoFile? linux =
+                files.FirstOrDefault(f => f.Type.Equals("AppImage", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase))
+                ?? files.FirstOrDefault(f => f.Type.Equals("AppImage", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals("universal", StringComparison.OrdinalIgnoreCase))
+                ?? files.FirstOrDefault(f => f.Type.Equals("AppImage", StringComparison.OrdinalIgnoreCase) && f.Arch.Equals("Any", StringComparison.OrdinalIgnoreCase));
+
+            return linux ?? throw new PlatformArtifactMissingException(
+                $"No compatible Linux installer (.AppImage) found in productinfo for architecture '{arch}'"
             );
         }
 

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -187,11 +187,23 @@ public partial class MainWindowViewModel : ViewModelBase
 
         AvaloniaAutoUpdater.UpdateAvailable += version => Dispatcher.UIThread.Post(() =>
         {
+            UpdatesBanner.Severity = InfoBarSeverity.Success;
             UpdatesBanner.Title = CoreTools.Translate("UniGetUI {0} is ready to be installed.", version);
             UpdatesBanner.Message = CoreTools.Translate("The update process will start after closing UniGetUI");
             UpdatesBanner.ActionButtonText = CoreTools.Translate("Update now");
             UpdatesBanner.ActionButtonCommand = new CommunityToolkit.Mvvm.Input.RelayCommand(AvaloniaAutoUpdater.TriggerInstall);
             UpdatesBanner.IsClosable = true;
+            UpdatesBanner.IsOpen = true;
+        });
+
+        AvaloniaAutoUpdater.StatusChanged += status => Dispatcher.UIThread.Post(() =>
+        {
+            UpdatesBanner.Severity = status.Severity;
+            UpdatesBanner.Title = status.Title;
+            UpdatesBanner.Message = status.Message;
+            UpdatesBanner.ActionButtonText = "";
+            UpdatesBanner.ActionButtonCommand = null;
+            UpdatesBanner.IsClosable = status.IsClosable;
             UpdatesBanner.IsOpen = true;
         });
 

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -201,11 +201,18 @@ public partial class MainWindowViewModel : ViewModelBase
             UpdatesBanner.Severity = status.Severity;
             UpdatesBanner.Title = status.Title;
             UpdatesBanner.Message = status.Message;
-            UpdatesBanner.ActionButtonText = "";
-            UpdatesBanner.ActionButtonCommand = null;
+            UpdatesBanner.ActionButtonText = status.ActionButtonText ?? "";
+            UpdatesBanner.ActionButtonCommand = status.ActionButtonAction is { } action
+                ? new CommunityToolkit.Mvvm.Input.RelayCommand(action)
+                : null;
             UpdatesBanner.IsClosable = status.IsClosable;
             UpdatesBanner.IsOpen = true;
         });
+
+        // If the previous update attempt was killed mid-flow (typically by the
+        // installer terminating us during file replacement), surface a banner now
+        // that subscriptions are wired up.
+        AvaloniaAutoUpdater.CheckForOrphanedUpdateAttempt();
 
         // Keep OperationsPanelVisible in sync with the live operations list
         Operations.CollectionChanged += (_, _) =>

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -86,7 +86,7 @@ public partial class SidebarViewModel : ViewModelBase
 
     [RelayCommand]
     private static Task CheckForUpdates() =>
-        AvaloniaAutoUpdater.CheckAndInstallUpdatesAsync(autoLaunch: false, verbose: true);
+        AvaloniaAutoUpdater.CheckAndInstallUpdatesAsync(autoLaunch: false, manualCheck: true);
 
     public void SelectNavButtonForPage(PageType page) =>
         SelectedPageType = page;

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -86,7 +86,7 @@ public partial class SidebarViewModel : ViewModelBase
 
     [RelayCommand]
     private static Task CheckForUpdates() =>
-        AvaloniaAutoUpdater.CheckAndInstallUpdatesAsync(autoLaunch: false);
+        AvaloniaAutoUpdater.CheckAndInstallUpdatesAsync(autoLaunch: false, verbose: true);
 
     public void SelectNavButtonForPage(PageType page) =>
         SelectedPageType = page;

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.Views;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.SettingsEngine;
@@ -82,6 +83,10 @@ public partial class SidebarViewModel : ViewModelBase
         if (Enum.TryParse<PageType>(pageName, out var page))
             NavigationRequested?.Invoke(this, page);
     }
+
+    [RelayCommand]
+    private static Task CheckForUpdates() =>
+        AvaloniaAutoUpdater.CheckAndInstallUpdatesAsync(autoLaunch: false);
 
     public void SelectNavButtonForPage(PageType page) =>
         SelectedPageType = page;

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -231,6 +231,9 @@
                         <MenuItem Header="{t:Translate Release notes}" Command="{Binding RequestNavigationCommand}" CommandParameter="ReleaseNotes">
                             <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/megaphone.svg" Width="16" Height="16"/></MenuItem.Icon>
                         </MenuItem>
+                        <MenuItem Header="{t:Translate Check for UniGetUI updates}" Command="{Binding CheckForUpdatesCommand}">
+                            <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/update.svg" Width="16" Height="16"/></MenuItem.Icon>
+                        </MenuItem>
                         <Separator/>
                         <MenuItem Header="{t:Translate Help}" Command="{Binding RequestNavigationCommand}" CommandParameter="Help">
                             <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/help.svg" Width="16" Height="16"/></MenuItem.Icon>

--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -37,8 +38,241 @@ public partial class AutoUpdater
     public static bool ReleaseLockForAutoupdate_UpdateBanner;
     public static bool UpdateReadyToBeInstalled { get; private set; }
 
+    // ------------------------------------------------------------------ per-attempt log
+    // Captures auto-updater log entries for the current update attempt. We keep a
+    // dedicated buffer (in addition to the global session log) so the "View log"
+    // banner button can show the user only the entries relevant to their failed
+    // update, instead of dumping the entire noisy session log.
+    private static readonly Lock _updateLogLock = new();
+    private static StringBuilder? _updateLogBuilder;
+    private static readonly string _updateLogPath = Path.Combine(
+        Path.GetTempPath(),
+        "UniGetUI",
+        "last-update-attempt.log"
+    );
+
+    private static void ResetUpdateLog(bool manualCheck, bool autoLaunch)
+    {
+        lock (_updateLogLock)
+        {
+            _updateLogBuilder = new StringBuilder()
+                .AppendLine($"=== UniGetUI update attempt started at {DateTime.Now:yyyy-MM-dd HH:mm:ss} ===")
+                .AppendLine($"Current version: {CoreData.VersionName} (build {CoreData.BuildNumber})")
+                .AppendLine($"Manual check: {manualCheck}")
+                .AppendLine($"Auto-launch: {autoLaunch}")
+                .AppendLine($"UI: WinUI")
+                .AppendLine();
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    private static void AppendToUpdateLog(string severity, string message)
+    {
+        lock (_updateLogLock)
+        {
+            if (_updateLogBuilder is null) return;
+            _updateLogBuilder.AppendLine($"[{DateTime.Now:HH:mm:ss}] [{severity}] {message}");
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    // Persists the current buffer to _updateLogPath. Caller MUST hold _updateLogLock.
+    // Failures are silently swallowed — a missing log file should never break the
+    // update flow itself.
+    private static void FlushUpdateLogToDiskNoLock()
+    {
+        if (_updateLogBuilder is null) return;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_updateLogPath)!);
+            File.WriteAllText(_updateLogPath, _updateLogBuilder.ToString());
+        }
+        catch { /* see comment above */ }
+    }
+
+    private const string AttemptFinishedMarker = "=== Attempt finished:";
+
+    // Appends a structured line indicating the update flow reached a terminal state.
+    // The presence/absence of this marker on disk lets a subsequent app launch tell
+    // whether the previous attempt completed cleanly or was killed mid-flow.
+    private static void MarkAttemptFinished(string outcome)
+    {
+        lock (_updateLogLock)
+        {
+            if (_updateLogBuilder is null) return;
+            _updateLogBuilder
+                .AppendLine()
+                .AppendLine($"{AttemptFinishedMarker} {outcome} at {DateTime.Now:yyyy-MM-dd HH:mm:ss} ===");
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    private static void RecordTargetVersion(string version)
+    {
+        lock (_updateLogLock)
+        {
+            _updateLogBuilder?.AppendLine($"Target version: {version}");
+            FlushUpdateLogToDiskNoLock();
+        }
+    }
+
+    /// <summary>
+    /// On app startup, detects an interrupted update attempt — the log file
+    /// from the previous attempt has no <see cref="AttemptFinishedMarker"/>,
+    /// indicating the app was killed mid-flow (almost always because the
+    /// installer terminated us during file replacement).
+    /// Caller must have already assigned <see cref="Window"/> and
+    /// <see cref="Banner"/> so the banner can render.
+    /// </summary>
+    public static void CheckForOrphanedUpdateAttempt()
+    {
+        try
+        {
+            if (!File.Exists(_updateLogPath)) return;
+
+            var info = new FileInfo(_updateLogPath);
+            if ((DateTime.Now - info.LastWriteTime).TotalMinutes > 10)
+                return;
+
+            string content = File.ReadAllText(_updateLogPath);
+            if (content.Contains(AttemptFinishedMarker))
+                return;
+
+            string currentVer = CoreData.VersionName;
+            string? targetVer = null;
+            foreach (string line in content.Split('\n'))
+            {
+                if (line.StartsWith("Target version: "))
+                {
+                    targetVer = line["Target version: ".Length..].Trim();
+                    break;
+                }
+            }
+
+            if (targetVer is not null && targetVer == currentVer)
+            {
+                Logger.Info($"Previous update attempt killed mid-flow but install succeeded (running version {currentVer} matches target). Marking as finished.");
+                try
+                {
+                    File.AppendAllText(
+                        _updateLogPath,
+                        $"{Environment.NewLine}{AttemptFinishedMarker} installer succeeded (detected on next launch — running version is {currentVer}) at {DateTime.Now:yyyy-MM-dd HH:mm:ss} ==={Environment.NewLine}");
+                }
+                catch { /* swallow */ }
+                return;
+            }
+
+            Logger.Warn($"Detected interrupted update attempt. Running={currentVer}, Target={targetVer ?? "(unknown)"}");
+
+            ShowMessage_ThreadSafe(
+                CoreTools.Translate("Your last update attempt did not complete."),
+                CoreTools.Translate("UniGetUI could not confirm whether the update succeeded. Open the log to see what happened."),
+                InfoBarSeverity.Warning,
+                true,
+                CreateViewLogButton()
+            );
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Could not check for orphaned update attempt: {ex.Message}");
+        }
+    }
+
+    private static void LogUpdateInfo(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Info(message, caller);
+        AppendToUpdateLog("INFO ", message);
+    }
+
+    private static void LogUpdateWarn(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Warn(message, caller);
+        AppendToUpdateLog("WARN ", message);
+    }
+
+    private static void LogUpdateWarn(Exception ex, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Warn(ex, caller);
+        AppendToUpdateLog("WARN ", ex.ToString());
+    }
+
+    private static void LogUpdateError(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Error(message, caller);
+        AppendToUpdateLog("ERROR", message);
+    }
+
+    private static void LogUpdateError(Exception ex, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Error(ex, caller);
+        AppendToUpdateLog("ERROR", ex.ToString());
+    }
+
+    private static void LogUpdateDebug(string message, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        Logger.Debug(message, caller);
+        AppendToUpdateLog("DEBUG", message);
+    }
+
+    private static void OpenUpdateLog()
+    {
+        // The buffer is flushed to disk on every append/reset, so the file should
+        // already be current. Only fall back to the full session log if no flow
+        // has ever run (button shouldn't appear in that case, but be defensive).
+        string pathToOpen = File.Exists(_updateLogPath)
+            ? _updateLogPath
+            : Logger.GetSessionLogPath();
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = pathToOpen,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Could not open log file '{pathToOpen}': {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Translates an Inno Setup installer exit code into a short human-readable
+    /// reason. The codes come from the Inno Setup documentation
+    /// (https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes).
+    /// </summary>
+    private static string DescribeInstallerExitCode(int code) => code switch
+    {
+        0 => CoreTools.Translate("The installer reported success but did not restart UniGetUI."),
+        1 => CoreTools.Translate("The installer failed to initialize."),
+        2 => CoreTools.Translate("Setup was canceled before installation began."),
+        3 => CoreTools.Translate("A fatal error occurred during the preparation phase."),
+        4 => CoreTools.Translate("A fatal error occurred during installation."),
+        5 => CoreTools.Translate("Installation was canceled while in progress."),
+        6 => CoreTools.Translate("The installer was terminated by another process."),
+        7 => CoreTools.Translate("The preparation phase determined the installation cannot proceed."),
+        8 => CoreTools.Translate("The installer could not start. UniGetUI may already be running, or you do not have permission to install."),
+        _ => CoreTools.Translate("Unexpected installer error."),
+    };
+
+    private static Button CreateViewLogButton()
+    {
+        var btn = new Button { Content = CoreTools.Translate("View log") };
+        btn.Click += (_, _) => OpenUpdateLog();
+        return btn;
+    }
+
     public static async Task UpdateCheckLoop(Window window, InfoBar banner)
     {
+        Window = window;
+        Banner = banner;
+
+        // If the previous update attempt was killed mid-flow (typically by the
+        // installer terminating us during file replacement), surface a banner
+        // before either entering or short-circuiting the auto-update loop.
+        CheckForOrphanedUpdateAttempt();
+
         if (Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
         {
             Logger.Warn("User has disabled updates");
@@ -46,8 +280,6 @@ public partial class AutoUpdater
         }
 
         bool IsFirstLaunch = true;
-        Window = window;
-        Banner = banner;
 
         await CoreTools.WaitForInternetConnection();
         while (true)
@@ -83,6 +315,7 @@ public partial class AutoUpdater
         Window = window;
         Banner = banner;
         bool WasCheckingForUpdates = true;
+        ResetUpdateLog(ManualCheck, AutoLaunch);
         UpdaterOverrides updaterOverrides = LoadUpdaterOverrides();
 
         try
@@ -97,14 +330,15 @@ public partial class AutoUpdater
 
             // Check for updates
             UpdateCandidate updateCandidate = await GetUpdateCandidate(updaterOverrides);
-            Logger.Info(
+            LogUpdateInfo(
                 $"Updater source '{updateCandidate.SourceName}' returned version {updateCandidate.VersionName} (upgradable={updateCandidate.IsUpgradable})"
             );
 
             if (updateCandidate.IsUpgradable)
             {
                 WasCheckingForUpdates = false;
-                Logger.Info(
+                RecordTargetVersion(updateCandidate.VersionName);
+                LogUpdateInfo(
                     $"An update to UniGetUI version {updateCandidate.VersionName} is available"
                 );
                 string InstallerPath = Path.Join(
@@ -122,7 +356,7 @@ public partial class AutoUpdater
                     && CheckInstallerSignerThumbprint(InstallerPath, updaterOverrides)
                 )
                 {
-                    Logger.Info($"A cached valid installer was found, launching update process...");
+                    LogUpdateInfo($"A cached valid installer was found, launching update process...");
                     return await PrepairToLaunchInstaller(
                         InstallerPath,
                         updateCandidate.VersionName,
@@ -158,7 +392,7 @@ public partial class AutoUpdater
                     ) && CheckInstallerSignerThumbprint(InstallerPath, updaterOverrides)
                 )
                 {
-                    Logger.Info("The downloaded installer is valid, launching update process...");
+                    LogUpdateInfo("The downloaded installer is valid, launching update process...");
                     return await PrepairToLaunchInstaller(
                         InstallerPath,
                         updateCandidate.VersionName,
@@ -171,8 +405,10 @@ public partial class AutoUpdater
                     CoreTools.Translate("The installer authenticity could not be verified."),
                     CoreTools.Translate("The update process has been aborted."),
                     InfoBarSeverity.Error,
-                    true
+                    true,
+                    CreateViewLogButton()
                 );
+                MarkAttemptFinished("authenticity verification failed");
                 return false;
             }
 
@@ -183,20 +419,23 @@ public partial class AutoUpdater
                     InfoBarSeverity.Success,
                     true
                 );
+            MarkAttemptFinished("no update available");
             return true;
         }
         catch (Exception e)
         {
-            Logger.Error("An error occurred while checking for updates: ");
-            Logger.Error(e);
+            LogUpdateError("An error occurred while checking for updates: ");
+            LogUpdateError(e);
             // We don't want an error popping if updates can't
             if (Verbose || !WasCheckingForUpdates)
                 ShowMessage_ThreadSafe(
                     CoreTools.Translate("An error occurred when checking for updates: "),
                     e.Message,
                     InfoBarSeverity.Error,
-                    true
+                    true,
+                    CreateViewLogButton()
                 );
+            MarkAttemptFinished($"exception: {e.Message}");
             return false;
         }
     }
@@ -213,7 +452,7 @@ public partial class AutoUpdater
         UpdaterOverrides updaterOverrides
     )
     {
-        Logger.Debug(
+        LogUpdateDebug(
             $"Begin check for updates on productinfo source {updaterOverrides.ProductInfoUrl}"
         );
 
@@ -283,7 +522,7 @@ public partial class AutoUpdater
         Version availableVersion = ParseVersionOrFallback(channel.Version, new Version(0, 0, 0, 0));
 
         bool isUpgradable = availableVersion > currentVersion;
-        Logger.Debug(
+        LogUpdateDebug(
             $"Productinfo check result: current={currentVersion}, available={availableVersion}, upgradable={isUpgradable}"
         );
 
@@ -307,11 +546,11 @@ public partial class AutoUpdater
     {
         if (updaterOverrides.SkipHashValidation)
         {
-            Logger.Warn("Registry override enabled: skipping updater hash validation.");
+            LogUpdateWarn("Registry override enabled: skipping updater hash validation.");
             return true;
         }
 
-        Logger.Debug($"Checking updater hash on location {installerLocation}");
+        LogUpdateDebug($"Checking updater hash on location {installerLocation}");
         using (FileStream stream = File.OpenRead(installerLocation))
         {
             string hash = Convert
@@ -319,10 +558,10 @@ public partial class AutoUpdater
                 .ToLower();
             if (hash == expectedHash.ToLower())
             {
-                Logger.Debug($"The hashes match ({hash})");
+                LogUpdateDebug($"The hashes match ({hash})");
                 return true;
             }
-            Logger.Warn($"Hash mismatch.\nExpected: {expectedHash}\nGot:      {hash}");
+            LogUpdateWarn($"Hash mismatch.\nExpected: {expectedHash}\nGot:      {hash}");
             return false;
         }
     }
@@ -334,7 +573,7 @@ public partial class AutoUpdater
     {
         if (updaterOverrides.SkipSignerThumbprintCheck)
         {
-            Logger.Warn(
+            LogUpdateWarn(
                 "Registry override enabled: skipping updater signer thumbprint validation."
             );
             return true;
@@ -352,7 +591,7 @@ public partial class AutoUpdater
             string signerThumbprint = NormalizeThumbprint(cert.Thumbprint ?? string.Empty);
             if (string.IsNullOrWhiteSpace(signerThumbprint))
             {
-                Logger.Warn(
+                LogUpdateWarn(
                     $"Could not read signer thumbprint for installer '{installerLocation}'"
                 );
                 return false;
@@ -365,17 +604,17 @@ public partial class AutoUpdater
                 )
             )
             {
-                Logger.Debug($"Installer signer thumbprint is trusted: {signerThumbprint}");
+                LogUpdateDebug($"Installer signer thumbprint is trusted: {signerThumbprint}");
                 return true;
             }
 
-            Logger.Warn($"Installer signer thumbprint is not trusted. Got: {signerThumbprint}");
+            LogUpdateWarn($"Installer signer thumbprint is not trusted. Got: {signerThumbprint}");
             return false;
         }
         catch (Exception ex)
         {
-            Logger.Warn("Could not validate installer signer thumbprint");
-            Logger.Warn(ex);
+            LogUpdateWarn("Could not validate installer signer thumbprint");
+            LogUpdateWarn(ex);
             return false;
         }
     }
@@ -394,7 +633,7 @@ public partial class AutoUpdater
             throw new InvalidOperationException($"Download URL is not allowed: {downloadUrl}");
         }
 
-        Logger.Debug($"Downloading installer from {downloadUrl} to {installerLocation}");
+        LogUpdateDebug($"Downloading installer from {downloadUrl} to {installerLocation}");
         using (HttpClient client = new(CreateHttpClientHandler(updaterOverrides)))
         {
             client.Timeout = TimeSpan.FromSeconds(600);
@@ -404,7 +643,7 @@ public partial class AutoUpdater
             using FileStream fs = new(installerLocation, FileMode.OpenOrCreate);
             await result.Content.CopyToAsync(fs);
         }
-        Logger.Debug("The download has finished successfully");
+        LogUpdateDebug("The download has finished successfully");
     }
 
     /// <summary>
@@ -417,7 +656,7 @@ public partial class AutoUpdater
         bool ManualCheck
     )
     {
-        Logger.Debug("Starting the process to launch the installer.");
+        LogUpdateDebug("Starting the process to launch the installer.");
         UpdateReadyToBeInstalled = true;
         ReleaseLockForAutoupdate_Window = false;
         ReleaseLockForAutoupdate_Notification = false;
@@ -428,7 +667,8 @@ public partial class AutoUpdater
         {
             // Banner is a UI element; always touch it from the UI thread.
             Window.DispatcherQueue.TryEnqueue(() => Banner.IsOpen = false);
-            Logger.Warn("User disabled updates!");
+            LogUpdateWarn("User disabled updates!");
+            MarkAttemptFinished("aborted - auto-update disabled before launch");
             return true;
         }
 
@@ -472,11 +712,11 @@ public partial class AutoUpdater
 
         if (AutoLaunch && !Window.Visible)
         {
-            Logger.Debug("AutoLaunch is enabled and the Window is hidden, launching installer...");
+            LogUpdateDebug("AutoLaunch is enabled and the Window is hidden, launching installer...");
         }
         else
         {
-            Logger.Debug(
+            LogUpdateDebug(
                 "Waiting for mainWindow to be closed or for user to trigger the update from the notification..."
             );
             while (
@@ -487,12 +727,13 @@ public partial class AutoUpdater
             {
                 await Task.Delay(100);
             }
-            Logger.Debug("Autoupdater lock released, launching installer...");
+            LogUpdateDebug("Autoupdater lock released, launching installer...");
         }
 
         if (!ManualCheck && Settings.Get(Settings.K.DisableAutoUpdateWingetUI))
         {
-            Logger.Warn("User has disabled updates");
+            LogUpdateWarn("User has disabled updates");
+            MarkAttemptFinished("aborted - auto-update disabled while waiting");
             return true;
         }
 
@@ -501,11 +742,13 @@ public partial class AutoUpdater
     }
 
     /// <summary>
-    /// Launches the installer located on the installerLocation argument and quits UniGetUI
+    /// Launches the installer located on the installerLocation argument. The installer
+    /// is expected to terminate UniGetUI before file replacement; if it returns control
+    /// to us, we surface the exit code so the user has something concrete to act on.
     /// </summary>
     private static async Task LaunchInstallerAndQuit(string installerLocation)
     {
-        Logger.Debug("Launching the updater...");
+        LogUpdateInfo($"Launching installer: {installerLocation}");
         using Process p = new()
         {
             StartInfo = new()
@@ -517,20 +760,88 @@ public partial class AutoUpdater
                 CreateNoWindow = true,
             },
         };
-        p.Start();
+
+        bool started;
+        try
+        {
+            started = p.Start();
+        }
+        catch (Exception ex)
+        {
+            LogUpdateError("Process.Start threw while launching the installer:");
+            LogUpdateError(ex);
+            ShowMessage_ThreadSafe(
+                CoreTools.Translate("The updater could not be launched."),
+                ex.Message,
+                InfoBarSeverity.Error,
+                true,
+                CreateViewLogButton()
+            );
+            MarkAttemptFinished($"installer launch threw: {ex.Message}");
+            return;
+        }
+
+        if (!started)
+        {
+            LogUpdateError("Failed to start installer process (Process.Start returned false).");
+            ShowMessage_ThreadSafe(
+                CoreTools.Translate("The updater could not be launched."),
+                CoreTools.Translate("The operating system did not start the installer process."),
+                InfoBarSeverity.Error,
+                true,
+                CreateViewLogButton()
+            );
+            MarkAttemptFinished("Process.Start returned false");
+            return;
+        }
+
+        LogUpdateInfo($"Installer process started (PID {p.Id}). The installer is expected to terminate UniGetUI before file replacement.");
+
         ShowMessage_ThreadSafe(
             CoreTools.Translate("UniGetUI is being updated..."),
             CoreTools.Translate("This may take a minute or two"),
             InfoBarSeverity.Informational,
             false
         );
+
         await p.WaitForExitAsync();
+
+        // If we reach here, the installer exited without terminating this process.
+        // Distinguish two cases:
+        //   - Exit code 0: installer succeeded; the new version IS installed at the
+        //     install location, but the running copy was not replaced (almost always
+        //     because UniGetUI is running from outside the install location — typically
+        //     a development build). This is not really an error.
+        //   - Any other code: installer reported a failure; the update did not apply.
+        int exitCode = p.ExitCode;
+        string reason = DescribeInstallerExitCode(exitCode);
+
+        if (exitCode == 0)
+        {
+            string runningPath = Environment.ProcessPath ?? "(unknown)";
+            LogUpdateWarn($"Installer reported success (exit code 0) but did not replace this running copy. Running from: {runningPath}");
+
+            ShowMessage_ThreadSafe(
+                CoreTools.Translate("Update installed."),
+                CoreTools.Translate("UniGetUI was updated successfully, but this running copy was not replaced. This usually means you are running a development build. Close this copy and start the newly-installed version to finish."),
+                InfoBarSeverity.Warning,
+                true,
+                CreateViewLogButton()
+            );
+            MarkAttemptFinished("installer succeeded but did not replace running copy");
+            return;
+        }
+
+        LogUpdateError($"Installer exited with code {exitCode} ({reason}) without restarting UniGetUI.");
+
         ShowMessage_ThreadSafe(
-            CoreTools.Translate("Something went wrong while launching the updater."),
-            CoreTools.Translate("Please try again later"),
+            CoreTools.Translate("The update could not be applied."),
+            CoreTools.Translate("Installer exit code {0}: {1}", exitCode, reason),
             InfoBarSeverity.Error,
-            true
+            true,
+            CreateViewLogButton()
         );
+        MarkAttemptFinished($"installer failed with code {exitCode}");
     }
 
     private static void ShowMessage_ThreadSafe(

--- a/src/UniGetUI/Pages/MainView.xaml
+++ b/src/UniGetUI/Pages/MainView.xaml
@@ -47,6 +47,12 @@
           IconName="megaphone"
           Text="Release notes"
         />
+        <widgets:BetterMenuItem
+          Name="CheckForUpdatesMenu"
+          Click="CheckForUpdates_Click"
+          IconName="Update"
+          Text="Check for UniGetUI updates"
+        />
         <MenuFlyoutSeparator Height="5" />
         <widgets:BetterMenuItem
           Name="HelpMenu"

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -371,6 +371,12 @@ namespace UniGetUI.Interface
         private void ReleaseNotesMenu_Click(object sender, RoutedEventArgs e) =>
             _ = DialogHelper.ShowReleaseNotes();
 
+        private void CheckForUpdates_Click(object sender, RoutedEventArgs e)
+        {
+            var mainWindow = MainApp.Instance.MainWindow;
+            _ = AutoUpdater.CheckAndInstallUpdates(mainWindow, mainWindow.UpdatesBanner, true, false, true);
+        }
+
         private void OperationHistoryMenu_Click(object sender, RoutedEventArgs e) =>
             NavigateTo(PageType.OperationHistory);
 


### PR DESCRIPTION
This pull request introduces significant improvements to the update flow for UniGetUI, focusing on better logging, user feedback, and robustness in handling interrupted update attempts. The changes also add a user-facing command to manually check for updates in the Avalonia UI and ensure all running app variants are properly terminated during updates or installation.

Key changes include:

**Auto-updater logging and robustness improvements:**

* Introduced a dedicated per-attempt updater log in `AutoUpdater.cs`, allowing users to view logs specific to their last update attempt. This log is now used for all update-related logging, with new helper methods (`LogUpdateInfo`, `LogUpdateWarn`, etc.) replacing direct `Logger` calls. A "View log" button is now provided in relevant update banners for better troubleshooting.
* Added detection for interrupted (orphaned) update attempts: on startup, if the previous update was interrupted, a warning banner is shown with an option to view the update log. This helps users understand if their update succeeded or failed. 
* Update banners now include more detailed feedback, including severity, titles, messages, and actionable buttons, improving user experience during update flows.

**User interface enhancements:**

* Added a "Check for UniGetUI updates" menu item to the sidebar in the Avalonia UI, allowing users to manually trigger update checks. This is backed by a new command in `SidebarViewModel`. 
* The update banner in the Avalonia UI now properly reflects update status changes and can show results from both automatic and manual checks.

**Installer and process management:**

* Ensured that `UniGetUI.Avalonia.exe` is also terminated during updates or uninstallation, preventing conflicts when replacing files. This change is reflected in both the Inno Setup script and the `KillRunningApps` procedure. 


These changes collectively make the update process more transparent, robust, and user-friendly.