### PR TITLE
Fix update-list loading messages, transparent tray menu, and search box text clipping

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
@@ -25,7 +25,7 @@
             <SolidColorBrush x:Key="AppDialogPanelBackground"    Color="#80FFFFFF"/>
             <SolidColorBrush x:Key="AppDialogSubtleBackground"   Color="#80FFFFFF"/>
             <SolidColorBrush x:Key="AppDialogDarkBackground"     Color="#80FFFFFF"/>
-            <!-- Flyouts / menus / dropdowns / tooltips: DWM Mica backdrop with the card tint over it -->
+            <!-- Flyouts / menus / dropdowns / tooltips: DWM acrylic backdrop with the card tint over it -->
             <SolidColorBrush x:Key="FlyoutPresenterBackground"     Color="#80FFFFFF"/>
             <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="#80FFFFFF"/>
             <SolidColorBrush x:Key="ComboBoxDropDownBackground"    Color="#80FFFFFF"/>
@@ -61,8 +61,8 @@
             <SolidColorBrush x:Key="AppDialogPanelBackground"    Color="#662C2C2C"/>
             <SolidColorBrush x:Key="AppDialogSubtleBackground"   Color="#66393939"/>
             <SolidColorBrush x:Key="AppDialogDarkBackground"     Color="#66181818"/>
-            <!-- Flyouts / menus / dropdowns / tooltips: MicaWindowHelper gives the popup window the same
-                 DWM Mica backdrop the app uses; this tint matches the cards so menus read identically -->
+            <!-- Flyouts / menus / dropdowns / tooltips: MicaWindowHelper gives the popup window a DWM
+                 acrylic backdrop (transient surfaces can't use Mica); this tint matches the cards -->
             <SolidColorBrush x:Key="FlyoutPresenterBackground"     Color="#662D2D2D"/>
             <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="#662D2D2D"/>
             <SolidColorBrush x:Key="ComboBoxDropDownBackground"    Color="#662D2D2D"/>

--- a/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
@@ -21,7 +21,8 @@ internal static class MicaWindowHelper
     private const int DWMWA_BORDER_COLOR = 34;
     private const int DWMWA_SYSTEMBACKDROP_TYPE = 38;
     private const int DWMWCP_ROUND = 2;
-    private const int DWMSBT_MAINWINDOW = 2; // Mica — same backdrop as the rest of the app, so menus match
+    private const int DWMSBT_MAINWINDOW = 2; // Mica — for long-lived windows (dialogs)
+    private const int DWMSBT_TRANSIENTWINDOW = 3; // Acrylic — for transient surfaces (menus/flyouts); Mica won't paint on these
     private const int DWMWA_COLOR_DEFAULT = unchecked((int)0xFFFFFFFF);
 
     private static bool _acrylicPopupsHooked;
@@ -69,15 +70,28 @@ internal static class MicaWindowHelper
             return;
         _acrylicPopupsHooked = true;
 
-        // Every flyout/menu/tooltip/combo popup is hosted in a PopupRoot; style it as it loads.
+        // In-app flyouts/menus/tooltips/combo popups are hosted in a PopupRoot; style each as it loads.
         Control.LoadedEvent.AddClassHandler<PopupRoot>((root, _) => ApplyAcrylicToPopup(root));
+
+        // The system-tray context menu is NOT a PopupRoot — Avalonia hosts it in its own Window
+        // (Avalonia.Win32.TrayIconImpl.TrayPopupRoot), so it misses the handler above and would
+        // render with no backdrop (transparent over the desktop). Catch it by type name and apply
+        // the same acrylic treatment. The other Windows (MainWindow/dialogs) are handled via Apply().
+        Control.LoadedEvent.AddClassHandler<Window>((win, _) =>
+        {
+            if (win.GetType().Name == "TrayPopupRoot")
+                ApplyAcrylicToPopup(win);
+        });
     }
 
-    private static void ApplyAcrylicToPopup(PopupRoot root)
+    private static void ApplyAcrylicToPopup(TopLevel root)
     {
-        // Transparent surface so the DWM acrylic shows; the presenter backgrounds are also
-        // transparent (Styles.WindowsMica) so only the acrylic + menu items are painted.
-        root.TransparencyLevelHint = new[] { WindowTransparencyLevel.Transparent };
+        // Request acrylic (not Transparent): the Transparent level makes a layered window, and DWM
+        // system backdrops never paint on those — so the popup ended up fully see-through with only
+        // the presenter tint, unreadable when shown over the desktop (e.g. the tray menu). AcrylicBlur
+        // gives a composited window DWM can actually fill. This path only runs when Mica is enabled
+        // (Win11 + transparency effects), so acrylic is always available here.
+        root.TransparencyLevelHint = new[] { WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Blur };
         root.Background = Brushes.Transparent;
 
         if (root.TryGetPlatformHandle()?.Handle is not { } handle || handle == 0)
@@ -85,7 +99,7 @@ internal static class MicaWindowHelper
 
         int corner = DWMWCP_ROUND;
         NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
-        int backdrop = DWMSBT_MAINWINDOW;
+        int backdrop = DWMSBT_TRANSIENTWINDOW;
         NativeMethods.DwmSetWindowAttribute(handle, DWMWA_SYSTEMBACKDROP_TYPE, ref backdrop, sizeof(int));
     }
 

--- a/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
@@ -21,7 +21,6 @@ internal static class MicaWindowHelper
     private const int DWMWA_BORDER_COLOR = 34;
     private const int DWMWA_SYSTEMBACKDROP_TYPE = 38;
     private const int DWMWCP_ROUND = 2;
-    private const int DWMSBT_MAINWINDOW = 2; // Mica — for long-lived windows (dialogs)
     private const int DWMSBT_TRANSIENTWINDOW = 3; // Acrylic — for transient surfaces (menus/flyouts); Mica won't paint on these
     private const int DWMWA_COLOR_DEFAULT = unchecked((int)0xFFFFFFFF);
 

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -126,6 +126,7 @@ public partial class PackagesPageViewModel : ViewModelBase
     public readonly bool MegaQueryBoxEnabled;
     public readonly bool DisableFilterOnQueryChange;
     public readonly bool DisableReload;
+    public readonly bool LoadsOnStart;
     public readonly bool RoleIsUpdateLike;
     public bool SimilarSearchEnabled { get; private set; }
     public readonly string NoPackagesText;
@@ -206,6 +207,7 @@ public partial class PackagesPageViewModel : ViewModelBase
         DisableFilterOnQueryChange = data.DisableFilterOnQueryChange;
         MegaQueryBoxEnabled = data.MegaQueryBlockEnabled;
         DisableReload = data.DisableReload;
+        LoadsOnStart = !data.DisableAutomaticPackageLoadOnStart;
         _showLastCheckedTime = data.ShowLastLoadTime;
         NoPackagesText = data.NoPackages_BackgroundText;
         NoMatchesText = data.NoMatches_BackgroundText;
@@ -516,12 +518,17 @@ public partial class PackagesPageViewModel : ViewModelBase
         UpdateSubtitle();
         PackageCountUpdated?.Invoke();
 
-        if (FilteredPackages.Count == 0)
+        bool loadingOrPending = Loader.IsLoading || (LoadsOnStart && !Loader.IsLoaded);
+
+        if (loadingOrPending && FilteredPackages.Count == 0)
         {
-            // Don't show the "no packages" message while a reload is in progress; the list is
-            // momentarily empty and the message would flash misleadingly.
+            BackgroundText = _stillLoadingSubtitle;
+            BackgroundTextVisible = true;
+        }
+        else if (FilteredPackages.Count == 0)
+        {
             BackgroundText = string.IsNullOrWhiteSpace(query) ? NoPackagesText : NoMatchesText;
-            BackgroundTextVisible = !Loader.IsLoading && (!MegaQueryBoxEnabled || !string.IsNullOrWhiteSpace(query));
+            BackgroundTextVisible = !MegaQueryBoxEnabled || !string.IsNullOrWhiteSpace(query);
         }
         else
         {
@@ -828,7 +835,7 @@ public partial class PackagesPageViewModel : ViewModelBase
     // ─── Subtitle ─────────────────────────────────────────────────────────────
     public void UpdateSubtitle()
     {
-        if (Loader.IsLoading)
+        if (Loader.IsLoading || (LoadsOnStart && !Loader.IsLoaded))
         {
             Subtitle = _stillLoadingSubtitle;
             return;

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -518,8 +518,10 @@ public partial class PackagesPageViewModel : ViewModelBase
 
         if (FilteredPackages.Count == 0)
         {
+            // Don't show the "no packages" message while a reload is in progress; the list is
+            // momentarily empty and the message would flash misleadingly.
             BackgroundText = string.IsNullOrWhiteSpace(query) ? NoPackagesText : NoMatchesText;
-            BackgroundTextVisible = !MegaQueryBoxEnabled || !string.IsNullOrWhiteSpace(query);
+            BackgroundTextVisible = !Loader.IsLoading && (!MegaQueryBoxEnabled || !string.IsNullOrWhiteSpace(query));
         }
         else
         {
@@ -533,7 +535,6 @@ public partial class PackagesPageViewModel : ViewModelBase
         if (!Loader.IsLoading && (!Loader.IsLoaded
             || reason is ReloadReason.External or ReloadReason.Manual or ReloadReason.Automated))
         {
-            Loader.ClearPackages(emitFinishSignal: false);
             await Loader.ReloadPackages();
         }
     }

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -362,6 +362,8 @@
                              FontSize="15"
                              CornerRadius="0"
                              BorderThickness="0"
+                             VerticalContentAlignment="Center"
+                             Padding="8,0,4,0"
                              Background="Transparent"
                              PlaceholderText="{Binding GlobalSearchPlaceholder}"
                              IsEnabled="{Binding GlobalSearchEnabled}"

--- a/src/UniGetUI.PackageEngine.PackageLoader/AbstractPackageLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/AbstractPackageLoader.cs
@@ -144,11 +144,16 @@ namespace UniGetUI.PackageEngine.PackageLoader
                     return;
                 }
 
-                ClearPackages(emitFinishSignal: false);
                 LoadOperationIdentifier = new Random().Next();
                 int current_identifier = LoadOperationIdentifier;
                 IsLoading = true;
                 StartedLoading?.Invoke(this, EventArgs.Empty);
+
+                // Clear packages only after signaling the load started, so the UI shows the
+                // loading state instead of briefly flashing the "no packages found" message.
+                PackageReference.Clear();
+                IsLoaded = false;
+                InvokePackagesChangedEvent(false, [], []);
 
                 if (REQUIRES_INTERNET)
                 {

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -697,7 +697,6 @@ namespace UniGetUI.Interface
                 )
             )
             {
-                Loader.ClearPackages(emitFinishSignal: false);
                 await Loader.ReloadPackages();
             }
         }


### PR DESCRIPTION
Fixes three small UI bugs in UniGetUI, one reported in #4867 and two found alongside it.

### Don't flash "Hooray! No updates were found" during reload                                                                                                                                                                                                                                                                                   
When reloading a package list, the list cleared before the loading indicator turned on, so the empty-state logic briefly showed the "no packages found" message before results repopulated.                                                                                                                                                         

 ### Fix transparent tray context menu under Mica
The Win11 Mica/acrylic work made the system-tray context menu render almost fully transparent (text visible, no background) — unreadable over the desktop.

 ### Fix global search box clipping the bottom of its text
 The 15px search text sat in a fixed 30px clipped border without enough vertical room, cutting off descenders. Centered the text (VerticalContentAlignment="Center") and zeroed its vertical padding.