### PR TITLE
Fix notification functionality in Avalonia

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -32,8 +32,8 @@ internal static class WindowsAppNotificationBridge
 
     private static readonly string[] _assemblyCandidates =
     {
-        "Microsoft.Windows.AppNotifications",
-        "Microsoft.WindowsAppSDK",
+        "Microsoft.Windows.AppNotifications.Projection",
+        "Microsoft.Windows.AppNotifications.Builder.Projection",
     };
 
     public static bool ShowProgress(AbstractOperation operation)
@@ -384,9 +384,6 @@ internal static class WindowsAppNotificationBridge
                     return _isRegistered;
                 }
 
-                managerType.GetMethod("Register", BindingFlags.Public | BindingFlags.Instance)
-                    ?.Invoke(_managerDefault, null);
-
                 _removeByTagAsyncMethod = managerType.GetMethod(
                     "RemoveByTagAsync",
                     BindingFlags.Public | BindingFlags.Instance,
@@ -415,6 +412,14 @@ internal static class WindowsAppNotificationBridge
                     var lambda = Expression.Lambda(handlerType, body, invokeParams);
                     notifEventInfo.AddEventHandler(_managerDefault, lambda.Compile());
                 }
+
+                managerType.GetMethod(
+                    "Register",
+                    BindingFlags.Public | BindingFlags.Instance,
+                    binder: null,
+                    types: Type.EmptyTypes,
+                    modifiers: null)
+                    ?.Invoke(_managerDefault, null);
 
                 _isRegistered = _showMethod is not null;
             }
@@ -495,9 +500,19 @@ internal static class WindowsAppNotificationBridge
 
     private static object InvokeFluent(object instance, string methodName, params object?[] args)
     {
-        return instance.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)
-            ?.Invoke(instance, args)
-            ?? instance;
+        Type type = instance.GetType();
+        Type[] argTypes = args.Select(a => a?.GetType() ?? typeof(object)).ToArray();
+
+        MethodInfo? method = type.GetMethod(
+                methodName,
+                BindingFlags.Public | BindingFlags.Instance,
+                binder: null,
+                types: argTypes,
+                modifiers: null)
+            ?? type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(m => m.Name == methodName && m.GetParameters().Length == args.Length);
+
+        return method?.Invoke(instance, args) ?? instance;
     }
 
     private static void SetPropertyIfPresent(object instance, string propertyName, object value)

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -30,6 +30,22 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <WindowsPackageType>None</WindowsPackageType>
+        <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+        <EnableCoreMrtTooling>false</EnableCoreMrtTooling>
+        <NoWarn>$(NoWarn);MVVMTK0045</NoWarn>
+        <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'arm64'">win-arm64</RuntimeIdentifier>
+        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and ('$(Platform)' == 'x64' or '$(Platform)' == 'x86')">win-$(Platform)</RuntimeIdentifier>
+        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
+    </PropertyGroup>
+
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <PingetCliRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</PingetCliRuntimeIdentifier>
         <PingetCliRuntimeIdentifier Condition="'$(PingetCliRuntimeIdentifier)' == '' and '$(Platform)' == 'arm64'">win-arm64</PingetCliRuntimeIdentifier>
         <PingetCliRuntimeIdentifier Condition="'$(PingetCliRuntimeIdentifier)' == ''">win-x64</PingetCliRuntimeIdentifier>


### PR DESCRIPTION
 ### Summary                                                                                                                                                                  
System (toast) notifications never appeared in the Avalonia app, while they work in the WinUI build. This wires the Windows App SDK into the Avalonia project and fixes the reflection bridge so toasts fire for the same events WinUI covers. #4861

### Changes
  - **csproj:** reference `Microsoft.WindowsAppSDK` 1.7 (Windows-only), mirroring  WinUI's unpackaged/self-contained setup; add `BuiltInComInteropSupport=true` (needed for WinRT activation), `EnableCoreMrtTooling=false` (drops the VS-only MSIX/PRI tooling that broke CLI builds), and suppress the `MVVMTK0045` CsWinRT false-positive.                                                                                                                                                            
  - **bridge:** fix the projection assembly names; resolve the parameterless `Register()` overload; subscribe to `NotificationInvoked` before `Register()`; and resolve builder overloads (e.g. `AddText`) by argument type.

### Coverage                                                                                                                                                                 
Achieves parity with WinUI — operation progress/success/error, updates-available, upgrading-packages, self-update-available, and new-desktop-shortcuts notifications, plus toast click/button actions. Windows uses the App SDK bridge; macOS uses the existing osascript bridge; Linux falls back to the in-app banner (unchanged).