### PR TITLE
Default beta testers to modern UI

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/Interface_PViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/Interface_PViewModel.cs
@@ -5,6 +5,7 @@ using global::Avalonia.Controls;
 using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 
 namespace UniGetUI.Avalonia.ViewModels.Pages.SettingsPages;
@@ -12,6 +13,12 @@ namespace UniGetUI.Avalonia.ViewModels.Pages.SettingsPages;
 public partial class Interface_PViewModel : ViewModelBase
 {
     public bool IsWindows { get; } = OperatingSystem.IsWindows();
+
+    /// <summary>
+    /// True when the user is enrolled in the beta program. In that case the modern UI is forced
+    /// and the classic-mode toggle should be disabled.
+    /// </summary>
+    public bool IsBetaTester { get; } = Settings.Get(Settings.K.EnableUniGetUIBeta);
 
     [ObservableProperty] private string _iconCacheSizeText = "";
 

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
@@ -31,6 +31,8 @@
                                    Text="{t:Translate Use classic mode}"
                                    WarningText="{t:Translate Restart UniGetUI to apply this change}"
                                    StateChangedCommand="{Binding ShowRestartRequiredCommand}"
+                                   IsEnabled="{Binding !IsBetaTester}"
+                                   ToolTip.Tip="{t:Translate The classic UI is disabled for beta testers}"
                                    CornerRadius="8"/>
 
              <StackPanel x:Name="SystemTraySection" Orientation="Vertical">

--- a/src/UniGetUI.Tests/ModernAppLauncherTests.cs
+++ b/src/UniGetUI.Tests/ModernAppLauncherTests.cs
@@ -38,6 +38,16 @@ public sealed class ModernAppLauncherTests : IDisposable
     }
 
     [Fact]
+    public void BetaTestersDefaultToModernUI()
+    {
+        Assert.True(ModernAppLauncher.IsClassicModeEnabled());
+
+        Settings.Set(Settings.K.EnableUniGetUIBeta, true);
+
+        Assert.False(ModernAppLauncher.IsClassicModeEnabled());
+    }
+
+    [Fact]
     public void ResolveModernExecutablePath_PrefersRootExecutable()
     {
         string baseDirectory = Path.Combine(_testRoot, "Launcher");

--- a/src/UniGetUI/ModernAppLauncher.cs
+++ b/src/UniGetUI/ModernAppLauncher.cs
@@ -9,7 +9,8 @@ internal static class ModernAppLauncher
     internal const string ModernAppDirectoryName = "Avalonia";
     internal const string ModernAppExecutableName = "UniGetUI.Avalonia.exe";
 
-    public static bool IsClassicModeEnabled() => !Settings.Get(Settings.K.DisableClassicMode);
+    public static bool IsClassicModeEnabled() =>
+        !Settings.Get(Settings.K.DisableClassicMode) && !Settings.Get(Settings.K.EnableUniGetUIBeta);
 
     public static void Launch(string[] args)
     {


### PR DESCRIPTION
## Summary
- launch the modern Avalonia UI by default when EnableUniGetUIBeta is enabled
- disable the Use classic mode toggle for beta testers in the Interface settings page
- add test coverage for the beta-tester launch behavior
