### PR TITLE
Avalonia UI: refine navigation, search boxes, filter pane & operation banners

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
@@ -235,14 +235,6 @@ public static class AvaloniaOperationRegistry
 
         if (OperatingSystem.IsMacOS() && MacOsNotificationBridge.ShowSuccess(op))
             return;
-
-        if (TryGetMainWindow() is not { } mainWindow)
-            return;
-
-        mainWindow.ShowRuntimeNotification(
-            title,
-            message,
-            UniGetUI.Avalonia.Views.MainWindow.RuntimeNotificationLevel.Success);
     }
 
     private static void ShowOperationFailureNotification(AbstractOperation op)

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -47,20 +47,26 @@ public partial class SidebarViewModel : ViewModelBase
     private bool _installedIsLoading;
 
     // ─── Pane open/closed ─────────────────────────────────────────────────────
+    // Starts collapsed: the pane is a floating overlay in every size class (see MainWindow's
+    // adaptive logic), so there is no persistent open-on-launch state.
     [ObservableProperty]
-    private bool isPaneOpen = !Settings.Get(Settings.K.CollapseNavMenuOnWideScreen);
+    private bool isPaneOpen;
+
+    // Only persist the open/closed choice as the "collapse on wide screen" preference
+    // while the pane is inline (Expanded mode). In the overlay modes used on smaller
+    // windows, opening/closing is transient and must not overwrite the saved preference.
+    // The MainWindow's adaptive logic keeps this in sync with the SplitView display mode.
+    public bool PersistPaneCollapsePreference { get; set; } = true;
 
     partial void OnIsPaneOpenChanged(bool value)
     {
-        Settings.Set(Settings.K.CollapseNavMenuOnWideScreen, !value);
-        OnPropertyChanged(nameof(PaneWidth));
+        if (PersistPaneCollapsePreference)
+            Settings.Set(Settings.K.CollapseNavMenuOnWideScreen, !value);
         OnPropertyChanged(nameof(UpdatesBadgeExpandedVisible));
         OnPropertyChanged(nameof(UpdatesBadgeCompactVisible));
         OnPropertyChanged(nameof(BundlesBadgeExpandedVisible));
         OnPropertyChanged(nameof(BundlesBadgeCompactVisible));
     }
-
-    public double PaneWidth => IsPaneOpen ? 250 : 64;
 
     public bool UpdatesBadgeExpandedVisible => UpdatesBadgeVisible && IsPaneOpen;
     public bool UpdatesBadgeCompactVisible => UpdatesBadgeVisible && !IsPaneOpen;

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -16,17 +16,34 @@
         Width="1450"
         MinWidth="700"
         MinHeight="500">
+    <Window.Styles>
+        <!-- Nav flyout cross-fade. The flyout's icons sit exactly over the static rail's icons, so
+             fading (rather than sliding) keeps the icons perfectly aligned — only the labels fade
+             in/out, reading as a clean expand/collapse with no second nav appearing and no gap.
+             Opacity is GPU-composited, so it stays smooth. States are set via styles (not a local
+             value, which would beat the .open setter). -->
+        <Style Selector="Border#NavFlyout">
+            <Setter Property="Opacity" Value="0"/>
+        </Style>
+        <Style Selector="Border#NavFlyout.open">
+            <Setter Property="Opacity" Value="1"/>
+        </Style>
+    </Window.Styles>
     <Panel>
-        <!-- Main content pushed below the native title bar -->
-        <Grid x:Name="MainContentGrid"
-              ColumnDefinitions="Auto,*"
-              RowDefinitions="*,4,Auto"
+        <!-- Main content pushed below the native title bar.
+             Navigation is a static icon rail (always laid out, never animated) plus a sliding
+             flyout (NavFlyout, below) that translates in over the content on the GPU compositor.
+             Nothing re-lays-out during the slide, which keeps it smooth. -->
+        <Grid x:Name="MainContentRoot"
+              Margin="{Binding $parent[Window].WindowDecorationMargin}"
               Background="{DynamicResource MicaPageBackground}"
-              Margin="{Binding $parent[Window].WindowDecorationMargin}">
+              ColumnDefinitions="Auto,*">
 
-            <!-- ── Sidebar (spans all rows) ── -->
-            <ContentControl Grid.Column="0" Grid.RowSpan="3"
-                            Width="{Binding Sidebar.PaneWidth}"
+            <!-- ── Icon rail (always visible ≥800px; collapsed below) ── -->
+            <ContentControl x:Name="NavRail"
+                            Grid.Column="0"
+                            Width="64"
+                            ClipToBounds="True"
                             Content="{Binding Sidebar}"
                             automation:AutomationProperties.AccessibilityView="Control"
                             automation:AutomationProperties.Name="{t:Translate Navigation panel}"
@@ -35,13 +52,16 @@
                             VerticalContentAlignment="Stretch">
                 <ContentControl.DataTemplates>
                     <DataTemplate DataType="vm:SidebarViewModel">
-                        <views:SidebarView/>
+                        <views:SidebarView ShowLabels="False"/>
                     </DataTemplate>
                 </ContentControl.DataTemplates>
             </ContentControl>
 
+            <!-- ── Content: banners + page + operations ── -->
+            <Grid x:Name="ContentRoot" Grid.Column="1" RowDefinitions="*,4,Auto">
+
             <!-- ── Banners + page content ── -->
-            <Grid Grid.Column="1" Grid.Row="0" RowDefinitions="Auto,*" Margin="0,10">
+            <Grid Grid.Row="0" RowDefinitions="Auto,*" Margin="0,10">
                 <StackPanel Grid.Row="0"
                             Spacing="0"
                             automation:AutomationProperties.AccessibilityView="Control">
@@ -69,7 +89,7 @@
             </Grid>
 
             <!-- ── GridSplitter (only visible when operations are present) ── -->
-            <GridSplitter Grid.Column="1" Grid.Row="1"
+            <GridSplitter Grid.Row="1"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           IsVisible="{Binding OperationsPanelVisible}"
@@ -78,7 +98,7 @@
                           Opacity="0.8"/>
 
             <!-- ── Operations panel ── -->
-            <Border Grid.Column="1" Grid.Row="2"
+            <Border Grid.Row="2"
                     IsVisible="{Binding OperationsPanelVisible}"
                     BorderThickness="0,1,0,0"
                     BorderBrush="{DynamicResource AppBorderBrush}"
@@ -289,6 +309,47 @@
                 </Grid>
             </Border>
 
+            </Grid>
+
+            <!-- ── Light-dismiss layer: transparent (no darkening), closes the flyout on outside click ── -->
+            <Border x:Name="FlyoutDismiss"
+                    Grid.Column="0" Grid.ColumnSpan="2"
+                    Background="Transparent"
+                    ZIndex="9"
+                    IsVisible="{Binding Sidebar.IsPaneOpen}"
+                    automation:AutomationProperties.AccessibilityView="Raw"
+                    PointerPressed="FlyoutDismiss_PointerPressed"/>
+
+            <!-- ── Sliding nav flyout: full labeled pane, parked off-screen, slid in via GPU translate ── -->
+            <Border x:Name="NavFlyout"
+                    Grid.Column="0" Grid.ColumnSpan="2"
+                    Width="250"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Stretch"
+                    ZIndex="10"
+                    Background="{DynamicResource AppWindowBackground}"
+                    IsHitTestVisible="{Binding Sidebar.IsPaneOpen}"
+                    Classes.open="{Binding Sidebar.IsPaneOpen}">
+                <Border.Transitions>
+                    <Transitions>
+                        <DoubleTransition Property="Opacity" Duration="0:0:0.18">
+                            <DoubleTransition.Easing>
+                                <SplineEasing X1="0.1" Y1="0.9" X2="0.2" Y2="1.0"/>
+                            </DoubleTransition.Easing>
+                        </DoubleTransition>
+                    </Transitions>
+                </Border.Transitions>
+                <ContentControl Content="{Binding Sidebar}"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch">
+                    <ContentControl.DataTemplates>
+                        <DataTemplate DataType="vm:SidebarViewModel">
+                            <views:SidebarView ShowLabels="True"/>
+                        </DataTemplate>
+                    </ContentControl.DataTemplates>
+                </ContentControl>
+            </Border>
+
         </Grid>
 
         <TextBlock x:Name="LiveAnnouncementHost"
@@ -329,6 +390,25 @@
                         Margin="65,0,8,0"
                         Spacing="8"
                         Opacity="0.6">
+                <!-- Back button — appears once there is navigation history (mirrors WinUI's title-bar back). -->
+                <Button x:Name="BackButton"
+                        Width="32" Height="32"
+                        Padding="4"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        CornerRadius="4"
+                        IsVisible="False"
+                        automation:AutomationProperties.Name="{t:Translate Go back}"
+                        ToolTip.Tip="{t:Translate Go back}"
+                        Click="BackButton_Click">
+                    <Path Width="16" Height="14"
+                          Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                          StrokeThickness="1.5"
+                          StrokeLineCap="Round"
+                          StrokeJoin="Round"
+                          automation:AutomationProperties.AccessibilityView="Raw"
+                          Data="M7,1 L1,7 L7,13 M1,7 H15"/>
+                </Button>
                 <Button Width="32" Height="32"
                         Padding="4"
                         Background="Transparent"
@@ -337,9 +417,12 @@
                         automation:AutomationProperties.Name="{t:Translate Toggle navigation panel}"
                         ToolTip.Tip="{t:Translate Toggle navigation panel}"
                         Command="{Binding ToggleSidebarCommand}">
-                    <PathIcon Width="14" Height="14"
-                              automation:AutomationProperties.AccessibilityView="Raw"
-                              Data="M1,1 H15 V3 H1 Z M1,7 H15 V9 H1 Z M1,13 H15 V15 H1 Z"/>
+                    <Path Width="16" Height="14"
+                          Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                          StrokeThickness="1.5"
+                          StrokeLineCap="Round"
+                          automation:AutomationProperties.AccessibilityView="Raw"
+                          Data="M0,1 H16 M0,7 H16 M0,13 H16"/>
                 </Button>
                 <TextBlock Text="{Binding TitleBarText}"
                            FontSize="13"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -17,6 +17,20 @@
         MinWidth="700"
         MinHeight="500">
     <Window.Styles>
+        <!-- Global search box focus: a WinUI-style accent underline that spans the whole box
+             (field + button) along the bottom, instead of recoloring the entire border. Toggled
+             via styles (opacity) so the .focus-within setter wins over the base. -->
+        <Style Selector="Border#SearchFocusUnderline">
+            <Setter Property="Opacity" Value="0"/>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.12"/>
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Border#GlobalSearchContainer:focus-within Border#SearchFocusUnderline">
+            <Setter Property="Opacity" Value="1"/>
+        </Style>
         <!-- Nav flyout cross-fade. The flyout's icons sit exactly over the static rail's icons, so
              fading (rather than sliding) keeps the icons perfectly aligned — only the labels fade
              in/out, reading as a clean expand/collapse with no second nav appearing and no gap.
@@ -430,48 +444,71 @@
                            VerticalAlignment="Center"/>
             </StackPanel>
 
-            <!-- Centre: search box — vertically centred, no platform-specific margin -->
+            <!-- Centre: search box — vertically centred, no platform-specific margin.
+                 Taller, rounded pill; the whole bar (field + button) clips to the rounded
+                 corners and shares a single accent focus border (see Window.Styles). -->
             <Border Grid.Column="1"
+                    x:Name="GlobalSearchContainer"
                     VerticalAlignment="Center"
-                    Margin="0,5,0,0"
-                    Height="30"
-                    CornerRadius="4"
+                    Margin="0,0,40,0"
+                    Height="32"
+                    CornerRadius="5"
                     BorderBrush="{DynamicResource AppBorderBrush}"
                     BorderThickness="1"
                     Background="{DynamicResource AppBadgeBackground}"
                     ClipToBounds="True"
                     automation:AutomationProperties.AccessibilityView="Control">
-                <Grid ColumnDefinitions="300,30">
-                    <TextBox x:Name="GlobalSearchBox"
-                             Grid.Column="0"
-                             MinHeight="20"
-                             FontSize="15"
-                             CornerRadius="3,0,0,3"
-                             BorderThickness="0"
-                             VerticalContentAlignment="Center"
-                             Padding="8,0,4,0"
-                             Background="Transparent"
-                             PlaceholderText="{Binding GlobalSearchPlaceholder}"
-                             IsEnabled="{Binding GlobalSearchEnabled}"
-                             automation:AutomationProperties.Name="{Binding GlobalSearchPlaceholder}"
-                             automation:AutomationProperties.AcceleratorKey="Ctrl+F"
-                             Text="{Binding GlobalSearchText}"
-                             KeyDown="SearchBox_KeyDown"/>
-                    <Button Grid.Column="1"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
-                            Padding="3"
-                            CornerRadius="0"
-                            BorderThickness="0"
-                            Background="Transparent"
-                            IsEnabled="{Binding GlobalSearchEnabled}"
-                            automation:AutomationProperties.Name="{Binding GlobalSearchPlaceholder}"
-                            Command="{Binding SubmitGlobalSearchCommand}">
-                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/search.svg"
-                                          Width="18"
-                                          Height="18"/>
-                    </Button>
-                </Grid>
+                <Panel>
+                    <Grid ColumnDefinitions="320,38">
+                        <TextBox x:Name="GlobalSearchBox"
+                                 Grid.Column="0"
+                                 MinHeight="20"
+                                 FontSize="15"
+                                 CornerRadius="0"
+                                 BorderThickness="0"
+                                 VerticalContentAlignment="Center"
+                                 Padding="12,0,4,0"
+                                 Background="Transparent"
+                                 PlaceholderText="{Binding GlobalSearchPlaceholder}"
+                                 IsEnabled="{Binding GlobalSearchEnabled}"
+                                 automation:AutomationProperties.Name="{Binding GlobalSearchPlaceholder}"
+                                 automation:AutomationProperties.AcceleratorKey="Ctrl+F"
+                                 Text="{Binding GlobalSearchText}"
+                                 KeyDown="SearchBox_KeyDown">
+                            <!-- Suppress the TextBox's own focus underline AND its focused/hover
+                                 background swap (which otherwise turns the field black on focus while
+                                 the button keeps the container fill). The container owns the fill and
+                                 the focus highlight (SearchFocusUnderline) instead. -->
+                            <TextBox.Resources>
+                                <Thickness x:Key="TextControlBorderThemeThicknessFocused">0</Thickness>
+                                <SolidColorBrush x:Key="TextControlBackground" Color="Transparent"/>
+                                <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="Transparent"/>
+                                <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="Transparent"/>
+                            </TextBox.Resources>
+                        </TextBox>
+                        <Button Grid.Column="1"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                Padding="3"
+                                CornerRadius="0"
+                                BorderThickness="0"
+                                Background="Transparent"
+                                IsEnabled="{Binding GlobalSearchEnabled}"
+                                automation:AutomationProperties.Name="{Binding GlobalSearchPlaceholder}"
+                                Command="{Binding SubmitGlobalSearchCommand}">
+                            <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/search.svg"
+                                              Width="18"
+                                              Height="18"/>
+                        </Button>
+                    </Grid>
+                    <!-- WinUI focus underline: 2px accent line across the bottom of the whole box -->
+                    <Border x:Name="SearchFocusUnderline"
+                            VerticalAlignment="Bottom"
+                            Height="2"
+                            Margin="1,0,1,0"
+                            IsHitTestVisible="False"
+                            Background="{DynamicResource SystemAccentColor}"/>
+                </Panel>
             </Border>
 
             <!-- Right column: Linux window buttons on the far right -->

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -22,14 +22,22 @@
              via styles (opacity) so the .focus-within setter wins over the base. -->
         <Style Selector="Border#SearchFocusUnderline">
             <Setter Property="Opacity" Value="0"/>
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
             <Setter Property="Transitions">
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.12"/>
                 </Transitions>
             </Setter>
         </Style>
+        <!-- Hover: subtle neutral underline (WinUI shows a lighter line on pointer-over). -->
+        <Style Selector="Border#GlobalSearchContainer:pointerover Border#SearchFocusUnderline">
+            <Setter Property="Opacity" Value="1"/>
+            <Setter Property="Background" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+        </Style>
+        <!-- Focus: accent underline (declared after hover so it wins when both apply). -->
         <Style Selector="Border#GlobalSearchContainer:focus-within Border#SearchFocusUnderline">
             <Setter Property="Opacity" Value="1"/>
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
         </Style>
         <!-- Nav flyout cross-fade. The flyout's icons sit exactly over the static rail's icons, so
              fading (rather than sliding) keeps the icons perfectly aligned — only the labels fade
@@ -506,8 +514,7 @@
                             VerticalAlignment="Bottom"
                             Height="2"
                             Margin="1,0,1,0"
-                            IsHitTestVisible="False"
-                            Background="{DynamicResource SystemAccentColor}"/>
+                            IsHitTestVisible="False"/>
                 </Panel>
             </Border>
 

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -96,11 +96,14 @@ public partial class MainWindow : Window
         DataContext = new MainWindowViewModel();
         InitializeComponent();
         SetupTitleBar();
+        SetupResponsiveRail();
 
         RestoreGeometry();
 
         KeyDown += Window_KeyDown;
         ViewModel.CurrentPageChanged += OnCurrentPageChanged;
+        // Title-bar back button: visible whenever there's somewhere to go back to (mirrors WinUI's TitleBar.IsBackButtonVisible).
+        ViewModel.CanGoBackChanged += (_, canGoBack) => BackButton.IsVisible = canGoBack;
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         UpdateOperationsPanelRow();
 
@@ -216,6 +219,9 @@ public partial class MainWindow : Window
 
     private void OnCurrentPageChanged(object? sender, PageType pageType)
     {
+        // Like WinUI's NavigationView: picking a page collapses the sliding flyout back to the rail.
+        ViewModel.Sidebar.IsPaneOpen = false;
+
         if (!_focusSidebarSelectionOnNextPageChange)
             return;
 
@@ -226,6 +232,8 @@ public partial class MainWindow : Window
             sidebar?.FocusSelectedItem();
         }, DispatcherPriority.Background);
     }
+
+    private void BackButton_Click(object? sender, RoutedEventArgs e) => ViewModel.NavigateBack();
 
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -240,10 +248,10 @@ public partial class MainWindow : Window
     // user's chosen size across collapse/expand.
     private void UpdateOperationsPanelRow()
     {
-        if (MainContentGrid.RowDefinitions.Count < 3)
+        if (ContentRoot.RowDefinitions.Count < 3)
             return;
 
-        RowDefinition row = MainContentGrid.RowDefinitions[2];
+        RowDefinition row = ContentRoot.RowDefinitions[2];
         if (ViewModel.OperationsPanelVisible && ViewModel.OperationsPanelExpanded)
         {
             row.MinHeight = 80;
@@ -257,6 +265,21 @@ public partial class MainWindow : Window
             row.Height = GridLength.Auto;
         }
     }
+
+    // ─── Navigation rail (responsive) ─────────────────────────────────────────
+    // The always-visible icon rail shows on roomy windows and collapses below 800px so narrow
+    // windows give the content full width (the hamburger + sliding flyout still provide nav).
+    private void SetupResponsiveRail()
+        => MainContentRoot.GetObservable(BoundsProperty)
+            .Subscribe(b =>
+            {
+                if (b.Width <= 0) return;
+                NavRail.IsVisible = b.Width >= 800;
+            });
+
+    // Light-dismiss: clicking outside the open flyout closes it (no darkening — the layer is transparent).
+    private void FlyoutDismiss_PointerPressed(object? sender, PointerPressedEventArgs e)
+        => ViewModel.Sidebar.IsPaneOpen = false;
 
     private void SetupTitleBar()
     {
@@ -278,8 +301,8 @@ public partial class MainWindow : Window
                 {
                     TitleBarGrid.ClearValue(HeightProperty);
                     TitleBarGrid.Height = 44;
-                    MainContentGrid.ClearValue(MarginProperty);
-                    MainContentGrid.Margin = new Thickness(0, 44, 0, 0);
+                    MainContentRoot.ClearValue(MarginProperty);
+                    MainContentRoot.Margin = new Thickness(0, 44, 0, 0);
                     HamburgerPanel.Margin = new Thickness(10, 0, 8, 0);
                 }
                 else
@@ -288,7 +311,7 @@ public partial class MainWindow : Window
                     {
                         RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor) { AncestorType = typeof(Window) },
                     });
-                    MainContentGrid.Bind(MarginProperty, new Binding("WindowDecorationMargin")
+                    MainContentRoot.Bind(MarginProperty, new Binding("WindowDecorationMargin")
                     {
                         RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor) { AncestorType = typeof(Window) },
                     });
@@ -311,7 +334,7 @@ public partial class MainWindow : Window
             TitleBarGrid.Height = 44;
             HamburgerPanel.Margin = new Thickness(10, 0, 8, 0);
             WindowButtons.IsVisible = true;
-            MainContentGrid.Margin = new Thickness(0, 44, 0, 0);
+            MainContentRoot.Margin = new Thickness(0, 44, 0, 0);
             this.GetObservable(WindowStateProperty).Subscribe(state =>
             {
                 UpdateMaximizeButtonState(state == WindowState.Maximized);
@@ -328,7 +351,7 @@ public partial class MainWindow : Window
             TitleBarGrid.Height = 44;
             HamburgerPanel.Margin = new Thickness(10, 0, 8, 0);
             WindowButtons.IsVisible = !useNativeDecorations;
-            MainContentGrid.Margin = new Thickness(0, 44, 0, 0);
+            MainContentRoot.Margin = new Thickness(0, 44, 0, 0);
             // Keep maximize icon in sync with window state
             this.GetObservable(WindowStateProperty).Subscribe(state =>
             {

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -4,10 +4,12 @@
              xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
              xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
              xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
+             xmlns:local="using:UniGetUI.Avalonia.Views"
              xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
+             x:Name="SidebarRoot"
              x:DataType="vm:SidebarViewModel"
              MinWidth="64">
 
@@ -36,13 +38,16 @@
                                    FontSize="16"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
-                                   IsVisible="{Binding IsPaneOpen}"/>
+                                   IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
                     <ProgressBar IsIndeterminate="True"
                                  IsVisible="{Binding DiscoverIsLoading}"
                                  Height="2"
+                                 Width="32"
+                                 MinWidth="0"
+                                 HorizontalAlignment="Left"
                                  VerticalAlignment="Bottom"
-                                 Margin="8,0"/>
+                                 Margin="4,0,0,2"/>
                 </Panel>
             </ListBoxItem>
 
@@ -58,26 +63,15 @@
                                    FontSize="16"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
-                                   IsVisible="{Binding IsPaneOpen}"/>
-                        <!-- Updates badge (expanded) -->
-                        <Border Background="{DynamicResource SystemAccentColor}"
-                                CornerRadius="10"
-                                Padding="6,1"
-                                IsVisible="{Binding UpdatesBadgeExpandedVisible}"
-                                VerticalAlignment="Center">
-                            <TextBlock Text="{Binding UpdatesBadgeCount}"
-                                       FontSize="11"
-                                       FontWeight="Bold"
-                                       Foreground="White"/>
-                        </Border>
+                                   IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
-                    <!-- Updates badge (compact overlay) -->
+                    <!-- Update count bubble (InfoBadge-style), anchored to the icon's top-right in both rail and flyout -->
                     <Border Background="{DynamicResource SystemAccentColor}"
                             CornerRadius="8"
                             Padding="3,1"
                             MinWidth="16"
                             Height="16"
-                            IsVisible="{Binding UpdatesBadgeCompactVisible}"
+                            IsVisible="{Binding UpdatesBadgeVisible}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Top"
                             Margin="26,3,0,0">
@@ -91,8 +85,11 @@
                     <ProgressBar IsIndeterminate="True"
                                  IsVisible="{Binding UpdatesIsLoading}"
                                  Height="2"
+                                 Width="32"
+                                 MinWidth="0"
+                                 HorizontalAlignment="Left"
                                  VerticalAlignment="Bottom"
-                                 Margin="8,0"/>
+                                 Margin="4,0,0,2"/>
                 </Panel>
             </ListBoxItem>
 
@@ -108,13 +105,16 @@
                                    FontSize="16"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
-                                   IsVisible="{Binding IsPaneOpen}"/>
+                                   IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
                     <ProgressBar IsIndeterminate="True"
                                  IsVisible="{Binding InstalledIsLoading}"
                                  Height="2"
+                                 Width="32"
+                                 MinWidth="0"
+                                 HorizontalAlignment="Left"
                                  VerticalAlignment="Bottom"
-                                 Margin="8,0"/>
+                                 Margin="4,0,0,2"/>
                 </Panel>
             </ListBoxItem>
 
@@ -130,27 +130,14 @@
                                    FontSize="16"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
-                                   IsVisible="{Binding IsPaneOpen}"/>
-                        <!-- Unsaved changes badge (expanded) -->
-                        <Border Background="{DynamicResource SystemFillColorCautionBrush}"
-                                CornerRadius="10"
-                                Width="16"
-                                Height="16"
-                                IsVisible="{Binding BundlesBadgeExpandedVisible}"
-                                VerticalAlignment="Center">
-                            <TextBlock Text="!"
-                                       FontSize="10"
-                                       FontWeight="Bold"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"/>
-                        </Border>
+                                   IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
-                    <!-- Unsaved changes badge (compact overlay dot) -->
+                    <!-- Unsaved changes dot, anchored to the icon's top-right in both rail and flyout -->
                     <Border Background="{DynamicResource SystemFillColorCautionBrush}"
                             CornerRadius="5"
                             Width="10"
                             Height="10"
-                            IsVisible="{Binding BundlesBadgeCompactVisible}"
+                            IsVisible="{Binding BundlesBadgeVisible}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Top"
                             Margin="28,5,0,0"/>
@@ -177,7 +164,7 @@
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                     <TextBlock Text="{t:Translate Settings}" FontSize="16" VerticalAlignment="Center"
-                               IsVisible="{Binding IsPaneOpen}"/>
+                               IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                 </StackPanel>
             </Button>
 
@@ -195,7 +182,7 @@
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/clipboard_list.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                     <TextBlock Text="{t:Translate Package Managers}" FontSize="16" VerticalAlignment="Center"
-                               IsVisible="{Binding IsPaneOpen}"/>
+                               IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                 </StackPanel>
             </Button>
 
@@ -211,7 +198,7 @@
                     <TextBlock Text="···" FontSize="20" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center"
                                automation:AutomationProperties.AccessibilityView="Raw"/>
                     <TextBlock Text="{t:Translate More}" FontSize="16" VerticalAlignment="Center"
-                               IsVisible="{Binding IsPaneOpen}"/>
+                               IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                 </StackPanel>
                 <Button.Flyout>
                     <MenuFlyout Placement="RightEdgeAlignedTop">

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using UniGetUI.Avalonia.ViewModels;
@@ -7,6 +8,20 @@ namespace UniGetUI.Avalonia.Views;
 public partial class SidebarView : BaseView<SidebarViewModel>
 {
     private bool _lastNavItemSelectionWasAuto;
+
+    /// <summary>
+    /// Whether the nav item text labels are shown. False renders an icon-only rail; true renders the
+    /// full labeled pane. Decoupled from the view-model's pane state so the same view can be used both
+    /// as the always-visible rail and as the sliding flyout simultaneously.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowLabelsProperty =
+        AvaloniaProperty.Register<SidebarView, bool>(nameof(ShowLabels), defaultValue: true);
+
+    public bool ShowLabels
+    {
+        get => GetValue(ShowLabelsProperty);
+        set => SetValue(ShowLabelsProperty, value);
+    }
 
     public SidebarView()
     {

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -51,6 +51,19 @@
          <Setter Property="Width" Value="10"/>
          <Setter Property="Height" Value="2"/>
       </Style>
+      <!-- Mega query box focus: WinUI-style accent underline across the whole box, instead of a
+           full-border accent or the field swapping to its focused (black) background. -->
+      <Style Selector="Border#MegaQueryUnderline">
+         <Setter Property="Opacity" Value="0"/>
+         <Setter Property="Transitions">
+            <Transitions>
+               <DoubleTransition Property="Opacity" Duration="0:0:0.12"/>
+            </Transitions>
+         </Setter>
+      </Style>
+      <Style Selector="Border#MegaQueryContainer:focus-within Border#MegaQueryUnderline">
+         <Setter Property="Opacity" Value="1"/>
+      </Style>
    </UserControl.Styles>
 
    <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="8,8,8,8">
@@ -742,7 +755,8 @@
                       RowDefinitions="*,64,*"
                       ColumnDefinitions="*,8*,64,*">
                     <!-- Single outer border unifies the search field and search button so the seam between them is invisible. -->
-                    <Border Grid.Row="1"
+                    <Border x:Name="MegaQueryContainer"
+                            Grid.Row="1"
                             Grid.Column="1"
                             Grid.ColumnSpan="2"
                             CornerRadius="8"
@@ -750,31 +764,49 @@
                             BorderThickness="1"
                             Background="{DynamicResource MicaPageBackground}"
                             ClipToBounds="True">
-                        <Grid ColumnDefinitions="*,64">
-                            <TextBox x:Name="MegaQueryBlock"
-                                     Grid.Column="0"
-                                     Padding="16,0,10,0"
-                                     VerticalContentAlignment="Center"
-                                     CornerRadius="7,0,0,7"
-                                     BorderThickness="0"
-                                     Background="Transparent"
-                                     FontSize="40"
-                                     PlaceholderText="{t:Translate Search for packages}"
-                                     automation:AutomationProperties.Name="{t:Translate Search for packages}"
-                                     Text="{Binding MegaQueryText, Mode=TwoWay}"
-                                     KeyDown="MegaQueryBlock_KeyDown"/>
-                            <Button x:Name="MegaFindButton"
-                                    Grid.Column="1"
-                                    HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Stretch"
-                                    CornerRadius="0"
-                                    BorderThickness="0"
-                                    Background="Transparent"
-                                    automation:AutomationProperties.Name="{t:Translate Search for packages}"
-                                    Command="{Binding SubmitSearch}">
-                                <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/search.svg" Width="40" Height="40"/>
-                            </Button>
-                        </Grid>
+                        <Panel>
+                            <Grid ColumnDefinitions="*,64">
+                                <TextBox x:Name="MegaQueryBlock"
+                                         Grid.Column="0"
+                                         Padding="16,0,10,0"
+                                         VerticalContentAlignment="Center"
+                                         CornerRadius="0"
+                                         BorderThickness="0"
+                                         Background="Transparent"
+                                         FontSize="40"
+                                         PlaceholderText="{t:Translate Search for packages}"
+                                         automation:AutomationProperties.Name="{t:Translate Search for packages}"
+                                         Text="{Binding MegaQueryText, Mode=TwoWay}"
+                                         KeyDown="MegaQueryBlock_KeyDown">
+                                    <!-- Keep the field on the container fill (no focused/hover black swap)
+                                         and drop its own focus underline; the container owns both. -->
+                                    <TextBox.Resources>
+                                        <Thickness x:Key="TextControlBorderThemeThicknessFocused">0</Thickness>
+                                        <SolidColorBrush x:Key="TextControlBackground" Color="Transparent"/>
+                                        <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="Transparent"/>
+                                        <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="Transparent"/>
+                                    </TextBox.Resources>
+                                </TextBox>
+                                <Button x:Name="MegaFindButton"
+                                        Grid.Column="1"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch"
+                                        CornerRadius="0"
+                                        BorderThickness="0"
+                                        Background="Transparent"
+                                        automation:AutomationProperties.Name="{t:Translate Search for packages}"
+                                        Command="{Binding SubmitSearch}">
+                                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/search.svg" Width="40" Height="40"/>
+                                </Button>
+                            </Grid>
+                            <!-- WinUI focus underline: accent line across the bottom of the whole box -->
+                            <Border x:Name="MegaQueryUnderline"
+                                    VerticalAlignment="Bottom"
+                                    Height="2"
+                                    Margin="1,0,1,0"
+                                    IsHitTestVisible="False"
+                                    Background="{DynamicResource SystemAccentColor}"/>
+                        </Panel>
                     </Border>
                 </Grid>
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -55,14 +55,22 @@
            full-border accent or the field swapping to its focused (black) background. -->
       <Style Selector="Border#MegaQueryUnderline">
          <Setter Property="Opacity" Value="0"/>
+         <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
          <Setter Property="Transitions">
             <Transitions>
                <DoubleTransition Property="Opacity" Duration="0:0:0.12"/>
             </Transitions>
          </Setter>
       </Style>
+      <!-- Hover: subtle neutral underline (WinUI shows a lighter line on pointer-over). -->
+      <Style Selector="Border#MegaQueryContainer:pointerover Border#MegaQueryUnderline">
+         <Setter Property="Opacity" Value="1"/>
+         <Setter Property="Background" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+      </Style>
+      <!-- Focus: accent underline (declared after hover so it wins when both apply). -->
       <Style Selector="Border#MegaQueryContainer:focus-within Border#MegaQueryUnderline">
          <Setter Property="Opacity" Value="1"/>
+         <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
       </Style>
    </UserControl.Styles>
 
@@ -811,8 +819,7 @@
                                     VerticalAlignment="Bottom"
                                     Height="2"
                                     Margin="1,0,1,0"
-                                    IsHitTestVisible="False"
-                                    Background="{DynamicResource SystemAccentColor}"/>
+                                    IsHitTestVisible="False"/>
                         </Panel>
                     </Border>
                 </Grid>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -116,6 +116,13 @@
                  with the package list when the pane is open, and collapse next to the Filters button when closed. -->
             <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="0,0,8,0"
                         MinWidth="{Binding FilterPaneColumnWidth}">
+                <!-- Animate the reserved width so opening/closing the filter pane slides the
+                     action buttons into place instead of snapping them sideways. -->
+                <StackPanel.Transitions>
+                    <Transitions>
+                        <DoubleTransition Property="MinWidth" Duration="0:0:0.2" Easing="CubicEaseOut"/>
+                    </Transitions>
+                </StackPanel.Transitions>
                 <ToggleButton x:Name="ToggleFiltersButton"
                               Classes="filter-toggle"
                               Height="40"
@@ -179,13 +186,13 @@
         <!-- ==================== MAIN CONTENT (filter pane + package list) ==================== -->
         <Grid x:Name="FilteringPanel"
               Grid.Row="2"
+              ClipToBounds="True"
               ColumnDefinitions="220,4,*">
 
             <!-- ===== FILTER PANE =====
                  SidePanel is the Border the code-behind positions (inline vs overlay mode). -->
                 <Border x:Name="SidePanel"
                         Grid.Column="0"
-                        IsVisible="{Binding IsFilterPaneOpen}"
                         CornerRadius="8"
                         ClipToBounds="True">
                 <ScrollViewer x:Name="SidePanelScroller"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -7,6 +9,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.Transformation;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels.Pages;
 using UniGetUI.Avalonia.Views.Controls;
@@ -25,6 +28,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
     private double _savedFilterPaneWidth = 220;
     private bool _isOverlayMode;
     private IDisposable? _sidePanelBgBinding;
+    private CancellationTokenSource? _filterPaneAnimCts;
 
     protected AbstractPackagesPage(PackagesPageData data)
     {
@@ -59,7 +63,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
             if (args.PropertyName is nameof(PackagesPageViewModel.IsFilterPaneOpen))
             {
                 SyncFiltersButtonName();
-                UpdateFilterPaneColumn(ViewModel.IsFilterPaneOpen);
+                UpdateFilterPaneColumn(ViewModel.IsFilterPaneOpen, animate: true);
             }
         };
         SyncFiltersButtonName();
@@ -146,6 +150,19 @@ public abstract partial class AbstractPackagesPage : UserControl,
 
         // Apply the initial filter-pane state (AXAML defaults to 220px open).
         UpdateFilterPaneColumn(ViewModel.IsFilterPaneOpen);
+
+        // Attach the pane slide AFTER the initial state so launch doesn't animate. The pane slides
+        // via a compositor RenderTransform (clipped by FilteringPanel) instead of width-tweening the
+        // column, which reflowed the package list every frame and felt laggy.
+        SidePanel.Transitions = new Transitions
+        {
+            new TransformOperationsTransition
+            {
+                Property = Visual.RenderTransformProperty,
+                Duration = TimeSpan.FromMilliseconds(200),
+                Easing = new SplineEasing(0.1, 0.9, 0.2, 1.0),
+            }
+        };
     }
 
     // Recompute the grid-view card slot width: fit as many >=275px columns as possible,
@@ -394,12 +411,14 @@ public abstract partial class AbstractPackagesPage : UserControl,
             UpdateFilterPaneColumn(ViewModel.IsFilterPaneOpen);
     }
 
-    private void UpdateFilterPaneColumn(bool open)
+    private void UpdateFilterPaneColumn(bool open, bool animate = false)
     {
         if (FilteringPanel.ColumnDefinitions.Count < 2) return;
 
         if (_isOverlayMode)
         {
+            _filterPaneAnimCts?.Cancel();
+
             // Package list fills full width; filter pane and splitter take no space.
             FilteringPanel.ColumnDefinitions[0].Width = new GridLength(0);
             FilteringPanel.ColumnDefinitions[1].Width = new GridLength(0);
@@ -409,6 +428,8 @@ public abstract partial class AbstractPackagesPage : UserControl,
             SidePanel.ZIndex = 10;
             SidePanel.Width = _savedFilterPaneWidth;
             SidePanel.HorizontalAlignment = HorizontalAlignment.Left;
+            SidePanel.IsVisible = open;
+            SetSidePanelTransformInstant(0);
 
             // Floating over content needs an opaque surface (the page surface is transparent under Mica).
             _sidePanelBgBinding ??= SidePanel.Bind(Border.BackgroundProperty, this.GetResourceObservable("AppWindowBackground"));
@@ -428,13 +449,74 @@ public abstract partial class AbstractPackagesPage : UserControl,
             SidePanel.Background = null;
             FilterOverlayBackdrop.IsVisible = false;
 
-            FilteringPanel.ColumnDefinitions[0].Width = open
-                ? new GridLength(_savedFilterPaneWidth)
-                : new GridLength(0);
-            FilteringPanel.ColumnDefinitions[1].Width = open
-                ? new GridLength(4)
-                : new GridLength(0);
+            if (animate)
+            {
+                AnimateInlineFilterPane(open);
+            }
+            else
+            {
+                _filterPaneAnimCts?.Cancel();
+                SidePanel.IsVisible = open;
+                SetSidePanelTransformInstant(open ? 0 : -_savedFilterPaneWidth);
+                FilteringPanel.ColumnDefinitions[0].Width = open ? new GridLength(_savedFilterPaneWidth) : new GridLength(0);
+                FilteringPanel.ColumnDefinitions[1].Width = open ? new GridLength(4) : new GridLength(0);
+            }
         }
+    }
+
+    // Reserve/release the inline pane's column in one step (a single reflow, not a per-frame tween),
+    // and slide the pane itself in/out via a compositor RenderTransform (clipped by FilteringPanel) —
+    // tweening the column width reflowed the package list every frame and felt laggy. The toolbar
+    // buttons still slide via their MinWidth transition.
+    private async void AnimateInlineFilterPane(bool open)
+    {
+        _filterPaneAnimCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _filterPaneAnimCts = cts;
+
+        var col0 = FilteringPanel.ColumnDefinitions[0];
+        var col1 = FilteringPanel.ColumnDefinitions[1];
+
+        if (open)
+        {
+            // Reserve the column (one reflow), then slide the pane in from -width to 0.
+            col0.Width = new GridLength(_savedFilterPaneWidth);
+            col1.Width = new GridLength(4);
+            SidePanel.IsVisible = true;
+            SidePanel.RenderTransform = TranslateX(0);
+        }
+        else
+        {
+            // Reclaim the list width in one reflow NOW and float the pane over the list, then slide
+            // the floating pane out — otherwise the list sits beside an empty gap and only snaps to
+            // full width when the slide ends. Inline positioning is restored on the next open by
+            // UpdateFilterPaneColumn.
+            double w = _savedFilterPaneWidth;
+            Grid.SetColumnSpan(SidePanel, 3);
+            SidePanel.ZIndex = 10;
+            SidePanel.Width = w;
+            SidePanel.HorizontalAlignment = HorizontalAlignment.Left;
+            _sidePanelBgBinding ??= SidePanel.Bind(Border.BackgroundProperty, this.GetResourceObservable("AppWindowBackground"));
+            col0.Width = new GridLength(0);
+            col1.Width = new GridLength(0);
+
+            SidePanel.RenderTransform = TranslateX(-w);
+            try { await Task.Delay(210, cts.Token); }
+            catch (TaskCanceledException) { return; }
+            SidePanel.IsVisible = false;
+        }
+    }
+
+    private static ITransform TranslateX(double x)
+        => TransformOperations.Parse(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"translateX({x}px)"));
+
+    // Set the pane transform without triggering the slide transition (for initial/mode-change states).
+    private void SetSidePanelTransformInstant(double translateX)
+    {
+        var transitions = SidePanel.Transitions;
+        SidePanel.Transitions = null;
+        SidePanel.RenderTransform = TranslateX(translateX);
+        SidePanel.Transitions = transitions;
     }
 
     // ─── Card overflow button (Grid / Icons view) ─────────────────────────────


### PR DESCRIPTION
Addresses users feedback on the Avalonia UI, bringing several interactions closer to the WinUI app and smoothing out the animations. 

### Navigation panel
- Replaced the single width sidebar with a WinUI `NavigationView`-style layout: a static icon rail plus a labeled flyout that **cross-fades** in over the content (GPU-composited, so the package list never reflows during the transition).
- Rail and flyout are one `SidebarView` bound to the same view-model (new `ShowLabels` property), so selection, badges and loading stay in sync.
- Fixed 64px rail so loading bars/badges can't inflate it; loading indicator is a small bar centered under the icon.
- Transparent light-dismiss, collapse-on-navigate, and a title-bar back button wired to the existing back-navigation.
- Thinner, more Fluent hamburger glyph.

### Search boxes (top bar + Discover mega query)              
  - WinUI-style focus treatment: a single **accent underline** across the whole box (field + button) instead of recoloring the entire border.   
  - The field keeps the container fill in every state (no black background swap on focus), so field and button stay one consistent color.              
  - **Hover** shows a subtle neutral underline; focus switches it to the accent color.                                       
  - Top box: subtler corner radius and a small left nudge to match WinUI placement.
  
  ### Filter pane                                               
  - Opening/closing now **slides** on a compositor `RenderTransform` (clipped by the panel) instead of width-tweening the column, which reflowed the package list every frame and felt laggy. The list resizes once up front so the pane never sits beside an empty gap.                                     
  - Toolbar buttons keep sliding via their `MinWidth`transition. 
  
  ### Operations                                                
  - Dropped the redundant in-app success banner — the operations panel already shows the completed status. OS toasts and accessibility announcements are unchanged; failures still surface a banner. 