### PR TITLE
Make "Open install location" resolve across package managers

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Cargo/Helpers/CargoPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Cargo/Helpers/CargoPkgDetailsHelper.cs
@@ -77,11 +77,14 @@ internal sealed class CargoPkgDetailsHelper(Cargo manager) : BasePkgDetailsHelpe
 
     protected override string? GetInstallLocation_UnSafe(IPackage package)
     {
-        return Path.Join(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".cargo",
-            "bin"
-        );
+        // Cargo installs binaries into $CARGO_HOME/bin (default ~/.cargo/bin).
+        var cargoHome = Environment.GetEnvironmentVariable("CARGO_HOME");
+        if (string.IsNullOrEmpty(cargoHome))
+            cargoHome = Path.Join(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".cargo"
+            );
+        return Path.Join(cargoHome, "bin");
     }
 
     protected override IReadOnlyList<string> GetInstallableVersions_UnSafe(IPackage package)

--- a/src/UniGetUI.PackageEngine.Managers.Chocolatey/Helpers/ChocolateyDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Chocolatey/Helpers/ChocolateyDetailsHelper.cs
@@ -94,11 +94,21 @@ namespace UniGetUI.PackageEngine.Managers.Choco
                     return path_with_id;
             }
 
-            return Path.Join(
-                Path.GetDirectoryName(Manager.Status.ExecutablePath),
-                "lib",
-                package.Id
-            );
+            // Chocolatey keeps each package under <ChocolateyInstall>\lib\<id>. Resolve the root
+            // from the environment variable, falling back to the executable's folder (stepping out
+            // of the \bin shim folder when choco.exe is found there).
+            string? chocoRoot = Environment.GetEnvironmentVariable("ChocolateyInstall");
+            if (string.IsNullOrEmpty(chocoRoot))
+            {
+                var exeDir = Path.GetDirectoryName(Manager.Status.ExecutablePath);
+                chocoRoot =
+                    exeDir is not null
+                    && Path.GetFileName(exeDir).Equals("bin", StringComparison.OrdinalIgnoreCase)
+                        ? Path.GetDirectoryName(exeDir)
+                        : exeDir;
+            }
+
+            return chocoRoot is null ? null : Path.Join(chocoRoot, "lib", package.Id);
         }
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.Flatpak/Helpers/FlatpakPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Flatpak/Helpers/FlatpakPkgDetailsHelper.cs
@@ -79,7 +79,23 @@ internal sealed class FlatpakPkgDetailsHelper : BasePkgDetailsHelper
         => Array.Empty<Uri>();
 
     protected override string? GetInstallLocation_UnSafe(IPackage package)
-        => $"/var/lib/flatpak/app/{package.Id}";
+    {
+        // System-wide installs live under /var/lib/flatpak, per-user installs under
+        // ~/.local/share/flatpak. Return whichever actually contains the app.
+        foreach (var baseDir in new[]
+        {
+            "/var/lib/flatpak",
+            Path.Join(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".local", "share", "flatpak"),
+        })
+        {
+            var path = Path.Join(baseDir, "app", package.Id);
+            if (Directory.Exists(path))
+                return path;
+        }
+        return null;
+    }
 
     protected override IReadOnlyList<string> GetInstallableVersions_UnSafe(IPackage package)
         => throw new InvalidOperationException("Flatpak does not support installing arbitrary versions");

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Helpers/HomebrewPkgDetailsHelper.cs
@@ -104,13 +104,16 @@ internal sealed class HomebrewPkgDetailsHelper : BasePkgDetailsHelper
 
     protected override string? GetInstallLocation_UnSafe(IPackage package)
     {
-        // Formulae: /opt/homebrew/Cellar/<name>  (Apple Silicon)
-        //           /usr/local/Cellar/<name>       (Intel)
-        foreach (var prefix in new[] { "/opt/homebrew", "/usr/local" })
+        // Apple Silicon prefix is /opt/homebrew, Intel/Linux is /usr/local (or /home/linuxbrew).
+        // Formulae live under Cellar/<name>, casks under Caskroom/<token>.
+        foreach (var prefix in new[] { "/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew" })
         {
-            var path = Path.Join(prefix, "Cellar", package.Id);
-            if (Directory.Exists(path))
-                return path;
+            foreach (var kind in new[] { "Cellar", "Caskroom" })
+            {
+                var path = Path.Join(prefix, kind, package.Id);
+                if (Directory.Exists(path))
+                    return path;
+            }
         }
         return null;
     }

--- a/src/UniGetUI.PackageEngine.Managers.Npm/Helpers/NpmPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Npm/Helpers/NpmPkgDetailsHelper.cs
@@ -176,9 +176,10 @@ namespace UniGetUI.PackageEngine.Managers.NpmManager
                     "node_modules",
                     package.Id
                 );
+            // ApplicationData already resolves to the Roaming folder; npm's default global prefix
+            // is %AppData%\npm, so global modules live under %AppData%\npm\node_modules.
             return Path.Join(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "Roaming",
                 "npm",
                 "node_modules",
                 package.Id

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgDetailsHelper.cs
@@ -289,13 +289,29 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
 
         protected override string? GetInstallLocation_UnSafe(IPackage package)
         {
-            return Path.Join(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                "scoop",
-                "apps",
-                package.Id,
-                "current"
-            );
+            // Honor custom Scoop roots (SCOOP / SCOOP_GLOBAL) and both user and global installs,
+            // returning the first that actually exists.
+            string?[] roots =
+            [
+                Environment.GetEnvironmentVariable("SCOOP"),
+                Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "scoop"),
+                Environment.GetEnvironmentVariable("SCOOP_GLOBAL"),
+                Path.Join(
+                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                    "scoop"
+                ),
+            ];
+
+            foreach (var root in roots)
+            {
+                if (string.IsNullOrEmpty(root))
+                    continue;
+                var path = Path.Join(root, "apps", package.Id, "current");
+                if (Directory.Exists(path))
+                    return path;
+            }
+
+            return null;
         }
 
         protected override IReadOnlyList<string> GetInstallableVersions_UnSafe(IPackage package)

--- a/src/UniGetUI.PackageEngine.Managers.Vcpkg/Helpers/VcpkgPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Vcpkg/Helpers/VcpkgPkgDetailsHelper.cs
@@ -115,11 +115,9 @@ namespace UniGetUI.PackageEngine.Managers.VcpkgManager
             var VcpkgInstalledPath = Path.Join(rootPath, "installed", package.Id.Split(":")[1]);
             return Directory.Exists(PackagePath)
                 ? PackagePath
-                : (
-                    Directory.Exists(VcpkgInstalledPath)
-                        ? VcpkgInstalledPath
-                        : Path.GetDirectoryName(PackageId)
-                );
+                : Directory.Exists(VcpkgInstalledPath)
+                    ? VcpkgInstalledPath
+                    : null;
         }
 
         protected override IReadOnlyList<string> GetInstallableVersions_UnSafe(IPackage package)

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetIconsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetIconsHelper.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.Management.Deployment;
 using Microsoft.Win32;
 using UniGetUI.Core.IconEngine;
@@ -207,5 +209,157 @@ internal static class WinGetIconsHelper
             return new CacheableIcon(displayIcon);
 
         return null;
+    }
+
+    private const long MsixCacheTtlMs = 30_000;
+    private static readonly Lock _msixLock = new();
+    private static Dictionary<string, string>? _msixIndex; // normalized name -> install path
+    private static long _msixBuiltAt = long.MinValue;
+
+    /// <summary>
+    /// Resolves an MSIX/Store package whose full name is encoded in the Id (Microsoft Store
+    /// source). Cheap — no package enumeration.
+    /// </summary>
+    public static string? GetMsixLocationFromId(IPackage package)
+    {
+        if (!package.Id.StartsWith("MSIX\\", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var fullName = package.Id["MSIX\\".Length..];
+        foreach (
+            var root in new[]
+            {
+                Path.Join(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                    "WindowsApps",
+                    fullName
+                ),
+                Path.Join(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+                    "SystemApps",
+                    fullName
+                ),
+            }
+        )
+            if (Directory.Exists(root))
+                return root;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves an MSIX/Store package by matching it against the installed AppX packages. These do
+    /// not appear in the "Add/Remove programs" registry, so this enumerates them via the platform
+    /// API (cached). Used as a last resort because the enumeration has a cost.
+    /// </summary>
+    public static string? GetMsixLocationByName(IPackage package)
+    {
+        var index = GetMsixIndex();
+        if (index.Count == 0)
+            return null;
+
+        string[] candidates = [NormalizeMsix(package.Id), NormalizeMsix(package.Name)];
+
+        // Exact match first (most reliable).
+        foreach (var candidate in candidates)
+            if (candidate.Length >= 3 && index.TryGetValue(candidate, out var location))
+                return location;
+
+        // Then a length-guarded fuzzy match (prefix or containment) to bridge identity/display-name
+        // differences, e.g. winget "Microsoft.AppInstaller" / "App Installer" vs the MSIX identity
+        // "Microsoft.DesktopAppInstaller". Only reached as a last resort, over the small MSIX set.
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Length < 6)
+                continue;
+            foreach (var (key, location) in index)
+                if (
+                    key.StartsWith(candidate, StringComparison.Ordinal)
+                    || candidate.StartsWith(key, StringComparison.Ordinal)
+                    || key.Contains(candidate, StringComparison.Ordinal)
+                )
+                    return location;
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, string> GetMsixIndex()
+    {
+        lock (_msixLock)
+        {
+            var now = Environment.TickCount64;
+            if (_msixIndex is null || now - _msixBuiltAt > MsixCacheTtlMs)
+            {
+                _msixIndex = BuildMsixIndex();
+                _msixBuiltAt = now;
+            }
+            return _msixIndex;
+        }
+    }
+
+    private const string AppxRepositoryKey =
+        @"Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages";
+
+    private static Dictionary<string, string> BuildMsixIndex()
+    {
+        // Read MSIX install locations straight from the AppModel repository registry rather than the
+        // WinRT PackageManager API: the latter fails to activate inside this process (the WinGet COM
+        // interop reconfigures process-wide COM security), whereas the registry is always readable.
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        try
+        {
+            using var root = Registry.CurrentUser.OpenSubKey(AppxRepositoryKey);
+            if (root is null)
+                return map;
+
+            foreach (var packageFullName in root.GetSubKeyNames())
+            {
+                try
+                {
+                    using var entry = root.OpenSubKey(packageFullName);
+                    if (entry?.GetValue("PackageRootFolder") is not string path)
+                        continue;
+                    if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+                        continue;
+
+                    // Full name is "<Name>_<version>_<arch>__<publisherHash>".
+                    AddMsixKey(map, packageFullName.Split('_')[0], path);
+
+                    if (
+                        entry.GetValue("DisplayName") is string displayName
+                        && !displayName.StartsWith("ms-resource:", StringComparison.OrdinalIgnoreCase)
+                    )
+                        AddMsixKey(map, displayName, path);
+                }
+                catch
+                {
+                    // Skip unreadable entries.
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Debug($"Could not read installed MSIX packages from the registry: {ex.Message}");
+        }
+        return map;
+    }
+
+    private static void AddMsixKey(Dictionary<string, string> map, string? key, string path)
+    {
+        var normalized = NormalizeMsix(key);
+        if (normalized.Length >= 3 && !map.ContainsKey(normalized))
+            map[normalized] = path;
+    }
+
+    private static string NormalizeMsix(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "";
+        var sb = new StringBuilder(value.Length);
+        foreach (var c in value)
+            if (char.IsLetterOrDigit(c))
+                sb.Append(char.ToLowerInvariant(c));
+        return sb.ToString();
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgDetailsHelper.cs
@@ -42,6 +42,26 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
         protected override string? GetInstallLocation_UnSafe(IPackage package)
         {
+            // Packages from the local "Add/Remove programs" source encode their exact registry key
+            // in the Id, so their install location can be read straight from that ARP entry. The
+            // generic name-based ARP lookup is handled by the base helper as a fallback.
+            if (package.Source is LocalWinGetSource { Type: LocalWinGetSource.Type_t.LocalPC })
+            {
+                var encodedLocation = ArpRegistryHelper.GetLocationFromEncodedId(package.Id);
+                if (encodedLocation is not null)
+                    return encodedLocation;
+            }
+
+            // MSIX/Store packages from the Microsoft Store source encode their full name in the Id.
+            var msixFromId = WinGetIconsHelper.GetMsixLocationFromId(package);
+            if (msixFromId is not null)
+                return msixFromId;
+
+            // Match against Add/Remove programs by name before the heavier lookups below.
+            var arpByName = ArpRegistryHelper.ResolveByName(package.Name, package.Id);
+            if (arpByName is not null)
+                return arpByName;
+
             foreach (
                 var base_path in new[]
                 {
@@ -84,7 +104,9 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                     return path_with_source;
             }
 
-            return null;
+            // Last resort: enumerate installed MSIX packages (has a cost, so only reached when
+            // nothing cheaper matched — e.g. Store apps surfaced through the winget catalog).
+            return WinGetIconsHelper.GetMsixLocationByName(package);
         }
 
         protected override IReadOnlyList<Uri> GetScreenshots_UnSafe(IPackage package)

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/ArpRegistryHelper.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/ArpRegistryHelper.cs
@@ -1,0 +1,239 @@
+#if WINDOWS
+using System.Text.RegularExpressions;
+using Microsoft.Win32;
+#endif
+
+namespace UniGetUI.PackageEngine.Classes.Manager.BaseProviders
+{
+    /// <summary>
+    /// Resolves the install location of a package from the Windows "Add/Remove programs" (ARP)
+    /// registry. This is a manager-agnostic fallback: any package that registered an uninstall
+    /// entry (which most Windows installers do, regardless of the manager that ran them) can be
+    /// located here when the manager's own logic cannot find the folder. On non-Windows platforms
+    /// every method is a no-op.
+    /// </summary>
+    public static partial class ArpRegistryHelper
+    {
+#if WINDOWS
+        private const long CacheTtlMs = 30_000;
+        private static readonly Lock _lock = new();
+        private static Dictionary<string, string>? _index; // normalized DisplayName -> install folder
+        private static long _indexBuiltAt = long.MinValue;
+
+        private static readonly (RegistryKey Hive, string SubKey)[] UninstallRoots =
+        [
+            (Registry.LocalMachine, @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+            (Registry.LocalMachine, @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"),
+            (Registry.CurrentUser, @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+        ];
+
+        /// <summary>
+        /// Resolves the install folder by matching the given candidate names against the system's
+        /// ARP display names. Returns null when no confident match has a resolvable folder.
+        /// </summary>
+        public static string? ResolveByName(params string?[] candidateNames)
+        {
+            var index = GetIndex();
+            if (index.Count == 0)
+                return null;
+
+            foreach (var name in candidateNames)
+            {
+                var target = Normalize(name);
+                if (target.Length < 3)
+                    continue;
+
+                // Exact normalized match is the most reliable.
+                if (index.TryGetValue(target, out var exact))
+                    return exact;
+
+                // Otherwise accept only the ARP name being the package name plus a version/edition
+                // suffix (e.g. "Mozilla Firefox" vs "Mozilla Firefox (x64 en-US)" once normalized,
+                // or "7-Zip" vs "7-Zip 23.01"). The reverse direction — the package name merely
+                // starting with a shorter ARP name — is intentionally excluded, as it can resolve an
+                // unrelated app (e.g. a package "javascript-x" matching an ARP entry "Java").
+                if (target.Length < 4)
+                    continue;
+                foreach (var (key, location) in index)
+                    if (key.StartsWith(target, StringComparison.Ordinal))
+                        return location;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves the install folder for a package whose Id encodes its registry location (as
+        /// produced by the WinGet LocalPC source), e.g. "ARP\Machine\X64\{key}".
+        /// </summary>
+        public static string? GetLocationFromEncodedId(string packageId)
+        {
+            var bits = packageId.Split('\\');
+            if (bits.Length < 4)
+                return null;
+
+            var hive = bits[1] == "Machine" ? Registry.LocalMachine : Registry.CurrentUser;
+            var subKey = "SOFTWARE";
+            if (bits[2] == "X86")
+                subKey += @"\WOW6432Node";
+            subKey += @"\Microsoft\Windows\CurrentVersion\Uninstall\" + bits[3];
+
+            try
+            {
+                using var entry = hive.OpenSubKey(subKey);
+                return entry is null ? null : ReadLocation(entry);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static Dictionary<string, string> GetIndex()
+        {
+            lock (_lock)
+            {
+                var now = Environment.TickCount64;
+                if (_index is null || now - _indexBuiltAt > CacheTtlMs)
+                {
+                    _index = BuildIndex();
+                    _indexBuiltAt = now;
+                }
+                return _index;
+            }
+        }
+
+        private static Dictionary<string, string> BuildIndex()
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var (hive, subKey) in UninstallRoots)
+            {
+                try
+                {
+                    using var root = hive.OpenSubKey(subKey);
+                    if (root is null)
+                        continue;
+
+                    foreach (var name in root.GetSubKeyNames())
+                    {
+                        try
+                        {
+                            using var entry = root.OpenSubKey(name);
+                            if (entry?.GetValue("DisplayName") is not string displayName)
+                                continue;
+                            if ((entry.GetValue("SystemComponent") as int?) == 1)
+                                continue;
+
+                            var normalized = Normalize(displayName);
+                            if (normalized.Length < 3 || map.ContainsKey(normalized))
+                                continue;
+
+                            var location = ReadLocation(entry);
+                            if (location is not null)
+                                map[normalized] = location;
+                        }
+                        catch
+                        {
+                            // Skip unreadable entries.
+                        }
+                    }
+                }
+                catch
+                {
+                    // Skip unreadable hives.
+                }
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Resolves the install folder from a single ARP entry, trying the most-to-least reliable
+        /// signals: the recorded InstallLocation, the folder of the DisplayIcon, then the folder of
+        /// the uninstaller (which for EXE/NSIS/Inno installers lives in the install directory).
+        /// </summary>
+        private static string? ReadLocation(RegistryKey entry)
+        {
+            if (entry.GetValue("InstallLocation") is string rawLocation)
+            {
+                var location = rawLocation.Trim().Trim('"').TrimEnd('\\');
+                if (location.Length > 0 && Directory.Exists(location))
+                    return location;
+            }
+
+            if (entry.GetValue("DisplayIcon") is string displayIcon && displayIcon.Length > 0)
+            {
+                var dir = DirectoryOf(displayIcon.Split(',')[0].Trim().Trim('"'));
+                if (dir is not null)
+                    return dir;
+            }
+
+            if (entry.GetValue("UninstallString") is string uninstall && uninstall.Length > 0)
+            {
+                var exe = ExtractExecutable(uninstall);
+                if (exe is not null
+                    && !Path.GetFileName(exe).Equals("msiexec.exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    var dir = DirectoryOf(exe);
+                    if (dir is not null && !IsSystemDirectory(dir))
+                        return dir;
+                }
+            }
+
+            return null;
+        }
+
+        private static string? DirectoryOf(string filePath)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(filePath);
+                return !string.IsNullOrEmpty(dir) && Directory.Exists(dir) ? dir : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string? ExtractExecutable(string command)
+        {
+            command = command.Trim();
+            if (command.StartsWith('"'))
+            {
+                var end = command.IndexOf('"', 1);
+                return end > 1 ? command[1..end] : null;
+            }
+
+            var idx = command.IndexOf(".exe", StringComparison.OrdinalIgnoreCase);
+            return idx >= 0 ? command[..(idx + 4)] : command.Split(' ')[0];
+        }
+
+        private static bool IsSystemDirectory(string dir)
+        {
+            var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            return !string.IsNullOrEmpty(windows)
+                && dir.StartsWith(windows, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string Normalize(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return "";
+            value = ParentheticalRegex().Replace(value, " ");
+            return NonAlphanumericRegex().Replace(value, "").ToLowerInvariant();
+        }
+
+        [GeneratedRegex(@"\([^)]*\)")]
+        private static partial Regex ParentheticalRegex();
+
+        [GeneratedRegex("[^a-zA-Z0-9]")]
+        private static partial Regex NonAlphanumericRegex();
+#else
+        public static string? ResolveByName(params string?[] candidateNames) => null;
+
+        public static string? GetLocationFromEncodedId(string packageId) => null;
+#endif
+    }
+}

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/ArpRegistryHelper.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/ArpRegistryHelper.cs
@@ -20,11 +20,18 @@ namespace UniGetUI.PackageEngine.Classes.Manager.BaseProviders
         private static Dictionary<string, string>? _index; // normalized DisplayName -> install folder
         private static long _indexBuiltAt = long.MinValue;
 
-        private static readonly (RegistryKey Hive, string SubKey)[] UninstallRoots =
+        private const string UninstallSubKey =
+            @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
+
+        // Open both registry views explicitly (instead of relying on process bitness + a hard-coded
+        // WOW6432Node path) so 64-bit and 32-bit entries are indexed regardless of the process arch,
+        // including per-user 32-bit apps under HKCU.
+        private static readonly (RegistryHive Hive, RegistryView View)[] UninstallRoots =
         [
-            (Registry.LocalMachine, @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
-            (Registry.LocalMachine, @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"),
-            (Registry.CurrentUser, @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+            (RegistryHive.LocalMachine, RegistryView.Registry64),
+            (RegistryHive.LocalMachine, RegistryView.Registry32),
+            (RegistryHive.CurrentUser, RegistryView.Registry64),
+            (RegistryHive.CurrentUser, RegistryView.Registry32),
         ];
 
         /// <summary>
@@ -72,15 +79,13 @@ namespace UniGetUI.PackageEngine.Classes.Manager.BaseProviders
             if (bits.Length < 4)
                 return null;
 
-            var hive = bits[1] == "Machine" ? Registry.LocalMachine : Registry.CurrentUser;
-            var subKey = "SOFTWARE";
-            if (bits[2] == "X86")
-                subKey += @"\WOW6432Node";
-            subKey += @"\Microsoft\Windows\CurrentVersion\Uninstall\" + bits[3];
+            var hive = bits[1] == "Machine" ? RegistryHive.LocalMachine : RegistryHive.CurrentUser;
+            var view = bits[2] == "X86" ? RegistryView.Registry32 : RegistryView.Registry64;
 
             try
             {
-                using var entry = hive.OpenSubKey(subKey);
+                using var baseKey = RegistryKey.OpenBaseKey(hive, view);
+                using var entry = baseKey.OpenSubKey(UninstallSubKey + "\\" + bits[3]);
                 return entry is null ? null : ReadLocation(entry);
             }
             catch
@@ -107,11 +112,12 @@ namespace UniGetUI.PackageEngine.Classes.Manager.BaseProviders
         {
             var map = new Dictionary<string, string>(StringComparer.Ordinal);
 
-            foreach (var (hive, subKey) in UninstallRoots)
+            foreach (var (hive, view) in UninstallRoots)
             {
                 try
                 {
-                    using var root = hive.OpenSubKey(subKey);
+                    using var baseKey = RegistryKey.OpenBaseKey(hive, view);
+                    using var root = baseKey.OpenSubKey(UninstallSubKey);
                     if (root is null)
                         continue;
 
@@ -155,23 +161,36 @@ namespace UniGetUI.PackageEngine.Classes.Manager.BaseProviders
         /// </summary>
         private static string? ReadLocation(RegistryKey entry)
         {
-            if (entry.GetValue("InstallLocation") is string rawLocation)
+            // Registry values can contain unexpanded environment variables (e.g. %ProgramFiles%),
+            // so expand before testing/returning any path.
+            if (entry.GetValue("InstallLocation") is string rawLocation && rawLocation.Length > 0)
             {
-                var location = rawLocation.Trim().Trim('"').TrimEnd('\\');
+                var location = Environment
+                    .ExpandEnvironmentVariables(rawLocation)
+                    .Trim()
+                    .Trim('"')
+                    .TrimEnd('\\');
                 if (location.Length > 0 && Directory.Exists(location))
                     return location;
             }
 
             if (entry.GetValue("DisplayIcon") is string displayIcon && displayIcon.Length > 0)
             {
-                var dir = DirectoryOf(displayIcon.Split(',')[0].Trim().Trim('"'));
-                if (dir is not null)
+                var iconPath = Environment
+                    .ExpandEnvironmentVariables(displayIcon)
+                    .Split(',')[0]
+                    .Trim()
+                    .Trim('"');
+                var dir = DirectoryOf(iconPath);
+                // MSI cached icons live under C:\Windows\Installer; never treat a system folder as
+                // an install location.
+                if (dir is not null && !IsSystemDirectory(dir))
                     return dir;
             }
 
             if (entry.GetValue("UninstallString") is string uninstall && uninstall.Length > 0)
             {
-                var exe = ExtractExecutable(uninstall);
+                var exe = ExtractExecutable(Environment.ExpandEnvironmentVariables(uninstall));
                 if (exe is not null
                     && !Path.GetFileName(exe).Equals("msiexec.exe", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/BasePkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/BasePkgDetailsHelper.cs
@@ -188,8 +188,13 @@ namespace UniGetUI.PackageEngine.Classes.Manager.BaseProviders
                     Logger.Warn(
                         $"Path returned by the package manager \"{path}\" did not exist while loading package install location for package Id={package.Id} with Manager={package.Manager.Name}"
                     );
-                    return null;
+                    path = null;
                 }
+
+                // Manager-agnostic fallback: most Windows installers register an "Add/Remove
+                // programs" entry regardless of which manager ran them, so try to locate the
+                // package there when the manager's own logic came up empty. No-op on non-Windows.
+                path ??= ArpRegistryHelper.ResolveByName(package.Name, package.Id);
 
                 return path;
             }


### PR DESCRIPTION
This pull request improves the accuracy and robustness of package install location detection across several package managers by enhancing environment variable support, adding fallback mechanisms, and handling multiple installation scenarios. It also introduces advanced logic for resolving MSIX/Store package locations for WinGet, including registry-based lookups and caching for performance.

**Enhancements to Install Location Detection:**

* Cargo: Now checks the `CARGO_HOME` environment variable for the install root, falling back to the user profile if unset.
* Chocolatey: Resolves the Chocolatey root from the `ChocolateyInstall` environment variable, with a fallback to the executable's directory, and properly steps out of the `bin` folder if needed.
* Flatpak: Checks both system-wide and per-user install locations, returning the first that exists.
* Homebrew: Adds support for the Linuxbrew prefix and checks both `Cellar` and `Caskroom` directories for formulae and casks.
* Scoop: Honors custom `SCOOP` and `SCOOP_GLOBAL` roots, checking both user and global install locations, and returns the first valid path found.
* Vcpkg: Simplifies the fallback logic and returns `null` if no valid install location is found.
* Npm: Clarifies that global modules are installed under `%AppData%\npm\node_modules`.

**Advanced MSIX/Store Package Resolution for WinGet:**

* Adds new methods in `WinGetIconsHelper` to resolve MSIX/Store package locations by full ID or by fuzzy name matching, using the Windows registry for fast lookups and caching results for performance.
* Updates WinGet package details helper to utilize these new MSIX resolution methods, prioritizing fast and accurate lookups before falling back to more expensive enumeration.

**General Improvements:**

* Improves comments and documentation throughout to clarify logic and intent. (All change references)
* Adds necessary `using` directives for threading and string manipulation.