### PR TITLE
Fix Mica readability: links, window border, overlay filter pane

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -18,6 +18,8 @@
                     <SolidColorBrush x:Key="AccentTextFillColorSecondaryBrush" Color="{DynamicResource SystemAccentColorDark3}"/>
                     <SolidColorBrush x:Key="AccentTextFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColorDark1}"/>
                     <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush"  Color="#5C000000"/>
+                    <!-- Hyperlinks: fixed blue, decoupled from the accent so links stay readable over accent-tinted Mica -->
+                    <SolidColorBrush x:Key="HyperlinkForeground"               Color="#1C5FB8"/>
                     <!-- Text fill -->
                     <SolidColorBrush x:Key="TextFillColorPrimaryBrush"   Color="#E4000000"/>
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#9E000000"/>
@@ -81,6 +83,7 @@
                     <SolidColorBrush x:Key="AccentTextFillColorSecondaryBrush" Color="{DynamicResource SystemAccentColorLight3}"/>
                     <SolidColorBrush x:Key="AccentTextFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColorLight2}"/>
                     <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush"  Color="#5CFFFFFF"/>
+                    <SolidColorBrush x:Key="HyperlinkForeground"               Color="#A6D4FF"/>
                     <!-- Text fill -->
                     <SolidColorBrush x:Key="TextFillColorPrimaryBrush"   Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#C5FFFFFF"/>

--- a/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
@@ -10,19 +10,18 @@ namespace UniGetUI.Avalonia.Infrastructure;
 
 /// <summary>
 /// Gives a standard Avalonia <see cref="Window"/> the native Windows 11 look:
-/// the Mica backdrop (whole-window), rounded corners, and an accent-colored border
-/// that follows focus. Windows-only and gated on Windows 11; a no-op elsewhere, so
+/// the Mica backdrop (whole-window) and rounded corners. The window border is left
+/// at the OS default, so it only shows an accent color if the user enabled that in
+/// Personalization. Windows-only and gated on Windows 11; a no-op elsewhere, so
 /// the window keeps its opaque look when Mica isn't available.
 /// Used by the secondary windows/dialogs; MainWindow has its own (custom-frame) variant.
 /// </summary>
 internal static class MicaWindowHelper
 {
     private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
-    private const int DWMWA_BORDER_COLOR = 34;
     private const int DWMWA_SYSTEMBACKDROP_TYPE = 38;
     private const int DWMWCP_ROUND = 2;
     private const int DWMSBT_TRANSIENTWINDOW = 3; // Acrylic — for transient surfaces (menus/flyouts); Mica won't paint on these
-    private const int DWMWA_COLOR_DEFAULT = unchecked((int)0xFFFFFFFF);
 
     private static bool _acrylicPopupsHooked;
 
@@ -44,20 +43,7 @@ internal static class MicaWindowHelper
                 NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
             }
             window.Background = Brushes.Transparent;
-            ApplyBorderAccent(window, window.IsActive);
         };
-
-        window.GetObservable(WindowBase.IsActiveProperty).Subscribe(active => ApplyBorderAccent(window, active));
-
-        if (Application.Current?.PlatformSettings is { } settings)
-        {
-            void Handler(object? s, PlatformColorValues e)
-            {
-                if (window.IsActive) ApplyBorderAccent(window, true);
-            }
-            settings.ColorValuesChanged += Handler;
-            window.Closed += (_, _) => settings.ColorValuesChanged -= Handler;
-        }
     }
 
     // Gives flyouts / menus / combo dropdowns / tooltips a native Win11 acrylic backdrop:
@@ -100,22 +86,6 @@ internal static class MicaWindowHelper
         NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
         int backdrop = DWMSBT_TRANSIENTWINDOW;
         NativeMethods.DwmSetWindowAttribute(handle, DWMWA_SYSTEMBACKDROP_TYPE, ref backdrop, sizeof(int));
-    }
-
-    // Accent-coloured window border that follows focus (kept on the dialogs).
-    private static void ApplyBorderAccent(Window window, bool active)
-    {
-        if (window.TryGetPlatformHandle()?.Handle is not { } handle || handle == 0)
-            return;
-
-        int colorRef = DWMWA_COLOR_DEFAULT;
-        if (active)
-        {
-            Color accent = Application.Current?.PlatformSettings?.GetColorValues().AccentColor1
-                           ?? Colors.Transparent;
-            colorRef = accent.R | (accent.G << 8) | (accent.B << 16); // Color -> COLORREF (0x00BBGGRR)
-        }
-        NativeMethods.DwmSetWindowAttribute(handle, DWMWA_BORDER_COLOR, ref colorRef, sizeof(int));
     }
 
     /// <summary>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
@@ -399,9 +399,10 @@ public partial class PackageDetailsWindow : Window
         host.Children.Add(tb);
     }
 
-    private static IBrush LinkBrush =>
-        Application.Current?.Resources["AccentTextFillColorPrimaryBrush"] as IBrush
-        ?? new SolidColorBrush(Color.FromArgb(255, 0, 120, 212));
+    private IBrush LinkBrush =>
+        this.TryFindResource("HyperlinkForeground", ActualThemeVariant, out var res) && res is IBrush b
+            ? b
+            : new SolidColorBrush(Color.FromArgb(255, 0, 120, 212));
 
     private static void OpenUrl(string url)
     {

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -24,6 +24,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
     private readonly ContextMenu? _contextMenu;
     private double _savedFilterPaneWidth = 220;
     private bool _isOverlayMode;
+    private IDisposable? _sidePanelBgBinding;
 
     protected AbstractPackagesPage(PackagesPageData data)
     {
@@ -349,16 +350,22 @@ public abstract partial class AbstractPackagesPage : UserControl,
             SidePanel.Width = _savedFilterPaneWidth;
             SidePanel.HorizontalAlignment = HorizontalAlignment.Left;
 
+            // Floating over content needs an opaque surface (the page surface is transparent under Mica).
+            _sidePanelBgBinding ??= SidePanel.Bind(Border.BackgroundProperty, this.GetResourceObservable("AppWindowBackground"));
+
             // Semi-transparent backdrop covers the package list behind the pane.
             FilterOverlayBackdrop.IsVisible = open;
         }
         else
         {
-            // Inline mode: pane sits beside the package list.
+            // Inline mode: pane sits beside the package list and blends with the Mica page surface.
             Grid.SetColumnSpan(SidePanel, 1);
             SidePanel.ZIndex = 0;
             SidePanel.Width = double.NaN;
             SidePanel.HorizontalAlignment = HorizontalAlignment.Stretch;
+            _sidePanelBgBinding?.Dispose();
+            _sidePanelBgBinding = null;
+            SidePanel.Background = null;
             FilterOverlayBackdrop.IsVisible = false;
 
             FilteringPanel.ColumnDefinitions[0].Width = open


### PR DESCRIPTION
This pull request focuses on improving visual consistency and accessibility in the application's UI, particularly around hyperlink colors, Mica window styling, and filter pane behavior. The main themes are better resource usage for link colors, simplification of Mica window border handling, and improved overlay panel background management.

**UI consistency and accessibility improvements:**

* Added a fixed blue `HyperlinkForeground` brush for hyperlinks in both light and dark themes in `Styles.Common.axaml`, ensuring links remain readable over accent-tinted Mica backgrounds. 
* Updated the `LinkBrush` in `PackageDetailsWindow.axaml.cs` to use the new `HyperlinkForeground` resource instead of an accent color, improving link color consistency across themes.

**Mica window styling simplification:**

* Removed custom accent-colored window border logic from `MicaWindowHelper.cs`, leaving the border at the OS default and simplifying the code. The border will now only show an accent color if the user has enabled that in Windows personalization settings. 

**Filter pane overlay enhancements:**

* Improved overlay mode for the filter pane in `AbstractPackagesPage.axaml.cs` by binding the side panel background to `AppWindowBackground` when floating and properly disposing the binding when switching back to inline mode, ensuring correct background appearance over Mica. 
