### PR TITLE
Fix Scoop shim failure under RedirectionGuard by retrying elevated

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgOperationHelper.cs
@@ -114,6 +114,13 @@ internal sealed class ScoopPkgOperationHelper : BasePkgOperationHelper
             return OperationVeredict.AutoRetry;
         }
 
+        // Scoop can't resolve shims through the fresh 'current' junction in some contexts; an elevated (trusted) junction fixes it. See #4892
+        if (package.OverridenOptions.RunAsAdministrator != true && returnCode is not 0 && output_string.Contains("Can't shim"))
+        {
+            package.OverridenOptions.RunAsAdministrator = true;
+            return OperationVeredict.AutoRetry;
+        }
+
         if (output_string.Contains("ERROR") || returnCode is not 0)
             return OperationVeredict.Failure;
 

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgOperationHelper.cs
@@ -1,3 +1,4 @@
+using UniGetUI.Core.SettingsEngine;
 using UniGetUI.PackageEngine.Classes.Manager.BaseProviders;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
@@ -114,8 +115,13 @@ internal sealed class ScoopPkgOperationHelper : BasePkgOperationHelper
             return OperationVeredict.AutoRetry;
         }
 
-        // Scoop can't resolve shims through the fresh 'current' junction in some contexts; an elevated (trusted) junction fixes it. See #4892
-        if (package.OverridenOptions.RunAsAdministrator != true && returnCode is not 0 && output_string.Contains("Can't shim"))
+        // Scoop can't resolve shims through the fresh 'current' junction in some contexts; an elevated (trusted) junction fixes it, so retry as admin unless elevation is disabled. See #4892
+        if (
+            package.OverridenOptions.RunAsAdministrator != true
+            && returnCode is not 0
+            && !Settings.Get(Settings.K.ProhibitElevation)
+            && output_string.Contains("Can't shim")
+        )
         {
             package.OverridenOptions.RunAsAdministrator = true;
             return OperationVeredict.AutoRetry;

--- a/src/UniGetUI.PackageEngine.Tests/ScoopManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/ScoopManagerTests.cs
@@ -346,6 +346,27 @@ public sealed class ScoopManagerTests : IDisposable
         OperationAssert.HasVeredict(veredict, OperationVeredict.Success);
     }
 
+    [Fact]
+    public void OperationResultDoesNotElevateShimFailureWhenElevationProhibited()
+    {
+        Settings.Set(Settings.K.ProhibitElevation, true);
+        var manager = new Scoop();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithOptions(new OverridenInstallationOptions(runAsAdministrator: false))
+            .Build();
+
+        var veredict = manager.OperationHelper.GetResult(
+            package,
+            OperationType.Update,
+            ["Can't shim 'notepad++.exe': File doesn't exist."],
+            1
+        );
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.False(package.OverridenOptions.RunAsAdministrator);
+    }
+
     private static Scoop CreateManagerWithKnownSources(params string[] sourceNames)
     {
         var manager = new Scoop();

--- a/src/UniGetUI.PackageEngine.Tests/ScoopManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/ScoopManagerTests.cs
@@ -301,6 +301,51 @@ public sealed class ScoopManagerTests : IDisposable
         OperationAssert.HasVeredict(success, OperationVeredict.Success);
     }
 
+    [Fact]
+    public void OperationResultRetriesElevatedOnShimResolutionFailure()
+    {
+        var manager = new Scoop();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithOptions(new OverridenInstallationOptions(runAsAdministrator: false))
+            .Build();
+
+        var retry = manager.OperationHelper.GetResult(
+            package,
+            OperationType.Update,
+            ["Creating shim for 'notepad++'.", "Can't shim 'notepad++.exe': File doesn't exist."],
+            1
+        );
+
+        OperationAssert.HasVeredict(retry, OperationVeredict.AutoRetry);
+        Assert.True(package.OverridenOptions.RunAsAdministrator);
+
+        // Already elevated: the same failure must not loop, it should surface as a plain failure
+        var failure = manager.OperationHelper.GetResult(
+            package,
+            OperationType.Update,
+            ["Can't shim 'notepad++.exe': File doesn't exist."],
+            1
+        );
+        OperationAssert.HasVeredict(failure, OperationVeredict.Failure);
+    }
+
+    [Fact]
+    public void OperationResultDoesNotRetryShimMessageOnSuccess()
+    {
+        var manager = new Scoop();
+        var package = new PackageBuilder().WithManager(manager).Build();
+
+        var veredict = manager.OperationHelper.GetResult(
+            package,
+            OperationType.Update,
+            ["Creating shim for 'tool'.", "Can't shim is mentioned but the operation succeeded"],
+            0
+        );
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Success);
+    }
+
     private static Scoop CreateManagerWithKnownSources(params string[] sourceNames)
     {
         var manager = new Scoop();


### PR DESCRIPTION
This pull request improves how the Scoop package manager handles shim creation failures that require elevation, and adds tests to ensure this behavior works as expected. The main change is to automatically retry failed shim operations with elevated privileges if a specific error is detected, preventing unnecessary failures and improving reliability.

**Scoop shim error handling:**

* Updated `ScoopPkgOperationHelper.cs` to detect shim resolution failures (messages containing "Can't shim") and automatically retry the operation with elevated privileges, unless already running as administrator. This prevents failures caused by permission issues when creating shims.

**Test coverage improvements:**

* Added unit tests in `ScoopManagerTests.cs` to verify:
  - The operation is retried with elevation on shim resolution failure, and does not loop if already elevated.
  - The presence of a "Can't shim" message does not trigger a retry if the operation succeeded.