### PR TITLE
Track support of minimum age in managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,32 +53,6 @@ src/.vs
 src/.vscode
 new-names.docx
 
-src/UniGetUI/choco-cli/logs/
-src/UniGetUI/choco-cli/lib/
-src/UniGetUI/choco-cli/lib-bad/
-src/UniGetUI/choco-cli/.chocolatey/
-src/UniGetUI/choco-cli/lib/chocolatey-compatibility.extension/*
-src/UniGetUI/choco-cli/extensions/chocolatey-core/*
-src/UniGetUI/choco-cli/extensions/chocolatey-compatibility/*
-src/UniGetUI/choco-cli/lib-bkp/
-src/UniGetUI/choco-cli/extensions/chocolatey-windowsupdate/*
-src/UniGetUI/choco-cli/bin/chocolatey.exe
-src/UniGetUI/choco-cli/redirects/chocolatey.exe
-src/UniGetUI/choco-cli/redirects/chocolatey.exe.ignore
-src/UniGetUI/choco-cli/redirects/cinst.exe
-src/UniGetUI/choco-cli/redirects/cinst.exe.ignore
-src/UniGetUI/choco-cli/redirects/clist.exe
-src/UniGetUI/choco-cli/redirects/clist.exe.ignore
-src/UniGetUI/choco-cli/redirects/cpush.exe
-src/UniGetUI/choco-cli/redirects/cpush.exe.ignore
-src/UniGetUI/choco-cli/redirects/cuninst.exe
-src/UniGetUI/choco-cli/redirects/cuninst.exe.ignore
-src/UniGetUI/choco-cli/redirects/cup.exe
-src/UniGetUI/choco-cli/redirects/cup.exe.ignore
-src/UniGetUI/choco-cli/bin/ssh-copy-id.exe
-src/UniGetUI/choco-cli/extensions/chocolatey-visualstudio/
-src/UniGetUI/choco-cli/extensions/chocolatey-dotnetfx/
-
 *.user
 /src/UniGetUI/Generated Files
 /src/UniGetUI.Avalonia/Infrastructure/Generated Files
@@ -96,3 +70,5 @@ src/UniGetUI.v3.ncrunchsolution
 # macOS Finder metadata
 .DS_Store
 /src/UniGetUI.Avalonia/Generated Files
+
+winget-cli_x64/

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/UpdatesViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/UpdatesViewModel.cs
@@ -20,10 +20,6 @@ public partial class UpdatesViewModel : ViewModelBase
     [ObservableProperty] private bool _isAutoCheckEnabled;
     [ObservableProperty] private bool _isCustomAgeSelected;
 
-    private static readonly HashSet<string> _managersWithoutUpdateDate =
-        new(StringComparer.OrdinalIgnoreCase)
-        { "Homebrew", "Scoop", "vcpkg" };
-
     /// <summary>Items for the minimum update age ComboboxCard, in display/value pairs.</summary>
     public IReadOnlyList<(string Name, string Value)> MinimumAgeItems { get; } =
     [
@@ -89,7 +85,7 @@ public partial class UpdatesViewModel : ViewModelBase
             var name = new TextBlock { Text = manager.DisplayName, VerticalAlignment = VerticalAlignment.Center };
             Grid.SetRow(name, row); Grid.SetColumn(name, 0);
 
-            bool supported = !_managersWithoutUpdateDate.Contains(manager.Name);
+            bool supported = manager.Capabilities.SupportsMinimumAge;
             var badge = _statusBadge(supported ? yesStr : noStr, supported ? Colors.Green : Colors.Red);
             Grid.SetRow(badge, row); Grid.SetColumn(badge, 1);
 

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml.cs
@@ -21,9 +21,6 @@ namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
 
 public sealed partial class PackageManagerPage : UserControl, ISettingsPage
 {
-    private static readonly HashSet<string> _managersWithoutUpdateDate =
-        new(StringComparer.OrdinalIgnoreCase)
-        { "Homebrew", "Scoop", "vcpkg" };
     private PackageManagerViewModel ViewModel => (PackageManagerViewModel)DataContext!;
 
     public bool CanGoBack => true;
@@ -260,7 +257,7 @@ public sealed partial class PackageManagerPage : UserControl, ISettingsPage
         };
 
         bool initiallyCustom = savedAge == "custom";
-        bool ageSupported = !_managersWithoutUpdateDate.Contains(manager.Name);
+        bool ageSupported = manager.Capabilities.SupportsMinimumAge;
         object ageDescription = !ageSupported
             ? new TextBlock
             {

--- a/src/UniGetUI.PackageEngine.Enums/ManagerCapabilities.cs
+++ b/src/UniGetUI.PackageEngine.Enums/ManagerCapabilities.cs
@@ -35,6 +35,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         public bool SupportsCustomSources = false;
         public bool SupportsCustomPackageIcons = false;
         public bool SupportsCustomPackageScreenshots = false;
+        public bool SupportsMinimumAge = false;
         public ProxySupport SupportsProxy = ProxySupport.No;
         public bool SupportsProxyAuth = false;
         public SourceCapabilities Sources { get; set; }

--- a/src/UniGetUI.PackageEngine.Managers.Bun/Bun.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Bun/Bun.cs
@@ -28,6 +28,7 @@ namespace UniGetUI.PackageEngine.Managers.BunManager
                 SupportsCustomScopes = false,
                 CanListDependencies = true,
                 SupportsPreRelease = true,
+                SupportsMinimumAge = true,
                 SupportsProxy = ProxySupport.No,
                 SupportsProxyAuth = false
             };

--- a/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
@@ -65,6 +65,7 @@ public partial class Cargo : PackageManager
             SupportsCustomVersions = true,
             SupportsCustomLocations = true,
             CanDownloadInstaller = true,
+            SupportsMinimumAge = true,
             SupportsProxy = ProxySupport.Partially,
             SupportsProxyAuth = true,
         };

--- a/src/UniGetUI.PackageEngine.Managers.Npm/Npm.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Npm/Npm.cs
@@ -27,6 +27,7 @@ namespace UniGetUI.PackageEngine.Managers.NpmManager
                 SupportsCustomScopes = true,
                 CanListDependencies = true,
                 SupportsPreRelease = true,
+                SupportsMinimumAge = true,
                 SupportsProxy = ProxySupport.No,
                 SupportsProxyAuth = false,
             };

--- a/src/UniGetUI.PackageEngine.Managers.Pip/Pip.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pip/Pip.cs
@@ -61,6 +61,7 @@ namespace UniGetUI.PackageEngine.Managers.PipManager
                 CanDownloadInstaller = true,
                 SupportsPreRelease = true,
                 CanListDependencies = true,
+                SupportsMinimumAge = true,
                 SupportsProxy = ProxySupport.Yes,
                 SupportsProxyAuth = true,
             };

--- a/src/UniGetUI/Pages/SettingsPages/GeneralPages/Updates.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/GeneralPages/Updates.xaml.cs
@@ -18,9 +18,6 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
     /// </summary>
     public sealed partial class Updates : Page, ISettingsPage
     {
-        private static readonly HashSet<string> _managersWithoutUpdateDate =
-            new(StringComparer.OrdinalIgnoreCase) { "Homebrew", "Scoop", "vcpkg", "WinGet" };
-
         public Updates()
         {
             this.InitializeComponent();
@@ -130,7 +127,7 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
                 int row = i + 1;
                 var name = new TextBlock { Text = manager.DisplayName, VerticalAlignment = VerticalAlignment.Center };
                 Grid.SetRow(name, row); Grid.SetColumn(name, 0);
-                bool supported = !_managersWithoutUpdateDate.Contains(manager.Name);
+                bool supported = manager.Capabilities.SupportsMinimumAge;
                 var badge = MakeStatusBadge(supported ? yesStr : noStr, supported);
                 Grid.SetRow(badge, row); Grid.SetColumn(badge, 1);
                 table.Children.Add(name);

--- a/src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs
@@ -35,9 +35,6 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
     /// </summary>
     public sealed partial class PackageManagerPage : Page, ISettingsPage
     {
-        private static readonly HashSet<string> _managersWithoutUpdateDate =
-            new(StringComparer.OrdinalIgnoreCase) { "Homebrew", "Scoop", "vcpkg", "WinGet" };
-
         IPackageManager? Manager;
         public event EventHandler? RestartRequired;
         public event EventHandler<Type>? NavigationRequested
@@ -493,7 +490,7 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
             };
 
             bool initiallyCustomAge = savedAgeVal == "custom";
-            bool ageSupported = !_managersWithoutUpdateDate.Contains(Manager.Name);
+            bool ageSupported = Manager.Capabilities.SupportsMinimumAge;
 
             object ageCardDescription = !ageSupported
                 ? new TextBlock


### PR DESCRIPTION
We define SupportsMinimumAge in the manager classes and use this value to display which package managers support this setting.

<img width="836" height="443" alt="image" src="https://github.com/user-attachments/assets/df70e4b5-43c5-4403-af3c-fdf300e99484" />
