### PR TITLE
Fix PowerShell 7 updates list silently dropping all modules

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.PowerShell7/InternalsVisibleTo.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell7/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UniGetUI.PackageEngine.Tests")]

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Formats.Asn1;
 using System.Text;
-using System.Text.RegularExpressions;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Classes.Manager;
@@ -81,8 +80,6 @@ namespace UniGetUI.PackageEngine.Managers.PowerShell7Manager
 
         protected override IReadOnlyList<Package> _getInstalledPackages_UnSafe()
         {
-            List<Package> Packages = [];
-
             using Process p = new()
             {
                 StartInfo = new ProcessStartInfo
@@ -91,9 +88,9 @@ namespace UniGetUI.PackageEngine.Managers.PowerShell7Manager
                     Arguments =
                         Status.ExecutableCallArgs
                         + " \"Write-Output '##SCOPE:AllUsers##';"
-                        + " Get-InstalledPSResource -Scope AllUsers | Format-Table -Property Name,Version,Repository;"
+                        + " Get-InstalledPSResource -Scope AllUsers | ForEach-Object { $_.Name + [char]9 + $_.Version + [char]9 + $_.Repository };"
                         + " Write-Output '##SCOPE:CurrentUser##';"
-                        + " Get-InstalledPSResource -Scope CurrentUser | Format-Table -Property Name,Version,Repository\"",
+                        + " Get-InstalledPSResource -Scope CurrentUser | ForEach-Object { $_.Name + [char]9 + $_.Version + [char]9 + $_.Repository }\"",
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
@@ -110,50 +107,59 @@ namespace UniGetUI.PackageEngine.Managers.PowerShell7Manager
 
             p.Start();
             string? line;
-            bool DashesPassed = false;
-            string currentScope = "AllUsers";
+            List<string> outputLines = [];
             while ((line = p.StandardOutput.ReadLine()) is not null)
             {
                 logger.AddToStdOut(line);
-                if (line.StartsWith("##SCOPE:"))
-                {
-                    currentScope = line.Trim('#').Split(':')[1];
-                    DashesPassed = false;
-                    continue;
-                }
-
-                if (!DashesPassed)
-                {
-                    if (line.Contains("-----"))
-                        DashesPassed = true;
-                }
-                else
-                {
-                    string[] elements = Regex.Replace(line, " {2,}", " ").Split(' ');
-                    if (elements.Length < 3)
-                        continue;
-
-                    for (int i = 0; i < elements.Length; i++)
-                        elements[i] = elements[i].Trim();
-
-                    Packages.Add(
-                        new Package(
-                            CoreTools.FormatAsName(elements[0]),
-                            elements[0],
-                            elements[1],
-                            SourcesHelper.Factory.GetSourceOrDefault(elements[2]),
-                            this,
-                            new(currentScope == "CurrentUser" ? PackageScope.User : PackageScope.Machine)
-                        )
-                    );
-                }
+                outputLines.Add(line);
             }
 
             logger.AddToStdErr(p.StandardError.ReadToEnd());
             p.WaitForExit();
             logger.Close(p.ExitCode);
 
-            return Packages;
+            return ParseInstalledPackages(outputLines, this);
+        }
+
+        internal static IReadOnlyList<Package> ParseInstalledPackages(
+            IEnumerable<string> outputLines,
+            PowerShell7 manager
+        )
+        {
+            List<Package> packages = [];
+            string currentScope = "AllUsers";
+
+            foreach (string line in outputLines)
+            {
+                if (line.StartsWith("##SCOPE:"))
+                {
+                    currentScope = line.Trim('#').Split(':')[1];
+                    continue;
+                }
+
+                string[] elements = line.Split('\t');
+                if (elements.Length < 3)
+                    continue;
+
+                for (int i = 0; i < elements.Length; i++)
+                    elements[i] = elements[i].Trim();
+
+                if (elements[0].Length == 0)
+                    continue;
+
+                packages.Add(
+                    new Package(
+                        CoreTools.FormatAsName(elements[0]),
+                        elements[0],
+                        elements[1],
+                        manager.SourcesHelper.Factory.GetSourceOrDefault(elements[2]),
+                        manager,
+                        new(currentScope == "CurrentUser" ? PackageScope.User : PackageScope.Machine)
+                    )
+                );
+            }
+
+            return packages;
         }
 
         protected override bool UseSubstringSearch => true;

--- a/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
@@ -1,0 +1,105 @@
+#if WINDOWS
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Managers.PowerShell7Manager;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class PowerShell7ManagerTests
+{
+    [Fact]
+    public void ParseInstalledPackages_BuildsPackagesFromTabDelimitedOutput()
+    {
+        var manager = new PowerShell7();
+
+        var packages = PowerShell7.ParseInstalledPackages(
+            [
+                "##SCOPE:AllUsers##",
+                "Pester\t5.7.1\tPSGallery",
+                "##SCOPE:CurrentUser##",
+                "PSReadLine\t2.2.5\tPSGallery",
+            ],
+            manager
+        );
+
+        Assert.Collection(
+            packages,
+            package =>
+            {
+                Assert.Equal("Pester", package.Id);
+                Assert.Equal("5.7.1", package.VersionString);
+                Assert.Equal("PSGallery", package.Source.Name);
+                Assert.Equal(PackageScope.Machine, package.OverridenOptions.Scope);
+            },
+            package =>
+            {
+                Assert.Equal("PSReadLine", package.Id);
+                Assert.Equal("2.2.5", package.VersionString);
+                Assert.Equal("PSGallery", package.Source.Name);
+                Assert.Equal(PackageScope.User, package.OverridenOptions.Scope);
+            }
+        );
+    }
+
+    [Fact]
+    public void ParseInstalledPackages_SkipsBlankAndMalformedLines()
+    {
+        var manager = new PowerShell7();
+
+        var package = Assert.Single(
+            PowerShell7.ParseInstalledPackages(
+                [
+                    "##SCOPE:AllUsers##",
+                    "",
+                    "not-enough-columns",
+                    "only\ttwo",
+                    "\t\t",
+                    "Pester\t5.7.1\tPSGallery",
+                ],
+                manager
+            )
+        );
+
+        Assert.Equal("Pester", package.Id);
+    }
+
+    // Regression for https://github.com/Devolutions/UniGetUI/issues/4781:
+    // the previous Format-Table-based pipeline truncated long names (e.g.
+    // "Microsoft.Graph.Beta.DeviceManagement.Administration" → "Microsoft.Graph.Beta..")
+    // which then poisoned the GetUpdates() URL sent to PSGallery, returning
+    // NotFound and silently dropping every PS7 update from the list.
+    [Fact]
+    public void ParseInstalledPackages_PreservesLongNamesAndVersionsVerbatim()
+    {
+        var manager = new PowerShell7();
+
+        var packages = PowerShell7.ParseInstalledPackages(
+            [
+                "##SCOPE:CurrentUser##",
+                "Microsoft.Graph.Beta.DeviceManagement.Administration\t2.34.0\tPSGallery",
+                "Az.RedisEnterpriseCache\t1.6.0\tPSGallery",
+                "Microsoft.PowerShell.SecretManagement\t1.1.2\tPSGallery",
+            ],
+            manager
+        );
+
+        Assert.Collection(
+            packages,
+            package =>
+            {
+                Assert.Equal("Microsoft.Graph.Beta.DeviceManagement.Administration", package.Id);
+                Assert.Equal("2.34.0", package.VersionString);
+            },
+            package =>
+            {
+                Assert.Equal("Az.RedisEnterpriseCache", package.Id);
+                Assert.Equal("1.6.0", package.VersionString);
+            },
+            package =>
+            {
+                Assert.Equal("Microsoft.PowerShell.SecretManagement", package.Id);
+                Assert.Equal("1.1.2", package.VersionString);
+            }
+        );
+    }
+}
+#endif

--- a/src/UniGetUI.PackageEngine.Tests/UniGetUI.PackageEngine.Tests.csproj
+++ b/src/UniGetUI.PackageEngine.Tests/UniGetUI.PackageEngine.Tests.csproj
@@ -43,6 +43,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == '$(WindowsTargetFramework)'">
         <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Chocolatey\UniGetUI.PackageEngine.Managers.Chocolatey.csproj" />
         <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.PowerShell\UniGetUI.PackageEngine.Managers.PowerShell.csproj" />
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.PowerShell7\UniGetUI.PackageEngine.Managers.PowerShell7.csproj" />
         <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Scoop\UniGetUI.PackageEngine.Managers.Scoop.csproj" />
         <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.WinGet\UniGetUI.PackageEngine.Managers.WinGet.csproj" />
     </ItemGroup>


### PR DESCRIPTION
## Problem

PowerShell 7 modules never show up on the Updates page for users with large module sets. When the user searches an installed module, UniGetUI incorrectly reports both PS5 and PS7 versions as up-to-date even when a newer version exists on PowerShellGallery.

The PS7 `ListUpdates` task fails completely with a NotFound response from `https://www.powershellgallery.com/api/v2/GetUpdates()...`, so the updates list comes back empty and every installed PS7 module looks current.

  ## Fix                                                                                                                                                                       
                                                                                                                                                                               
  Replace the `Format-Table` pipeline with a property-level projection:                                                                                                        
                                                                                                                                                                               
  ```powershell                                                                                                                                                                
  Get-InstalledPSResource -Scope <scope> |                                                                                                                                     
      ForEach-Object { $_.Name + [char]9 + $_.Version + [char]9 + $_.Repository }                                                                                              
  ```                                                                                                                                                                             
  This emits tab-delimited rows directly from object properties — no formatter, no buffer width, no truncation, regardless of module count. The parser is updated to split on \t and the now-unneeded header/dashes handling is removed. 

fix #4781