### PR TITLE
Fix broken icon mappings for pip tenacity and starlette (#4845)

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -1,8 +1,8 @@
 {
   "package_count": {
-    "total": 12409,
-    "done": 5930,
-    "packages_with_icon": 5930,
+    "total": 12411,
+    "done": 5933,
+    "packages_with_icon": 5933,
     "packages_with_screenshot": 1368,
     "total_screenshots": 4140
   },
@@ -42105,7 +42105,15 @@
       "images": []
     },
     "tenacity": {
-      "icon": "https://codeberg.org/tenacityteam/tenacity/raw/branch/main/images/icons/48x48/tenacity.png",
+      "icon": "",
+      "images": []
+    },
+    "Chocolatey.tenacity": {
+      "icon": "https://community.chocolatey.org/content/packageimages/tenacity.1.3.4.20250612.png",
+      "images": []
+    },
+    "Winget.TenacityTeam.Tenacity": {
+      "icon": "https://community.chocolatey.org/content/packageimages/tenacity.1.3.4.20250612.png",
       "images": []
     },
     "tencentdocs": {
@@ -54577,7 +54585,7 @@
       "images": []
     },
     "starlette": {
-      "icon": "https://i.postimg.cc/2y15VgpK/starlette.png",
+      "icon": "https://raw.githubusercontent.com/encode/starlette/master/docs/img/starlette.svg",
       "images": []
     },
     "trio": {


### PR DESCRIPTION
Fixes #4845

### Problem

Two Python (pip) packages had broken icon metadata that produced persistent NotFound errors in the operation log:

Icon download attempt at https://i.postimg.cc/2y15VgpK/starlette.png failed with code NotFound
Icon download attempt at https://codeberg.org/tenacityteam/tenacity/raw/branch/main/images/icons/48x48/tenacity.png failed with code NotFound

### Fix                                                                                                                       
                                                                                                                                                                               
  - Empty the bare tenacity key. Removes the wrong mapping and the dead URL. The PyPI library has no logo, so it now shows the generic placeholder instead of erroring. The bare key was never used by the choco/winget audio editor (those resolve icons from native package metadata first), so nothing that should have an icon loses one.            
  - Repoint starlette to the canonical first-party SVG (raw.githubusercontent.com/encode/starlette/.../starlette.svg), replacing the unreliable third-party host. SVG is already supported by the icon engine.                                                                                                                                        
  - Add manager-namespaced Chocolatey.tenacity / Winget.TenacityTeam.Tenacity entries (Chocolatey CDN icon) as defensive fallbacks for the actual audio editor. These follow the DB's existing convention (~34 such keys) for resolving cross-ecosystem id collisions. Note: both managers use native icons, so these are belt-and-suspenders, not the primary source.                                                                                                                                                              