### PR TITLE
Fix operations panel list not growing on resize (#4947)

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -86,7 +86,7 @@
                     automation:AutomationProperties.Name="{t:Translate Operations}"
                     automation:AutomationProperties.LandmarkType="{x:Static peers:AutomationLandmarkType.Region}"
                     Background="{DynamicResource AppOperationsPanelBackground}">
-                <Grid RowDefinitions="Auto,Auto">
+                <Grid RowDefinitions="Auto,*">
 
                     <!-- Toolbar: expand/collapse + bulk-ops menu -->
                     <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto"
@@ -144,7 +144,6 @@
                     <!-- Operations list (hidden when panel is collapsed) -->
                     <ScrollViewer Grid.Row="1"
                                   IsVisible="{Binding OperationsPanelExpanded}"
-                                  MaxHeight="220"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                     <ItemsControl ItemsSource="{Binding Operations}"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -75,6 +75,9 @@ public partial class MainWindow : Window
     private bool _allowClose;
     private int _isQuitting;
 
+    // Last user-chosen height (px) of the operations panel; restored when re-expanded.
+    private double _operationsPanelHeight = 240;
+
     public enum RuntimeNotificationLevel
     {
         Progress,
@@ -98,6 +101,8 @@ public partial class MainWindow : Window
 
         KeyDown += Window_KeyDown;
         ViewModel.CurrentPageChanged += OnCurrentPageChanged;
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        UpdateOperationsPanelRow();
 
         Resized += (_, _) => _ = SaveGeometryAsync();
         PositionChanged += (_, _) => _ = SaveGeometryAsync();
@@ -220,6 +225,37 @@ public partial class MainWindow : Window
             var sidebar = this.GetVisualDescendants().OfType<SidebarView>().FirstOrDefault();
             sidebar?.FocusSelectedItem();
         }, DispatcherPriority.Background);
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MainWindowViewModel.OperationsPanelExpanded)
+                           or nameof(MainWindowViewModel.OperationsPanelVisible))
+            UpdateOperationsPanelRow();
+    }
+
+    // Drive the operations-panel grid row: a resizable pixel height while the panel is
+    // open, Auto otherwise so it collapses to just the toolbar (or vanishes when empty).
+    // The GridSplitter writes the row height directly, so we read it back to preserve the
+    // user's chosen size across collapse/expand.
+    private void UpdateOperationsPanelRow()
+    {
+        if (MainContentGrid.RowDefinitions.Count < 3)
+            return;
+
+        RowDefinition row = MainContentGrid.RowDefinitions[2];
+        if (ViewModel.OperationsPanelVisible && ViewModel.OperationsPanelExpanded)
+        {
+            row.MinHeight = 80;
+            row.Height = new GridLength(_operationsPanelHeight, GridUnitType.Pixel);
+        }
+        else
+        {
+            if (row.Height.IsAbsolute && row.Height.Value > 0)
+                _operationsPanelHeight = row.Height.Value;
+            row.MinHeight = 0;
+            row.Height = GridLength.Auto;
+        }
     }
 
     private void SetupTitleBar()


### PR DESCRIPTION
This pull request improves the user experience of the operations panel in the main window by making its height resizable and persistent across expand/collapse actions. The key changes ensure that when the panel is expanded, it restores the last user-chosen height, and when collapsed, it saves the current height and collapses the panel cleanly. The grid layout and event handling have been updated to support this behavior.

**Operations panel resizability and persistence:**

* Changed the operations panel grid's row definition from two auto-sized rows to one auto and one star-sized row, enabling flexible height adjustment. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml`)
* Removed the fixed `MaxHeight` constraint from the operations panel's `ScrollViewer`, allowing the panel to expand as needed. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml`)
* Added a private `_operationsPanelHeight` field to store the last user-selected height of the operations panel, and logic to restore this value when the panel is re-expanded. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs`)
* Subscribed to `ViewModel.PropertyChanged` to detect changes to the operations panel's visibility and expansion state, triggering updates to the panel's grid row. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs`)
* Implemented the `UpdateOperationsPanelRow` method to manage the grid row's height and minimum height, ensuring the panel's size is preserved across state changes. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs`)
