### PR TITLE
Fix margin issues

### DIFF
--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -57,7 +57,7 @@
               Grid.Row="0"
               ColumnDefinitions="80,*"
               ColumnSpacing="8"
-              Margin="0,0,0,4">
+              Margin="0,0,0,8">
 
             <controls:SvgIcon x:Name="HeaderIcon"
                               Grid.Column="0"
@@ -116,7 +116,7 @@
             <StackPanel Grid.Column="1" Orientation="Horizontal">
                 <Button x:Name="MainToolbarButton"
                         Height="36"
-                        Margin="0,0,1,0"
+                        Margin="-9,0,1,0"
                         CornerRadius="4,0,0,4">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <controls:SvgIcon x:Name="MainToolbarButtonIcon"
@@ -163,7 +163,7 @@
                               Grid.Column="0"
                               IsVisible="{Binding IsFilterPaneOpen}"
                               HorizontalScrollBarVisibility="Disabled"
-                              Padding="0,0,4,0"
+                              Padding="0,8,4,0"
                               automation:AutomationProperties.AccessibilityView="Control"
                               automation:AutomationProperties.Name="{t:Translate Filters}"
                               automation:AutomationProperties.LandmarkType="{x:Static peers:AutomationLandmarkType.Search}"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -70,7 +70,6 @@ public abstract partial class AbstractPackagesPage : UserControl,
             var reloadBtn = ViewModel.AddToolbarButton("reload", CoreTools.Translate("Reload"),
                 ViewModel.TriggerReload);
             UpdateReloadButtonTooltip(reloadBtn);
-            ViewModel.AddToolbarSeparator();
         }
 
         // Build the toolbar now that both AXAML controls and the ViewModel are ready


### PR DESCRIPTION
This pull request makes several minor UI adjustments to the `AbstractPackagesPage` in order to improve layout consistency and spacing. The changes primarily focus on margins and padding in the XAML layout, as well as a small update to the toolbar button setup in the code-behind.

UI layout improvements:

* Increased the bottom margin of the main grid to add more vertical spacing at the top of the page. (`src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml`)
* Adjusted the left margin of the `MainToolbarButton` for better alignment with other UI elements. (`src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml`)
* Increased the top padding of the filter pane to improve visual separation from other elements. (`src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml`)

Toolbar setup update:

* Removed an unnecessary call to `AddToolbarSeparator()` after adding the reload button 