### PR TITLE
Fix PowerShell updates failing (#4865)

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.PowerShell/Helpers/PowerShellPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell/Helpers/PowerShellPkgOperationHelper.cs
@@ -33,7 +33,8 @@ internal sealed class PowerShellPkgOperationHelper : BasePkgOperationHelper
             if (options.PreRelease)
                 parameters.Add("-AllowPrerelease");
 
-            if (!package.OverridenOptions.PowerShell_DoNotSetScopeParameter)
+            // Update-Module (PowerShellGet) has no -Scope parameter; only Install-Module accepts it
+            if (operation is OperationType.Install && !package.OverridenOptions.PowerShell_DoNotSetScopeParameter)
             {
                 if (
                     package.OverridenOptions.Scope == PackageScope.Global
@@ -65,6 +66,10 @@ internal sealed class PowerShellPkgOperationHelper : BasePkgOperationHelper
                 _ => options.CustomParameters_Install,
             }
         );
+
+        // Windows PowerShell 5.x defaults to TLS 1.0/1.1, which the PowerShell Gallery rejects; force TLS 1.2 so gallery operations can connect under -NoProfile
+        if (operation is not OperationType.Uninstall)
+            parameters.Insert(0, "[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;");
 
         return parameters;
     }

--- a/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
@@ -103,6 +103,18 @@ public abstract class AbstractProcessOperation : AbstractOperation
         Line($" - Arguments: \"{process.StartInfo.Arguments.Trim()}\"", LineType.VerboseDetails);
         Line($"Start Time: \"{DateTime.Now}\"", LineType.VerboseDetails);
 
+        // An empty FileName means elevation was required but no elevator (UniGetUI Elevator/GSudo) is available
+        if (string.IsNullOrWhiteSpace(process.StartInfo.FileName))
+        {
+            Line(
+                CoreTools.Translate(
+                    "This operation requires administrator privileges, but the elevation tool could not be found. The operation cannot continue."
+                ),
+                LineType.Error
+            );
+            return OperationVeredict.Failure;
+        }
+
         if (_requiresUACCache)
         {
             _requiresUACCache = false;


### PR DESCRIPTION
This pull request introduces important improvements to the PowerShell package operation helper and the process operation logic, focusing on better compatibility and error handling. The most significant changes are summarized below (#4865):

### PowerShell Package Operation Improvements

* Ensured the `-Scope` parameter is only added for install operations, as `Update-Module` does not accept it, improving command correctness and preventing errors during updates.
* Added a step to force TLS 1.2 for all operations except uninstall, addressing compatibility issues with the PowerShell Gallery on Windows PowerShell 5.x, which defaults to outdated TLS versions.

### Process Operation Error Handling

* Added a check to detect when an elevation tool (like UniGetUI Elevator or Gsudo) is unavailable, and gracefully abort the operation with a clear error message if administrator privileges cannot be obtained.
