### PR TITLE
Fix #4795 - Update GnuPG icon and remove associated images

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -17126,12 +17126,8 @@
       "images": []
     },
     "gnupg": {
-      "icon": "https://www.tech-faq.com/wp-content/uploads/gnupg-shell.png",
-      "images": [
-        "https://www.tech-faq.com/gnupg-shell/keyring_editor.png",
-        "https://www.tech-faq.com/gnupg-shell/create_new_keyring.png",
-        "https://www.tech-faq.com/gnupg-shell/file_manager.png"
-      ]
+      "icon": "https://gnupg.org/share/logo-gnupg-light-purple-bg.png",
+      "images": []
     },
     "gnupg-modern": {
       "icon": "",


### PR DESCRIPTION
Fixes https://github.com/Devolutions/UniGetUI/issues/4795

## Summary

The `gnupg` entry in `screenshot-database-v2.json` referenced `www.tech-faq.com`, a domain that has been compromised and now serves malicious redirects through DGA infrastructure (confirmed by Cloudflare Radar).

Additionally, the screenshots were for "GnuPG Shell" (a separate, abandoned GUI frontend listed at gnupg.org/software/frontends.html), not the GnuPG CLI tool (`GnuPG.GnuPG` on winget) that this package ID represents. The winget package is a command-line tool with no GUI, so GUI screenshots are inappropriate.

## Changes

- Replaced icon URL with official GnuPG logo from gnupg.org
- Set images to empty array (no legitimate screenshots exist for the CLI tool, and the old ones were for a different program)

## Evidence

Cloudflare Radar scans confirming the malicious redirect chain from tech-faq.com:
- https://radar.cloudflare.com/scan/b88f3403-977c-4b5f-814b-6d3501cc3ffc
- https://radar.cloudflare.com/scan/a996b5fc-9c8a-434a-91ee-8c0384e16f2e

DGA domain classified as malicious:
- https://radar.cloudflare.com/scan/479492e6-e459-47d1-acb5-9165018d0c1e