### PR TITLE
Fix empty WinGet update list on fresh launch + bump pinget to 0.9.0

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -138,7 +138,7 @@
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.8.2" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.9.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetCliHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetCliHelper.cs
@@ -178,6 +178,7 @@ internal sealed partial class PingetCliHelper : IWinGetManagerHelper
 
     private T RunJson<T>(LoggableTaskType taskType, string arguments)
     {
+        using var _cliLock = WinGet.AcquireCliLock();
         using Process process = new()
         {
             StartInfo = new ProcessStartInfo

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetPackageDetailsProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetPackageDetailsProvider.cs
@@ -149,6 +149,7 @@ internal sealed class PingetCliPackageDetailsProvider(string cliExecutablePath)
 
     private string RunPinget(IReadOnlyList<string> arguments, INativeTaskLogger logger)
     {
+        using var _cliLock = WinGet.AcquireCliLock();
         using Process process = new()
         {
             StartInfo = new ProcessStartInfo

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
@@ -40,6 +40,7 @@ internal sealed class WinGetCliHelper : IWinGetManagerHelper
 
     public IReadOnlyList<Package> GetAvailableUpdates_UnSafe()
     {
+        using var _cliLock = WinGet.AcquireCliLock();
         List<Package> Packages = [];
         using Process p = new()
         {
@@ -175,6 +176,7 @@ internal sealed class WinGetCliHelper : IWinGetManagerHelper
 
     public IReadOnlyList<Package> GetInstalledPackages_UnSafe()
     {
+        using var _cliLock = WinGet.AcquireCliLock();
         List<Package> Packages = [];
         using Process p = new()
         {
@@ -307,6 +309,7 @@ internal sealed class WinGetCliHelper : IWinGetManagerHelper
 
     public IReadOnlyList<Package> FindPackages_UnSafe(string query)
     {
+        using var _cliLock = WinGet.AcquireCliLock();
         List<Package> Packages = [];
         using Process p = new()
         {
@@ -435,6 +438,7 @@ internal sealed class WinGetCliHelper : IWinGetManagerHelper
 
     public IReadOnlyList<string> GetInstallableVersions_Unsafe(IPackage package)
     {
+        using var _cliLock = WinGet.AcquireCliLock();
         using Process p = new()
         {
             StartInfo = new ProcessStartInfo
@@ -498,6 +502,7 @@ internal sealed class WinGetCliHelper : IWinGetManagerHelper
 
     public IReadOnlyList<IManagerSource> GetSources_UnSafe()
     {
+        using var _cliLock = WinGet.AcquireCliLock();
         List<IManagerSource> sources = [];
 
         using Process p = new()

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Pinget.Core" Version="0.8.2" />
+        <PackageReference Include="Devolutions.Pinget.Core" Version="0.9.0" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
     </ItemGroup>
 </Project>

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -59,6 +59,35 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
         internal WinGetCliToolKind SelectedCliToolKind { get; private set; } =
             WinGetCliToolKind.SystemWinGet;
 
+        // winget's local index isn't safe under concurrent process access: a `source update` (writer)
+        // running alongside list/upgrade/search (readers) yields partial or empty results. The COM
+        // backend serialized this implicitly; the CLI backends (winget.exe / pinget.exe) must do it
+        // explicitly. Reentrant (Monitor) so same-thread nested invocations don't self-deadlock.
+        private static readonly object _cliInvocationLock = new();
+
+        // Safety valve: never wait on the CLI lock longer than this, so a hung process can't freeze all WinGet queries.
+        private static readonly TimeSpan CliLockTimeout = TimeSpan.FromSeconds(120);
+
+        internal static IDisposable AcquireCliLock()
+        {
+            bool taken = false;
+            Monitor.TryEnter(_cliInvocationLock, CliLockTimeout, ref taken);
+            if (!taken)
+                Logger.Warn("WinGet CLI lock not acquired within timeout; proceeding unserialized to avoid a hang.");
+            return new CliLockReleaser(taken);
+        }
+
+        private sealed class CliLockReleaser(bool taken) : IDisposable
+        {
+            private bool _released;
+            public void Dispose()
+            {
+                if (_released || !taken) return;
+                _released = true;
+                Monitor.Exit(_cliInvocationLock);
+            }
+        }
+
         public WinGet()
         {
             Capabilities = new ManagerCapabilities
@@ -719,6 +748,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
         public override void RefreshPackageIndexes()
         {
+            using var _cliLock = AcquireCliLock();
             using Process p = new()
             {
                 StartInfo = new ProcessStartInfo

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -221,7 +221,7 @@
         <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.8.2" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.9.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
 
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>


### PR DESCRIPTION
On a cold start the WinGet update list was frequently empty or partial, only populating after a manual reload. _getAvailableUpdates runs `pinget source update` via Task.Run(RefreshPackageIndexes).Wait(60s) and then `pinget upgrade`; .Wait(timeout) does not cancel the task, so when source update runs longer than 60s the wait is abandoned and upgrade reads a half-rewritten index, returning 0 or partial results. The COM backend serialized winget access implicitly; the pinget/winget CLI backends did not.

Add WinGet.AcquireCliLock(), a static reentrant lock wrapping every CLI invocation (PingetCliHelper.RunJson, WinGet.RefreshPackageIndexes, WinGetCliHelper query methods, PingetCliPackageDetailsProvider.RunPinget) so upgrade waits for source update to finish instead of racing it. Lock acquisition is bounded (Monitor.TryEnter, 120s): a hung CLI process falls back to running unserialized rather than freezing all WinGet queries.

Also bump pinget to 0.9.0 (Cli.Rust for both apps, Core for the manager).