### PR TITLE
Update UniGetUI Pinget consumer for Pinget 0.6.0 JSON contract

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
         "version": "10.0.103",
-        "rollForward": "latestPatch"
+        "rollForward": "latestFeature"
     }
 }

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -94,7 +94,7 @@
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.5.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.6.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -108,13 +108,11 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private void SubscribeToPageViewModel(AbstractPackagesPage? page)
     {
-        if (_subscribedPageViewModel is not null)
-            _subscribedPageViewModel.PropertyChanged -= OnPageViewModelPropertyChanged;
+        _subscribedPageViewModel?.PropertyChanged -= OnPageViewModelPropertyChanged;
 
         _subscribedPageViewModel = page?.ViewModel;
 
-        if (_subscribedPageViewModel is not null)
-            _subscribedPageViewModel.PropertyChanged += OnPageViewModelPropertyChanged;
+        _subscribedPageViewModel?.PropertyChanged += OnPageViewModelPropertyChanged;
     }
 
     private void OnPageViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
@@ -23,16 +23,13 @@ public partial class InfoBar : UserControl
 
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
-        if (_vm is not null)
-            _vm.PropertyChanged -= OnViewModelPropertyChanged;
+        _vm?.PropertyChanged -= OnViewModelPropertyChanged;
 
         _vm = DataContext as InfoBarViewModel;
 
+        _vm?.PropertyChanged += OnViewModelPropertyChanged;
         if (_vm is not null)
-        {
-            _vm.PropertyChanged += OnViewModelPropertyChanged;
             ApplySeverity(_vm.Severity);
-        }
     }
 
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetCliHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetCliHelper.cs
@@ -18,7 +18,6 @@ internal sealed partial class PingetCliHelper : IWinGetManagerHelper
     private static readonly JsonSerializerOptions SerializationOptions = new()
     {
         PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
     };
     private static readonly PingetCliJsonContext SerializationContext = new(SerializationOptions);
 
@@ -55,7 +54,7 @@ internal sealed partial class PingetCliHelper : IWinGetManagerHelper
                 match.Id,
                 match.InstalledVersion,
                 match.AvailableVersion!,
-                GetSource(match.SourceName, match.Id),
+                GetSource(match),
                 Manager
             );
 
@@ -87,7 +86,7 @@ internal sealed partial class PingetCliHelper : IWinGetManagerHelper
                     match.Name,
                     match.Id,
                     match.InstalledVersion,
-                    GetSource(match.SourceName, match.Id),
+                    GetSource(match),
                     Manager
                 )
             )
@@ -232,6 +231,32 @@ internal sealed partial class PingetCliHelper : IWinGetManagerHelper
         return JsonSerializer.Deserialize(output, typeof(T), SerializationContext) is T result
             ? result
             : throw new InvalidOperationException("Pinget returned empty JSON output.");
+    }
+
+    internal static string? InferSourceName(ListMatch match)
+    {
+        if (!string.IsNullOrWhiteSpace(match.SourceName))
+        {
+            return match.SourceName;
+        }
+
+        if (match.Id.Contains("_Microsoft.Winget.Source_8wekyb3d8bbwe", StringComparison.OrdinalIgnoreCase))
+        {
+            return "winget";
+        }
+
+        if (!string.IsNullOrWhiteSpace(match.InstallLocation)
+            && match.InstallLocation.Contains("\\Microsoft\\WinGet\\Packages\\", StringComparison.OrdinalIgnoreCase))
+        {
+            return "winget";
+        }
+
+        return null;
+    }
+
+    private IManagerSource GetSource(ListMatch match)
+    {
+        return GetSource(InferSourceName(match), match.Id);
     }
 
     private IManagerSource GetSource(string? sourceName, string packageId)

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetPackageDetailsProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetPackageDetailsProvider.cs
@@ -84,10 +84,10 @@ internal sealed class PingetCliPackageDetailsProvider(string cliExecutablePath)
     {
         try
         {
-            string output = RunPinget(["source", "list", "--output", "json"], logger);
+            string output = RunPinget(["source", "export", "--output", "json"], logger);
             using JsonDocument document = JsonDocument.Parse(output);
             if (
-                !document.RootElement.TryGetProperty("sources", out JsonElement sources)
+                !document.RootElement.TryGetProperty("Sources", out JsonElement sources)
                 || sources.ValueKind != JsonValueKind.Array
             )
             {
@@ -97,7 +97,7 @@ internal sealed class PingetCliPackageDetailsProvider(string cliExecutablePath)
             return sources
                 .EnumerateArray()
                 .Select(source =>
-                    source.TryGetProperty("name", out JsonElement name)
+                    source.TryGetProperty("Name", out JsonElement name)
                         ? name.GetString()
                         : null
                 )

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Pinget.Core" Version="0.5.0" />
+        <PackageReference Include="Devolutions.Pinget.Core" Version="0.6.0" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
     </ItemGroup>
 </Project>

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -300,28 +300,28 @@ public sealed class WinGetManagerTests : IDisposable
     [Fact]
     public void PingetCliHelperDeserializesListResponsesWithGeneratedContext()
     {
-        // pinget 0.4.1+ emits snake_case keys.
+        // Pinget emits PascalCase keys.
         const string json = """
             {
-                "matches": [
+                "Matches": [
                     {
-                        "name": "Contoso Tool",
-                        "id": "Contoso.Tool",
-                        "local_id": null,
-                        "installed_version": "1.2.3",
-                        "available_version": "2.0.0",
-                        "source_name": "winget",
-                        "publisher": null,
-                        "scope": null,
-                        "installer_category": null,
-                        "install_location": null,
-                        "package_family_names": [],
-                        "product_codes": [],
-                        "upgrade_codes": []
+                        "Name": "Contoso Tool",
+                        "Id": "Contoso.Tool",
+                        "LocalId": null,
+                        "InstalledVersion": "1.2.3",
+                        "AvailableVersion": "2.0.0",
+                        "SourceName": "winget",
+                        "Publisher": null,
+                        "Scope": null,
+                        "InstallerCategory": null,
+                        "InstallLocation": null,
+                        "PackageFamilyNames": [],
+                        "ProductCodes": [],
+                        "UpgradeCodes": []
                     }
                 ],
-                "warnings": [],
-                "truncated": false
+                "Warnings": [],
+                "Truncated": false
             }
             """;
 
@@ -333,6 +333,38 @@ public sealed class WinGetManagerTests : IDisposable
         Assert.Equal("1.2.3", match.InstalledVersion);
         Assert.Equal("2.0.0", match.AvailableVersion);
         Assert.Equal("winget", match.SourceName);
+    }
+
+    [Fact]
+    public void PingetCliHelperInfersWingetSourceWhenInstalledSourceNameIsMissing()
+    {
+        const string json = """
+            {
+                "Matches": [
+                    {
+                        "Name": "Contoso Tool",
+                        "Id": "ARP\\User\\X64\\Contoso.Tool_Microsoft.Winget.Source_8wekyb3d8bbwe",
+                        "LocalId": null,
+                        "InstalledVersion": "1.2.3",
+                        "AvailableVersion": null,
+                        "SourceName": null,
+                        "Publisher": "Contoso",
+                        "Scope": "User",
+                        "InstallerCategory": "exe",
+                        "InstallLocation": "C:\\Users\\example\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Contoso.Tool_Microsoft.Winget.Source_8wekyb3d8bbwe",
+                        "PackageFamilyNames": [],
+                        "ProductCodes": [],
+                        "UpgradeCodes": []
+                    }
+                ],
+                "Warnings": [],
+                "Truncated": false
+            }
+            """;
+
+        ListMatch match = Assert.Single(PingetCliHelper.DeserializeJson<ListResponse>(json).Matches);
+
+        Assert.Equal("winget", PingetCliHelper.InferSourceName(match));
     }
 
     [Fact]

--- a/src/UniGetUI/Controls/PackageItemContainer.cs
+++ b/src/UniGetUI/Controls/PackageItemContainer.cs
@@ -17,15 +17,9 @@ namespace UniGetUI.Interface.Widgets
             get => _wrapper;
             set
             {
-                if (_wrapper != null)
-                {
-                    _wrapper.PropertyChanged -= Wrapper_PropertyChanged;
-                }
+                _wrapper?.PropertyChanged -= Wrapper_PropertyChanged;
                 _wrapper = value;
-                if (_wrapper != null)
-                {
-                    _wrapper.PropertyChanged += Wrapper_PropertyChanged;
-                }
+                _wrapper?.PropertyChanged += Wrapper_PropertyChanged;
             }
         }
 

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -221,7 +221,7 @@
         <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.5.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.6.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
 
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- update the UniGetUI Pinget consumer to the new Pinget JSON contract
- switch the Pinget source fallback parsing to the PascalCase source export shape
- update Pinget-related UniGetUI tests accordingly
- relax \global.json\ SDK roll-forward policy to \latestFeature\

## Blocking dependency
This PR should not be merged until **Pinget 0.6.0 is released** and available for UniGetUI to consume.

Related Pinget PR:
- https://github.com/Devolutions/pinget/pull/26

## Validation
- dotnet test src/UniGetUI.PackageEngine.Tests/UniGetUI.PackageEngine.Tests.csproj -c Debug
- manual Avalonia verification with bundled C# and Rust Pinget builds