### PR TITLE
Reduce Windows release package size

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -197,7 +197,7 @@ jobs:
           Get-ChildItem $PublishDir | Move-Item -Destination "unigetui_bin" -Force
 
           $MaxShippedPdbSizeBytes = 1MB
-          $PdbsToRemove = Get-ChildItem "unigetui_bin" -Filter "*.pdb" -File | Where-Object {
+          $PdbsToRemove = Get-ChildItem "unigetui_bin" -Filter "*.pdb" -File -Recurse | Where-Object {
             $_.Length -gt $MaxShippedPdbSizeBytes
           }
 

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -45,7 +45,7 @@
         <MSBuild
             Projects="$(PingetCliProject)"
             Targets="Restore;Publish"
-            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=true;TrimMode=partial;PublishReadyToRun=false;JsonSerializerIsReflectionEnabledByDefault=true;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
+            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=true;TrimMode=partial;JsonSerializerIsReflectionEnabledByDefault=true;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
         />
         <ItemGroup>
             <PingetCliOutputFiles Include="$(PingetCliExecutablePath)" Condition="Exists('$(PingetCliExecutablePath)')" />

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -45,7 +45,7 @@
         <MSBuild
             Projects="$(PingetCliProject)"
             Targets="Restore;Publish"
-            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=false;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
+            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=true;TrimMode=partial;PublishReadyToRun=false;JsonSerializerIsReflectionEnabledByDefault=true;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
         />
         <ItemGroup>
             <PingetCliOutputFiles Include="$(PingetCliExecutablePath)" Condition="Exists('$(PingetCliExecutablePath)')" />

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -93,7 +93,7 @@
         <MSBuild
             Projects="$(PingetCliProject)"
             Targets="Restore;Publish"
-            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=true;TrimMode=partial;PublishReadyToRun=false;JsonSerializerIsReflectionEnabledByDefault=true;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
+            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=true;TrimMode=partial;JsonSerializerIsReflectionEnabledByDefault=true;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
         />
         <Copy
             SourceFiles="$(PingetCliExecutablePath)"

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -93,7 +93,7 @@
         <MSBuild
             Projects="$(PingetCliProject)"
             Targets="Restore;Publish"
-            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=false;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
+            Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=net10.0;RuntimeIdentifier=$(PingetCliRuntimeIdentifier);SelfContained=true;PublishSingleFile=true;PublishTrimmed=true;TrimMode=partial;PublishReadyToRun=false;JsonSerializerIsReflectionEnabledByDefault=true;PublishDir=$(PingetCliPublishDir);AppendRuntimeIdentifierToOutputPath=false"
         />
         <Copy
             SourceFiles="$(PingetCliExecutablePath)"


### PR DESCRIPTION
## Summary
- publish the bundled `pinget.exe` as trimmed single-file output while keeping Release ReadyToRun enabled
- keep JSON reflection enabled for pinget so structured output still works after trimming
- remove oversized PDBs recursively from the Windows release staging directory

## Size impact
- x64 staged ZIP after these changes: **185.01 MiB compressed**, **470.49 MiB uncompressed**
- x64 `pinget.exe`: **32.29 MiB** after changes, down from about **83.65 MiB**
- isolated arm64 pinget publish with trimming and ReadyToRun disabled previously showed the lower bound at **18.31 MiB**; ReadyToRun is intentionally kept enabled in this PR despite the extra size

## Validation
- `dotnet publish src\UniGetUI\UniGetUI.csproj --tl:off /noLogo /p:Configuration=Release /p:Platform=x64 -p:RuntimeIdentifier=win-x64 -v minimal`
- bundled `pinget.exe source list -o json`
- focused `pinget.exe --help`
- focused `pinget.exe source list -o json`
- `dotnet restore UniGetUI.Windows.slnx /p:Platform=x64 --tl:off --verbosity minimal`
- `dotnet test UniGetUI.Windows.slnx --no-restore --verbosity q --nologo /p:Platform=x64`