### PR TITLE
improve avalonia consistencies 

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml
+++ b/src/UniGetUI.Avalonia/App.axaml
@@ -11,6 +11,7 @@
 
     <Application.Styles>
         <FluentTheme />
+        <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml"/>
         <StyleInclude Source="avares://UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml"/>
     </Application.Styles>
 </Application>

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -126,6 +126,7 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.4" />
+        <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -60,7 +60,7 @@ public partial class SidebarViewModel : ViewModelBase
         OnPropertyChanged(nameof(BundlesBadgeCompactVisible));
     }
 
-    public double PaneWidth => IsPaneOpen ? 250 : 72;
+    public double PaneWidth => IsPaneOpen ? 250 : 64;
 
     public bool UpdatesBadgeExpandedVisible => UpdatesBadgeVisible && IsPaneOpen;
     public bool UpdatesBadgeCompactVisible => UpdatesBadgeVisible && !IsPaneOpen;

--- a/src/UniGetUI.Avalonia/Views/Controls/LogTextEditor.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/LogTextEditor.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using Avalonia;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+using Avalonia.Styling;
+using AvaloniaEdit;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Rendering;
+using UniGetUI.Avalonia.ViewModels.Pages.LogPages;
+
+namespace UniGetUI.Avalonia.Views.Controls;
+
+// Read-only colored log/console viewer shared by every log and command-output view: virtualized
+// rendering (smooth scroll), free character-level selection across lines, per-line colors, and a
+// theme-aware hyperlink color.
+public class LogTextEditor : TextEditor
+{
+    // Per physical line color, indexed by 0-based document line number.
+    private readonly List<IBrush> _lineColors = [];
+
+    // Use AvaloniaEdit's TextEditor theme/template; a subclass key has no matching ControlTheme.
+    protected override Type StyleKeyOverride => typeof(TextEditor);
+
+    public LogTextEditor()
+    {
+        IsReadOnly = true;
+        ShowLineNumbers = false;
+        WordWrap = true;
+        Background = Brushes.Transparent;
+        FontFamily = new FontFamily("Cascadia Mono,Consolas,Menlo,monospace");
+        FontSize = 12;
+        Padding = new Thickness(8);
+        HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+        VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+
+        TextArea.TextView.LineTransformers.Add(new SeverityColorizer(_lineColors));
+        UpdateLinkColor();
+        ActualThemeVariantChanged += (_, _) => UpdateLinkColor();
+    }
+
+    public void SetLines(IEnumerable<LogLineItem> lines)
+    {
+        _lineColors.Clear();
+        var sb = new StringBuilder();
+        bool first = true;
+
+        foreach (var item in lines)
+        {
+            foreach (string physicalLine in item.Text.Split('\n'))
+            {
+                if (!first) sb.Append('\n');
+                sb.Append(physicalLine);
+                _lineColors.Add(item.Foreground);
+                first = false;
+            }
+        }
+
+        Text = sb.ToString();
+        TextArea.TextView.Redraw();
+    }
+
+    public void AppendLine(LogLineItem line)
+    {
+        var sb = new StringBuilder();
+        foreach (string physicalLine in line.Text.Split('\n'))
+        {
+            if (Document.TextLength > 0 || sb.Length > 0)
+                sb.Append('\n');
+            sb.Append(physicalLine);
+            _lineColors.Add(line.Foreground);
+        }
+
+        Document.Insert(Document.TextLength, sb.ToString());
+    }
+
+    public void ClearLines()
+    {
+        _lineColors.Clear();
+        Text = string.Empty;
+    }
+
+    public void ScrollToBottom() => ScrollToEnd();
+
+    // AvaloniaEdit auto-links URLs; its default link brush is too dark to read on the dark theme.
+    private void UpdateLinkColor()
+    {
+        bool isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+        TextArea.TextView.LinkTextForegroundBrush =
+            new SolidColorBrush(isDark ? Color.FromRgb(100, 170, 255) : Color.FromRgb(0, 0, 205));
+    }
+
+    private sealed class SeverityColorizer(List<IBrush> lineColors) : DocumentColorizingTransformer
+    {
+        protected override void ColorizeLine(DocumentLine line)
+        {
+            if (line.Length == 0) return;
+            int index = line.LineNumber - 1;
+            if (index < 0 || index >= lineColors.Count) return;
+
+            IBrush brush = lineColors[index];
+            ChangeLinePart(line.Offset, line.EndOffset, element => element.TextRunProperties.SetForegroundBrush(brush));
+        }
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/SettingsCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/SettingsCard.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using UniGetUI.Avalonia.Views.Controls;
 using ICommand = System.Windows.Input.ICommand;
 
 namespace UniGetUI.Avalonia.Views.Controls.Settings;
@@ -23,7 +24,7 @@ public class SettingsCard : UserControl
     private readonly ContentControl _descriptionPresenter;
     private readonly ContentControl _contentPresenter;
     private readonly StackPanel _descriptionRow;
-    private readonly TextBlock _chevron;
+    private readonly SvgIcon _chevron;
 
     // ── Styled properties ──────────────────────────────────────────────────
     public static readonly StyledProperty<object?> HeaderProperty =
@@ -178,10 +179,11 @@ public class SettingsCard : UserControl
             Margin = new Thickness(16, 0, 0, 0),
         };
 
-        _chevron = new TextBlock
+        _chevron = new SvgIcon
         {
-            Text = "›",
-            FontSize = 20,
+            Path = "avares://UniGetUI.Avalonia/Assets/Symbols/forward.svg",
+            Width = 16,
+            Height = 16,
             VerticalAlignment = VerticalAlignment.Center,
             Opacity = 0.6,
             Margin = new Thickness(8, 0, 0, 0),

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
+        xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.OperationFailedDialog"
         Width="800" MinWidth="500"
         Height="550" MinHeight="300"
@@ -19,20 +20,14 @@
         </Border>
 
         <!-- ── Colored output log ── -->
-        <ScrollViewer Grid.Row="1"
-                      x:Name="OutputScroll"
-                      Margin="8,0,8,8"
-                      HorizontalScrollBarVisibility="Auto"
-                      VerticalScrollBarVisibility="Auto"
-                      Background="{DynamicResource AppDialogDarkBackground}"
-                      CornerRadius="6">
-            <SelectableTextBlock x:Name="OutputText"
-                                 Padding="8"
-                                 FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
-                                 FontSize="12"
-                                 TextWrapping="Wrap"
-                                 automation:AutomationProperties.AccessibilityView="Raw"/>
-        </ScrollViewer>
+        <Border Grid.Row="1"
+                Margin="8,0,8,8"
+                CornerRadius="6"
+                ClipToBounds="True"
+                Background="{DynamicResource AppDialogDarkBackground}">
+            <controls:LogTextEditor x:Name="OutputText"
+                                    automation:AutomationProperties.AccessibilityView="Raw"/>
+        </Border>
 
         <!-- ── Footer buttons ── -->
         <Border Grid.Row="2"

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -1,9 +1,9 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Documents;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
+using UniGetUI.Avalonia.ViewModels.Pages.LogPages;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Operations;
@@ -30,8 +30,7 @@ public partial class OperationFailedDialog : Window
         var normalBrush = Application.Current?.FindResource("SystemControlForegroundBaseHighBrush") as IBrush
                           ?? Brushes.White;
 
-        var inlines = OutputText.Inlines ??= new InlineCollection();
-        bool first = true;
+        var lines = new List<LogLineItem>();
         foreach (var (text, type) in operation.GetOutput())
         {
             IBrush brush = type switch
@@ -40,10 +39,9 @@ public partial class OperationFailedDialog : Window
                 AbstractOperation.LineType.VerboseDetails => debugBrush,
                 _ => normalBrush,
             };
-            if (!first) inlines.Add(new LineBreak());
-            inlines.Add(new Run(text) { Foreground = brush });
-            first = false;
+            lines.Add(new LogLineItem(text, brush));
         }
+        OutputText.SetLines(lines);
 
         var closeButton = new Button
         {
@@ -64,7 +62,7 @@ public partial class OperationFailedDialog : Window
     protected override void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
-        Dispatcher.UIThread.Post(OutputScroll.ScrollToEnd, DispatcherPriority.Background);
+        Dispatcher.UIThread.Post(OutputText.ScrollToBottom, DispatcherPriority.Background);
     }
 
     private Control BuildRetryButton(AbstractOperation operation)

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels.DialogPages"
+        xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.OperationOutputWindow"
         x:DataType="vm:OperationOutputViewModel"
         Width="700" MinWidth="400"
@@ -12,19 +13,13 @@
         WindowStartupLocation="CenterOwner"
         Title="{Binding Title}">
 
-    <ScrollViewer x:Name="OutputScroll"
-                  Margin="8"
-                  HorizontalScrollBarVisibility="Auto"
-                  VerticalScrollBarVisibility="Auto"
-                  Background="{DynamicResource AppDialogDarkBackground}"
-                  CornerRadius="6">
-        <SelectableTextBlock x:Name="OutputText"
-                             Padding="8"
-                             FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
-                             FontSize="12"
-                             TextWrapping="Wrap"
-                             automation:AutomationProperties.Name="{Binding Title}"
-                             automation:AutomationProperties.AccessibilityView="Raw"/>
-    </ScrollViewer>
+    <Border Margin="8"
+            CornerRadius="6"
+            ClipToBounds="True"
+            Background="{DynamicResource AppDialogDarkBackground}">
+        <controls:LogTextEditor x:Name="OutputText"
+                                automation:AutomationProperties.Name="{Binding Title}"
+                                automation:AutomationProperties.AccessibilityView="Raw"/>
+    </Border>
 
 </Window>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
@@ -1,6 +1,5 @@
 using System.Collections.Specialized;
 using Avalonia.Controls;
-using Avalonia.Controls.Documents;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels.DialogPages;
 using UniGetUI.Avalonia.ViewModels.Pages.LogPages;
@@ -17,9 +16,7 @@ public partial class OperationOutputWindow : Window
         InitializeComponent();
         UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
-        foreach (var line in vm.OutputLines)
-            AppendLine(line);
-
+        OutputText.SetLines(vm.OutputLines);
         vm.OutputLines.CollectionChanged += OnOutputLinesChanged;
     }
 
@@ -29,28 +26,20 @@ public partial class OperationOutputWindow : Window
         {
             if (e.Action == NotifyCollectionChangedAction.Reset)
             {
-                OutputText.Inlines?.Clear();
+                OutputText.ClearLines();
             }
             else if (e.NewItems is not null)
             {
                 foreach (LogLineItem item in e.NewItems)
-                    AppendLine(item);
+                    OutputText.AppendLine(item);
             }
-            OutputScroll.ScrollToEnd();
+            OutputText.ScrollToBottom();
         }, DispatcherPriority.Background);
-    }
-
-    private void AppendLine(LogLineItem line)
-    {
-        var inlines = OutputText.Inlines ??= new InlineCollection();
-        if (inlines.Count > 0)
-            inlines.Add(new LineBreak());
-        inlines.Add(new Run(line.Text) { Foreground = line.Foreground });
     }
 
     protected override void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
-        OutputScroll.ScrollToEnd();
+        OutputText.ScrollToBottom();
     }
 }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -253,9 +253,11 @@
                                 Spacing="8">
                         <Border CornerRadius="8" ClipToBounds="True"
                                 x:Name="ScreenshotsBorder"
-                                Background="#000000"
                                 Height="320">
                             <Panel>
+                                <!-- Black letterbox only behind actual screenshots; the empty-state
+                                     banner below composites over the themed window background instead. -->
+                                <Border Background="#000000" IsVisible="{Binding HasScreenshots}"/>
                                 <Carousel x:Name="ScreenshotsCarousel"
                                           IsVisible="{Binding HasScreenshots}"
                                           ItemsSource="{Binding Screenshots}"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -364,7 +364,7 @@
                              Grid.Column="0"
                              MinHeight="20"
                              FontSize="15"
-                             CornerRadius="0"
+                             CornerRadius="3,0,0,3"
                              BorderThickness="0"
                              VerticalContentAlignment="Center"
                              Padding="8,0,4,0"

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
@@ -10,50 +10,75 @@
              mc:Ignorable="d"
              x:DataType="vm:HelpPageViewModel">
 
+    <UserControl.Styles>
+        <!-- Nav buttons: same as the toolbar's main action button (Button#MainToolbarButton) -->
+        <Style Selector="Button.nav">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+        <!-- Disabled: keep the card background (not the gray disabled brush), just fade it -->
+        <Style Selector="Button.nav:disabled /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+        </Style>
+        <Style Selector="Button.nav:disabled">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+        <!-- Non-nav buttons: flat/transparent like the toolbar -->
+        <Style Selector="Button.flat">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+    </UserControl.Styles>
+
     <Grid RowDefinitions="Auto,2,*" Margin="8,4,8,8">
 
         <!-- Toolbar -->
-        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto">
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto" Margin="0,0,0,6">
 
             <Button Grid.Column="0"
                     x:Name="BackButton"
+                    Classes="nav"
                     Width="35" Height="35" Padding="6"
                     CornerRadius="4,0,0,4"
                     automation:AutomationProperties.Name="{t:Translate Go back}"
                     Click="BackButton_Click">
                 <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/backward.svg"
-                                  Foreground="White" Width="16" Height="16"/>
+                                  Width="16" Height="16"/>
             </Button>
 
             <Button Grid.Column="1"
                     x:Name="ForwardButton"
+                    Classes="nav"
                     Width="35" Height="35" Padding="6"
                     CornerRadius="0"
                     automation:AutomationProperties.Name="{t:Translate Go forward}"
                     Click="ForwardButton_Click">
                 <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/forward.svg"
-                                  Foreground="White" Width="16" Height="16"/>
+                                  Width="16" Height="16"/>
             </Button>
 
             <Button Grid.Column="2"
+                    Classes="nav"
                     Width="35" Height="35" Padding="6"
                     CornerRadius="0"
                     automation:AutomationProperties.Name="{t:Translate Go to home page}"
                     Click="HomeButton_Click">
                 <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/home.svg"
-                                  Foreground="White" Width="16" Height="16"/>
+                                  Width="16" Height="16"/>
             </Button>
 
             <Button Grid.Column="3"
+                    Classes="nav"
                     Width="35" Height="35" Padding="6"
                     CornerRadius="0,4,4,0"
                     automation:AutomationProperties.Name="{t:Translate Reload page}"
                     Click="ReloadButton_Click">
                 <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/reload.svg"
-                                  Foreground="White" Width="16" Height="16"/>
+                                  Width="16" Height="16"/>
             </Button>
 
             <Button Grid.Column="5"
+                    Classes="flat"
                     Height="35"
                     Command="{Binding OpenInBrowserCommand}"
                     automation:AutomationProperties.Name="{t:Translate View page on browser}">
@@ -83,7 +108,7 @@
                     Spacing="12" IsVisible="False">
             <TextBlock Text="{t:Translate The built-in browser is not supported on Linux yet.}"
                        TextAlignment="Center" TextWrapping="Wrap" MaxWidth="400"/>
-            <Button HorizontalAlignment="Center" Command="{Binding OpenInBrowserCommand}">
+            <Button Classes="flat" HorizontalAlignment="Center" Command="{Binding OpenInBrowserCommand}">
                 <TextBlock Text="{t:Translate Open in browser}"
                            automation:AutomationProperties.AccessibilityView="Raw"/>
             </Button>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
              xmlns:vm="using:UniGetUI.Avalonia.ViewModels.Pages.LogPages"
+             xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
              xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -44,6 +45,7 @@
             </StackPanel>
 
             <Button Grid.Column="5"
+                    Margin="0,0,12,0"
                     Command="{Binding ReloadCommand}"
                     automation:AutomationProperties.Name="{t:Translate Reload log}">
                 <TextBlock Text="{t:Translate Reload log}"
@@ -54,24 +56,9 @@
         <!-- Log content -->
         <Border Grid.Row="1"
                 CornerRadius="8"
+                ClipToBounds="True"
                 Background="{DynamicResource ApplicationPageBackgroundThemeBrush}">
-            <ScrollViewer x:Name="MainScroller"
-                          HorizontalScrollBarVisibility="Disabled"
-                          VerticalScrollBarVisibility="Auto">
-                <ItemsControl ItemsSource="{Binding LogLines}"
-                              Margin="8">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate DataType="vm:LogLineItem">
-                            <SelectableTextBlock Text="{Binding Text}"
-                                                 Foreground="{Binding Foreground}"
-                                                 FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
-                                                 FontSize="12"
-                                                 TextWrapping="Wrap"
-                                                 Margin="0,1"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
+            <controls:LogTextEditor x:Name="LogEditor"/>
         </Border>
 
     </Grid>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+using System.Collections.Specialized;
 using Avalonia.Controls;
 using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
@@ -11,6 +11,7 @@ namespace UniGetUI.Avalonia.Views.Pages.LogPages;
 public partial class BaseLogPage : UserControl, IEnterLeaveListener, IKeyboardShortcutListener
 {
     protected readonly BaseLogPageViewModel ViewModel;
+    private bool _rebuildQueued;
 
     protected BaseLogPage(BaseLogPageViewModel viewModel)
     {
@@ -21,6 +22,22 @@ public partial class BaseLogPage : UserControl, IEnterLeaveListener, IKeyboardSh
         ViewModel.CopyTextRequested += OnCopyTextRequested;
         ViewModel.ExportTextRequested += OnExportTextRequested;
         ViewModel.ScrollToBottomRequested += OnScrollToBottomRequested;
+        ViewModel.LogLines.CollectionChanged += OnLogLinesChanged;
+
+        LogEditor.SetLines(ViewModel.LogLines);
+    }
+
+    // LoadLog clears and re-adds the lines one by one, firing many events; coalesce them into a
+    // single rebuild on the next dispatcher pass instead of rebuilding the document each time.
+    private void OnLogLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (_rebuildQueued) return;
+        _rebuildQueued = true;
+        Dispatcher.UIThread.Post(() =>
+        {
+            _rebuildQueued = false;
+            LogEditor.SetLines(ViewModel.LogLines);
+        }, DispatcherPriority.Background);
     }
 
     private async void OnCopyTextRequested(object? sender, string text)
@@ -51,10 +68,7 @@ public partial class BaseLogPage : UserControl, IEnterLeaveListener, IKeyboardSh
 
     private void OnScrollToBottomRequested(object? sender, EventArgs e)
     {
-        Dispatcher.UIThread.Post(() =>
-        {
-            MainScroller.Offset = new Vector(MainScroller.Offset.X, double.MaxValue);
-        }, DispatcherPriority.Background);
+        Dispatcher.UIThread.Post(LogEditor.ScrollToBottom, DispatcherPriority.Background);
     }
 
     public void OnEnter() => ViewModel.LoadLog();
@@ -63,7 +77,7 @@ public partial class BaseLogPage : UserControl, IEnterLeaveListener, IKeyboardSh
 
     public void ReloadTriggered() => ViewModel.LoadLog(isReload: true);
 
-    public void SelectAllTriggered() { }
+    public void SelectAllTriggered() => LogEditor.SelectAll();
 
     public void SearchTriggered() { }
 

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
@@ -10,10 +10,18 @@
              mc:Ignorable="d"
              x:DataType="vm:ReleaseNotesPageViewModel">
 
+    <UserControl.Styles>
+        <!-- Flat/transparent buttons like the toolbar -->
+        <Style Selector="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+    </UserControl.Styles>
+
     <Grid RowDefinitions="Auto,2,*" Margin="8,4,8,8">
 
         <!-- Toolbar -->
-        <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,6">
 
             <Button Grid.Column="1"
                     Height="35"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
@@ -50,6 +50,7 @@
                 <settings:ComboboxCard x:Name="TrayIconStyleSelector"
                                        IsVisible="{Binding ShowTrayIconStyleSelector}"
                                        ValueChangedCommand="{Binding RefreshSystemTrayCommand}"
+                                       CornerRadius="0"
                                        BorderThickness="1,0,1,1"/>
 
                 <settings:ButtonCard x:Name="EditAutostartSettings"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml
@@ -109,8 +109,8 @@
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
 
-            <!-- Logs link card -->
-            <settings:SettingsPageButton x:Name="ManagerLogs" CornerRadius="8,8,0,0"/>
+            <!-- Logs link card (standalone; Pip overrides to a top tile when the alias warning shows) -->
+            <settings:SettingsPageButton x:Name="ManagerLogs" CornerRadius="8"/>
 
             <!-- Python App Execution Alias warning (pip only) -->
             <settings:SettingsCard x:Name="AppExecutionAliasWarning"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml
@@ -12,13 +12,15 @@
 
     <Grid RowDefinitions="Auto,Auto,*">
 
-        <!-- Row 0: Header -->
-        <StackPanel Grid.Row="0"
-                    Orientation="Horizontal"
-                    VerticalAlignment="Center"
-                    Margin="16,12,16,8">
+        <!-- Row 0: Header. Title is left-aligned to the settings cards (40px), with the back
+             button sitting in the gutter to its left. -->
+        <Grid Grid.Row="0"
+              VerticalAlignment="Center"
+              Margin="0,12,16,8">
             <Button Command="{Binding BackCommand}"
-                    Margin="0,0,12,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Margin="4,0,0,0"
                     Padding="4"
                     Background="Transparent"
                     BorderThickness="0"
@@ -30,8 +32,9 @@
                        FontSize="26"
                        FontWeight="SemiBold"
                        VerticalAlignment="Center"
+                       Margin="40,0,0,0"
                        automation:AutomationProperties.HeadingLevel="1"/>
-        </StackPanel>
+        </Grid>
 
         <!-- Row 1: Restart-required banner -->
         <Border x:Name="RestartBannerBorder"

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -9,7 +9,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              x:DataType="vm:SidebarViewModel"
-             MinWidth="72">
+             MinWidth="64">
 
     <Grid RowDefinitions="*,Auto">
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -575,7 +575,7 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="pkg:PackageWrapper">
-                                        <Border CornerRadius="4" Margin="4" Width="275" Height="56"
+                                        <Border CornerRadius="4" Margin="4" Width="275" Height="70"
                                             automation:AutomationProperties.Name="{Binding Package.AutomationName}"
                                             automation:AutomationProperties.ItemType="{t:Translate Package}"
                                                 Background="{DynamicResource SettingsCardBackground}"
@@ -611,20 +611,23 @@
                                                                FontSize="11" Opacity="0.5"
                                                                TextTrimming="CharacterEllipsis"/>
                                                 </StackPanel>
-                                                <!-- Col 2: checkbox (top) + overflow button (bottom) -->
+                                                <!-- Col 2: checkbox (top) + overflow button (bottom). The taller card leaves
+                                                     room to stack them without overlap. -->
                                                 <Panel Grid.Column="2">
                                                     <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}"
                                                               automation:AutomationProperties.Name="{Binding Package.AutomationName}"
                                                               VerticalAlignment="Top"
                                                               HorizontalAlignment="Center"
+                                                              MinHeight="0"
                                                               Padding="0"/>
                                                     <Button Click="CardOverflowButton_Click"
-                                                            Width="22" Height="22" Padding="0"
+                                                            Width="26" Height="26" Padding="0"
+                                                            MinWidth="0" MinHeight="0"
                                                             VerticalAlignment="Bottom"
                                                             HorizontalAlignment="Center"
                                                             Background="Transparent" BorderThickness="0"
                                                             automation:AutomationProperties.Name="{t:Translate More options}">
-                                                        <TextBlock Text="···" FontSize="16"
+                                                        <TextBlock Text="···" FontSize="20"
                                                                    HorizontalAlignment="Center"
                                                                    VerticalAlignment="Center"/>
                                                     </Button>
@@ -647,28 +650,33 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="pkg:PackageWrapper">
-                                        <Border CornerRadius="4" Margin="4" Width="128" Height="134"
+                                        <Border CornerRadius="4" Margin="4" Width="128" Height="142"
                                             automation:AutomationProperties.Name="{Binding Package.AutomationName}"
                                             automation:AutomationProperties.ItemType="{t:Translate Package}"
                                                 Background="{DynamicResource SettingsCardBackground}"
                                                 BorderBrush="{DynamicResource SettingsCardBorderBrush}" BorderThickness="1" Padding="4">
-                                            <Grid RowDefinitions="22,60,30,15">
+                                            <Grid RowDefinitions="30,57,30,15">
                                                 <CheckBox Grid.Row="0"
                                                           IsChecked="{Binding IsChecked, Mode=TwoWay}"
                                                           automation:AutomationProperties.Name="{Binding Package.AutomationName}"
                                                           HorizontalAlignment="Left"
-                                                          VerticalAlignment="Top"
-                                                          Padding="0" Margin="2,2,0,0"/>
+                                                          VerticalAlignment="Center"
+                                                          MinHeight="0"
+                                                          Padding="0" Margin="2,0,0,0"/>
                                                 <Button Grid.Row="0"
                                                         Click="CardOverflowButton_Click"
-                                                        Width="22" Height="22" Padding="0"
+                                                        Width="26" Height="24" Padding="0"
+                                                        MinWidth="0" MinHeight="0"
                                                         HorizontalAlignment="Right"
-                                                        VerticalAlignment="Top"
+                                                        VerticalAlignment="Center"
+                                                        HorizontalContentAlignment="Center"
+                                                        VerticalContentAlignment="Center"
                                                         Background="Transparent" BorderThickness="0"
                                                         automation:AutomationProperties.Name="{t:Translate More options}">
-                                                    <TextBlock Text="···" FontSize="16"
+                                                    <TextBlock Text="···" FontSize="20"
                                                                HorizontalAlignment="Center"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,-3,0,0"/>
                                                 </Button>
                                                 <Panel Grid.Row="1" Width="64" Height="64"
                                                        Margin="0,-8,0,4"
@@ -743,7 +751,7 @@
                                      Grid.Column="0"
                                      Padding="16,0,10,0"
                                      VerticalContentAlignment="Center"
-                                     CornerRadius="0"
+                                     CornerRadius="7,0,0,7"
                                      BorderThickness="0"
                                      Background="Transparent"
                                      FontSize="40"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -169,15 +169,15 @@
               ColumnDefinitions="220,4,*">
 
             <!-- ===== FILTER PANE =====
-                 SidePanel is a Border (the grid child the code-behind positions) so it can cast a
-                 BoxShadow — the WinUI elevated filter-panel shadow (most visible in overlay mode). -->
+                 SidePanel is the Border the code-behind positions (inline vs overlay mode). -->
                 <Border x:Name="SidePanel"
                         Grid.Column="0"
                         IsVisible="{Binding IsFilterPaneOpen}"
-                        BoxShadow="3 0 14 0 #40000000">
+                        CornerRadius="8"
+                        ClipToBounds="True">
                 <ScrollViewer x:Name="SidePanelScroller"
                               HorizontalScrollBarVisibility="Disabled"
-                              Padding="0,8,4,0"
+                              Padding="4,8,4,0"
                               automation:AutomationProperties.AccessibilityView="Control"
                               automation:AutomationProperties.Name="{t:Translate Filters}"
                               automation:AutomationProperties.LandmarkType="{x:Static peers:AutomationLandmarkType.Search}"
@@ -344,7 +344,7 @@
                                   Background="{DynamicResource SettingsCardBackground}">
                             <Expander.Header>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/search.svg" Width="16" Height="16" VerticalAlignment="Center"/>
+                                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/search_filled.svg" Width="16" Height="16" VerticalAlignment="Center"/>
                                     <TextBlock Text="{t:Translate Search mode}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Expander.Header>

--- a/src/UniGetUI/Assets/Symbols/search_filled.svg
+++ b/src/UniGetUI/Assets/Symbols/search_filled.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" version="1.1" viewBox="0 0 32 32">
+  <!-- Filled magnifier matching the Sources/Filter icon family weight -->
+  <path fill="#010101" d="M2,13 a11,11 0 1,0 22,0 a11,11 0 1,0 -22,0 Z M6.5,13 a6.5,6.5 0 1,1 13,0 a6.5,6.5 0 1,1 -13,0 Z"/>
+  <path fill="#010101" d="M22.12,17.88 L30.62,26.38 L26.38,30.62 L17.88,22.12 Z"/>
+</svg>


### PR DESCRIPTION
This pull request introduces a new, reusable `LogTextEditor` control based on AvaloniaEdit to provide a performant, colored, and selectable log/console viewer across the app. It replaces the previous use of `SelectableTextBlock` for log output in dialogs, improving performance, visual consistency, and theming. The update also includes some UI tweaks for consistency and polish. (#4884)

### Logs & command output                                                                                                      
                                                                                                                             
- Replaced the per-line SelectableTextBlock log rendering with a shared LogTextEditor control (read-only AvaloniaEdit.TextEditor). This gives all log/output views virtualized scrolling, free character-level selection across lines, per-line severity colors, and a theme-aware hyperlink color. 
- Applied to the UniGetUI log / Manager logs / Operation history pages (via BaseLogPage) and to the operation output and failed-operation dialogs.                                                                                                  
- Added the Avalonia.AvaloniaEdit dependency and registered its theme in App.axaml.                                        
                                                                                                                             
### Settings pages                                                                                                             
                                                                                                                             
  - Page title now aligns with the left edge of the settings tiles (back button moved into the gutter).                      
  - Navigation tile chevron switched from a text glyph to the forward.svg icon so it's vertically centered and theme-correct.
  - System-tray icon style tile no longer renders as a standalone (rounded) tile mid-group.                                  
  - "View logs" card defaults to a standalone rounded tile (Pip still groups it with the alias warning).                     
                                                                                                                             
###   Package list (abstract view)                                                                                               
                                                                                                                             
  - Filter pane: filled magnifier icon for Search mode (matches Sources/Filter), symmetric left/right padding, rounded       
  corners, and removed the one-off box shadow.                                                                               
  - Grid cards: taller cards so the checkbox and ⋯ overflow button stack without overlapping/clipping; sized and aligned the overflow button.                                                                                                           
  - Icons cards: checkbox/⋯ row sized so the checkbox isn't clipped and both are aligned and centered.                       
                                                                                                                             
###   Webview pages (Help / Release notes)                                                                                       
                                                                                                                             
  - "View page on browser" button is flat/transparent like the toolbar.                                                      
  - Help nav buttons (back/forward/home/reload) match the main toolbar button, with a faded (not gray) disabled state and theme-colored icons.                                                                                                       
  - Added bottom spacing between the toolbar and the webview.