### PR TITLE
Fix UniGetUI not quitting properly on macOS

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -122,6 +122,24 @@ public partial class App : Application
         AvaloniaAppHost.SecondaryInstanceArgsReceived += args =>
             HandleSecondaryInstanceArgs(mainWindow, args);
 
+        desktop.ShutdownRequested += (_, e) =>
+        {
+            if (mainWindow.IsQuitting)
+                return;
+
+            e.Cancel = true;
+            mainWindow.QuitApplication();
+        };
+
+        if (Current?.TryGetFeature<IActivatableLifetime>() is { } activatable)
+        {
+            activatable.Activated += (_, e) =>
+            {
+                if (e.Kind == ActivationKind.Reopen)
+                    mainWindow.ShowFromTray();
+            };
+        }
+
         if (CoreData.WasDaemon)
         {
             // Start silently: hide the window on first open only.

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -324,7 +324,7 @@ public partial class MainWindowViewModel : ViewModelBase
     public void NavigateTo(PageType newPage_t, bool toHistory = true)
     {
         if (newPage_t is PageType.About) { _ = ShowAboutDialog(); return; }
-        if (newPage_t is PageType.Quit) { (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.Shutdown(); return; }
+        if (newPage_t is PageType.Quit) { MainWindow.Instance?.QuitApplication(); return; }
 
         if (_currentPage == newPage_t)
         {

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -73,6 +73,7 @@ public partial class MainWindow : Window
     private bool _focusSidebarSelectionOnNextPageChange;
     private TrayService? _trayService;
     private bool _allowClose;
+    private int _isQuitting;
 
     public enum RuntimeNotificationLevel
     {
@@ -136,18 +137,23 @@ public partial class MainWindow : Window
 
     protected override void OnClosing(WindowClosingEventArgs e)
     {
-        if (!_allowClose && !Settings.Get(Settings.K.DisableSystemTray))
+        if (!_allowClose && (OperatingSystem.IsMacOS() || !Settings.Get(Settings.K.DisableSystemTray)))
         {
             e.Cancel = true;
             Hide();
             return;
         }
 
+        e.Cancel = true;
+        QuitApplication();
+    }
+
+    private void ReleaseWindowResources()
+    {
         SaveGeometryNow();
         AvaloniaAutoUpdater.ReleaseLockForAutoupdate_Window = true;
         _trayService?.Dispose();
         _trayService = null;
-        base.OnClosing(e);
     }
 
     private void Window_KeyDown(object? sender, KeyEventArgs e)
@@ -1004,14 +1010,25 @@ public partial class MainWindow : Window
         Activate();
     }
 
+    public bool IsQuitting => Interlocked.CompareExchange(ref _isQuitting, 0, 0) == 1;
+
     public void QuitApplication()
     {
+        if (Interlocked.Exchange(ref _isQuitting, 1) == 1)
+            return;
+
         _allowClose = true;
+        ReleaseWindowResources();
+
+        if (IsVisible)
+            Hide();
+
         _ = QuitApplicationAsync();
     }
 
     private static async Task QuitApplicationAsync()
     {
+        Logger.Warn("Quitting UniGetUI");
         try
         {
             await AvaloniaBootstrapper.StopIpcApiAsync().WaitAsync(TimeSpan.FromSeconds(5));
@@ -1026,9 +1043,7 @@ public partial class MainWindow : Window
             Logger.Error(ex);
         }
 
-        Dispatcher.UIThread.Post(() =>
-            (global::Avalonia.Application.Current?.ApplicationLifetime
-                as IClassicDesktopStyleApplicationLifetime)?.Shutdown());
+        Environment.Exit(0);
     }
 
     public static void ApplyProxyVariableToProcess()


### PR DESCRIPTION
 On macOS, UniGetUI couldn't be quit normally and had to be Force Quit from Activity Monitor. Three distinct issues (#4887):                                                                    
                                                                                                                                                                                         
  1. The process never terminated. Quitting only called ApplicationLifetime.Shutdown(), which doesn't stop the background loops (auto-update checker, telemetry, icon database) or the Kestrel IPC host. The process lingered at 2-3% CPU after "closing."                                                                                                                    
  2. Native quit gestures did nothing. Cmd+Q, the application-menu Quit, and Dock → Quit raise the lifetime's ShutdownRequested event, which was unhandled — so they fell through to the hide-to-dock path and the app could never actually be quit.                                                                                                                            
  3. Closing to the Dock was a dead end. Once the window was hidden, clicking the Dock icon never brought it back.

### Changes                                                                                                                                                                                
                                                                                                                                                                                         
  - Single hard-exit quit path. All real quits now funnel through QuitApplication(), which releases window resources (saves geometry, disposes the tray icon) and hard-exits via Environment.Exit(0) after stopping the IPC server — mirroring the WinUI app's existing StopIpcAndExitAsync. A re-entrancy guard (IsQuitting) prevents double-teardown.                 
  - Handle ShutdownRequested in App so macOS quit gestures (Cmd+Q, app menu, Dock → Quit) and OS session-end route into the clean quit path.                                             
  - Handle IActivatableLifetime Reopen so clicking the Dock icon restores a hidden window.                                                                                               
  - Platform-correct close button. On macOS the close button always hides the window to the Dock (the platform standard) regardless of the tray setting; the app is quit via Cmd+Q / app menu / Dock. On Windows/Linux, close-to-tray is unchanged when the tray is enabled, and closing with the tray disabled now fully terminates the process instead of leaving background threads alive.                                                                                                                                                                         
  - The in-app Quit (PageType.Quit) and app-restart helper already route through the same path.                                                                                          
                                                                                                                                                                                         
 ###  Cross-platform safety                                                                                                                                                                  
                                                                                                                                                                                         
  - Environment.Exit(0) loses no data: logs, settings, and operation history all write synchronously, and window geometry is saved continuously. This matches what the WinUI app already does.                                                                                                                                                                                  
  - The new ShutdownRequested handler doesn't affect the normal Windows/Linux flow — Avalonia's OnLastWindowClose calls Shutdown() internally without raising ShutdownRequested.         
  - The Dock-reopen handler is a no-op off macOS (TryGetFeature<IActivatableLifetime>() is guarded; Reopen is macOS-only).                                                               
  - The tray icon is explicitly disposed before exit to avoid a ghost notification-area icon on Windows.