### PR TITLE
Respect OS "reduce motion" setting for Avalonia UI animations

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/DirectionalSlideTransition.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/DirectionalSlideTransition.cs
@@ -29,6 +29,14 @@ public sealed class DirectionalSlideTransition : IPageTransition
 
     public async Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
     {
+        // Honor the OS "reduce motion" preference: swap pages instantly, no slide.
+        if (MotionPreference.ReducedMotion)
+        {
+            if (from is not null) { from.IsVisible = false; from.RenderTransform = null; }
+            to?.RenderTransform = null;
+            return;
+        }
+
         double sign = Reverse ? -1d : 1d;
         double width = (to ?? from)?.GetVisualParent()?.Bounds.Width
                        ?? (to ?? from)?.Bounds.Width ?? 0d;

--- a/src/UniGetUI.Avalonia/Infrastructure/EntrancePageTransition.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/EntrancePageTransition.cs
@@ -22,6 +22,14 @@ public sealed class EntrancePageTransition : IPageTransition
 
     public async Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
     {
+        // Honor "reduce motion": hide the outgoing page and show the incoming one instantly, no overlap.
+        if (MotionPreference.ReducedMotion)
+        {
+            if (from is not null) from.Opacity = 0;
+            if (to is not null) to.Opacity = 1;
+            return;
+        }
+
         // Drop the outgoing page immediately so only the incoming page animates in.
         from?.Opacity = 0;
 

--- a/src/UniGetUI.Avalonia/Infrastructure/EntrancePageTransition.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/EntrancePageTransition.cs
@@ -25,8 +25,8 @@ public sealed class EntrancePageTransition : IPageTransition
         // Honor "reduce motion": hide the outgoing page and show the incoming one instantly, no overlap.
         if (MotionPreference.ReducedMotion)
         {
-            if (from is not null) from.Opacity = 0;
-            if (to is not null) to.Opacity = 1;
+            from?.Opacity = 0;
+            to?.Opacity = 1;
             return;
         }
 

--- a/src/UniGetUI.Avalonia/Infrastructure/MotionPreference.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MotionPreference.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using UniGetUI.Core.Logging;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Reads the OS "reduce motion / show animations" accessibility preference so UI
+/// transitions can honor it (Windows: Settings → Accessibility → Visual effects →
+/// Animation effects; macOS: Accessibility → Display → Reduce motion). Windows is read
+/// live on each access (cheap P/Invoke); macOS/Linux are read once and cached because
+/// they spawn a process. Defaults to "animations on" if the preference can't be read.
+/// </summary>
+internal static class MotionPreference
+{
+    private static bool? _cachedUnix;
+
+    /// <summary>True when the user has asked the OS to minimize animations.</summary>
+    public static bool ReducedMotion
+    {
+        get
+        {
+            if (OperatingSystem.IsWindows())
+                return GetWindowsReducedMotion();
+            return _cachedUnix ??= GetUnixReducedMotion();
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool GetWindowsReducedMotion()
+    {
+        try
+        {
+            // Same signal WinUI's UISettings.AnimationsEnabled reads; pvParam is a BOOL.
+            int enabled = 1;
+            if (NativeMethods.SystemParametersInfoW(NativeMethods.SPI_GETCLIENTAREAANIMATION, 0, ref enabled, 0))
+                return enabled == 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not read SPI_GETCLIENTAREAANIMATION; assuming animations enabled");
+            Logger.Warn(ex);
+        }
+        return false;
+    }
+
+    private static bool GetUnixReducedMotion()
+    {
+        try
+        {
+            if (OperatingSystem.IsMacOS())
+                return ReadCommand("/usr/bin/defaults", ["read", "com.apple.universalaccess", "reduceMotion"]) is "1";
+
+            if (OperatingSystem.IsLinux())
+                return string.Equals(
+                    ReadCommand("/usr/bin/gsettings", ["get", "org.gnome.desktop.interface", "gtk-enable-animations"]),
+                    "false", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not read OS reduce-motion preference; assuming animations enabled");
+            Logger.Warn(ex);
+        }
+        return false;
+    }
+
+    private static string? ReadCommand(string fileName, string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var proc = Process.Start(psi);
+        if (proc is null)
+            return null;
+
+        string output = proc.StandardOutput.ReadToEnd();
+        if (!proc.WaitForExit(2000))
+        {
+            try { proc.Kill(); } catch { /* best effort */ }
+            return null;
+        }
+        return proc.ExitCode == 0 ? output.Trim() : null;
+    }
+
+    private static class NativeMethods
+    {
+        public const uint SPI_GETCLIENTAREAANIMATION = 0x1042;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SystemParametersInfoW(uint uiAction, uint uiParam, ref int pvParam, uint fWinIni);
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
@@ -45,6 +45,10 @@ public partial class PackageDetailsWindow : Window
         InitializeComponent();
         UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
+        // Honor the OS "reduce motion" preference: drop the screenshot slide animation.
+        if (MotionPreference.ReducedMotion)
+            ScreenshotsCarousel.PageTransition = null;
+
         _vm.CloseRequested += (_, _) => Close();
         _vm.DetailsLoaded += (_, _) =>
         {


### PR DESCRIPTION
This pull request adds support for honoring the operating system's "reduce motion" accessibility preference throughout the application's UI transitions. When the user enables "reduce motion" in their OS settings, page transitions and certain animations are disabled or simplified for improved accessibility. The main changes include the implementation of a cross-platform `MotionPreference` utility and updates to transition and animation logic to respect this preference.

**Accessibility: Reduce Motion Preference**
* Added a new `MotionPreference` utility class that detects the OS-level "reduce motion" or "show animations" accessibility setting on Windows, macOS, and Linux, using platform-specific APIs and commands. The result is cached on Unix systems for efficiency.

**Page Transitions and Animations**
* Updated `DirectionalSlideTransition` to skip slide animations and instantly swap pages if "reduce motion" is enabled.
* Updated `EntrancePageTransition` to bypass fade/slide animations and instantly transition between pages when "reduce motion" is active.
* Modified `PackageDetailsWindow` to disable the screenshot carousel slide animation if the "reduce motion" preference is set.