### PR TITLE
change linux manager support

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs
@@ -26,7 +26,7 @@ public class Apt : PackageManager
             SupportsCustomSources = false,
             SupportsProxy = ProxySupport.No,
             SupportsProxyAuth = false,
-            KnowsPackageReleaseDate = PackageReleaseDateSupport.Yes,
+            KnowsPackageReleaseDate = PackageReleaseDateSupport.No,
         };
 
         Properties = new ManagerProperties

--- a/src/UniGetUI.PackageEngine.Managers.Dnf/Dnf.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Dnf/Dnf.cs
@@ -29,7 +29,7 @@ public class Dnf : PackageManager
             SupportsCustomSources = false,
             SupportsProxy = ProxySupport.No,
             SupportsProxyAuth = false,
-            KnowsPackageReleaseDate = PackageReleaseDateSupport.Yes,
+            KnowsPackageReleaseDate = PackageReleaseDateSupport.No,
         };
 
         Properties = new ManagerProperties

--- a/src/UniGetUI.PackageEngine.Managers.Flatpak/Flatpak.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Flatpak/Flatpak.cs
@@ -35,7 +35,7 @@ public partial class Flatpak : PackageManager
             },
             SupportsProxy = ProxySupport.No,
             SupportsProxyAuth = false,
-            KnowsPackageReleaseDate = PackageReleaseDateSupport.Yes,
+            KnowsPackageReleaseDate = PackageReleaseDateSupport.No,
         };
 
         Properties = new ManagerProperties

--- a/src/UniGetUI.PackageEngine.Managers.Pacman/Pacman.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pacman/Pacman.cs
@@ -25,7 +25,7 @@ public class Pacman : PackageManager
             SupportsCustomSources = false,
             SupportsProxy = ProxySupport.No,
             SupportsProxyAuth = false,
-            KnowsPackageReleaseDate = PackageReleaseDateSupport.Yes,
+            KnowsPackageReleaseDate = PackageReleaseDateSupport.No,
         };
 
         Properties = new ManagerProperties

--- a/src/UniGetUI.PackageEngine.Managers.Snap/Snap.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Snap/Snap.cs
@@ -32,7 +32,7 @@ public partial class Snap : PackageManager
             SupportsCustomSources = false,
             SupportsProxy = ProxySupport.No,
             SupportsProxyAuth = false,
-            KnowsPackageReleaseDate = PackageReleaseDateSupport.Yes,
+            KnowsPackageReleaseDate = PackageReleaseDateSupport.No,
         };
 
         var snapcraftSource = new ManagerSource(this, "snapcraft", new Uri("https://snapcraft.io"));


### PR DESCRIPTION
This pull request updates the metadata for several Linux package manager integrations by marking that they do not support reporting package release dates. This change ensures that the application does not incorrectly assume that release date information is available from these backends.

Package manager metadata updates:

* Set `KnowsPackageReleaseDate` to `PackageReleaseDateSupport.No` for the following managers:
  - `Apt` (`src/UniGetUI.PackageEngine.Managers.Apt/Apt.cs`)
  - `Dnf` (`src/UniGetUI.PackageEngine.Managers.Dnf/Dnf.cs`)
  - `Flatpak` (`src/UniGetUI.PackageEngine.Managers.Flatpak/Flatpak.cs`)
  - `Pacman` (`src/UniGetUI.PackageEngine.Managers.Pacman/Pacman.cs`)
  - `Snap` (`src/UniGetUI.PackageEngine.Managers.Snap/Snap.cs`)