### PR TITLE
Show operations progress counter in the operations panel header

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -1,4 +1,5 @@
 {
+  "{0} of {1} operations completed": "{0} of {1} operations completed",
   "{0} is now {1}": "{0} is now {1}",
   "Enabled": "Enabled",
   "Disabled": "Disabled",

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -22,6 +22,7 @@ using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.PackageLoader;
+using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.ViewModels;
 
@@ -66,6 +67,41 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _operationsPanelExpanded = true;
+
+    private readonly List<AbstractOperation> _operationBatch = new();
+
+    public string OperationsHeaderText
+    {
+        get
+        {
+            int total = _operationBatch.Count;
+            if (total == 0)
+                return CoreTools.Translate("Operations");
+            int completed = _operationBatch.Count(o =>
+                o.Status is OperationStatus.Succeeded or OperationStatus.Failed or OperationStatus.Canceled);
+            return CoreTools.Translate("{0} of {1} operations completed", completed, total);
+        }
+    }
+
+    private void AddToBatch(AbstractOperation op)
+    {
+        if (_operationBatch.Count > 0
+            && _operationBatch.All(o => o.Status is not (OperationStatus.InQueue or OperationStatus.Running)))
+        {
+            foreach (var old in _operationBatch)
+                old.StatusChanged -= OnOperationStatusChanged;
+            _operationBatch.Clear();
+        }
+
+        if (!_operationBatch.Contains(op))
+        {
+            _operationBatch.Add(op);
+            op.StatusChanged += OnOperationStatusChanged;
+        }
+    }
+
+    private void OnOperationStatusChanged(object? sender, OperationStatus e)
+        => Dispatcher.UIThread.Post(() => OnPropertyChanged(nameof(OperationsHeaderText)));
 
     [RelayCommand]
     private void ToggleOperationsPanel() => OperationsPanelExpanded = !OperationsPanelExpanded;
@@ -221,8 +257,14 @@ public partial class MainWindowViewModel : ViewModelBase
         AvaloniaAutoUpdater.CheckForOrphanedUpdateAttempt();
 
         // Keep OperationsPanelVisible in sync with the live operations list
-        Operations.CollectionChanged += (_, _) =>
+        Operations.CollectionChanged += (_, e) =>
+        {
+            if (e.NewItems is not null)
+                foreach (OperationViewModel vm in e.NewItems)
+                    AddToBatch(vm.Operation);
             OperationsPanelVisible = Operations.Count > 0;
+            OnPropertyChanged(nameof(OperationsHeaderText));
+        };
 
         if (OperatingSystem.IsWindows() && CoreTools.IsAdministrator() && !Settings.Get(Settings.K.AlreadyWarnedAboutAdmin))
         {

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -112,7 +112,7 @@
                         </Button>
 
                         <TextBlock Grid.Column="1"
-                                   Text="{t:Translate Operations}"
+                                   Text="{Binding OperationsHeaderText}"
                                    FontSize="11" Opacity="0.6"
                                    VerticalAlignment="Center"
                                    Margin="4,0,0,0"/>

--- a/src/UniGetUI/Pages/MainView.xaml
+++ b/src/UniGetUI/Pages/MainView.xaml
@@ -407,6 +407,16 @@
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="15" />
         </Grid.ColumnDefinitions>
+        <TextBlock
+          Name="OperationCountLabel"
+          Grid.Column="0"
+          Margin="4,0,0,0"
+          VerticalAlignment="Center"
+          FontSize="12"
+          Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+          IsHitTestVisible="False"
+          TextTrimming="CharacterEllipsis"
+        />
         <HyperlinkButton
           Name="ExpandCollapseOpList"
           AutomationProperties.Name="Expand or collapse operation list"

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using UniGetUI.Controls;
+using UniGetUI.Controls.OperationWidgets;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -185,8 +186,13 @@ namespace UniGetUI.Interface
             }
 
             UpdateOperationsLayout();
-            MainApp.Operations._operationList.CollectionChanged += (_, _) =>
+            MainApp.Operations._operationList.CollectionChanged += (_, e) =>
+            {
+                if (e.NewItems is not null)
+                    foreach (OperationControl c in e.NewItems)
+                        AddToBatch(c.Operation);
                 UpdateOperationsLayout();
+            };
 
             if (!Settings.Get(Settings.K.ShownTelemetryBanner))
             {
@@ -478,6 +484,38 @@ namespace UniGetUI.Interface
                 OperationSplitterMenuButton.Visibility = Visibility.Collapsed;
             }
             ResizingOPLayout = false;
+            UpdateOperationCount();
+        }
+
+        private readonly List<AbstractOperation> _operationBatch = new();
+
+        private void AddToBatch(AbstractOperation op)
+        {
+            if (_operationBatch.Count > 0
+                && _operationBatch.All(o => o.Status is not (OperationStatus.InQueue or OperationStatus.Running)))
+            {
+                foreach (var old in _operationBatch)
+                    old.StatusChanged -= OnAnyOperationStatusChanged;
+                _operationBatch.Clear();
+            }
+
+            if (!_operationBatch.Contains(op))
+            {
+                _operationBatch.Add(op);
+                op.StatusChanged += OnAnyOperationStatusChanged;
+            }
+        }
+
+        private void OnAnyOperationStatusChanged(object? sender, OperationStatus e)
+            => DispatcherQueue.TryEnqueue(UpdateOperationCount);
+
+        private void UpdateOperationCount()
+        {
+            int total = _operationBatch.Count;
+            int completed = _operationBatch.Count(o =>
+                o.Status is OperationStatus.Succeeded or OperationStatus.Failed or OperationStatus.Canceled);
+            OperationCountLabel.Text =
+                total > 0 ? CoreTools.Translate("{0} of {1} operations completed", completed, total) : "";
         }
 
         private void OperationScrollView_SizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
This pull request improves the user experience by displaying a dynamic summary of operation progress in both the Avalonia and WinUI main views. The summary now shows how many operations have completed out of the total, updating live as operation statuses change. The implementation introduces logic to track batches of operations and update the UI accordingly.

**Operation progress summary improvements:**

* Added an `OperationsHeaderText` property and supporting logic to `MainWindowViewModel` to display a live summary of completed operations out of the total. The summary updates automatically as operation statuses change. (`src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs`) 
* Updated the Avalonia main window view to bind the operations panel header to `OperationsHeaderText`, replacing the previous static label. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml`)

**WinUI operation summary integration:**

* Added a new `TextBlock` (`OperationCountLabel`) to the WinUI main view to display the operation summary. (`src/UniGetUI/Pages/MainView.xaml`)
* Implemented batch tracking and live updating of the operation summary in `MainView.xaml.cs`, mirroring the Avalonia logic. The summary text updates as operations are added or their statuses change. (`src/UniGetUI/Pages/MainView.xaml.cs`) 
**Code organization:**

These changes ensure users receive clear, real-time feedback on operation progress in both UI frameworks.