### PR TITLE
Add MS Store installer mode

### DIFF
--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -179,6 +179,31 @@ begin
     end;
 end;
 
+function IsMSStoreInstall: Boolean;
+begin
+  Result := CmdLineParamExists('/MSStore');
+end;
+
+function ShouldInstallVCRedist: Boolean;
+begin
+  Result := not (CmdLineParamExists('/NoVCRedist') or IsMSStoreInstall);
+end;
+
+function ShouldInstallEdgeWebView: Boolean;
+begin
+  Result := not (CmdLineParamExists('/NoEdgeWebView') or IsMSStoreInstall);
+end;
+
+function ShouldLaunchAfterInstall: Boolean;
+begin
+  Result := not (CmdLineParamExists('/NoAutoStart') or IsMSStoreInstall);
+end;
+
+function ShouldSuppressRunOnStartup: Boolean;
+begin
+  Result := CmdLineParamExists('/NoRunOnStartup') or IsMSStoreInstall;
+end;
+
 var CustomExitCode: integer;
 
 procedure ExitProcess(exitCode:integer);
@@ -228,11 +253,11 @@ end;
 function InitializeSetup: Boolean;
 begin
   try
-    if not CmdLineParamExists('/NoVCRedist') then
+    if ShouldInstallVCRedist then
     begin
       Dependency_AddVC2015To2022;
     end;
-    if not CmdLineParamExists('/NoEdgeWebView') then
+    if ShouldInstallEdgeWebView then
     begin
       Dependency_AddWebView2;
     end;
@@ -251,7 +276,7 @@ Name: "regularinstall\desktopicon"; Description: "{cm:RegDesktopIcon}"; GroupDes
 
 [Registry]
 Root: HKCU; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "WingetUI"; ValueData: """{app}\UniGetUI.exe"" --daemon"; Flags: uninsdeletevalue noerror; Tasks: regularinstall;
-Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run"; ValueType: binary; ValueName: "WingetUI"; ValueData: "03"; Flags: uninsdeletevalue; Tasks: regularinstall; Check: CmdLineParamExists('/NoRunOnStartup');
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run"; ValueType: binary; ValueName: "WingetUI"; ValueData: "03"; Flags: uninsdeletevalue; Tasks: regularinstall; Check: ShouldSuppressRunOnStartup;
 
 // Register the unigetui:// deep link
 Root: HKA; Subkey: "Software\Classes\unigetui"; ValueType: "string"; ValueData: "URL:UniGetUI Protocol"; Flags: uninsdeletekey; Tasks: regularinstall;
@@ -284,7 +309,7 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: re
 
 [Run]
 ; Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File -NonInteractive ""{tmp}\EnsureWinGet.ps1"""; StatusMsg: "Ensuring WinGet is properly installed... (this may take a while)"; WorkingDir: {app}; Check: not CmdLineParamExists('/NoWinGet'); Flags: runhidden
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: runasoriginaluser nowait postinstall; Check: not CmdLineParamExists('/NoAutoStart');
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: runasoriginaluser nowait postinstall; Check: ShouldLaunchAfterInstall;
 Filename: "{app}\{#MyAppExeName}"; Parameters: "--migrate-wingetui-to-unigetui"; StatusMsg: "Removing old icons...";
 
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -259,3 +259,4 @@ The installer is Inno Setup based. It supports the standard [Inno Setup command-
 | `/NoChocolatey` | Deprecated no-op kept for compatibility. |
 | `/EnableSystemChocolatey` | Deprecated no-op kept for compatibility. |
 | `/NoWinGet` | Do not install WinGet and Microsoft.WinGet.Client if they are missing. |
+| `/MSStore` | Microsoft Store install mode: skip the MSVC and WebView2 dependency installers, do not launch UniGetUI after installation, and disable startup at login. Use with `/CURRENTUSER` to select user-local scope. |


### PR DESCRIPTION
## Summary
- Add a compact `/MSStore` installer parameter for Microsoft Store submissions.
- Make `/MSStore` skip the MSVC and WebView2 dependency installers, suppress post-install auto-launch, and disable startup at login.
- Document the new installer parameter and keep Store submissions using Inno's explicit `/CURRENTUSER` scope switch.

## Context
Microsoft Store package submissions cap `InstallerParameters` at 40 characters. The previous expanded parameter set cannot fit under that limit, causing Store submission updates to fail with `Packages, maximum length allowed for InstallerParameters is 40`.

With this change, the Store can use:

```text
/VERYSILENT /CURRENTUSER /MSStore
```

This is 33 characters and preserves the Store-specific install behavior without listing every individual UniGetUI switch.