### PR TITLE
Fix: username redaction must not corrupt operation result detection

### DIFF
--- a/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
@@ -99,15 +99,19 @@ public abstract partial class AbstractOperation : IDisposable
 
     protected void Line(string line, LineType type)
     {
-        line = Logger.Redact(line);
+        // LogList stays raw: it is the source of truth for result parsing. Only display redacts.
         if (type != LineType.ProgressIndicator)
             LogList.Add((line, type));
-        LogLineAdded?.Invoke(this, (line, type));
+        LogLineAdded?.Invoke(this, (Logger.Redact(line), type));
     }
+
+    protected IReadOnlyList<(string, LineType)> GetRawOutput() => LogList;
 
     public IReadOnlyList<(string, LineType)> GetOutput()
     {
-        return LogList;
+        if (!Logger.RedactUsername)
+            return LogList;
+        return LogList.Select(l => (Logger.Redact(l.Item1), l.Item2)).ToList();
     }
 
     public async Task MainThread()

--- a/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
@@ -185,8 +185,9 @@ public abstract class AbstractProcessOperation : AbstractOperation
         if (ProcessKilled)
             return OperationVeredict.Canceled;
 
+        // Raw output: redacting here would corrupt the phrases result detection matches on.
         List<string> output = new();
-        foreach (var line in GetOutput())
+        foreach (var line in GetRawOutput())
         {
             if (line.Item2 is LineType.VerboseDetails && line.Item1 == "-----------------------")
                 output.Clear();

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Enums;
@@ -332,6 +333,35 @@ public sealed class PackageOperationsTests
         );
     }
 
+    [Fact]
+    public void UsernameRedactionAppliesToDisplayOutputButNeverToResultParsingOutput()
+    {
+        // Regression: result parsing must see raw output; only display (GetOutput) may redact.
+        var username = Environment.UserName;
+        if (string.IsNullOrEmpty(username))
+            return;
+
+        using var operation = new LoggingStubOperation();
+        var rawLine = $"Error: the operation was canceled by C:\\Users\\{username}\\app";
+        operation.EmitLine(rawLine, AbstractOperation.LineType.Information);
+
+        bool previous = Logger.RedactUsername;
+        Logger.RedactUsername = true;
+        try
+        {
+            var parsingOutput = operation.RawOutputForTests();
+            var displayOutput = operation.GetOutput();
+
+            Assert.Contains(parsingOutput, l => l.Item1 == rawLine);
+            Assert.DoesNotContain(displayOutput, l => l.Item1.Contains(username));
+            Assert.Contains(displayOutput, l => l.Item1.Contains("****"));
+        }
+        finally
+        {
+            Logger.RedactUsername = previous;
+        }
+    }
+
     private static IReadOnlyList<AbstractOperation.InnerOperation> GetInnerOperations(
         AbstractOperation operation,
         string fieldName
@@ -461,6 +491,23 @@ public sealed class PackageOperationsTests
         {
             return Task.FromResult(_veredict);
         }
+    }
+
+    private sealed class LoggingStubOperation : AbstractOperation
+    {
+        public LoggingStubOperation()
+            : base(queue_enabled: false) { }
+
+        public void EmitLine(string line, LineType type) => Line(line, type);
+
+        public IReadOnlyList<(string, LineType)> RawOutputForTests() => GetRawOutput();
+
+        protected override void ApplyRetryAction(string retryMode) { }
+
+        protected override Task<OperationVeredict> PerformOperation()
+            => Task.FromResult(OperationVeredict.Success);
+
+        public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));
     }
 
     private sealed class StubOperation : AbstractOperation


### PR DESCRIPTION
This pull request improves how sensitive information (specifically usernames) is handled in operation logs, ensuring that redaction only applies to user-facing output and not to internal result parsing. It also adds tests to prevent regressions in this behavior.

**Sensitive information handling:**

* Updated `AbstractOperation` so that log redaction (e.g., username masking) is only applied when displaying output, not when storing or parsing logs. The new `GetRawOutput()` method returns unredacted logs for internal use, while `GetOutput()` applies redaction for display if enabled.
* Modified `AbstractProcessOperation` to use raw output for result parsing, ensuring that phrase detection and result matching are not affected by redaction.

**Testing improvements:**

* Added a regression test (`UsernameRedactionAppliesToDisplayOutputButNeverToResultParsingOutput`) to verify that redaction is only applied to display output and not to the raw logs used for result parsing.
* Introduced a `LoggingStubOperation` test helper to facilitate testing of logging and redaction behaviors.

**Code maintenance:**

* Added a missing `using` statement for `UniGetUI.Core.Logging` in the test file.