### PR TITLE
bump pinget to 0.8.2

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -121,7 +121,7 @@
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.8.1" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.8.2" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Pinget.Core" Version="0.8.1" />
+        <PackageReference Include="Devolutions.Pinget.Core" Version="0.8.2" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
     </ItemGroup>
 </Project>

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -221,7 +221,7 @@
         <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.8.1" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.8.2" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
 
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>


### PR DESCRIPTION
This pull request updates dependency versions for Devolutions Pinget packages across several project files to ensure the use of the latest bug fixes and improvements.

Dependency updates:

* Upgraded `Devolutions.Pinget.Cli.Rust` from version `0.8.1` to `0.8.2` in `UniGetUI.Avalonia.csproj` and `UniGetUI.csproj` to incorporate the latest changes.
* Upgraded `Devolutions.Pinget.Core` from version `0.8.1` to `0.8.2` in `UniGetUI.PackageEngine.Managers.WinGet.csproj`.
