### PR TITLE
Fix race condition on startup and improve fault tolerance

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Avalonia;
+using Avalonia.Threading;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
@@ -67,6 +68,11 @@ public static class AvaloniaAppHost
         Logger.ImportantInfo($"Elevated: {CoreTools.IsAdministrator()}");
         Logger.ImportantInfo($"Packaged (MSIX): {CoreTools.IsPackagedApp()}");
         Logger.ImportantInfo($"Args: {(args.Length > 0 ? string.Join(" ", args) : "(none)")}");
+
+        // Bind Avalonia's UI-thread dispatcher to this (main/STA) thread before the single-instance
+        // listener starts: if a second instance connects mid-startup, the listener's Dispatcher.UIThread.Post
+        // would otherwise bind it to the worker thread and make Win32Platform.Initialize throw.
+        _ = Dispatcher.UIThread;
 
         if (!TryRegisterSingleInstance(args))
         {

--- a/src/UniGetUI.PackageEngine.PackageEngine/PEInterface.cs
+++ b/src/UniGetUI.PackageEngine.PackageEngine/PEInterface.cs
@@ -69,8 +69,15 @@ namespace UniGetUI.PackageEngine
             }
             catch (Exception ex)
             {
-                Logger.Error($"Failed to construct package manager {typeof(T).Name}; it will be unavailable this session.");
-                Logger.Error(ex);
+                // Logging runs inside its own guard: this method must never throw, or it would
+                // re-trigger the TypeInitializationException it exists to prevent (it runs from
+                // a static field initializer).
+                try
+                {
+                    Logger.Error($"Failed to construct package manager {typeof(T).Name}; it will be unavailable this session.");
+                    Logger.Error(ex);
+                }
+                catch { /* swallow: never let static initialization fail */ }
                 return null;
             }
         }

--- a/src/UniGetUI.PackageEngine.PackageEngine/PEInterface.cs
+++ b/src/UniGetUI.PackageEngine.PackageEngine/PEInterface.cs
@@ -33,57 +33,78 @@ namespace UniGetUI.PackageEngine
     {
         private const int ManagerLoadTimeout = 60; // 60 seconds timeout for Package Manager initialization (in seconds)
 #if WINDOWS
-        public static readonly WinGet WinGet = new();
-        public static readonly Scoop Scoop = new();
-        public static readonly Chocolatey Chocolatey = new();
+        public static readonly WinGet? WinGet = Create(() => new WinGet());
+        public static readonly Scoop? Scoop = Create(() => new Scoop());
+        public static readonly Chocolatey? Chocolatey = Create(() => new Chocolatey());
 #endif
-        public static readonly Npm Npm = new();
-        public static readonly Bun Bun = new();
-        public static readonly Pip Pip = new();
-        public static readonly DotNet DotNet = new();
-        public static readonly PowerShell7 PowerShell7 = new();
+        public static readonly Npm? Npm = Create(() => new Npm());
+        public static readonly Bun? Bun = Create(() => new Bun());
+        public static readonly Pip? Pip = Create(() => new Pip());
+        public static readonly DotNet? DotNet = Create(() => new DotNet());
+        public static readonly PowerShell7? PowerShell7 = Create(() => new PowerShell7());
 #if WINDOWS
-        public static readonly PowerShell PowerShell = new();
+        public static readonly PowerShell? PowerShell = Create(() => new PowerShell());
 #endif
-        public static readonly Cargo Cargo = new();
-        public static readonly Vcpkg Vcpkg = new();
+        public static readonly Cargo? Cargo = Create(() => new Cargo());
+        public static readonly Vcpkg? Vcpkg = Create(() => new Vcpkg());
 #if !WINDOWS
-        public static readonly Apt Apt = new();
-        public static readonly Dnf Dnf = new();
-        public static readonly Pacman Pacman = new();
-        public static readonly Homebrew Homebrew = new();
-        public static readonly Snap Snap = new();
-        public static readonly Flatpak Flatpak = new();
+        public static readonly Apt? Apt = Create(() => new Apt());
+        public static readonly Dnf? Dnf = Create(() => new Dnf());
+        public static readonly Pacman? Pacman = Create(() => new Pacman());
+        public static readonly Homebrew? Homebrew = Create(() => new Homebrew());
+        public static readonly Snap? Snap = Create(() => new Snap());
+        public static readonly Flatpak? Flatpak = Create(() => new Flatpak());
 #endif
 
         public static readonly IPackageManager[] Managers = CreateManagers();
 
+        // A single manager that fails to construct must not take down the whole engine (and with it
+        // the app, via TypeInitializationException). Log it and leave the field null; CreateManagers
+        // drops nulls so the rest of the managers stay usable.
+        private static T? Create<T>(Func<T> factory) where T : class, IPackageManager
+        {
+            try
+            {
+                return factory();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to construct package manager {typeof(T).Name}; it will be unavailable this session.");
+                Logger.Error(ex);
+                return null;
+            }
+        }
+
         private static IPackageManager[] CreateManagers()
         {
-            List<IPackageManager> managers = [Npm, Bun, Pip, Cargo, Vcpkg, DotNet, PowerShell7];
+            List<IPackageManager?> candidates = [Npm, Bun, Pip, Cargo, Vcpkg, DotNet, PowerShell7];
 #if WINDOWS
-            managers.InsertRange(0, [WinGet, Scoop, Chocolatey]);
-            managers.Add(PowerShell);
+            candidates.InsertRange(0, [WinGet, Scoop, Chocolatey]);
+            candidates.Add(PowerShell);
 #else
-            managers.Insert(0, Homebrew);
+            candidates.Insert(0, Homebrew);
             if (OperatingSystem.IsLinux())
             {
                 var families = ReadLinuxDistroFamilies();
                 // If /etc/os-release is unreadable, include both as a safe fallback.
                 bool unknown = families.Count == 0;
                 if (unknown || families.Contains("debian") || families.Contains("ubuntu"))
-                    managers.Add(Apt);
+                    candidates.Add(Apt);
                 if (unknown || families.Contains("fedora") || families.Contains("rhel") || families.Contains("centos"))
-                    managers.Add(Dnf);
+                    candidates.Add(Dnf);
                 if (unknown || families.Contains("arch"))
-                    managers.Add(Pacman);
+                    candidates.Add(Pacman);
                 if (unknown || families.Contains("ubuntu") || families.Contains("debian") || families.Contains("fedora") || families.Contains("arch"))
                 {
-                    managers.Add(Snap);
-                    managers.Add(Flatpak);
+                    candidates.Add(Snap);
+                    candidates.Add(Flatpak);
                 }
             }
 #endif
+            List<IPackageManager> managers = [];
+            foreach (IPackageManager? manager in candidates)
+                if (manager is not null)
+                    managers.Add(manager);
             return [.. managers];
         }
 

--- a/src/UniGetUI/CrashHandler.cs
+++ b/src/UniGetUI/CrashHandler.cs
@@ -182,6 +182,8 @@ public static class CrashHandler
                     {{e.StackTrace?.Replace("\n", "\n        ")}}
             """;
 
+        Exception originalException = e;
+
         try
         {
             int i = 0;
@@ -210,6 +212,19 @@ public static class CrashHandler
             {
                 Error_String += $"\n\n\nNo inner exceptions found";
             }
+        }
+        catch
+        {
+            // ignore
+        }
+
+        // Authoritative fallback: ToString() recurses through every inner exception (and all of an
+        // AggregateException's inners) with their stack traces. The walk above only follows the single
+        // .InnerException chain, so it can drop the real cause of e.g. a TypeInitializationException.
+        try
+        {
+            Error_String += "\n\n\n———————————————————————————————————————————————————————————\n"
+                + "Full exception detail (ToString):\n" + originalException;
         }
         catch
         {

--- a/src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml.cs
@@ -44,11 +44,14 @@ namespace UniGetUI.Interface
 
             foreach (var (ignoredId, version) in rawIgnoredPackages)
             {
-                IPackageManager manager = PEInterface.WinGet; // Manager by default
+                IPackageManager? manager = PEInterface.WinGet; // Manager by default
                 if (ManagerNameReference.ContainsKey(ignoredId.Split("\\")[0]))
                 {
                     manager = ManagerNameReference[ignoredId.Split("\\")[0]];
                 }
+
+                if (manager is null)
+                    continue;
 
                 ignoredPackages.Add(
                     new IgnoredPackageEntry(

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -175,7 +175,7 @@ namespace UniGetUI.Interface
             }
 
             if (
-                !PEInterface.Chocolatey.Status.Found
+                PEInterface.Chocolatey is { Status.Found: false }
                 && Chocolatey.HasLegacyBundledInstallation()
                 && !Settings.Get(Settings.K.AlreadyWarnedAboutChocolateyMigration)
             )

--- a/src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs
@@ -85,6 +85,10 @@ namespace UniGetUI.Pages.SettingsPages.GeneralPages
             else
                 throw new InvalidCastException("The specified type was not a package manager!");
 
+            // The manager failed to construct at startup (see PEInterface): there is nothing to configure.
+            if (Manager is null)
+                return;
+
             ReapplyProperties?.Invoke(this, new());
 
             ApplyManagerState();


### PR DESCRIPTION
This pull request improves the robustness of package manager initialization and error reporting throughout the application, ensuring that failures in constructing individual package managers do not crash the entire app. It also enhances exception logging and updates code to handle package managers that may be unavailable at runtime.

### Package Manager Initialization and Handling

* Refactored `PEInterface` so that each package manager (`WinGet`, `Scoop`, `Chocolatey`, etc.) is now initialized via a safe `Create` method that catches and logs exceptions, returning `null` if construction fails. This prevents a single manager's failure from crashing the app during static initialization. (`src/UniGetUI.PackageEngine.PackageEngine/PEInterface.cs` [src/UniGetUI.PackageEngine.PackageEngine/PEInterface.csL36-R114](diffhunk://#diff-a55832b389ed6a0993f4a791b076be288fc7b51c1442ff6819b4b344ca9a6057L36-R114))
* Updated all usages of package manager fields to handle the possibility of `null` values, including in `IgnoredUpdates.xaml.cs`, `MainView.xaml.cs`, and `PackageManager.xaml.cs`, preventing null reference exceptions and gracefully skipping unavailable managers. (`src/UniGetUI/Pages/DialogPages/IgnoredUpdates.xaml.cs` `src/UniGetUI/Pages/MainView.xaml.cs` `src/UniGetUI/Pages/SettingsPages/ManagersPages/PackageManager.xaml.cs`

### Exception Logging Improvements

* Enhanced the crash handler to include the full exception detail using `Exception.ToString()`, ensuring that all inner exceptions (including those in `AggregateException`) are logged, not just the direct `InnerException` chain. (`src/UniGetUI/CrashHandler.cs`

### Application Startup Stability

* Ensured that Avalonia's UI-thread dispatcher is bound to the main thread before starting the single-instance listener, preventing threading issues if a second instance connects during startup. (`src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs`