### PR TITLE
Fix WinUI splash screen icon not rendering

### DIFF
--- a/src/UniGetUI/MainWindow.xaml
+++ b/src/UniGetUI/MainWindow.xaml
@@ -113,9 +113,9 @@
           Grid.ColumnSpan="3"
           Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
         />
-        <!-- Splash: Height matches the 620:300 aspect ratio of SplashScreen.svg so the image fills the grid exactly. SvgImageSource is used so the host window's background shows through the transparent SVG. The tagline's 90px left margin shifts its centering from the image center (x=270) to the wordmark center (x≈315) within the 540-wide grid. -->
+        <!-- Splash: 540x261 keeps the 620:300 aspect ratio of the artwork. Source is a transparent PNG set theme-aware in code-behind (SvgImageSource renders blank here). The tagline's 90px left margin shifts its centering to the wordmark center (x≈315) within the 540-wide grid. -->
         <Grid Grid.Row="1" Grid.Column="1" Width="540" Height="261">
-          <Image Stretch="Uniform">
+          <Image x:Name="SplashImage" Stretch="Uniform">
             <animations:Explicit.Animations>
               <animations:AnimationSet x:Name="InAnimation_Border">
                 <animations:TranslationAnimation
@@ -132,9 +132,6 @@
                 />
               </animations:AnimationSet>
             </animations:Explicit.Animations>
-            <Image.Source>
-              <SvgImageSource UriSource="ms-appx:///Assets/SplashScreen.svg" RasterizePixelWidth="540" RasterizePixelHeight="261" />
-            </Image.Source>
           </Image>
           <widgets:TranslatedTextBlock
             HorizontalAlignment="Center"

--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -68,6 +68,7 @@ namespace UniGetUI.Interface
 
             LoadTrayMenu();
             ApplyTheme();
+            ApplySplashImage();
             ApplyProxyVariableToProcess();
             _applySubtitleToWindow();
 
@@ -704,6 +705,13 @@ namespace UniGetUI.Interface
         {
             AppWindow.Show();
             Activate();
+        }
+
+        private void ApplySplashImage()
+        {
+            bool dark = MainApp.Instance.ThemeListener.CurrentTheme == ApplicationTheme.Dark;
+            string asset = dark ? "SplashScreen.theme-dark.png" : "SplashScreen.png";
+            SplashImage.Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri($"ms-appx:///Assets/{asset}"));
         }
 
         public void ApplyTheme()


### PR DESCRIPTION
This pull request updates the splash image handling in the main window to improve theme support and fix rendering issues. The SVG splash image is replaced with a theme-aware PNG, and logic is added to select the appropriate image based on the current theme. ( #4874)

**Splash image improvements:**

* Changed the splash image in `MainWindow.xaml` from an SVG (`SvgImageSource`) to a PNG (`SplashScreen.png`), and set up the `Image` control with the name `SplashImage` for dynamic source assignment. [
* Added the `ApplySplashImage` method in `MainWindow.xaml.cs` to select and set the splash image (`SplashScreen.theme-dark.png` for dark theme, `SplashScreen.png` otherwise) at runtime based on the current theme.
* Called `ApplySplashImage()` during main window initialization to ensure the correct splash image is displayed on startup.