### PR TITLE
Improve small-window layout for package pages

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -174,6 +174,11 @@ public partial class PackagesPageViewModel : ViewModelBase
     public AvaloniaList<SourceTreeNode> SourceNodes { get; } = new();
     public AvaloniaList<object> ToolBarItems { get; } = new();
 
+    // Labels of toolbar buttons that can be hidden to collapse the menu bar to icon-only
+    // on narrow windows (buttons created with showLabel: false are never tracked here).
+    private readonly List<TextBlock> _collapsibleToolbarLabels = new();
+    private bool _toolbarLabelsCollapsed;
+
     // ─── Internal state ───────────────────────────────────────────────────────
     private string _searchQuery = "";
     public string QueryBackup { get; set; } = "";
@@ -280,12 +285,15 @@ public partial class PackagesPageViewModel : ViewModelBase
         content.Children.Add(icon);
         if (showLabel)
         {
-            content.Children.Add(new TextBlock
+            var labelBlock = new TextBlock
             {
                 Text = label,
                 FontSize = 12,
                 VerticalAlignment = VerticalAlignment.Center,
-            });
+                IsVisible = !_toolbarLabelsCollapsed,
+            };
+            content.Children.Add(labelBlock);
+            _collapsibleToolbarLabels.Add(labelBlock);
         }
 
         var btn = new Button
@@ -300,6 +308,18 @@ public partial class PackagesPageViewModel : ViewModelBase
         btn.Click += (_, _) => onClick();
         ToolBarItems.Add(btn);
         return btn;
+    }
+
+    /// <summary>
+    /// Collapses the menu bar to icon-only (or restores labels) on narrow windows,
+    /// mirroring the WinUI CommandBar's DefaultLabelPosition behavior.
+    /// </summary>
+    public void SetToolbarLabelsCollapsed(bool collapsed)
+    {
+        if (_toolbarLabelsCollapsed == collapsed) return;
+        _toolbarLabelsCollapsed = collapsed;
+        foreach (var label in _collapsibleToolbarLabels)
+            label.IsVisible = !collapsed;
     }
 
     /// <summary>Adds a thin vertical separator to the toolbar.</summary>
@@ -807,6 +827,14 @@ public partial class PackagesPageViewModel : ViewModelBase
     public bool IsListViewMode => ViewMode == PackageViewMode.List;
     public bool IsGridViewMode => ViewMode == PackageViewMode.Grid;
     public bool IsIconsViewMode => ViewMode == PackageViewMode.Icons;
+
+    // Width of each grid-view card slot. The code-behind recomputes this from the available
+    // viewport width so cards stretch to fill the row then reflow, matching WinUI's
+    // UniformGridLayout (ItemsStretch=Fill, MinItemWidth=275) instead of leaving dead space.
+    [ObservableProperty] private double _gridCardWidth = 275;
+
+    // Same idea for the icons view: stretch tiles to fill the row then reflow (min 128px).
+    [ObservableProperty] private double _iconCardWidth = 128;
 
     // Shim for SelectedIndex="{Binding ViewModeIndex}" in AXAML (ListBox requires int)
     public int ViewModeIndex

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -465,7 +465,7 @@
                                 </DataGridTemplateColumn>
                                 <DataGridTemplateColumn Tag="Name" SortMemberPath="Package.Name"
                                                         Header="{Binding $parent[UserControl].((vm:PackagesPageViewModel)DataContext).NameHeaderText}"
-                                                        Width="2*">
+                                                        Width="*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
                                             <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0"
@@ -489,7 +489,7 @@
                                 </DataGridTemplateColumn>
                                 <DataGridTemplateColumn Tag="Id" SortMemberPath="Package.Id"
                                                         Header="{Binding $parent[UserControl].((vm:PackagesPageViewModel)DataContext).IdHeaderText}"
-                                                        Width="2*">
+                                                        Width="*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
                                             <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0">
@@ -567,15 +567,17 @@
                         <!-- ===== GRID VIEW ===== -->
                         <ScrollViewer IsVisible="{Binding IsGridViewMode}"
                                       HorizontalScrollBarVisibility="Disabled">
-                            <ItemsControl ItemsSource="{Binding FilteredPackages}">
+                            <ItemsControl x:Name="GridViewItems" ItemsSource="{Binding FilteredPackages}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <WrapPanel Orientation="Horizontal"/>
+                                        <WrapPanel Orientation="Horizontal"
+                                                   ItemWidth="{Binding GridCardWidth}"/>
                                     </ItemsPanelTemplate>
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="pkg:PackageWrapper">
-                                        <Border CornerRadius="4" Margin="4" Width="275" Height="70"
+                                        <Border CornerRadius="4" Margin="4" Height="70"
+                                            HorizontalAlignment="Stretch"
                                             automation:AutomationProperties.Name="{Binding Package.AutomationName}"
                                             automation:AutomationProperties.ItemType="{t:Translate Package}"
                                                 Background="{DynamicResource SettingsCardBackground}"
@@ -642,15 +644,17 @@
                         <!-- ===== ICONS VIEW ===== -->
                         <ScrollViewer IsVisible="{Binding IsIconsViewMode}"
                                       HorizontalScrollBarVisibility="Disabled">
-                            <ItemsControl ItemsSource="{Binding FilteredPackages}">
+                            <ItemsControl x:Name="IconsViewItems" ItemsSource="{Binding FilteredPackages}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <WrapPanel Orientation="Horizontal"/>
+                                        <WrapPanel Orientation="Horizontal"
+                                                   ItemWidth="{Binding IconCardWidth}"/>
                                     </ItemsPanelTemplate>
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="pkg:PackageWrapper">
-                                        <Border CornerRadius="4" Margin="4" Width="128" Height="142"
+                                        <Border CornerRadius="4" Margin="4" Height="142"
+                                            HorizontalAlignment="Stretch"
                                             automation:AutomationProperties.Name="{Binding Package.AutomationName}"
                                             automation:AutomationProperties.ItemType="{t:Translate Package}"
                                                 Background="{DynamicResource SettingsCardBackground}"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -111,6 +111,18 @@ public abstract partial class AbstractPackagesPage : UserControl,
         FilteringPanel.GetObservable(BoundsProperty)
             .Subscribe(bounds => OnFilteringPanelWidthChanged(bounds.Width));
 
+        // Responsive: collapse the menu bar to icon-only on narrow windows so the
+        // toolbar buttons stay reachable instead of overflowing (mirrors WinUI).
+        this.GetObservable(BoundsProperty)
+            .Subscribe(bounds => ViewModel.SetToolbarLabelsCollapsed(bounds.Width < 900));
+
+        // Grid/icons views: stretch cards to fill each row then reflow (mirrors WinUI's
+        // UniformGridLayout) instead of leaving wasted space to the right.
+        GridViewItems.GetObservable(BoundsProperty)
+            .Subscribe(bounds => UpdateGridCardWidth(bounds.Width));
+        IconsViewItems.GetObservable(BoundsProperty)
+            .Subscribe(bounds => UpdateIconCardWidth(bounds.Width));
+
         // Overlay backdrop dismisses the filter pane when tapped.
         FilterOverlayBackdrop.PointerPressed += (_, _) => ViewModel.IsFilterPaneOpen = false;
 
@@ -133,6 +145,25 @@ public abstract partial class AbstractPackagesPage : UserControl,
 
         // Apply the initial filter-pane state (AXAML defaults to 220px open).
         UpdateFilterPaneColumn(ViewModel.IsFilterPaneOpen);
+    }
+
+    // Recompute the grid-view card slot width: fit as many >=275px columns as possible,
+    // then divide the row evenly among them so cards stretch to fill (WinUI parity).
+    private void UpdateGridCardWidth(double availableWidth)
+    {
+        if (availableWidth <= 0) return;
+        const double minSlotWidth = 275 + 8; // 275px card + 4px margin per side
+        int columns = Math.Max(1, (int)(availableWidth / minSlotWidth));
+        ViewModel.GridCardWidth = Math.Floor(availableWidth / columns);
+    }
+
+    // Same as UpdateGridCardWidth, for the smaller icon tiles (>=128px columns).
+    private void UpdateIconCardWidth(double availableWidth)
+    {
+        if (availableWidth <= 0) return;
+        const double minSlotWidth = 128 + 8; // 128px tile + 4px margin per side
+        int columns = Math.Max(1, (int)(availableWidth / minSlotWidth));
+        ViewModel.IconCardWidth = Math.Floor(availableWidth / columns);
     }
 
     // ─── UI-only: focus the package list ─────────────────────────────────────

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
@@ -681,8 +681,8 @@
           HorizontalAlignment="Left"
           x:FieldModifier="protected"
           DefaultLabelPosition="Right"
-          IsDynamicOverflowEnabled="False"
-          OverflowButtonVisibility="Collapsed"
+          IsDynamicOverflowEnabled="True"
+          OverflowButtonVisibility="Auto"
         />
       </Grid>
     </Grid>

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -1663,6 +1663,7 @@ namespace UniGetUI.Interface
 
         private bool? _pageIsWide;
         private bool? _titleHidden;
+        private bool? _toolbarLabelsHidden;
 
         private void ABSTRACT_PAGE_SizeChanged(object sender, SizeChangedEventArgs e)
         {
@@ -1697,6 +1698,25 @@ namespace UniGetUI.Interface
                 {
                     MainTitle.FontSize = 24;
                     _pageIsWide = true;
+                }
+            }
+
+            // Collapse the menu bar labels to icon-only on narrow windows so the buttons
+            // stay reachable instead of being clipped off the right edge.
+            if (ActualWidth < 900)
+            {
+                if (_toolbarLabelsHidden != true)
+                {
+                    _toolbarLabelsHidden = true;
+                    ToolBar.DefaultLabelPosition = CommandBarDefaultLabelPosition.Collapsed;
+                }
+            }
+            else
+            {
+                if (_toolbarLabelsHidden != false)
+                {
+                    _toolbarLabelsHidden = false;
+                    ToolBar.DefaultLabelPosition = CommandBarDefaultLabelPosition.Right;
                 }
             }
         }


### PR DESCRIPTION
This pull request improves the responsive layout of the packages page, ensuring that the toolbar and package views adapt gracefully to different window sizes. The main changes include making the toolbar collapse to icon-only mode on narrow windows, and updating the grid and icon views so package cards stretch to fill available space, closely matching WinUI's behavior.

**Responsive toolbar and layout improvements:**

* Added logic to track and control the visibility of toolbar button labels in `PackagesPageViewModel`, allowing the toolbar to collapse to icon-only mode when the window is narrow. This prevents toolbar buttons from overflowing off-screen. (`src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs`, `src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs`, `src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs`) 
* Updated the XAML for the WinUI CommandBar to enable dynamic overflow and automatic overflow button visibility, improving toolbar usability on smaller screens. (`src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml`)

**Grid and icons view enhancements:**

* Introduced observable properties for grid and icon card widths in the view model, and added logic to dynamically compute the optimal width for each card based on the available viewport size. This ensures cards stretch to fill each row and reflow as needed, minimizing wasted space. (`src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs`, `src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs`) [
* Updated the grid and icon views in XAML to bind the `ItemWidth` property of the `WrapPanel` to the computed card widths, and removed fixed widths from individual cards to allow them to stretch. (`src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml`)

**Minor UI adjustments:**

* Adjusted the column widths in the data grid for package name and ID to use proportional sizing, improving table layout consistency. (`src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml`)

These changes significantly improve the application's usability and appearance on a range of window sizes, especially for users on smaller screens.