### PR TITLE
fix update of Portable packages

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -94,7 +94,7 @@
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.6.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.7.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -109,16 +109,22 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
 
             if (!usePinget)
             {
-                if (options.CustomInstallLocation != "")
+                // For portable packages, always preserve the actual current install
+                // location read from the registry. A stale CustomInstallLocation in the
+                // saved InstallOptions would otherwise leave --location off and cause
+                // WinGet to uninstall the portable from its custom path and reinstall to
+                // the default portable root, silently deleting the original directory.
+                var detectedLocation = TryGetPortableInstallLocation(package);
+                if (detectedLocation is not null)
                 {
-                    if (Settings.Get(Settings.K.WinGetForceLocationOnUpdate))
-                        parameters.AddRange(["--location", $"\"{options.CustomInstallLocation}\""]);
+                    parameters.AddRange(["--location", $"\"{detectedLocation}\""]);
                 }
-                else
+                else if (
+                    options.CustomInstallLocation != ""
+                    && Settings.Get(Settings.K.WinGetForceLocationOnUpdate)
+                )
                 {
-                    var detectedLocation = TryGetPortableInstallLocation(package);
-                    if (detectedLocation is not null)
-                        parameters.AddRange(["--location", $"\"{detectedLocation}\""]);
+                    parameters.AddRange(["--location", $"\"{options.CustomInstallLocation}\""]);
                 }
             }
         }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Pinget.Core" Version="0.6.0" />
+        <PackageReference Include="Devolutions.Pinget.Core" Version="0.7.0" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
     </ItemGroup>
 </Project>

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -221,7 +221,7 @@
         <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.6.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.7.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
 
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>


### PR DESCRIPTION
This pull request updates several dependencies to newer versions and improves how custom install locations are handled for portable packages during updates operations with WinGet. The most significant functional change ensures that portable packages are updated from their actual install location, preventing accidental data loss.

Dependency updates:

* Updated `Devolutions.Pinget.Cli.Rust` package to version 0.7.0 in `UniGetUI.Avalonia.csproj` and `UniGetUI.csproj`. 
* Updated `Devolutions.Pinget.Core` package to version 0.7.0 in `UniGetUI.PackageEngine.Managers.WinGet.csproj`.

Improvements to portable package uninstall logic:

* Modified `WinGetPkgOperationHelper.cs` to always use the detected install location from the registry for portable packages during uninstall, preventing WinGet from reinstalling to the default location and deleting the original directory. If the detected location is unavailable, it falls back to the custom install location if forced by settings.

#4823
