### PR TITLE
splashscreen not showing in winui

### DIFF
--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -707,8 +707,14 @@ namespace UniGetUI.Interface
             bool dark = MainApp.Instance.ThemeListener.CurrentTheme == ApplicationTheme.Dark;
             string asset = dark ? "SplashScreen.theme-dark.png" : "SplashScreen.png";
             string path = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", asset);
-            if (File.Exists(path))
-                SplashImage.Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(path));
+            if (!File.Exists(path)) return;
+
+            // BitmapImage can't load file:// URIs and ms-appx folds ".theme-dark" into a PRI
+            // theme qualifier, so load the bytes and decode from a stream instead.
+            var bitmap = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage();
+            using (var stream = File.OpenRead(path))
+                bitmap.SetSource(stream.AsRandomAccessStream());
+            SplashImage.Source = bitmap;
         }
 
         public void ApplyTheme()

--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -706,7 +706,9 @@ namespace UniGetUI.Interface
         {
             bool dark = MainApp.Instance.ThemeListener.CurrentTheme == ApplicationTheme.Dark;
             string asset = dark ? "SplashScreen.theme-dark.png" : "SplashScreen.png";
-            SplashImage.Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri($"ms-appx:///Assets/{asset}"));
+            string path = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", asset);
+            if (File.Exists(path))
+                SplashImage.Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(path));
         }
 
         public void ApplyTheme()

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -286,6 +286,12 @@
         <PRIResource Remove="Intereface\**" />
     </ItemGroup>
     <ItemGroup>
+        <!-- WinUI default content deploys these to the build output but not to publish, leaving the
+             installed (unpackaged) app with no splash image. Force them into the publish output. -->
+        <Content Update="Assets\SplashScreen.png" CopyToPublishDirectory="PreserveNewest" />
+        <Content Update="Assets\SplashScreen.theme-dark.png" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+    <ItemGroup>
         <None Update="Assets\Images\*.png">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>


### PR DESCRIPTION
This pull request improves how splash images are loaded and ensures they are correctly included in published builds. The most important changes are:

**Splash image loading improvements:**

* Updated `ApplySplashImage()` in `MainWindow.xaml.cs` to load splash images directly from the executable directory, reading the image bytes and decoding from a stream to work around limitations with URI loading and theme qualifiers.

**Build and deployment fixes:**

* Modified `UniGetUI.csproj` to explicitly include `SplashScreen.png` and `SplashScreen.theme-dark.png` in the publish output, ensuring the splash image appears in installed (unpackaged) apps.
