### PR TITLE
Avalonia: Fix webview crash. CR:forestmaxime

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -158,15 +158,17 @@ public partial class App : Application
         };
     }
 
+    public static string WebViewUserDataFolder { get; } =
+        Path.Join(Path.GetTempPath(), "UniGetUI", "WebView");
+
     private static void SetUpWebViewUserDataFolder()
     {
         try
         {
-            string webViewPath = Path.Join(Path.GetTempPath(), "UniGetUI", "WebView");
-            if (!Directory.Exists(webViewPath))
-                Directory.CreateDirectory(webViewPath);
+            if (!Directory.Exists(WebViewUserDataFolder))
+                Directory.CreateDirectory(WebViewUserDataFolder);
 
-            Environment.SetEnvironmentVariable("WEBVIEW2_USER_DATA_FOLDER", webViewPath);
+            Environment.SetEnvironmentVariable("WEBVIEW2_USER_DATA_FOLDER", WebViewUserDataFolder);
         }
         catch (Exception e)
         {

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -96,6 +96,10 @@
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
         <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.4.2" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
+    <ItemGroup>
+        <TrimmerRootAssembly Include="Avalonia.Controls.WebView" />
+        <PublishReadyToRunExclude Include="Avalonia.Controls.WebView.dll" />
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\UniGetUI.Core.Data\UniGetUI.Core.Data.csproj" />

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -96,10 +96,6 @@
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
         <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.4.2" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
-    <ItemGroup>
-        <TrimmerRootAssembly Include="Avalonia.Controls.WebView" RootMode="all" />
-        <PublishReadyToRunExclude Include="Avalonia.Controls.WebView.dll" />
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\UniGetUI.Core.Data\UniGetUI.Core.Data.csproj" />

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -97,7 +97,7 @@
         <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.4.2" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
     <ItemGroup>
-        <TrimmerRootAssembly Include="Avalonia.Controls.WebView" />
+        <TrimmerRootAssembly Include="Avalonia.Controls.WebView" RootMode="all" />
         <PublishReadyToRunExclude Include="Avalonia.Controls.WebView.dll" />
     </ItemGroup>
 

--- a/src/UniGetUI.Avalonia/Views/Controls/UniGetUiWebView.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/UniGetUiWebView.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+using Avalonia.Platform;
+
+namespace UniGetUI.Avalonia.Views.Controls;
+
+public sealed class UniGetUiWebView : NativeWebView
+{
+    public UniGetUiWebView()
+    {
+        EnvironmentRequested += (_, args) =>
+        {
+            if (args is WindowsWebView2EnvironmentRequestedEventArgs winArgs)
+                winArgs.UserDataFolder = App.WebViewUserDataFolder;
+        };
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
@@ -4,7 +4,6 @@
              xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
              xmlns:vm="using:UniGetUI.Avalonia.ViewModels.Pages"
              xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
-             xmlns:wv="using:Avalonia.Controls"
              xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -75,7 +74,7 @@
 
         <!-- WebView -->
         <Border x:Name="WebViewBorder" Grid.Row="2" CornerRadius="6" ClipToBounds="True">
-            <wv:NativeWebView x:Name="WebViewControl"/>
+            <controls:UniGetUiWebView x:Name="WebViewControl"/>
         </Border>
 
         <!-- Linux fallback -->

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
              xmlns:vm="using:UniGetUI.Avalonia.ViewModels.Pages"
-             xmlns:wv="using:Avalonia.Controls"
+             xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
              xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,7 +36,7 @@
 
         <!-- WebView -->
         <Border x:Name="WebViewBorder" Grid.Row="2" CornerRadius="6" ClipToBounds="True">
-            <wv:NativeWebView x:Name="WebViewControl"/>
+            <controls:UniGetUiWebView x:Name="WebViewControl"/>
         </Border>
 
         <!-- Linux fallback -->


### PR DESCRIPTION
This pull request introduces a custom `UniGetUiWebView` control to better manage the WebView user data folder, and updates the Help and Release Notes pages to use this new control. The most important changes are grouped below:

**WebView user data folder management:**

* Added a static property `WebViewUserDataFolder` in `App.axaml.cs` to centralize the WebView user data folder path, and updated the setup logic to use this property.
* Created a new `UniGetUiWebView` control that sets the `UserDataFolder` for WebView2 on Windows using the centralized path.

**Usage of the new custom WebView control:**

* Updated `HelpPage.axaml` and `ReleaseNotesPage.axaml` to use `UniGetUiWebView` instead of the default `NativeWebView` control, and adjusted their XML namespaces accordingly. 

fix issue #4765