### PR TITLE
Update release notes links. CR:forestmaxime

### DIFF
--- a/package/chocolatey/unigetui/unigetui.template.nuspec
+++ b/package/chocolatey/unigetui/unigetui.template.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://devolutions.net/unigetui/</projectUrl>
     <tags>unigetui wingetui cli package-manager windows-10 windows-11 scoop winget chocolatey npm pip dotnet-tool dotnet windows package-manager-interface gui powershell powershell-ui gallery devolutions</tags>
     <copyright>Copyright © 2006-2026</copyright>
-    <releaseNotes>https://github.com/Devolutions/UniGetUI/releases/tag/v$VAR1$</releaseNotes>
+    <releaseNotes>https://devolutions.net/unigetui/release-notes/</releaseNotes>
     <licenseUrl>https://github.com/Devolutions/UniGetUI/blob/HEAD/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdnweb.devolutions.net/web/common/logos/img-devolutions-unigetui-white.svg</iconUrl>

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/ReleaseNotesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/ReleaseNotesPageViewModel.cs
@@ -6,10 +6,10 @@ namespace UniGetUI.Avalonia.ViewModels.Pages;
 
 public partial class ReleaseNotesPageViewModel : ViewModels.ViewModelBase
 {
-    public string ReleaseNotesUrl { get; } = CoreData.GetGitHubReleasePageUrl();
+    public string ReleaseNotesUrl { get; } = CoreData.ReleaseNotesUrl;
 
     // Kept in sync from the WebView's NavigationCompleted event via code-behind
-    public string CurrentUrl { get; set; } = CoreData.GetGitHubReleasePageUrl();
+    public string CurrentUrl { get; set; } = CoreData.ReleaseNotesUrl;
 
     [RelayCommand]
     private void OpenInBrowser() => CoreTools.Launch(CurrentUrl);

--- a/src/UniGetUI.Core.Data.Tests/CoreTests.cs
+++ b/src/UniGetUI.Core.Data.Tests/CoreTests.cs
@@ -98,6 +98,8 @@ namespace UniGetUI.Core.Data.Tests
                 "https://api.github.com/repos/Devolutions/UniGetUI/releases/tags/3.3.7-beta1",
                 CoreData.GetGitHubReleaseApiUrlFromTag("3.3.7-beta1")
             );
+            Assert.Equal("https://devolutions.net/unigetui/release-notes/", CoreData.ReleaseNotesUrl);
+            Assert.Equal(CoreData.ReleaseNotesUrl, CoreData.GetGitHubReleasePageUrl());
         }
     }
 }

--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -11,6 +11,7 @@ namespace UniGetUI.Core.Data
         private const string BundledModernAppDirectoryName = "Avalonia";
         private const string ClassicExecutableName = "UniGetUI.exe";
         private const string BundledPingetExecutableName = "pinget.exe";
+        public const string ReleaseNotesUrl = "https://devolutions.net/unigetui/release-notes/";
 
         private static int? __code_page;
         public static int CODE_PAGE
@@ -60,7 +61,7 @@ namespace UniGetUI.Core.Data
 
         public static string GetGitHubReleasePageUrl()
         {
-            return GetGitHubReleasePageUrlFromTag(GetGitHubReleaseTag());
+            return ReleaseNotesUrl;
         }
 
         public static string GetGitHubReleasePageUrlFromTag(string releaseTag)

--- a/src/UniGetUI/Pages/DialogPages/ReleaseNotes.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/ReleaseNotes.xaml.cs
@@ -32,7 +32,7 @@ namespace UniGetUI.Interface.Dialogs
         private async Task InitializeWebView()
         {
             await WebView.EnsureCoreWebView2Async();
-            WebView.Source = new Uri(CoreData.GetGitHubReleasePageUrl());
+            WebView.Source = new Uri(CoreData.ReleaseNotesUrl);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- Point the in-app release notes page to https://devolutions.net/unigetui/release-notes/ for WinUI and Avalonia.
- Expose the release notes URL through CoreData and update Chocolatey package metadata.

## Tests
- `dotnet test src\UniGetUI.Core.Data.Tests\UniGetUI.Core.Data.Tests.csproj --verbosity q --nologo`

Note: full app build attempts hung in MSBuild and were cancelled.