### PR TITLE
WinUI: Reduce navigation bar item size to fit long translations

### DIFF
--- a/src/UniGetUI/Controls/CustomNavViewItem.cs
+++ b/src/UniGetUI/Controls/CustomNavViewItem.cs
@@ -10,7 +10,7 @@ namespace UniGetUI.Controls;
 
 internal sealed partial class CustomNavViewItem : NavigationViewItem
 {
-    int _iconSize = 24;
+    int _iconSize = 20;
     public IconType LocalIcon
     {
         set => base.Icon = new LocalIcon(value);
@@ -64,7 +64,7 @@ internal sealed partial class CustomNavViewItem : NavigationViewItem
 
     public CustomNavViewItem()
     {
-        Height = 54;
+        Height = 48;
         Resources["NavigationViewItemOnLeftIconBoxHeight"] = _iconSize;
         Resources["NavigationViewItemContentPresenterMargin"] = new Thickness(0);
 
@@ -72,9 +72,9 @@ internal sealed partial class CustomNavViewItem : NavigationViewItem
 
         _progressRing = new ProgressRing
         {
-            Width = 24,
-            Height = 24,
-            Margin = new Thickness(-42, 0, 0, 0),
+            Width = 20,
+            Height = 20,
+            Margin = new Thickness(-32, 0, 0, 0),
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Center,
             IsIndeterminate = true,

--- a/src/UniGetUI/Pages/MainView.xaml
+++ b/src/UniGetUI/Pages/MainView.xaml
@@ -271,7 +271,7 @@
     VerticalAlignment="Stretch"
     x:FieldModifier="public"
     CompactModeThresholdWidth="800"
-    CompactPaneLength="68"
+    CompactPaneLength="52"
     ExpandedModeThresholdWidth="1600"
     IsBackButtonVisible="Collapsed"
     IsPaneOpen="False"
@@ -290,7 +290,7 @@
     <NavigationView.MenuItems>
       <controls1:CustomNavViewItem
         x:Name="DiscoverNavBtn"
-        FontSize="16"
+        FontSize="14"
         FontWeight="SemiBold"
         GlyphIcon="&#xF6FA;"
         Tag="Discover"
@@ -299,7 +299,7 @@
 
       <controls1:CustomNavViewItem
         x:Name="UpdatesNavBtn"
-        FontSize="16"
+        FontSize="14"
         FontWeight="SemiBold"
         GlyphIcon="&#xE895;"
         Tag="Updates"
@@ -311,7 +311,7 @@
       </controls1:CustomNavViewItem>
       <controls1:CustomNavViewItem
         x:Name="InstalledNavBtn"
-        FontSize="16"
+        FontSize="14"
         FontWeight="SemiBold"
         GlyphIcon="&#xE977;"
         Tag="Installed"
@@ -319,7 +319,7 @@
       />
       <controls1:CustomNavViewItem
         x:Name="BundlesNavBtn"
-        FontSize="16"
+        FontSize="14"
         FontWeight="SemiBold"
         GlyphIcon="&#xF133;"
         Tag="Bundles"
@@ -375,7 +375,7 @@
       />
     </NavigationView.FooterMenuItems>
     <NavigationView.PaneFooter>
-      <services:UserAvatar Margin="12,4,12,8" />
+      <services:UserAvatar Margin="6,4,6,8" />
     </NavigationView.PaneFooter>
 
     <Grid Name="ContentGrid" Grid.Row="0" Grid.Column="1" Margin="8,8,8,8" RowSpacing="0">

--- a/src/UniGetUI/Services/UserAvatar.cs
+++ b/src/UniGetUI/Services/UserAvatar.cs
@@ -120,7 +120,7 @@ namespace UniGetUI.Services
 
         private PointButton GenerateLoginControl()
         {
-            var personPicture = new PersonPicture { Width = 36, Height = 36 };
+            var personPicture = new PersonPicture { Width = 32, Height = 32 };
 
             var translatedTextBlock = new TextBlock
             {
@@ -208,8 +208,8 @@ namespace UniGetUI.Services
 
             var personPicture = new PersonPicture
             {
-                Width = 36,
-                Height = 36,
+                Width = 32,
+                Height = 32,
                 ProfilePicture = new BitmapImage(new Uri(user.AvatarUrl)),
             };
 


### PR DESCRIPTION
This pull request focuses on refining the UI by reducing the size and spacing of several navigation and avatar elements to create a more compact and visually consistent interface. The main changes involve adjusting icon and control sizes, margins, and font sizes across navigation items and user avatar components.

UI Compactness and Visual Consistency:

* Reduced the icon size in `CustomNavViewItem` from 24px to 20px and adjusted the progress ring's size and margin to match. The height of the navigation item was also decreased from 54px to 48px. (`src/UniGetUI/Controls/CustomNavViewItem.cs`) 
* Decreased the `CompactPaneLength` of the main navigation view from 68px to 52px, making the collapsed navigation pane narrower. (`src/UniGetUI/Pages/MainView.xaml`)
* Reduced the font size of all main navigation buttons from 16px to 14px for a more streamlined appearance. (`src/UniGetUI/Pages/MainView.xaml`) 
* Adjusted the margin of the `UserAvatar` control in the navigation pane footer to be smaller, aligning it with the new compact design. (`src/UniGetUI/Pages/MainView.xaml`)
* Updated the `PersonPicture` avatar size in both login and logout controls from 36px to 32px for consistency with other UI elements. (`src/UniGetUI/Services/UserAvatar.cs`)
**

issue #4738