### PR TITLE
Improves the operation output views in the Avalonia UI

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
@@ -328,12 +328,12 @@ public sealed partial class OperationViewModel : ViewModelBase
         if (Operation.Status is OperationStatus.Failed)
         {
             var win = new OperationFailedDialog(Operation);
-            _ = win.ShowDialog(mainWindow);
+            win.Show(mainWindow);
         }
         else
         {
             var win = new OperationOutputWindow(Operation);
-            _ = win.ShowDialog(mainWindow);
+            win.Show(mainWindow);
         }
     }
 

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
@@ -1,7 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
-        xmlns:local="using:UniGetUI.Avalonia.Views.DialogPages"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.OperationFailedDialog"
         Width="800" MinWidth="500"
         Height="550" MinHeight="300"
@@ -28,19 +27,12 @@
                       VerticalScrollBarVisibility="Auto"
                       Background="{DynamicResource AppDialogDarkBackground}"
                       CornerRadius="6">
-            <ItemsControl x:Name="OutputLines"
-                          Padding="8"
-                          automation:AutomationProperties.AccessibilityView="Raw">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="local:OutputLineVm">
-                        <TextBlock Text="{Binding Text}"
-                                   Foreground="{Binding Foreground}"
-                                   FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
-                                   FontSize="12"
-                                   TextWrapping="Wrap"/>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+            <SelectableTextBlock x:Name="OutputText"
+                                 Padding="8"
+                                 FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
+                                 FontSize="12"
+                                 TextWrapping="Wrap"
+                                 automation:AutomationProperties.AccessibilityView="Raw"/>
         </ScrollViewer>
 
         <!-- ── Footer buttons ── -->

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
@@ -4,7 +4,6 @@
         x:Class="UniGetUI.Avalonia.Views.DialogPages.OperationFailedDialog"
         Width="800" MinWidth="500"
         Height="550" MinHeight="300"
-        MaxWidth="800"
         CanResize="True"
         ShowInTaskbar="False"
         Background="{DynamicResource AppDialogBackground}"

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -28,7 +29,8 @@ public partial class OperationFailedDialog : Window
         var normalBrush = Application.Current?.FindResource("SystemControlForegroundBaseHighBrush") as IBrush
                           ?? Brushes.White;
 
-        var lines = new List<OutputLineVm>();
+        var inlines = OutputText.Inlines ??= new InlineCollection();
+        bool first = true;
         foreach (var (text, type) in operation.GetOutput())
         {
             IBrush brush = type switch
@@ -37,9 +39,10 @@ public partial class OperationFailedDialog : Window
                 AbstractOperation.LineType.VerboseDetails => debugBrush,
                 _ => normalBrush,
             };
-            lines.Add(new OutputLineVm(text, brush));
+            if (!first) inlines.Add(new LineBreak());
+            inlines.Add(new Run(text) { Foreground = brush });
+            first = false;
         }
-        OutputLines.ItemsSource = lines;
 
         var closeButton = new Button
         {
@@ -131,11 +134,4 @@ public partial class OperationFailedDialog : Window
         item.Click += (_, _) => action();
         return item;
     }
-}
-
-/// <summary>View model for a single colored output line in OperationFailedDialog.</summary>
-public sealed class OutputLineVm(string text, IBrush foreground)
-{
-    public string Text { get; } = text;
-    public IBrush Foreground { get; } = foreground;
 }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml
@@ -2,7 +2,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels.DialogPages"
-        xmlns:logVm="using:UniGetUI.Avalonia.ViewModels.Pages.LogPages"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.OperationOutputWindow"
         x:DataType="vm:OperationOutputViewModel"
         Width="700" MinWidth="400"
@@ -19,20 +18,13 @@
                   VerticalScrollBarVisibility="Auto"
                   Background="{DynamicResource AppDialogDarkBackground}"
                   CornerRadius="6">
-        <ItemsControl ItemsSource="{Binding OutputLines}"
-                      Padding="8"
-                      automation:AutomationProperties.Name="{Binding Title}"
-                      automation:AutomationProperties.AccessibilityView="Raw">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate x:DataType="logVm:LogLineItem">
-                    <TextBlock Text="{Binding Text}"
-                               Foreground="{Binding Foreground}"
-                               FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
-                               FontSize="12"
-                               TextWrapping="Wrap"/>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <SelectableTextBlock x:Name="OutputText"
+                             Padding="8"
+                             FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
+                             FontSize="12"
+                             TextWrapping="Wrap"
+                             automation:AutomationProperties.Name="{Binding Title}"
+                             automation:AutomationProperties.AccessibilityView="Raw"/>
     </ScrollViewer>
 
 </Window>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
@@ -1,6 +1,9 @@
+using System.Collections.Specialized;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels.DialogPages;
+using UniGetUI.Avalonia.ViewModels.Pages.LogPages;
 using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
@@ -9,11 +12,39 @@ public partial class OperationOutputWindow : Window
 {
     public OperationOutputWindow(AbstractOperation operation)
     {
-        DataContext = new OperationOutputViewModel(operation);
+        var vm = new OperationOutputViewModel(operation);
+        DataContext = vm;
         InitializeComponent();
 
-        ((OperationOutputViewModel)DataContext).OutputLines.CollectionChanged +=
-            (_, _) => Dispatcher.UIThread.Post(OutputScroll.ScrollToEnd, DispatcherPriority.Background);
+        foreach (var line in vm.OutputLines)
+            AppendLine(line);
+
+        vm.OutputLines.CollectionChanged += OnOutputLinesChanged;
+    }
+
+    private void OnOutputLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                OutputText.Inlines?.Clear();
+            }
+            else if (e.NewItems is not null)
+            {
+                foreach (LogLineItem item in e.NewItems)
+                    AppendLine(item);
+            }
+            OutputScroll.ScrollToEnd();
+        }, DispatcherPriority.Background);
+    }
+
+    private void AppendLine(LogLineItem line)
+    {
+        var inlines = OutputText.Inlines ??= new InlineCollection();
+        if (inlines.Count > 0)
+            inlines.Add(new LineBreak());
+        inlines.Add(new Run(line.Text) { Foreground = line.Foreground });
     }
 
     protected override void OnOpened(EventArgs e)


### PR DESCRIPTION
#4681

 - **Selectable text across multiple lines.** Previously each log line was rendered as its own `TextBlock` inside an `ItemsControl`, so selection could not span more than one line. Replaced with a single `SelectableTextBlock` populated with colored `Run` inlines (one per line) + `LineBreak`s, preserving per-line coloring (error / debug / normal) while allowing click-drag selection across the whole log and Ctrl+C copy.
  - **Non-modal windows.** Both the live/success log (`OperationOutputWindow`) and the failed-operation dialog (`OperationFailedDialog`) were shown via `ShowDialog`, which blocked all interaction with the main window. Switched to `Show(owner)` so the windows remain owned by the main window (stay on top, close with it) but no longer block the rest of the app.

  ## Files changed

  - `UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml` + `.axaml.cs`
  - `UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml` + `.axaml.cs` (also removed the now-unused `OutputLineVm` helper class)
  - `UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs` (`ShowDetails` now uses `Show` instead of `ShowDialog` for both branches)
