### PR TITLE
Show release notes on first run after an update

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -252,7 +252,27 @@ public partial class MainWindowViewModel : ViewModelBase
             TelemetryWarner.IsOpen = true;
         }
 
-        LoadDefaultPage();
+        if (WasUpdatedSinceLastRun() && !Settings.Get(Settings.K.DisableReleaseNotesOnUpdate))
+        {
+            NavigateTo(PageType.ReleaseNotes);
+        }
+        else
+        {
+            LoadDefaultPage();
+        }
+    }
+
+    // Returns true the first time the app runs after being updated to a newer build
+    private static bool WasUpdatedSinceLastRun()
+    {
+        _ = int.TryParse(Settings.GetValue(Settings.K.LastKnownBuildNumber), out int lastBuild);
+
+        if (lastBuild != CoreData.BuildNumber)
+        {
+            Settings.SetValue(Settings.K.LastKnownBuildNumber, CoreData.BuildNumber.ToString());
+        }
+
+        return lastBuild != 0 && lastBuild < CoreData.BuildNumber;
     }
 
     private void OnAnnouncementRequested(object? _, AccessibilityAnnouncement announcement)

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/General.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/General.axaml
@@ -34,6 +34,11 @@
 
             <settings:CheckboxCard SettingName="EnableUniGetUIBeta"
                                    Text="{t:Translate Install prerelease versions of UniGetUI}"
+                                   CornerRadius="0"
+                                   BorderThickness="1,0,1,1"/>
+
+            <settings:CheckboxCard SettingName="DisableReleaseNotesOnUpdate"
+                                   Text="{t:Translate Show the release notes after UniGetUI is updated}"
                                    CornerRadius="0,0,8,8"
                                    BorderThickness="1,0,1,1"/>
 

--- a/src/UniGetUI.Core.Settings/SettingsEngine_Names.cs
+++ b/src/UniGetUI.Core.Settings/SettingsEngine_Names.cs
@@ -95,6 +95,8 @@ public static partial class Settings
         BunPreferLatestVersions,
         TrayIconStyle,
         RedactUsernameInLog,
+        DisableReleaseNotesOnUpdate,
+        LastKnownBuildNumber,
 
         Test1,
         Test2,
@@ -201,6 +203,8 @@ public static partial class Settings
             K.BunPreferLatestVersions => "BunPreferLatestVersions",
             K.TrayIconStyle => "TrayIconStyle",
             K.RedactUsernameInLog => "RedactUsernameInLog",
+            K.DisableReleaseNotesOnUpdate => "DisableReleaseNotesOnUpdate",
+            K.LastKnownBuildNumber => "LastKnownBuildNumber",
 
             K.Test1 => "TestSetting1",
             K.Test2 => "TestSetting2",

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -193,6 +193,8 @@ namespace UniGetUI.Interface
                 DialogHelper.ShowTelemetryBanner();
             }
 
+            ShowReleaseNotesIfUpdated();
+
             if (!Settings.Get(Settings.K.CollapseNavMenuOnWideScreen))
             {
                 NavView.IsPaneOpen = true;
@@ -371,6 +373,23 @@ namespace UniGetUI.Interface
 
         private void ReleaseNotesMenu_Click(object sender, RoutedEventArgs e) =>
             _ = DialogHelper.ShowReleaseNotes();
+
+        // Show the changelog the first time the app runs after being updated to a newer build
+        private static void ShowReleaseNotesIfUpdated()
+        {
+            _ = int.TryParse(Settings.GetValue(Settings.K.LastKnownBuildNumber), out int lastBuild);
+
+            if (lastBuild != 0 && lastBuild < CoreData.BuildNumber
+                && !Settings.Get(Settings.K.DisableReleaseNotesOnUpdate))
+            {
+                _ = DialogHelper.ShowReleaseNotes();
+            }
+
+            if (lastBuild != CoreData.BuildNumber)
+            {
+                Settings.SetValue(Settings.K.LastKnownBuildNumber, CoreData.BuildNumber.ToString());
+            }
+        }
 
         private void CheckForUpdates_Click(object sender, RoutedEventArgs e)
         {

--- a/src/UniGetUI/Pages/SettingsPages/GeneralPages/General.xaml
+++ b/src/UniGetUI/Pages/SettingsPages/GeneralPages/General.xaml
@@ -73,9 +73,15 @@
       />
       <widgets:CheckboxCard
         BorderThickness="1,0,1,1"
-        CornerRadius="0,0,8,8"
+        CornerRadius="0"
         SettingName="EnableUniGetUIBeta"
         Text="Install prerelease versions of UniGetUI"
+      />
+      <widgets:CheckboxCard
+        BorderThickness="1,0,1,1"
+        CornerRadius="0,0,8,8"
+        SettingName="DisableReleaseNotesOnUpdate"
+        Text="Show the release notes after UniGetUI is updated"
       />
 
       <widgets:TranslatedTextBlock Margin="4,32,4,8" FontWeight="SemiBold" Text="Telemetry" />


### PR DESCRIPTION
This pull request introduces a new feature that automatically shows the release notes to users the first time they run the app after an update, unless the user disables this behavior in the settings. To support this, two new settings have been added: one to track the last known build number and another to allow users to disable the automatic release notes display. The release notes display logic has been integrated into both the Avalonia and WinUI code paths, and the settings UI has been updated to expose the new option.

**Release notes display on update:**

* Added logic in `MainWindowViewModel.cs` and `MainView.xaml.cs` to automatically show release notes after an update, only if the user hasn't disabled this feature. The logic checks the build number and updates it after showing the release notes. 

**Settings infrastructure:**

* Added two new settings keys to the `SettingsEngine_Names.cs` enum: `DisableReleaseNotesOnUpdate` and `LastKnownBuildNumber`, and updated the key resolution logic to support them. [
**User interface updates:**

* Added a new checkbox to the general settings pages in both Avalonia (`General.axaml`) and WinUI (`General.xaml`) to allow users to enable or disable the automatic display of release notes after an update. 