### PR TITLE
hide "use classic mode" button for non windows platform

### DIFF
--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
@@ -32,6 +32,7 @@
                                    WarningText="{t:Translate Restart UniGetUI to apply this change}"
                                    StateChangedCommand="{Binding ShowRestartRequiredCommand}"
                                    IsEnabled="{Binding !IsBetaTester}"
+                                   IsVisible="{Binding IsWindows}"
                                    ToolTip.Tip="{t:Translate The classic UI is disabled for beta testers}"
                                    CornerRadius="8"/>
 


### PR DESCRIPTION
This pull request introduces a minor UI change to the `Interface_P.axaml` settings page. The visibility of a specific UI element is now bound to the `IsWindows` property, ensuring that it is only shown on Windows systems.

* UI visibility improvement:
  * [`src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml`](diffhunk://#diff-0985fd1cefa11506bb8a4c2df7695fad77c26467a8de9a3727a6ecfc5419bd1fR35): Added `IsVisible="{Binding IsWindows}"` to conditionally display the UI element based on the operating system.