### PR TITLE
Fix: remove duplicated cmd.exe /C call in generated PowerShell script

### DIFF
--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
@@ -614,7 +614,7 @@ public class PackageBundlesPage : AbstractPackagesPage
             $commands= @(
                 {{string.Join(
                     ",\n    ",
-                    commands.Select(x => $"'cmd.exe /C {x.Replace("'", "''")}'")
+                    commands.Select(x => $"'{x.Replace("'", "''")}'")
                 )}}
             )
 

--- a/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
@@ -1011,7 +1011,7 @@ namespace UniGetUI.Interface.SoftwarePages
                 $commands= @(
                     {{string.Join(
                     ",\n    ",
-                    commands.Select(x => $"'cmd.exe /C {x.Replace("'", "''")}'")
+                    commands.Select(x => $"'{x.Replace("'", "''")}'")
                 )}}
                 )
 


### PR DESCRIPTION
This pull request makes a small change to how command strings are generated for package bundles. The change removes the explicit use of `cmd.exe /C` from the generated command strings, simplifying them.

* The command generation logic in both `PackageBundlesPage.cs` and `PackageBundlesPage.cs` (Avalonia version) now creates command strings without prefixing them with `cmd.exe /C`, which may affect how commands are executed in different contexts.