### PR TITLE
Fix update banner display issue for successful updates

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -134,18 +134,18 @@ internal static partial class AvaloniaAutoUpdater
         }
     }
 
-    // Persists the current buffer to _updateLogPath. Caller MUST hold _updateLogLock.
-    // Failures are silently swallowed — a missing log file should never break the
-    // update flow itself.
+    // Tmp + rename so a kill mid-flush (installer terminates us during file replacement) can't leave a 0-byte file.
     private static void FlushUpdateLogToDiskNoLock()
     {
         if (_updateLogBuilder is null) return;
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_updateLogPath)!);
-            File.WriteAllText(_updateLogPath, _updateLogBuilder.ToString());
+            string tempPath = _updateLogPath + ".tmp";
+            File.WriteAllText(tempPath, _updateLogBuilder.ToString());
+            File.Move(tempPath, _updateLogPath, overwrite: true);
         }
-        catch { /* see comment above */ }
+        catch { }
     }
 
     private const string AttemptFinishedMarker = "=== Attempt finished:";
@@ -213,9 +213,15 @@ internal static partial class AvaloniaAutoUpdater
                 }
             }
 
-            if (targetVer is not null && targetVer == currentVer)
+            if (targetVer is null)
             {
-                Logger.Info($"Previous update attempt killed mid-flow but install succeeded (running version {currentVer} matches target). Marking as finished.");
+                Logger.Info("Update log has no recorded target version; skipping orphan-attempt banner.");
+                return;
+            }
+
+            if (VersionsMatch(targetVer, currentVer))
+            {
+                Logger.Info($"Previous update attempt killed mid-flow but install succeeded (running version {currentVer} matches target {targetVer}). Marking as finished.");
                 try
                 {
                     File.AppendAllText(
@@ -226,7 +232,7 @@ internal static partial class AvaloniaAutoUpdater
                 return;
             }
 
-            Logger.Warn($"Detected interrupted update attempt. Running={currentVer}, Target={targetVer ?? "(unknown)"}");
+            Logger.Warn($"Detected interrupted update attempt. Running={currentVer}, Target={targetVer}");
 
             RaiseStatus(
                 CoreTools.Translate("Your last update attempt did not complete."),
@@ -1218,6 +1224,21 @@ internal static partial class AvaloniaAutoUpdater
 
         LogUpdateWarn($"Could not parse version '{raw}', using fallback '{fallback}'");
         return fallback;
+    }
+
+    // Normalize trailing zero components so "2026.1.11" and "2026.1.11.0" compare equal.
+    private static bool VersionsMatch(string a, string b)
+    {
+        string sa = a.Trim().TrimStart('v', 'V');
+        string sb = b.Trim().TrimStart('v', 'V');
+
+        if (Version.TryParse(sa, out Version? va) && Version.TryParse(sb, out Version? vb))
+        {
+            return CoreTools.NormalizeVersionForComparison(va)
+                .Equals(CoreTools.NormalizeVersionForComparison(vb));
+        }
+
+        return string.Equals(sa, sb, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string NormalizeThumbprint(string thumbprint) =>

--- a/src/UniGetUI/AutoUpdater.Helpers.cs
+++ b/src/UniGetUI/AutoUpdater.Helpers.cs
@@ -129,6 +129,21 @@ public partial class AutoUpdater
         return fallbackVersion;
     }
 
+    // Normalize trailing zero components so "2026.1.11" and "2026.1.11.0" compare equal.
+    internal static bool VersionsMatch(string a, string b)
+    {
+        string sa = a.Trim().TrimStart('v', 'V');
+        string sb = b.Trim().TrimStart('v', 'V');
+
+        if (Version.TryParse(sa, out Version? va) && Version.TryParse(sb, out Version? vb))
+        {
+            return CoreTools.NormalizeVersionForComparison(va)
+                .Equals(CoreTools.NormalizeVersionForComparison(vb));
+        }
+
+        return string.Equals(sa, sb, StringComparison.OrdinalIgnoreCase);
+    }
+
     internal static string NormalizeThumbprint(string thumbprint)
     {
         char[] normalized = thumbprint.ToLowerInvariant().Where(char.IsAsciiHexDigit).ToArray();

--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -76,18 +76,18 @@ public partial class AutoUpdater
         }
     }
 
-    // Persists the current buffer to _updateLogPath. Caller MUST hold _updateLogLock.
-    // Failures are silently swallowed — a missing log file should never break the
-    // update flow itself.
+    // Tmp + rename so a kill mid-flush (installer terminates us during file replacement) can't leave a 0-byte file.
     private static void FlushUpdateLogToDiskNoLock()
     {
         if (_updateLogBuilder is null) return;
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_updateLogPath)!);
-            File.WriteAllText(_updateLogPath, _updateLogBuilder.ToString());
+            string tempPath = _updateLogPath + ".tmp";
+            File.WriteAllText(tempPath, _updateLogBuilder.ToString());
+            File.Move(tempPath, _updateLogPath, overwrite: true);
         }
-        catch { /* see comment above */ }
+        catch { }
     }
 
     private const string AttemptFinishedMarker = "=== Attempt finished:";
@@ -149,9 +149,15 @@ public partial class AutoUpdater
                 }
             }
 
-            if (targetVer is not null && targetVer == currentVer)
+            if (targetVer is null)
             {
-                Logger.Info($"Previous update attempt killed mid-flow but install succeeded (running version {currentVer} matches target). Marking as finished.");
+                Logger.Info("Update log has no recorded target version; skipping orphan-attempt banner.");
+                return;
+            }
+
+            if (VersionsMatch(targetVer, currentVer))
+            {
+                Logger.Info($"Previous update attempt killed mid-flow but install succeeded (running version {currentVer} matches target {targetVer}). Marking as finished.");
                 try
                 {
                     File.AppendAllText(
@@ -162,7 +168,7 @@ public partial class AutoUpdater
                 return;
             }
 
-            Logger.Warn($"Detected interrupted update attempt. Running={currentVer}, Target={targetVer ?? "(unknown)"}");
+            Logger.Warn($"Detected interrupted update attempt. Running={currentVer}, Target={targetVer}");
 
             ShowMessage_ThreadSafe(
                 CoreTools.Translate("Your last update attempt did not complete."),


### PR DESCRIPTION
This pull request improves the reliability and correctness of the update logging and orphaned update detection logic in both `UniGetUI` and `UniGetUI.Avalonia`. The changes ensure that update log files are written atomically to prevent corruption, enhance version comparison logic to handle version strings with trailing zeros, and improve the clarity of log messages during orphaned update detection.

**Version comparison improvements:**
- Introduced a new `VersionsMatch` method in both codebases to normalize version strings (e.g., treating "2026.1.11" and "2026.1.11.0" as equal), improving the accuracy of update attempt status checks. 

**Orphaned update attempt detection and logging:**
- Updated the orphaned update detection logic to:
  - Properly handle cases where no target version is recorded, skipping unnecessary warnings. 
  - Use the new `VersionsMatch` method for more robust version equality checks. [
  - Improve warning and info log messages for better clarity and context. 