### PR TITLE
Fix typos in settings menu

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -487,7 +487,7 @@
   "Enter proxy URL here": "Enter proxy URL here",
   "Authenticate to the proxy with a user and a password": "Authenticate to the proxy with a user and a password",
   "Internet and proxy settings": "Internet and proxy settings",
-  "Package manager preferences": "Package managers preferences",
+  "Package manager preferences": "Package manager preferences",
   "Ready": "Ready",
   "Not found": "Not found",
   "Notification preferences": "Notification preferences",

--- a/src/UniGetUI/Pages/SettingsPages/GeneralPages/Operations.xaml
+++ b/src/UniGetUI/Pages/SettingsPages/GeneralPages/Operations.xaml
@@ -31,7 +31,7 @@
         x:Name="ParallelOperationCount"
         CornerRadius="8,8,0,0"
         SettingName="ParallelOperationCount"
-        Text="Choose how many operations shouls be performed in parallel"
+        Text="Choose how many operations should be performed in parallel"
         ValueChanged="ParallelOperationCount_OnValueChanged"
       />
 


### PR DESCRIPTION
issue #4734
This pull request makes minor corrections to user-facing text in the application to improve clarity and fix typographical errors.

Text corrections:

* Fixed a typo in the description for the parallel operation count setting in `Operations.xaml` ("shouls" → "should").
* Corrected the label for "Package manager preferences" in the English language file to use proper grammar ("managers preferences" → "manager preferences") in `lang_en.json`.