### PR TITLE
Fix UI not fully updating on runtime system theme change

### DIFF
--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -61,7 +61,10 @@ namespace UniGetUI.Interface
             ExtendsContentIntoTitleBar = true;
             AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
             SetTitleBar(MainContentGrid);
-            MainContentGrid.ActualThemeChanged += (_, _) => ApplyTitleBarButtonColors();
+            // System theme changed at runtime: re-sync the cached theme, title bar and tray icon
+            MainContentGrid.ActualThemeChanged += (_, _) => { ApplyTheme(); UpdateSystemTrayStatus(); };
+            // Tray icon follows the system theme even when the app theme is fixed
+            MainApp.Instance.ThemeListener.ThemeChanged += (_) => DispatcherQueue.TryEnqueue(UpdateSystemTrayStatus);
             AppWindow.SetIcon(
                 Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Images", "icon.ico")
             );


### PR DESCRIPTION
This pull request improves how the application's theme and system tray icon are updated in response to system and theme changes. The main changes focus on ensuring the tray icon and theme stay in sync with the system, even when the app's theme is fixed.

**Theme and system tray synchronization:**

* Updated the `MainContentGrid.ActualThemeChanged` event handler to call both `ApplyTheme()` and `UpdateSystemTrayStatus()`, ensuring the app's cached theme, title bar, and tray icon update when the system theme changes at runtime.
* Added a listener to `ThemeListener.ThemeChanged` so that the tray icon updates to follow the system theme, even if the app's theme setting is fixed.