### PR TITLE
Fill Avalonia executable properties

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -111,6 +111,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
       <Compile Include="..\Shared\SharedPreUiCommandDispatcher.cs" Link="Shared\SharedPreUiCommandDispatcher.cs" />
     </ItemGroup>
 


### PR DESCRIPTION
This pull request makes a minor update to the project file by including a shared assembly info file for compilation. This helps ensure that shared assembly metadata is available to the project.

* Added `..\SharedAssemblyInfo.cs` to the list of compiled files in `UniGetUI.Avalonia.csproj`, linking it as `SharedAssemblyInfo.cs` for shared assembly metadata.

issue #4827