### PR TITLE
Rework package details view

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/PackageDetailsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/PackageDetailsViewModel.cs
@@ -16,6 +16,9 @@ namespace UniGetUI.Avalonia.ViewModels;
 public partial class PackageDetailsViewModel : ObservableObject
 {
     public event EventHandler? CloseRequested;
+    /// <summary>Raised on the UI thread after details have been loaded so the view
+    /// can (re)populate the inline rich-text blocks.</summary>
+    public event EventHandler? DetailsLoaded;
 
     public readonly IPackage Package;
     public readonly OperationType OperationRole;
@@ -46,14 +49,12 @@ public partial class PackageDetailsViewModel : ObservableObject
     [ObservableProperty]
     private string _description = CoreTools.Translate("Loading...");
 
-    // ── Basic info ─────────────────────────────────────────────────────────────
+    // ── Basic info (raw values exposed; the view builds the inline rich text) ──
     [ObservableProperty]
     private string _versionDisplay = "";
 
     [ObservableProperty]
-    private string _homepageText = CoreTools.Translate("Loading...");
-    [ObservableProperty]
-    private bool _hasHomepageUrl;
+    private Uri? _homepageUrl;
 
     [ObservableProperty]
     private string _author = CoreTools.Translate("Loading...");
@@ -61,9 +62,9 @@ public partial class PackageDetailsViewModel : ObservableObject
     private string _publisher = CoreTools.Translate("Loading...");
 
     [ObservableProperty]
-    private string _licenseText = CoreTools.Translate("Loading...");
+    private string? _licenseName;
     [ObservableProperty]
-    private bool _hasLicenseUrl;
+    private Uri? _licenseUrl;
 
     // ── Actions ────────────────────────────────────────────────────────────────
     public string MainActionLabel { get; }
@@ -78,9 +79,7 @@ public partial class PackageDetailsViewModel : ObservableObject
     public string PackageId { get; }
 
     [ObservableProperty]
-    private string _manifestText = CoreTools.Translate("Loading...");
-    [ObservableProperty]
-    private bool _hasManifestUrl;
+    private Uri? _manifestUrl;
 
     [ObservableProperty]
     private string _installerHashLabel = CoreTools.Translate("Installer SHA256") + ":";
@@ -89,9 +88,7 @@ public partial class PackageDetailsViewModel : ObservableObject
     [ObservableProperty]
     private string _installerType = CoreTools.Translate("Loading...");
     [ObservableProperty]
-    private string _installerUrlText = CoreTools.Translate("Loading...");
-    [ObservableProperty]
-    private bool _hasInstallerUrl;
+    private Uri? _installerUrl;
     [ObservableProperty]
     private string _installerSize = "";
 
@@ -118,60 +115,43 @@ public partial class PackageDetailsViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasScreenshots))]
-    [NotifyPropertyChangedFor(nameof(SelectedScreenshot))]
-    [NotifyPropertyChangedFor(nameof(ScreenshotPageLabel))]
-    [NotifyPropertyChangedFor(nameof(CanGoNextScreenshot))]
     private int _screenshotCount;
 
     public bool HasScreenshots => ScreenshotCount > 0;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(SelectedScreenshot))]
-    [NotifyPropertyChangedFor(nameof(ScreenshotPageLabel))]
-    [NotifyPropertyChangedFor(nameof(CanGoPrevScreenshot))]
-    [NotifyPropertyChangedFor(nameof(CanGoNextScreenshot))]
     private int _selectedScreenshotIndex;
-
-    public Bitmap? SelectedScreenshot =>
-        ScreenshotCount > 0 && SelectedScreenshotIndex < Screenshots.Count
-            ? Screenshots[SelectedScreenshotIndex]
-            : null;
-
-    public string ScreenshotPageLabel =>
-        ScreenshotCount > 0 ? $"{SelectedScreenshotIndex + 1} / {ScreenshotCount}" : "";
-
-    public bool CanGoPrevScreenshot => SelectedScreenshotIndex > 0;
-    public bool CanGoNextScreenshot => SelectedScreenshotIndex < ScreenshotCount - 1;
 
     // ── Release notes ──────────────────────────────────────────────────────────
     [ObservableProperty]
     private string _releaseNotes = CoreTools.Translate("Loading...");
     [ObservableProperty]
-    private string _releaseNotesUrlText = CoreTools.Translate("Loading...");
-    [ObservableProperty]
-    private bool _hasReleaseNotesUrl;
+    private Uri? _releaseNotesUrl;
 
     // ── Translated labels ──────────────────────────────────────────────────────
     public string LabelVersion { get; }
-    public string LabelHomepage { get; } = CoreTools.Translate("Homepage") + ":";
-    public string LabelAuthor { get; } = CoreTools.Translate("Author") + ":";
-    public string LabelPublisher { get; } = CoreTools.Translate("Publisher") + ":";
-    public string LabelLicense { get; } = CoreTools.Translate("License") + ":";
-    public string LabelPackageId { get; } = CoreTools.Translate("Package ID") + ":";
-    public string LabelManifest { get; } = CoreTools.Translate("Manifest") + ":";
-    public string LabelInstallerType { get; } = CoreTools.Translate("Installer Type") + ":";
-    public string LabelInstallerSize { get; } = CoreTools.Translate("Size") + ":";
-    public string LabelInstallerUrl { get; } = CoreTools.Translate("Installer URL") + ":";
-    public string LabelUpdateDate { get; } = CoreTools.Translate("Last updated:");
-    public string LabelReleaseNotesUrl { get; } = CoreTools.Translate("Release notes URL") + ":";
-    public string LabelOpen { get; } = CoreTools.Translate("Open");
-    public string LabelClose { get; } = CoreTools.Translate("Close");
-    public string HeaderDetails { get; } = CoreTools.Translate("Package details");
-    public string HeaderDeps { get; } = CoreTools.Translate("Dependencies:");
-    public string HeaderReleaseNotes { get; } = CoreTools.Translate("Release notes");
-    public string HeaderScreenshots { get; } = CoreTools.Translate("Screenshots");
-    public string LabelScreenshotContribute { get; } = CoreTools.Translate(
+    public string LabelHomepage { get; } = CoreTools.Translate("Homepage");
+    public string LabelAuthor { get; } = CoreTools.Translate("Author");
+    public string LabelPublisher { get; } = CoreTools.Translate("Publisher");
+    public string LabelLicense { get; } = CoreTools.Translate("License");
+    public string LabelSource { get; } = CoreTools.Translate("Package Manager");
+    public string LabelPackageId { get; } = CoreTools.Translate("Package ID");
+    public string LabelManifest { get; } = CoreTools.Translate("Manifest");
+    public string LabelInstallerType { get; } = CoreTools.Translate("Installer Type");
+    public string LabelInstallerUrl { get; } = CoreTools.Translate("Installer URL");
+    public string LabelUpdateDate { get; } = CoreTools.Translate("Last updated");
+    public string LabelDependencies { get; } = CoreTools.Translate("Dependencies");
+    public string LabelReleaseNotes { get; } = CoreTools.Translate("Release notes");
+    public string LabelReleaseNotesUrl { get; } = CoreTools.Translate("Release notes URL");
+    public string LabelDownloadInstaller { get; } = CoreTools.Translate("Download installer");
+    public string LabelInstallerNotAvailable { get; } = CoreTools.Translate("Installer not available");
+    public string LabelNotAvailable { get; } = CoreTools.Translate("Not available");
+    public string LabelNoDependencies { get; } = CoreTools.Translate("No dependencies specified");
+    public string LabelInstallationOptions { get; } = CoreTools.Translate("Installation options");
+    public string LabelSave { get; } = CoreTools.Translate("Save");
+    public string LabelContributorBanner { get; } = CoreTools.Translate(
         "This package has no screenshots or is missing the icon? Contribute to UniGetUI by adding the missing icons and screenshots to our open, public database.");
+    public string LabelContribute { get; } = CoreTools.Translate("Become a contributor");
 
     public PackageDetailsViewModel(IPackage package, OperationType role)
     {
@@ -197,7 +177,7 @@ public partial class PackageDetailsViewModel : ObservableObject
         if (role == OperationType.Install)
         {
             MainActionLabel = CoreTools.Translate("Install");
-            LabelVersion = CoreTools.Translate("Version") + ":";
+            LabelVersion = CoreTools.Translate("Version");
             VersionDisplay = available?.VersionString ?? package.VersionString;
             AsAdminLabel = CoreTools.Translate("Install as administrator");
             InteractiveLabel = CoreTools.Translate("Interactive installation");
@@ -208,10 +188,10 @@ public partial class PackageDetailsViewModel : ObservableObject
         {
             MainActionLabel = CoreTools.Translate(
                 "Update to version {0}", upgradable?.NewVersionString ?? package.NewVersionString);
-            LabelVersion = CoreTools.Translate("Installed Version") + ":";
+            LabelVersion = CoreTools.Translate("Installed Version");
             VersionDisplay = (upgradable?.VersionString ?? package.VersionString)
-                                         + " \u27a4 "
-                                         + (upgradable?.NewVersionString ?? package.NewVersionString);
+                             + " ➤ "
+                             + (upgradable?.NewVersionString ?? package.NewVersionString);
             AsAdminLabel = CoreTools.Translate("Update as administrator");
             InteractiveLabel = CoreTools.Translate("Interactive update");
             SkipHashOrRemoveDataLabel = CoreTools.Translate("Skip hash check");
@@ -220,7 +200,7 @@ public partial class PackageDetailsViewModel : ObservableObject
         else
         {
             MainActionLabel = CoreTools.Translate("Uninstall");
-            LabelVersion = CoreTools.Translate("Installed Version") + ":";
+            LabelVersion = CoreTools.Translate("Installed Version");
             VersionDisplay = installed?.VersionString ?? package.VersionString;
             AsAdminLabel = CoreTools.Translate("Uninstall as administrator");
             InteractiveLabel = CoreTools.Translate("Interactive uninstall");
@@ -229,20 +209,18 @@ public partial class PackageDetailsViewModel : ObservableObject
         }
     }
 
-    [RelayCommand(CanExecute = nameof(CanGoPrevScreenshot))]
+    [RelayCommand]
     private void PreviousScreenshot()
     {
-        SelectedScreenshotIndex = Math.Max(0, SelectedScreenshotIndex - 1);
-        PreviousScreenshotCommand.NotifyCanExecuteChanged();
-        NextScreenshotCommand.NotifyCanExecuteChanged();
+        if (SelectedScreenshotIndex > 0)
+            SelectedScreenshotIndex--;
     }
 
-    [RelayCommand(CanExecute = nameof(CanGoNextScreenshot))]
+    [RelayCommand]
     private void NextScreenshot()
     {
-        SelectedScreenshotIndex = Math.Min(ScreenshotCount - 1, SelectedScreenshotIndex + 1);
-        PreviousScreenshotCommand.NotifyCanExecuteChanged();
-        NextScreenshotCommand.NotifyCanExecuteChanged();
+        if (SelectedScreenshotIndex < ScreenshotCount - 1)
+            SelectedScreenshotIndex++;
     }
 
     public async Task LoadDetailsAsync()
@@ -257,39 +235,28 @@ public partial class PackageDetailsViewModel : ObservableObject
         IsLoading = false;
 
         Description = details.Description ?? CoreTools.Translate("Not available");
-        HomepageText = details.HomepageUrl?.ToString() ?? CoreTools.Translate("Not available");
-        HasHomepageUrl = details.HomepageUrl is not null;
+        HomepageUrl = details.HomepageUrl;
         Author = details.Author ?? CoreTools.Translate("Not available");
         Publisher = details.Publisher ?? CoreTools.Translate("Not available");
 
-        if (details.License is not null && details.LicenseUrl is not null)
-            LicenseText = $"{details.License} ({details.LicenseUrl})";
-        else if (details.License is not null)
-            LicenseText = details.License;
-        else if (details.LicenseUrl is not null)
-            LicenseText = details.LicenseUrl.ToString();
-        else
-            LicenseText = CoreTools.Translate("Not available");
-        HasLicenseUrl = details.LicenseUrl is not null;
+        LicenseName = details.License;
+        LicenseUrl = details.LicenseUrl;
 
-        ManifestText = details.ManifestUrl?.ToString() ?? CoreTools.Translate("Not available");
-        HasManifestUrl = details.ManifestUrl is not null;
+        ManifestUrl = details.ManifestUrl;
 
         if (Package.Manager.Properties.Name.Equals("chocolatey", StringComparison.OrdinalIgnoreCase))
             InstallerHashLabel = CoreTools.Translate("Installer SHA512") + ":";
 
         InstallerHash = details.InstallerHash ?? CoreTools.Translate("Not available");
         InstallerType = details.InstallerType ?? CoreTools.Translate("Not available");
-        InstallerUrlText = details.InstallerUrl?.ToString() ?? CoreTools.Translate("Not available");
-        HasInstallerUrl = details.InstallerUrl is not null;
+        InstallerUrl = details.InstallerUrl;
         InstallerSize = details.InstallerSize > 0
             ? CoreTools.FormatAsSize(details.InstallerSize, 2)
             : CoreTools.Translate("Unknown size");
         UpdateDate = details.UpdateDate ?? CoreTools.Translate("Not available");
 
         ReleaseNotes = details.ReleaseNotes ?? CoreTools.Translate("Not available");
-        ReleaseNotesUrlText = details.ReleaseNotesUrl?.ToString() ?? CoreTools.Translate("Not available");
-        HasReleaseNotesUrl = details.ReleaseNotesUrl is not null;
+        ReleaseNotesUrl = details.ReleaseNotesUrl;
 
         if (!CanListDependencies)
         {
@@ -313,23 +280,41 @@ public partial class PackageDetailsViewModel : ObservableObject
         foreach (var tag in details.Tags)
             Tags.Add(tag);
         TagCount = Tags.Count;
+
+        DetailsLoaded?.Invoke(this, EventArgs.Empty);
     }
 
     private async Task LoadIconAsync()
     {
         try
         {
-            var iconUrl = await Task.Run(Package.GetIconUrl);
-            if (iconUrl is not null)
+            var uri = await Task.Run(Package.GetIconUrlIfAny);
+            if (uri is not null)
             {
-                using var http = new HttpClient(CoreTools.GenericHttpClientParameters);
-                var bytes = await http.GetByteArrayAsync(iconUrl);
-                using var ms = new MemoryStream(bytes);
-                PackageIcon = new Bitmap(ms);
-                return;
+                Bitmap? bitmap = null;
+                if (uri.IsFile)
+                {
+                    bitmap = await Task.Run(() => new Bitmap(uri.LocalPath));
+                }
+                else if (uri.Scheme is "http" or "https")
+                {
+                    using var http = new HttpClient(CoreTools.GenericHttpClientParameters);
+                    var bytes = await http.GetByteArrayAsync(uri);
+                    using var ms = new MemoryStream(bytes);
+                    bitmap = new Bitmap(ms);
+                }
+
+                if (bitmap is not null)
+                {
+                    PackageIcon = bitmap;
+                    return;
+                }
             }
         }
-        catch { /* icon is optional */ }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[PackageDetailsViewModel] Failed to load icon: {ex.Message}");
+        }
 
         try
         {
@@ -359,8 +344,6 @@ public partial class PackageDetailsViewModel : ObservableObject
                     {
                         Screenshots.Add(bmp);
                         ScreenshotCount = Screenshots.Count;
-                        PreviousScreenshotCommand.NotifyCanExecuteChanged();
-                        NextScreenshotCommand.NotifyCanExecuteChanged();
                     });
                 }
                 catch { /* skip failed screenshots */ }
@@ -373,7 +356,7 @@ public partial class PackageDetailsViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private static void OpenUrl(string? url)
+    public static void OpenUrl(string? url)
     {
         if (string.IsNullOrEmpty(url) || !url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
             return;
@@ -391,7 +374,7 @@ public class DependencyViewModel
 
     public DependencyViewModel(IPackageDetails.Dependency dep)
     {
-        var text = $"  \u2022 {dep.Name}";
+        var text = $"  • {dep.Name}";
         if (!string.IsNullOrEmpty(dep.Version))
             text += $" v{dep.Version}";
         text += dep.Mandatory

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -6,8 +6,8 @@
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.PackageDetailsWindow"
         x:DataType="vm:PackageDetailsViewModel"
-        Width="900" MinWidth="600"
-        Height="680" MinHeight="400"
+        Width="1000" MinWidth="640"
+        Height="720" MinHeight="420"
         CanResize="True"
         ShowInTaskbar="False"
         Background="{DynamicResource AppDialogBackground}"
@@ -18,441 +18,321 @@
         <Style Selector="Expander /template/ ToggleButton#ExpanderHeader">
             <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
         </Style>
+
+        <!-- Tag pill -->
+        <Style Selector="Border.tag-pill">
+            <Setter Property="Height" Value="24"/>
+            <Setter Property="Margin" Value="0,0,6,6"/>
+            <Setter Property="Padding" Value="10,2"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+        </Style>
+        <Style Selector="Border.tag-pill > TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="FontSize" Value="12"/>
+        </Style>
+
+        <!-- Split action button: fused look -->
+        <Style Selector="Button.action-main">
+            <Setter Property="Height" Value="40"/>
+            <Setter Property="CornerRadius" Value="8,0,0,8"/>
+            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+        </Style>
+        <Style Selector="Button.action-chevron">
+            <Setter Property="Width" Value="34"/>
+            <Setter Property="Height" Value="40"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="1,0,0,0"/>
+            <Setter Property="CornerRadius" Value="0,8,8,0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+
+        <!-- Screenshot pip dots (Button hosting an Ellipse) -->
+        <Style Selector="Button.pip">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="3,4"/>
+            <Setter Property="Width" Value="18"/>
+            <Setter Property="Height" Value="18"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </Style>
+        <Style Selector="Ellipse.pip">
+            <Setter Property="Width" Value="8"/>
+            <Setter Property="Height" Value="8"/>
+            <Setter Property="Fill" Value="{DynamicResource TextFillColorTertiaryBrush}"/>
+        </Style>
+        <Style Selector="Ellipse.pip.active">
+            <Setter Property="Fill" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+            <Setter Property="Width" Value="10"/>
+            <Setter Property="Height" Value="10"/>
+        </Style>
+
+        <!-- Screenshot prev/next chevrons (overlay on hover) -->
+        <Style Selector="Button.carousel-nav">
+            <Setter Property="Width" Value="32"/>
+            <Setter Property="Height" Value="48"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Background" Value="#80000000"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="Opacity" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.15"/>
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Border#ScreenshotsBorder:pointerover Button.carousel-nav">
+            <Setter Property="Opacity" Value="0.9"/>
+        </Style>
     </Window.Styles>
 
-    <Grid RowDefinitions="Auto,*,Auto">
-
-        <!-- Loading indicator -->
-        <ProgressBar Grid.Row="0"
-                     IsIndeterminate="True"
+    <Grid>
+        <!-- Loading indicator across the very top -->
+        <ProgressBar IsIndeterminate="True"
                      IsVisible="{Binding IsLoading}"
                      automation:AutomationProperties.Name="{Binding PackageName}"
+                     VerticalAlignment="Top"
                      Height="3"/>
 
-        <!-- ── Scrollable body ── -->
-        <ScrollViewer Grid.Row="1"
-                      VerticalScrollBarVisibility="Auto"
+        <!-- ── Scrollable content area ── -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto"
                       HorizontalScrollBarVisibility="Disabled">
-            <StackPanel Margin="20,16,20,12" Spacing="12">
+            <Grid x:Name="MainGrid"
+                  Margin="24,20,24,24"
+                  ColumnSpacing="32">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
 
-                <!-- ── Header: icon + name + source ── -->
-                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
-                    <Border
-                        Width="72" Height="72"
-                            CornerRadius="12"
-                            Background="{DynamicResource AppDialogPanelBackground}"
-                            ClipToBounds="True">
-                        <Image Source="{Binding PackageIcon}"
-                               automation:AutomationProperties.AccessibilityView="Raw"
-                               Stretch="Uniform"
-                               RenderOptions.BitmapInterpolationMode="HighQuality"/>
-                    </Border>
+                <!-- Left column: title, description, basic info, actions, install options.
+                     Children are reparented by code-behind for the narrow layout. -->
+                <StackPanel x:Name="LeftPanel" Grid.Column="0" Spacing="16" VerticalAlignment="Top">
 
-                    <StackPanel Grid.Column="1"
-                                VerticalAlignment="Center"
-                                Spacing="4">
-                        <TextBlock Text="{Binding PackageName}"
-                                   FontSize="22" FontWeight="Bold"
-                                   TextWrapping="Wrap"
-                                   automation:AutomationProperties.HeadingLevel="1"/>
-                        <TextBlock Text="{Binding SourceDisplay}"
-                                   FontSize="13" Opacity="0.65"/>
-                    </StackPanel>
-
-                </Grid>
-
-                <!-- ── Tags ── -->
-                <ItemsControl ItemsSource="{Binding Tags}"
-                              IsVisible="{Binding HasTags}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="x:String">
-                            <Border Background="{DynamicResource AppDialogSubtleBackground}"
-                                    CornerRadius="4"
-                                    Padding="8,3"
-                                    Margin="0,0,6,6">
-                                <TextBlock Text="{Binding}" FontSize="12"/>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-
-                <!-- ── Description ── -->
-                <Border Background="{DynamicResource SettingsCardBackground}" CornerRadius="8" Padding="14">
-                    <TextBlock Text="{Binding Description}"
-                               TextWrapping="Wrap"
-                               Opacity="0.9"/>
-                </Border>
-
-                <!-- ── Basic info ── -->
-                <Border Background="{DynamicResource SettingsCardBackground}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="10">
-
-                        <Grid ColumnDefinitions="160,*">
-                            <TextBlock Text="{Binding LabelVersion}"
-                                       Opacity="0.65" VerticalAlignment="Top"/>
-                            <TextBlock Grid.Column="1"
-                                       Text="{Binding VersionDisplay}"
-                                       TextWrapping="Wrap"/>
-                        </Grid>
-
-                        <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                        <Grid ColumnDefinitions="160,*,Auto">
-                            <TextBlock Text="{Binding LabelHomepage}"
-                                       Opacity="0.65" VerticalAlignment="Center"/>
-                            <TextBlock Grid.Column="1"
-                                       Text="{Binding HomepageText}"
-                                       TextTrimming="CharacterEllipsis"
-                                       VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding HomepageText}"/>
-                            <Button Grid.Column="2"
-                                    Content="{Binding LabelOpen}"
-                                    IsVisible="{Binding HasHomepageUrl}"
-                                    Command="{Binding OpenUrlCommand}"
-                                    CommandParameter="{Binding HomepageText}"
-                                    automation:AutomationProperties.Name="{Binding LabelHomepage}"
-                                    Padding="8,3" Margin="8,0,0,0"/>
-                        </Grid>
-
-                        <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                        <Grid ColumnDefinitions="160,*">
-                            <TextBlock Text="{Binding LabelAuthor}"
-                                       Opacity="0.65" VerticalAlignment="Top"/>
-                            <TextBlock Grid.Column="1"
-                                       Text="{Binding Author}"
-                                       TextWrapping="Wrap"/>
-                        </Grid>
-
-                        <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                        <Grid ColumnDefinitions="160,*">
-                            <TextBlock Text="{Binding LabelPublisher}"
-                                       Opacity="0.65" VerticalAlignment="Top"/>
-                            <TextBlock Grid.Column="1"
-                                       Text="{Binding Publisher}"
-                                       TextWrapping="Wrap"/>
-                        </Grid>
-
-                        <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                        <Grid ColumnDefinitions="160,*,Auto">
-                            <TextBlock Text="{Binding LabelLicense}"
-                                       Opacity="0.65" VerticalAlignment="Center"/>
-                            <TextBlock Grid.Column="1"
-                                       Text="{Binding LicenseText}"
-                                       TextTrimming="CharacterEllipsis"
-                                       VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding LicenseText}"/>
-                            <Button Grid.Column="2"
-                                    Content="{Binding LabelOpen}"
-                                    IsVisible="{Binding HasLicenseUrl}"
-                                    Command="{Binding OpenUrlCommand}"
-                                    CommandParameter="{Binding LicenseText}"
-                                    automation:AutomationProperties.Name="{Binding LabelLicense}"
-                                    Padding="8,3" Margin="8,0,0,0"/>
-                        </Grid>
-
-                    </StackPanel>
-                </Border>
-
-                <!-- ── Actions ── -->
-                <Border Background="{DynamicResource SettingsCardBackground}" CornerRadius="8" Padding="16">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="4">
-                        <Button x:Name="MainActionButton"
-                                Content="{Binding MainActionLabel}"
-                                automation:AutomationProperties.Name="{Binding MainActionLabel}"
-                                HorizontalAlignment="Stretch"
-                                HorizontalContentAlignment="Center"
-                                Classes="accent"
-                                Padding="16,8"/>
-                        <Button x:Name="ActionVariantsButton"
-                                Grid.Column="1"
-                                Content="▾"
-                                automation:AutomationProperties.Name="{Binding MainActionLabel}"
-                                automation:AutomationProperties.HelpText="{Binding HeaderDetails}"
-                                Width="30"
-                                Height="30"
-                                FontSize="30"
-                                HorizontalContentAlignment="Center"
-                                Padding="0"/>
-                    </Grid>
-                </Border>
-
-                <!-- ── Installation options (inline expander) ── -->
-                <Expander HorizontalAlignment="Stretch"
-                          HorizontalContentAlignment="Stretch"
-                          IsExpanded="False"
-                          CornerRadius="8"
-                          Padding="4"
-                          Background="{DynamicResource SettingsCardBackground}">
-                    <Expander.Header>
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/options.svg"
-                                              Width="16" Height="16" VerticalAlignment="Center"/>
-                            <TextBlock Text="{t:Translate Installation options}"
-                                       FontWeight="SemiBold"
-                                       VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Expander.Header>
-                    <StackPanel Margin="16,8" Spacing="8">
-                        <ContentControl x:Name="InstallOptionsHolder"/>
-                        <Button x:Name="InstallOptionsSaveButton"
-                                Content="{t:Translate Save}"
-                                Classes="accent"
-                                HorizontalAlignment="Right"
-                                Padding="16,6"/>
-                    </StackPanel>
-                </Expander>
-
-                <!-- ── Screenshots ── -->
-                <Border Background="{DynamicResource SettingsCardBackground}"
-                        CornerRadius="8" Padding="8"
-                        IsVisible="{Binding HasScreenshots}">
-                    <StackPanel Spacing="6">
-                        <Border CornerRadius="4" ClipToBounds="True"
-                                Height="225"
-                                Background="#000000">
-                            <Image Source="{Binding SelectedScreenshot}"
+                    <!-- ── Top: icon + title ── -->
+                    <Grid x:Name="TitlePanel"
+                          ColumnDefinitions="Auto,*"
+                          ColumnSpacing="16">
+                        <Border Width="112" Height="112"
+                                CornerRadius="20"
+                                Background="{DynamicResource AppDialogPanelBackground}"
+                                ClipToBounds="True">
+                            <Image Source="{Binding PackageIcon}"
+                                   Width="72" Height="72"
+                                   Margin="12"
+                                   automation:AutomationProperties.AccessibilityView="Raw"
                                    Stretch="Uniform"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"/>
+                                   RenderOptions.BitmapInterpolationMode="HighQuality"/>
                         </Border>
-                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
-                            <Button Content="◀"
-                                    Command="{Binding PreviousScreenshotCommand}"
-                                    IsEnabled="{Binding CanGoPrevScreenshot}"
-                                    Padding="10,4"/>
-                            <TextBlock Grid.Column="1"
-                                       Text="{Binding ScreenshotPageLabel}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"/>
-                            <Button Grid.Column="2"
-                                    Content="▶"
-                                    Command="{Binding NextScreenshotCommand}"
-                                    IsEnabled="{Binding CanGoNextScreenshot}"
-                                    Padding="10,4"/>
-                        </Grid>
+
+                        <StackPanel Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Spacing="4">
+                            <TextBlock Text="{Binding PackageName}"
+                                       FontSize="36" FontWeight="Bold"
+                                       TextWrapping="Wrap"
+                                       LineHeight="42"
+                                       automation:AutomationProperties.HeadingLevel="1"/>
+                            <TextBlock Text="{Binding SourceDisplay}"
+                                       FontSize="13" Opacity="0.65"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- ── Description: tag pills ── -->
+                    <StackPanel x:Name="DescriptionPanel"
+                                VerticalAlignment="Top"
+                                Spacing="10">
+                        <ItemsControl ItemsSource="{Binding Tags}"
+                                      IsVisible="{Binding HasTags}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="x:String">
+                                    <Border Classes="tag-pill">
+                                        <TextBlock Text="{Binding}"/>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </StackPanel>
-                </Border>
 
-                <!-- ── Details expander ── -->
-                <Expander HorizontalAlignment="Stretch"
-                          HorizontalContentAlignment="Stretch"
-                          IsExpanded="False"
-                          CornerRadius="8"
-                          Padding="4"
-                          Background="{DynamicResource SettingsCardBackground}">
-                    <Expander.Header>
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/options.svg"
-                                              Width="16" Height="16"
-                                              VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding HeaderDetails}"
-                                       FontWeight="SemiBold"
-                                       VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Expander.Header>
+                    <!-- ── Basic info: inline rows built in code-behind ── -->
+                    <StackPanel x:Name="BasicInfoPanel"
+                                VerticalAlignment="Top"
+                                Spacing="6"/>
 
-                    <Border Padding="16,12">
-                        <StackPanel Spacing="10">
+                    <!-- ── Action button (split: main + chevron dropdown) ── -->
+                    <Grid x:Name="ActionsPanel"
+                          VerticalAlignment="Top"
+                          HorizontalAlignment="Left"
+                          ColumnSpacing="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="10000*" MaxWidth="260"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Button x:Name="MainActionButton"
+                                    Grid.Column="0"
+                                    Classes="accent action-main"
+                                    Content="{Binding MainActionLabel}"
+                                    automation:AutomationProperties.Name="{Binding MainActionLabel}"/>
+                            <Button x:Name="ActionVariantsButton"
+                                    Grid.Column="1"
+                                    Classes="accent action-chevron"
+                                    automation:AutomationProperties.Name="{Binding MainActionLabel}">
+                                <Path Data="M 0,0 L 4,4 L 8,0"
+                                      Stroke="White"
+                                      StrokeThickness="1.5"
+                                      StrokeJoin="Miter"
+                                      Fill="Transparent"
+                                      HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      automation:AutomationProperties.AccessibilityView="Raw"/>
+                            </Button>
+                        </Grid>
+                    </Grid>
 
-                            <Grid ColumnDefinitions="160,*">
-                                <TextBlock Text="{Binding LabelPackageId}"
-                                           Opacity="0.65" VerticalAlignment="Top"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding PackageId}"
-                                           TextWrapping="Wrap"/>
-                            </Grid>
-
-                            <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                            <Grid ColumnDefinitions="160,*,Auto">
-                                <TextBlock Text="{Binding LabelManifest}"
-                                           Opacity="0.65" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding ManifestText}"
-                                       automation:AutomationProperties.Name="{Binding LabelManifest}"
-                                           TextTrimming="CharacterEllipsis"
-                                           VerticalAlignment="Center"
-                                           ToolTip.Tip="{Binding ManifestText}"/>
-                                <Button Grid.Column="2"
-                                        Content="{Binding LabelOpen}"
-                                    automation:AutomationProperties.Name="{Binding LabelManifest}"
-                                        IsVisible="{Binding HasManifestUrl}"
-                                        Command="{Binding OpenUrlCommand}"
-                                        CommandParameter="{Binding ManifestText}"
-                                        Padding="8,3" Margin="8,0,0,0"/>
-                            </Grid>
-
-                            <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                            <Grid ColumnDefinitions="160,*">
-                                <TextBlock Text="{Binding InstallerHashLabel}"
-                                           Opacity="0.65" VerticalAlignment="Top"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding InstallerHash}"
-                                           automation:AutomationProperties.Name="{Binding InstallerHashLabel}"
-                                           automation:AutomationProperties.HelpText="{Binding InstallerHash}"
-                                           TextWrapping="Wrap"
-                                           FontSize="11"/>
-                            </Grid>
-
-                            <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                            <Grid ColumnDefinitions="160,*">
-                                <TextBlock Text="{Binding LabelInstallerType}"
-                                           Opacity="0.65" VerticalAlignment="Top"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding InstallerType}"
-                                           TextWrapping="Wrap"/>
-                            </Grid>
-
-                            <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                            <Grid ColumnDefinitions="160,*,Auto">
-                                <TextBlock Text="{Binding LabelInstallerUrl}"
-                                           Opacity="0.65" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding InstallerUrlText}"
-                                       automation:AutomationProperties.Name="{Binding LabelInstallerUrl}"
-                                           TextTrimming="CharacterEllipsis"
-                                           VerticalAlignment="Center"
-                                           ToolTip.Tip="{Binding InstallerUrlText}"/>
-                                <Button Grid.Column="2"
-                                        Content="{Binding LabelOpen}"
-                                    automation:AutomationProperties.Name="{Binding LabelInstallerUrl}"
-                                        IsVisible="{Binding HasInstallerUrl}"
-                                        Command="{Binding OpenUrlCommand}"
-                                        CommandParameter="{Binding InstallerUrlText}"
-                                        Padding="8,3" Margin="8,0,0,0"/>
-                            </Grid>
-
-                            <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                            <Grid ColumnDefinitions="160,*">
-                                <TextBlock Text="{Binding LabelInstallerSize}"
-                                           Opacity="0.65" VerticalAlignment="Top"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding InstallerSize}"
-                                           TextWrapping="Wrap"/>
-                            </Grid>
-
-                            <Border Height="1" Background="{DynamicResource AppBorderBrush}"/>
-
-                            <Grid ColumnDefinitions="160,*">
-                                <TextBlock Text="{Binding LabelUpdateDate}"
-                                           Opacity="0.65" VerticalAlignment="Top"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding UpdateDate}"
-                                           TextWrapping="Wrap"/>
-                            </Grid>
-
-                        </StackPanel>
+                    <!-- ── Installation options (collapsible) ── -->
+                    <Border x:Name="InstallOptionsBorder" VerticalAlignment="Top">
+                        <Expander x:Name="InstallOptionsExpander"
+                                  HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="Stretch"
+                                  VerticalAlignment="Top"
+                                  IsExpanded="False"
+                                  CornerRadius="8"
+                                  Padding="4">
+                            <Expander.Header>
+                                <Grid ColumnDefinitions="Auto,*,Auto"
+                                      ColumnSpacing="12">
+                                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/options.svg"
+                                                      Width="18" Height="18"
+                                                      VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding LabelInstallationOptions}"
+                                               FontSize="15"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center"/>
+                                    <Button x:Name="InstallOptionsSaveButton"
+                                            Grid.Column="2"
+                                            Content="{Binding LabelSave}"
+                                            Classes="accent"
+                                            Height="32"
+                                            MinWidth="64"
+                                            Padding="12,0"
+                                            CornerRadius="6"
+                                            HorizontalContentAlignment="Center"
+                                            VerticalContentAlignment="Center"/>
+                                </Grid>
+                            </Expander.Header>
+                            <ContentControl x:Name="InstallOptionsHolder"
+                                            Margin="0,8,0,4"/>
+                        </Expander>
                     </Border>
-                </Expander>
+                </StackPanel>
 
-                <!-- ── Dependencies expander ── -->
-                <Expander HorizontalAlignment="Stretch"
-                          HorizontalContentAlignment="Stretch"
-                          IsExpanded="False"
-                          CornerRadius="8"
-                          Padding="4"
-                          Background="{DynamicResource SettingsCardBackground}">
-                    <Expander.Header>
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/id.svg"
-                                              Width="16" Height="16"
-                                              VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding HeaderDeps}"
-                                       FontWeight="SemiBold"
-                                       VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Expander.Header>
+                <!-- Right column: screenshots + details. Reparented to LeftPanel in narrow mode. -->
+                <StackPanel x:Name="RightPanel" Grid.Column="1" Spacing="16" VerticalAlignment="Top">
 
-                    <Border Padding="16,12">
-                        <StackPanel Spacing="4">
-                            <TextBlock Text="{Binding DependencyNote}"
-                                       IsVisible="{Binding HasDependencyNote}"
-                                       Opacity="0.65"/>
-                            <ItemsControl ItemsSource="{Binding Dependencies}"
-                                          IsVisible="{Binding HasDependenciesList}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate x:DataType="vm:DependencyViewModel">
-                                        <TextBlock Text="{Binding DisplayText}"
-                                                   TextWrapping="Wrap"
-                                                   Margin="0,2"/>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-                </Expander>
+                    <!-- ── Screenshots: Carousel + custom pips ── -->
+                    <StackPanel x:Name="ScreenshotsPanel"
+                                VerticalAlignment="Top"
+                                Spacing="8">
+                        <Border CornerRadius="8" ClipToBounds="True"
+                                x:Name="ScreenshotsBorder"
+                                Background="#000000"
+                                Height="320">
+                            <Panel>
+                                <Carousel x:Name="ScreenshotsCarousel"
+                                          IsVisible="{Binding HasScreenshots}"
+                                          ItemsSource="{Binding Screenshots}"
+                                          SelectedIndex="{Binding SelectedScreenshotIndex, Mode=TwoWay}">
+                                    <Carousel.PageTransition>
+                                        <PageSlide Duration="0:0:0.25" Orientation="Horizontal"/>
+                                    </Carousel.PageTransition>
+                                    <Carousel.ItemTemplate>
+                                        <DataTemplate>
+                                            <Image Source="{Binding}"
+                                                   Stretch="Uniform"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"/>
+                                        </DataTemplate>
+                                    </Carousel.ItemTemplate>
+                                </Carousel>
 
-                <!-- ── Release notes expander ── -->
-                <Expander HorizontalAlignment="Stretch"
-                          HorizontalContentAlignment="Stretch"
-                          IsExpanded="False"
-                          CornerRadius="8"
-                          Padding="4"
-                          Background="{DynamicResource SettingsCardBackground}">
-                    <Expander.Header>
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/megaphone.svg"
-                                              Width="16" Height="16"
-                                              VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding HeaderReleaseNotes}"
-                                       FontWeight="SemiBold"
-                                       VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Expander.Header>
+                                <!-- Contributor banner shown when no screenshots -->
+                                <Grid IsVisible="{Binding !HasScreenshots}"
+                                      Background="{DynamicResource AppDialogSubtleBackground}"
+                                      ColumnDefinitions="*,Auto"
+                                      Margin="0"
+                                      ColumnSpacing="12">
+                                    <TextBlock Grid.Column="0"
+                                               Text="{Binding LabelContributorBanner}"
+                                               TextWrapping="Wrap"
+                                               VerticalAlignment="Center"
+                                               Margin="18,12"/>
+                                    <Button Grid.Column="1"
+                                            x:Name="ContributeButton"
+                                            Content="{Binding LabelContribute}"
+                                            VerticalAlignment="Center"
+                                            Margin="0,12,18,12"/>
+                                </Grid>
 
-                    <Border Padding="16,12">
-                        <StackPanel Spacing="10">
+                                <!-- Prev / next overlay chevrons (only when there are screenshots) -->
+                                <Button x:Name="PrevScreenshotButton"
+                                        Classes="carousel-nav"
+                                        HorizontalAlignment="Left"
+                                        Margin="6,0,0,0"
+                                        Content="‹"
+                                        IsVisible="{Binding HasScreenshots}"/>
+                                <Button x:Name="NextScreenshotButton"
+                                        Classes="carousel-nav"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,6,0"
+                                        Content="›"
+                                        IsVisible="{Binding HasScreenshots}"/>
+                            </Panel>
+                        </Border>
 
-                            <TextBlock Text="{Binding ReleaseNotes}"
-                                       TextWrapping="Wrap"/>
+                        <!-- Pip indicator (clickable to jump to a screenshot) -->
+                        <ItemsControl x:Name="ScreenshotPips"
+                                      IsVisible="{Binding HasScreenshots}"
+                                      HorizontalAlignment="Center"
+                                      ItemsSource="{Binding Screenshots}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Button Classes="pip">
+                                        <Ellipse Classes="pip"/>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
 
-                            <Grid ColumnDefinitions="160,*,Auto">
-                                <TextBlock Text="{Binding LabelReleaseNotesUrl}"
-                                           Opacity="0.65" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1"
-                                           Text="{Binding ReleaseNotesUrlText}"
-                                       automation:AutomationProperties.Name="{Binding LabelReleaseNotesUrl}"
-                                           TextTrimming="CharacterEllipsis"
-                                           VerticalAlignment="Center"
-                                           ToolTip.Tip="{Binding ReleaseNotesUrlText}"/>
-                                <Button Grid.Column="2"
-                                        Content="{Binding LabelOpen}"
-                                    automation:AutomationProperties.Name="{Binding LabelReleaseNotesUrl}"
-                                        IsVisible="{Binding HasReleaseNotesUrl}"
-                                        Command="{Binding OpenUrlCommand}"
-                                        CommandParameter="{Binding ReleaseNotesUrlText}"
-                                        Padding="8,3" Margin="8,0,0,0"/>
-                            </Grid>
-
-                        </StackPanel>
-                    </Border>
-                </Expander>
-
-            </StackPanel>
+                    <!-- ── Details: inline rows built in code-behind ── -->
+                    <StackPanel x:Name="DetailsPanel"
+                                VerticalAlignment="Top"
+                                Spacing="6"/>
+                </StackPanel>
+            </Grid>
         </ScrollViewer>
-
-        <!-- ── Footer: close button ── -->
-        <Border Grid.Row="2"
-                BorderThickness="0,1,0,0"
-                Padding="16,10">
-            <Button Content="{Binding LabelClose}"
-                    automation:AutomationProperties.Name="{Binding LabelClose}"
-                    Command="{Binding RequestCloseCommand}"
-                    HorizontalAlignment="Right"
-                    Padding="16,6"/>
-        </Border>
-
     </Grid>
 </Window>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
@@ -1,8 +1,18 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.Avalonia.Views.DialogPages;
+using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Telemetry;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
@@ -15,10 +25,13 @@ namespace UniGetUI.Avalonia.Views;
 
 public partial class PackageDetailsWindow : Window
 {
-    /// <summary>
-    /// True when the user confirmed the main action (install/update/uninstall) without extras.
-    /// Callers check this after ShowDialog() to trigger the default operation.
-    /// </summary>
+    private const double WideThreshold = 950;
+    private const string ContributeUrl = "https://github.com/Devolutions/UniGetUI";
+
+    private enum LayoutMode { Unset, Normal, Wide }
+    private LayoutMode _layoutMode = LayoutMode.Unset;
+
+    /// <summary>True when the user confirmed the main action (install/update/uninstall) without extras.</summary>
     public bool ShouldProceedWithOperation { get; private set; }
 
     private readonly PackageDetailsViewModel _vm;
@@ -32,23 +45,52 @@ public partial class PackageDetailsWindow : Window
         InitializeComponent();
 
         _vm.CloseRequested += (_, _) => Close();
+        _vm.DetailsLoaded += (_, _) =>
+        {
+            BuildBasicInfoInlines();
+            BuildDetailsInlines();
+        };
+        _vm.PropertyChanged += OnVmPropertyChanged;
+        _vm.Screenshots.CollectionChanged += (_, _) => Dispatcher.UIThread.Post(UpdatePips);
 
         MainActionButton.Click += (_, _) => OnMainAction();
         ActionVariantsButton.Flyout = BuildActionFlyout();
         InstallOptionsSaveButton.Click += (_, _) => _ = SaveInstallOptionsAsync();
+        ContributeButton.Click += (_, _) => OpenUrl(ContributeUrl);
+        PrevScreenshotButton.Click += (_, _) =>
+        {
+            if (_vm.SelectedScreenshotIndex > 0)
+                _vm.SelectedScreenshotIndex--;
+        };
+        NextScreenshotButton.Click += (_, _) =>
+        {
+            if (_vm.SelectedScreenshotIndex < _vm.ScreenshotCount - 1)
+                _vm.SelectedScreenshotIndex++;
+        };
+        ScreenshotPips.AddHandler(Button.ClickEvent, OnPipClicked);
+
+        SizeChanged += (_, _) => ApplyLayoutForCurrentSize();
+
+        // Seed inline blocks with loading placeholders.
+        BuildBasicInfoInlines();
+        BuildDetailsInlines();
     }
 
-    protected override async void OnOpened(EventArgs e)
+    protected override void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
+        ApplyLayoutForCurrentSize();
         Dispatcher.UIThread.Post(() => MainActionButton.Focus(), DispatcherPriority.Background);
         _ = _vm.LoadDetailsAsync();
         TelemetryHandler.PackageDetails(_vm.Package, _vm.OperationRole.ToString());
+        _ = InitInstallOptionsAsync();
+    }
 
+    private async Task InitInstallOptionsAsync()
+    {
         _installOpts = await InstallOptionsFactory.LoadForPackageAsync(_vm.Package);
         _installVm = new InstallOptionsViewModel(_vm.Package, _vm.OperationRole, _installOpts);
-        var embed = new InstallOptionsControl();
-        embed.DataContext = _installVm;
+        var embed = new InstallOptionsControl { DataContext = _installVm };
         InstallOptionsHolder.Content = embed;
     }
 
@@ -59,25 +101,329 @@ public partial class PackageDetailsWindow : Window
         await InstallOptionsFactory.SaveForPackageAsync(_installOpts, _vm.Package);
     }
 
+    private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(PackageDetailsViewModel.SelectedScreenshotIndex)
+            || e.PropertyName == nameof(PackageDetailsViewModel.ScreenshotCount))
+            Dispatcher.UIThread.Post(UpdatePips);
+    }
+
+    private void OnPipClicked(object? sender, RoutedEventArgs e)
+    {
+        if (e.Source is not Control src) return;
+        // Walk up to find the pip Button container; ask the ItemsControl for its index.
+        Control? cursor = src;
+        while (cursor is not null && cursor.Parent is not ItemsControl)
+            cursor = cursor.Parent as Control;
+        if (cursor is null) return;
+        int idx = ScreenshotPips.IndexFromContainer(cursor);
+        if (idx >= 0 && idx < _vm.ScreenshotCount)
+            _vm.SelectedScreenshotIndex = idx;
+    }
+
+    private void UpdatePips()
+    {
+        int active = _vm.SelectedScreenshotIndex;
+        int i = 0;
+        foreach (var container in ScreenshotPips.GetRealizedContainers())
+        {
+            // The pip template is <Button><Ellipse/></Button>; the realized container is the Button itself.
+            if (container is Button btn && btn.Content is Ellipse ellipse)
+                ellipse.Classes.Set("active", i == active);
+            i++;
+        }
+    }
+
+    // ── Responsive layout ────────────────────────────────────────────────────
+
+    private void ApplyLayoutForCurrentSize()
+    {
+        var wide = Bounds.Width >= WideThreshold;
+        var mode = wide ? LayoutMode.Wide : LayoutMode.Normal;
+        if (mode == _layoutMode) return;
+        _layoutMode = mode;
+
+        if (mode == LayoutMode.Wide)
+        {
+            // Ensure two columns and the right-column panels live in RightPanel.
+            EnsureChild(RightPanel, ScreenshotsPanel, 0);
+            EnsureChild(RightPanel, DetailsPanel, 1);
+            RightPanel.IsVisible = true;
+            MainGrid.ColumnDefinitions[1].Width = new GridLength(1, GridUnitType.Star);
+
+            ScreenshotsBorder.Height = _vm.HasScreenshots ? 320 : 150;
+            InstallOptionsExpander.IsExpanded = true;
+        }
+        else
+        {
+            // Move screenshots + details into LeftPanel (after install options) and collapse the right column.
+            EnsureChild(LeftPanel, ScreenshotsPanel, LeftPanel.Children.Count);
+            EnsureChild(LeftPanel, DetailsPanel, LeftPanel.Children.Count);
+            RightPanel.IsVisible = false;
+            MainGrid.ColumnDefinitions[1].Width = new GridLength(0);
+
+            ScreenshotsBorder.Height = _vm.HasScreenshots ? 225 : 130;
+            InstallOptionsExpander.IsExpanded = false;
+        }
+    }
+
+    /// <summary>Move <paramref name="child"/> to <paramref name="target"/> at the given index, removing from its old parent first.</summary>
+    private static void EnsureChild(Panel target, Control child, int index)
+    {
+        if (child.Parent is Panel current && current != target)
+            current.Children.Remove(child);
+        if (!target.Children.Contains(child))
+            target.Children.Insert(Math.Min(index, target.Children.Count), child);
+    }
+
+    // ── Per-row layout builders (inline flow like WinUI's RichTextBlock) ─────
+
+    private void BuildBasicInfoInlines()
+    {
+        BasicInfoPanel.Children.Clear();
+
+        if (!string.IsNullOrWhiteSpace(_vm.Description))
+        {
+            BasicInfoPanel.Children.Add(new SelectableTextBlock
+            {
+                Text = _vm.Description,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 8),
+            });
+        }
+
+        AddInlineRow(BasicInfoPanel, _vm.LabelHomepage, _vm.HomepageUrl);
+        AddInlineRow(BasicInfoPanel, _vm.LabelPublisher, _vm.Publisher);
+        AddInlineRow(BasicInfoPanel, _vm.LabelAuthor, _vm.Author);
+        AddLicenseRow(BasicInfoPanel);
+        AddInlineRow(BasicInfoPanel, _vm.LabelUpdateDate, _vm.UpdateDate);
+        AddInlineRow(BasicInfoPanel, _vm.LabelSource, _vm.SourceDisplay);
+    }
+
+    private void BuildDetailsInlines()
+    {
+        DetailsPanel.Children.Clear();
+
+        AddInlineRow(DetailsPanel, _vm.LabelPackageId, _vm.PackageId);
+        AddInlineRow(DetailsPanel, _vm.LabelManifest, _vm.ManifestUrl);
+        AddInlineRow(DetailsPanel, _vm.LabelVersion, _vm.VersionDisplay);
+
+        AddSpacer(DetailsPanel);
+
+        AddInlineRow(DetailsPanel, _vm.LabelInstallerType, _vm.InstallerType);
+        AddInlineRow(DetailsPanel, _vm.LabelInstallerUrl, _vm.InstallerUrl);
+        AddInlineRow(DetailsPanel, _vm.InstallerHashLabel.TrimEnd(':'), _vm.InstallerHash);
+
+        AddDownloadRow(DetailsPanel);
+
+        AddSpacer(DetailsPanel);
+
+        // Dependencies header + list
+        DetailsPanel.Children.Add(new SelectableTextBlock
+        {
+            Text = _vm.LabelDependencies + ":",
+            FontWeight = FontWeight.Bold,
+            Margin = new Thickness(0, 0, 0, 4),
+        });
+        if (_vm.HasDependencyNote)
+        {
+            DetailsPanel.Children.Add(new SelectableTextBlock
+            {
+                Text = "  " + _vm.DependencyNote,
+                Foreground = NotAvailableBrush,
+                Margin = new Thickness(0, 0, 0, 4),
+            });
+        }
+        else
+        {
+            foreach (var dep in _vm.Dependencies)
+            {
+                DetailsPanel.Children.Add(new SelectableTextBlock
+                {
+                    Text = dep.DisplayText,
+                    TextWrapping = TextWrapping.Wrap,
+                });
+            }
+        }
+
+        AddSpacer(DetailsPanel);
+
+        // Release notes
+        DetailsPanel.Children.Add(new SelectableTextBlock
+        {
+            Text = _vm.LabelReleaseNotes + ":",
+            FontWeight = FontWeight.Bold,
+            Margin = new Thickness(0, 0, 0, 4),
+        });
+        DetailsPanel.Children.Add(new SelectableTextBlock
+        {
+            Text = _vm.ReleaseNotes,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 0, 0, 8),
+        });
+        AddInlineRow(DetailsPanel, _vm.LabelReleaseNotesUrl, _vm.ReleaseNotesUrl);
+    }
+
+    private static readonly IBrush NotAvailableBrush =
+        new SolidColorBrush(Color.FromArgb(255, 127, 127, 127));
+
+    private static void AddSpacer(StackPanel host) =>
+        host.Children.Add(new Border { Height = 10 });
+
+    /// <summary>
+    /// Builds a single wrap-able row with "<bold>Label:</bold> value" all on one line,
+    /// matching the WinUI RichTextBlock paragraph layout.
+    /// </summary>
+    private void AddInlineRow(StackPanel host, string label, string value)
+    {
+        var tb = new SelectableTextBlock { TextWrapping = TextWrapping.Wrap };
+        var inlines = tb.Inlines ??= new InlineCollection();
+        inlines.Add(new Run(label + ": ") { FontWeight = FontWeight.Bold });
+        if (string.IsNullOrWhiteSpace(value) || value == _vm.LabelNotAvailable)
+            inlines.Add(new Run(_vm.LabelNotAvailable)
+            {
+                Foreground = NotAvailableBrush,
+                FontStyle = FontStyle.Italic,
+            });
+        else
+            inlines.Add(new Run(value));
+        host.Children.Add(tb);
+    }
+
+    private void AddInlineRow(StackPanel host, string label, Uri? url)
+    {
+        var tb = new SelectableTextBlock { TextWrapping = TextWrapping.Wrap };
+        var inlines = tb.Inlines ??= new InlineCollection();
+        inlines.Add(new Run(label + ": ") { FontWeight = FontWeight.Bold });
+
+        if (url is null)
+        {
+            inlines.Add(new Run(_vm.LabelNotAvailable)
+            {
+                Foreground = NotAvailableBrush,
+                FontStyle = FontStyle.Italic,
+            });
+        }
+        else
+        {
+            inlines.Add(new Run(url.ToString())
+            {
+                Foreground = LinkBrush,
+                TextDecorations = TextDecorations.Underline,
+            });
+            tb.Cursor = new Cursor(StandardCursorType.Hand);
+            tb.PointerPressed += (_, e) =>
+            {
+                if (e.GetCurrentPoint(tb).Properties.IsLeftButtonPressed)
+                    OpenUrl(url.ToString());
+            };
+        }
+        host.Children.Add(tb);
+    }
+
+    private void AddLicenseRow(StackPanel host)
+    {
+        var tb = new SelectableTextBlock { TextWrapping = TextWrapping.Wrap };
+        var inlines = tb.Inlines ??= new InlineCollection();
+        inlines.Add(new Run(_vm.LabelLicense + ": ") { FontWeight = FontWeight.Bold });
+
+        bool hasName = !string.IsNullOrEmpty(_vm.LicenseName);
+        bool hasUrl = _vm.LicenseUrl is not null;
+
+        if (hasName)
+            inlines.Add(new Run(_vm.LicenseName!));
+
+        if (hasUrl)
+        {
+            if (hasName) inlines.Add(new Run(" "));
+            var url = _vm.LicenseUrl!.ToString();
+            inlines.Add(new Run(url)
+            {
+                Foreground = LinkBrush,
+                TextDecorations = TextDecorations.Underline,
+            });
+            tb.Cursor = new Cursor(StandardCursorType.Hand);
+            tb.PointerPressed += (_, e) =>
+            {
+                if (e.GetCurrentPoint(tb).Properties.IsLeftButtonPressed)
+                    OpenUrl(url);
+            };
+        }
+        else if (!hasName)
+        {
+            inlines.Add(new Run(_vm.LabelNotAvailable)
+            {
+                Foreground = NotAvailableBrush,
+                FontStyle = FontStyle.Italic,
+            });
+        }
+
+        host.Children.Add(tb);
+    }
+
+    private void AddDownloadRow(StackPanel host)
+    {
+        var tb = new SelectableTextBlock { TextWrapping = TextWrapping.Wrap };
+        var inlines = tb.Inlines ??= new InlineCollection();
+
+        if (_vm.CanDownloadInstaller && !_vm.IsLoading)
+        {
+            inlines.Add(new Run(_vm.LabelDownloadInstaller)
+            {
+                Foreground = LinkBrush,
+                TextDecorations = TextDecorations.Underline,
+                FontWeight = FontWeight.SemiBold,
+            });
+            if (!string.IsNullOrEmpty(_vm.InstallerSize))
+                inlines.Add(new Run($" ({_vm.InstallerSize})"));
+            tb.Cursor = new Cursor(StandardCursorType.Hand);
+            tb.PointerPressed += (_, e) =>
+            {
+                if (e.GetCurrentPoint(tb).Properties.IsLeftButtonPressed)
+                    DownloadInstaller();
+            };
+        }
+        else
+        {
+            inlines.Add(new Run(_vm.LabelInstallerNotAvailable)
+            {
+                Foreground = NotAvailableBrush,
+                FontStyle = FontStyle.Italic,
+            });
+        }
+        host.Children.Add(tb);
+    }
+
+    private static IBrush LinkBrush =>
+        Application.Current?.Resources["AccentTextFillColorPrimaryBrush"] as IBrush
+        ?? new SolidColorBrush(Color.FromArgb(255, 0, 120, 212));
+
+    private static void OpenUrl(string url)
+    {
+        if (string.IsNullOrEmpty(url) || !url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            return;
+        try { Process.Start(new ProcessStartInfo(url) { UseShellExecute = true }); }
+        catch { }
+    }
+
+    private void DownloadInstaller()
+    {
+        if (!_vm.Package.Manager.Capabilities.CanDownloadInstaller) return;
+        Close();
+        // Hook into the platform's download path if/when wired up. For now, fall back to opening
+        // the installer URL so the user can still grab the file.
+        if (_vm.InstallerUrl is not null)
+            OpenUrl(_vm.InstallerUrl.ToString());
+    }
+
+    // ── Action flyout ────────────────────────────────────────────────────────
+
     private MenuFlyout BuildActionFlyout()
     {
         var flyout = new MenuFlyout();
-
-        var asAdmin = new MenuItem
-        {
-            Header = _vm.AsAdminLabel,
-            IsEnabled = _vm.CanRunAsAdmin,
-        };
-        var interactive = new MenuItem
-        {
-            Header = _vm.InteractiveLabel,
-            IsEnabled = _vm.CanRunInteractively,
-        };
-        var skipOrRemove = new MenuItem
-        {
-            Header = _vm.SkipHashOrRemoveDataLabel,
-            IsEnabled = _vm.CanSkipHashOrRemoveData,
-        };
+        var asAdmin = new MenuItem { Header = _vm.AsAdminLabel, IsEnabled = _vm.CanRunAsAdmin };
+        var interactive = new MenuItem { Header = _vm.InteractiveLabel, IsEnabled = _vm.CanRunInteractively };
+        var skipOrRemove = new MenuItem { Header = _vm.SkipHashOrRemoveDataLabel, IsEnabled = _vm.CanSkipHashOrRemoveData };
 
         var role = _vm.OperationRole;
         if (role is OperationType.Uninstall)
@@ -98,8 +444,6 @@ public partial class PackageDetailsWindow : Window
         flyout.Items.Add(skipOrRemove);
         return flyout;
     }
-
-    // ── Action handlers ────────────────────────────────────────────────────────
 
     private void OnMainAction()
     {


### PR DESCRIPTION
This pull request significantly refactors the `PackageDetailsViewModel` and its associated view to improve separation of concerns, data binding, and UI flexibility. The main changes include switching from text-based to strongly-typed properties for URLs, cleaning up screenshot navigation logic, and moving rich text construction from the view model into the view. Additional improvements include new events and properties to support a more dynamic and maintainable UI.

**UI and View Logic Enhancements**
* Moved rich text and inline construction (for labels, links, and details) out of the view model and into the view (`PackageDetailsWindow.axaml.cs`), supporting more flexible and maintainable UI updates.
* Added event handlers in the view for property changes, screenshot navigation, and the new contribute button, and restructured the initialization to update the UI as soon as data is available.

**Screenshot Navigation Simplification**
* Removed custom command can-execute logic and manual command state updates for screenshot navigation; replaced with simple index bounds checks in the handlers. 
* Removed derived properties for screenshot navigation state and replaced with direct logic in the view. 

**Label and Display Improvements**
* Cleaned up and standardized label properties, removing trailing colons and adding new labels for additional UI elements (e.g., source, download installer, not available). 
* Updated dependency bullet and navigation symbols to use Unicode glyphs for improved appearance. 

**Icon and Resource Loading**
* Improved icon loading logic to handle both file and HTTP(S) URIs, added error logging, and updated to use the new `GetIconUrlIfAny` method.

These changes modernize the package details dialog, making it more robust, maintainable, and ready for future UI improvements.