### PR TITLE
Log UI variant and environment info on startup

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
@@ -1,6 +1,8 @@
+using System.Runtime.InteropServices;
 using Avalonia;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
 using UniGetUI.Interface;
 
 namespace UniGetUI.Avalonia.Infrastructure;
@@ -42,6 +44,27 @@ public static class AvaloniaAppHost
         }
 
         CoreData.WasDaemon = CoreData.IsDaemon = args.Contains(AvaloniaCliHandler.DAEMON);
+
+        string textart = $"""
+               __  __      _ ______     __  __  ______
+              / / / /___  (_) ____/__  / /_/ / / /  _/
+             / / / / __ \/ / / __/ _ \/ __/ / / // /
+            / /_/ / / / / / /_/ /  __/ /_/ /_/ // /
+            \____/_/ /_/_/\____/\___/\__/\____/___/
+                Welcome to UniGetUI Version {CoreData.VersionName}
+            """;
+
+        Logger.ImportantInfo(textart);
+        Logger.ImportantInfo("  ");
+        Logger.ImportantInfo($"Build {CoreData.BuildNumber}");
+        Logger.ImportantInfo("UI Framework: Avalonia");
+        Logger.ImportantInfo($"Data directory {CoreData.UniGetUIDataDirectory}");
+        Logger.ImportantInfo($"OS: {RuntimeInformation.OSDescription}");
+        Logger.ImportantInfo($"Process arch: {RuntimeInformation.ProcessArchitecture} (OS: {RuntimeInformation.OSArchitecture})");
+        Logger.ImportantInfo($"Runtime: {RuntimeInformation.FrameworkDescription}");
+        Logger.ImportantInfo($"Elevated: {CoreTools.IsAdministrator()}");
+        Logger.ImportantInfo($"Packaged (MSIX): {CoreTools.IsPackagedApp()}");
+        Logger.ImportantInfo($"Args: {(args.Length > 0 ? string.Join(" ", args) : "(none)")}");
 
         if (!TryRegisterSingleInstance(args))
         {

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;
@@ -290,6 +291,34 @@ namespace UniGetUI.Core.Tools
                 return false;
             }
         }
+
+        /// <summary>
+        /// Checks whether the current process is running inside an MSIX package (Store / sideloaded).
+        /// </summary>
+        /// <returns>True when packaged, false when running unpackaged or on a non-Windows platform.</returns>
+        public static bool IsPackagedApp()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return false;
+            }
+
+            try
+            {
+                int len = 0;
+                int rc = GetCurrentPackageFullName(ref len, IntPtr.Zero);
+                return rc != APPMODEL_ERROR_NO_PACKAGE;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private const int APPMODEL_ERROR_NO_PACKAGE = 15700;
+
+        [DllImport("kernel32.dll", SetLastError = false)]
+        private static extern int GetCurrentPackageFullName(ref int packageFullNameLength, IntPtr packageFullName);
 
         public static Task<long> GetFileSizeAsLongAsync(Uri? url) =>
             Task.Run(() => GetFileSizeAsLong(url));

--- a/src/UniGetUI/EntryPoint.cs
+++ b/src/UniGetUI/EntryPoint.cs
@@ -1,8 +1,10 @@
+using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
 using UniGetUI.Interface;
 using UniGetUI.Shared;
 
@@ -89,8 +91,16 @@ namespace UniGetUI
                 Logger.ImportantInfo(textart);
                 Logger.ImportantInfo("  ");
                 Logger.ImportantInfo($"Build {CoreData.BuildNumber}");
+                Logger.ImportantInfo("UI Framework: WinUI 3");
                 Logger.ImportantInfo($"Data directory {CoreData.UniGetUIDataDirectory}");
                 Logger.ImportantInfo($"Encoding Code Page set to {CoreData.CODE_PAGE}");
+                Logger.ImportantInfo($"OS: {RuntimeInformation.OSDescription}");
+                Logger.ImportantInfo($"Process arch: {RuntimeInformation.ProcessArchitecture} (OS: {RuntimeInformation.OSArchitecture})");
+                Logger.ImportantInfo($"Runtime: {RuntimeInformation.FrameworkDescription}");
+                Logger.ImportantInfo($"Elevated: {CoreTools.IsAdministrator()}");
+                Logger.ImportantInfo($"Packaged (MSIX): {CoreTools.IsPackagedApp()}");
+                string[] cmdArgs = Environment.GetCommandLineArgs();
+                Logger.ImportantInfo($"Args: {(cmdArgs.Length > 1 ? string.Join(" ", cmdArgs.Skip(1)) : "(none)")}");
 
                 // WinRT single-instance fancy stuff
                 WinRT.ComWrappersSupport.InitializeComWrappers();


### PR DESCRIPTION
 ## Summary
  - Adds a `UI Framework:` line and an environment block (OS, arch, runtime, elevated, packaged, args) to the startup log on both UI variants.
  - The Avalonia path was previously logging neither the textart banner nor any version/build info — it now mirrors the WinUI banner so bug reports from both variants look the same.
  - Adds a `CoreTools.IsPackagedApp()` helper (P/Invoke to `GetCurrentPackageFullName`) so we can distinguish MSIX vs unpackaged installs in logs.

Motivation: incoming bug reports often don't say which build the user is running, and there's no way to tell from the log. With this change, the first ~15 lines of every log file answer "WinUI or Avalonia, MSIX or portable, x64 or arm64, elevated or not, what args".
