### PR TITLE
Fix race condition in PEInterface build and improve icon loading

### DIFF
--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -201,6 +201,13 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
 
                 if (uri.IsFile)
                 {
+                    if (!IsSkiaDecodableExtension(uri.LocalPath))
+                    {
+                        // Avalonia's Bitmap (Skia) can't decode SVG/AVIF/ICO/TIFF — the
+                        // icon cache may produce those. Reject upfront so we don't throw.
+                        _iconCache[hash] = null;
+                        return;
+                    }
                     bitmap = await Task.Run(() => new Bitmap(uri.LocalPath)).ConfigureAwait(false);
                 }
                 else if (uri.Scheme is "http" or "https")
@@ -221,6 +228,17 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
             await Dispatcher.UIThread.InvokeAsync(() => IconBitmap = bitmap);
         }
         catch { _iconCache[hash] = null; }
+    }
+
+    private static bool IsSkiaDecodableExtension(string path)
+    {
+        string ext = Path.GetExtension(path);
+        return ext.Equals(".png", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".gif", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".webp", StringComparison.OrdinalIgnoreCase);
     }
 
     private void Package_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/UniGetUI.PackageEngine.PackageEngine/UniGetUI.PackageEngine.PEInterface.csproj
+++ b/src/UniGetUI.PackageEngine.PackageEngine/UniGetUI.PackageEngine.PEInterface.csproj
@@ -24,20 +24,49 @@
         <ProjectReference Include="..\UniGetUI.PackageEngine.PackageManagerClasses\UniGetUI.PackageEngine.Classes.csproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.PowerShell\UniGetUI.PackageEngine.Managers.PowerShell.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Scoop\UniGetUI.PackageEngine.Managers.Scoop.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.WinGet\UniGetUI.PackageEngine.Managers.WinGet.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Chocolatey\UniGetUI.PackageEngine.Managers.Chocolatey.csproj" />
+    <!-- Windows-only managers (only target $(WindowsTargetFramework)). Declared unconditionally on Windows builds
+         so the project graph sees them; SetTargetFramework pins them to their only TFM regardless of consumer,
+         and ReferenceOutputAssembly disables the /reference inclusion for the net10.0 inner build. -->
+    <ItemGroup Condition="'$(BuildSharedWindowsTargetFrameworks)' == 'true'">
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.PowerShell\UniGetUI.PackageEngine.Managers.PowerShell.csproj"
+                          SetTargetFramework="TargetFramework=$(WindowsTargetFramework)">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' != '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Scoop\UniGetUI.PackageEngine.Managers.Scoop.csproj"
+                          SetTargetFramework="TargetFramework=$(WindowsTargetFramework)">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' != '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.WinGet\UniGetUI.PackageEngine.Managers.WinGet.csproj"
+                          SetTargetFramework="TargetFramework=$(WindowsTargetFramework)">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' != '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Chocolatey\UniGetUI.PackageEngine.Managers.Chocolatey.csproj"
+                          SetTargetFramework="TargetFramework=$(WindowsTargetFramework)">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' != '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' != '$(WindowsTargetFramework)'">
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Apt\UniGetUI.PackageEngine.Managers.Apt.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Dnf\UniGetUI.PackageEngine.Managers.Dnf.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Pacman\UniGetUI.PackageEngine.Managers.Pacman.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Homebrew\UniGetUI.PackageEngine.Managers.Homebrew.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Snap\UniGetUI.PackageEngine.Managers.Snap.csproj" />
-        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Flatpak\UniGetUI.PackageEngine.Managers.Flatpak.csproj" />
+    <!-- Multi-target managers (Linux + Windows TFMs). Declared unconditionally so the graph is correct;
+         ReferenceOutputAssembly disables the /reference for the Windows inner build. -->
+    <ItemGroup>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Apt\UniGetUI.PackageEngine.Managers.Apt.csproj">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Dnf\UniGetUI.PackageEngine.Managers.Dnf.csproj">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Pacman\UniGetUI.PackageEngine.Managers.Pacman.csproj">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Homebrew\UniGetUI.PackageEngine.Managers.Homebrew.csproj">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Snap\UniGetUI.PackageEngine.Managers.Snap.csproj">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Flatpak\UniGetUI.PackageEngine.Managers.Flatpak.csproj">
+            <ReferenceOutputAssembly Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">false</ReferenceOutputAssembly>
+        </ProjectReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Summary
Two unrelated-but-small fixes to the Avalonia build & UI that surfaced during day-to-day work on UniGetUI.Avalonia.slnx:                                      
                                                                                  

1. CS0006 race when building UniGetUI.PackageEngine.PEInterface in parallel IDEs                                

  Building UniGetUI.Avalonia.slnx from a clean state in Rider (and presumably VS)intermittently fails with errors like:                                                                                                               `CSC: Error CS0006 : Metadata file '…\UniGetUI.PackageEngine.Managers.Chocolatey\obj\x64\Debug\net10.0-windows10.0.26100.0\ref\UniGetUI.PackageEngine.Managers.Chocolatey.dll' could not be found `

2. ArgumentException: Unable to load bitmap from provided data spam when searching packages                                                              

Typing in the package search bar produced a flood of caught-but-logged exceptions in Rider:                                                            
`System.ArgumentException: Unable to load bitmap from provided data at Avalonia.Skia.ImmutableBitmap..ctor(Stream stream)`