### PR TITLE
Reduce release package size and clean publish output

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -196,6 +196,17 @@ jobs:
           New-Item "unigetui_bin" -ItemType Directory | Out-Null
           Get-ChildItem $PublishDir | Move-Item -Destination "unigetui_bin" -Force
 
+          $MaxShippedPdbSizeBytes = 1MB
+          $PdbsToRemove = Get-ChildItem "unigetui_bin" -Filter "*.pdb" -File | Where-Object {
+            $_.Length -gt $MaxShippedPdbSizeBytes
+          }
+
+          if ($PdbsToRemove.Count -gt 0) {
+            $RemovedPdbBytes = ($PdbsToRemove | Measure-Object -Property Length -Sum).Sum
+            $PdbsToRemove | Remove-Item -Force
+            Write-Host ("Removed {0} oversized PDBs above {1:N2} MiB ({2:N2} MiB total)." -f $PdbsToRemove.Count, ($MaxShippedPdbSizeBytes / 1MB), ($RemovedPdbBytes / 1MB))
+          }
+
           # Backward-compat alias
           Copy-Item "unigetui_bin/UniGetUI.exe" "unigetui_bin/WingetUI.exe" -Force
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -88,6 +88,19 @@ New-Item $BinDir -ItemType Directory | Out-Null
 # Move published output into unigetui_bin
 Get-ChildItem $PublishDir | Move-Item -Destination $BinDir -Force
 
+# Keep smaller symbols for useful local crash source information, and prune oversized ones.
+$MaxShippedPdbSizeBytes = 1MB
+
+$PdbsToRemove = Get-ChildItem $BinDir -Filter "*.pdb" -File | Where-Object {
+    $_.Length -gt $MaxShippedPdbSizeBytes
+}
+
+if ($PdbsToRemove.Count -gt 0) {
+    $RemovedPdbBytes = ($PdbsToRemove | Measure-Object -Property Length -Sum).Sum
+    $PdbsToRemove | Remove-Item -Force
+    Write-Host ("Removed {0} oversized PDBs above {1:N2} MiB ({2:N2} MiB total)." -f $PdbsToRemove.Count, ($MaxShippedPdbSizeBytes / 1MB), ($RemovedPdbBytes / 1MB))
+}
+
 # WingetUI.exe alias for backward compat
 Copy-Item (Join-Path $BinDir "UniGetUI.exe") (Join-Path $BinDir "WingetUI.exe") -Force
 

--- a/scripts/merge-publish-output.ps1
+++ b/scripts/merge-publish-output.ps1
@@ -37,6 +37,7 @@ $sourceWinsConflicts = @{
     'Microsoft.VisualBasic.dll' = $true
     'Microsoft.Win32.SystemEvents.dll' = $true
     'System.Diagnostics.EventLog.dll' = $true
+    'System.Diagnostics.EventLog.Messages.dll' = $true
     'System.Drawing.Common.dll' = $true
     'System.Drawing.dll' = $true
     'System.Private.Windows.Core.dll' = $true

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -233,7 +233,7 @@
         <PackageReference Include="YamlDotNet" Version="17.0.1" />
         <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
         <PackageReference Include="Octokit" Version="14.0.0" />
-        <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive" />
+        <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
 
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- prune staged PDBs larger than 1 MiB from local and CI release packages
- allow the expected System.Diagnostics.EventLog.Messages.dll publish merge so arm64 packaging succeeds
- exclude duplicate native elevator assets from the WinUI project publish output

## Validation
- inspected x64 release artifact contents after CI dry run
- reran the arm64 workflow after the merge fix and confirmed packaging succeeded
- verified the arm64 zip contains ARM64 binaries and no AMD64 payload files
- confirmed shipped PDBs in the release zips total about 1.82 MiB with no PDB above 1 MiB