### PR TITLE
Fix bundled Avalonia publish path for release builds

### DIFF
--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -113,7 +113,8 @@
     >
         <PropertyGroup>
             <!-- Keep the trimmed Avalonia app isolated; trimmed shared assemblies are entry-point specific. -->
-            <BundledAvaloniaPublishDir>$(PublishDir)$(ModernAppDirectoryName)\</BundledAvaloniaPublishDir>
+            <!-- Resolve to an absolute path so the inner MSBuild call doesn't re-anchor it to the Avalonia project directory. -->
+            <BundledAvaloniaPublishDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(PublishDir)', '$(ModernAppDirectoryName)'))</BundledAvaloniaPublishDir>
             <BundledAvaloniaExecutablePath>$(BundledAvaloniaPublishDir)UniGetUI.Avalonia.exe</BundledAvaloniaExecutablePath>
         </PropertyGroup>
         <MSBuild


### PR DESCRIPTION
This pull request updates the way the `BundledAvaloniaPublishDir` property is set in the `UniGetUI.csproj` project file. The change ensures that the directory path is always resolved to an absolute path, preventing issues with path anchoring during MSBuild operations.

Build process improvement:

* Updated the `BundledAvaloniaPublishDir` property to use `MSBuild::NormalizeDirectory` for generating an absolute path, ensuring consistent behavior during inner MSBuild calls and avoiding incorrect path anchoring.