### PR TITLE
Fix WinGet uninstall failing for ARP/MSIX/Steam/GOG packages

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -47,10 +47,10 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
         ];
 
         parameters.AddRange(GetIdNamePiece(package).Split(" "));
-        parameters.AddRange([
-            "--source",
-            package.Source.IsVirtualManager ? "winget" : package.Source.Name,
-        ]);
+        if (!package.Source.IsVirtualManager)
+        {
+            parameters.AddRange(["--source", package.Source.Name]);
+        }
         parameters.AddRange(["--accept-source-agreements", "--disable-interactivity"]);
 
         // package.OverridenInstallationOptions.Scope is meaningless in WinGet packages. Default is unspecified, hence the _ => [].


### PR DESCRIPTION
## Summary
- Packages detected only via ARP/MSIX (Local PC, MicrosoftStore, Steam, GOG, Android Subsystem, Ubisoft Connect) failed to uninstall with `No installed package found matching the query`, because UniGetUI forced `--source winget` on every virtual source — scoping pinget's lookup to the WinGet repository, where these packages don't exist.
- Now, when the package source is a `LocalWinGetSource`(`IsVirtualManager = true`), `--source` is omitted so pinget WinGet resolves against the installed-packages list (ARP/MSIX) instead.
- Real `winget`/`msstore` repo packages are unaffected: they still receive `--source <name>` as before. As an incidental cleanup, real-source uninstalls now pass their actual source name (e.g. `--source msstore`) instead of being hardcoded to `winget`.

