### PR TITLE
Align Avalonia UI with WinUI styling and behavior

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -35,6 +35,14 @@
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#FBFBFB"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#ECECEC"/>
                     <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#F6F6F6"/>
+                    <!-- Package list container; near-transparent over Mica (see Styles.WindowsMica) -->
+                    <SolidColorBrush x:Key="PackageListBackground"       Color="#FBFBFB"/>
+                    <!-- Column header: WinUI default button (ControlFillColorDefault fill + ControlStrokeColorDefault border) -->
+                    <SolidColorBrush x:Key="PackageListHeaderBackground" Color="#B3FFFFFF"/>
+                    <SolidColorBrush x:Key="PackageListHeaderBorderBrush" Color="#0F000000"/>
+                    <!-- Subtle header hover/press (WinUI-style), over the rest fill -->
+                    <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackgroundBrush" Color="#05000000"/>
+                    <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackgroundBrush" Color="#14000000"/>
                     <!-- Window structure -->
                     <SolidColorBrush x:Key="AppWindowBackground"         Color="#F3F3F3"/>
                     <SolidColorBrush x:Key="AppTitleBarBackground"       Color="#F3F3F3"/>
@@ -99,6 +107,14 @@
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#2D2D2D"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#393939"/>
                     <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#323232"/>
+                    <!-- Package list container; near-transparent over Mica (see Styles.WindowsMica) -->
+                    <SolidColorBrush x:Key="PackageListBackground"       Color="#2D2D2D"/>
+                    <!-- Column header: WinUI default button (ControlFillColorDefault fill + ControlStrokeColorDefault border) -->
+                    <SolidColorBrush x:Key="PackageListHeaderBackground" Color="#0FFFFFFF"/>
+                    <SolidColorBrush x:Key="PackageListHeaderBorderBrush" Color="#12FFFFFF"/>
+                    <!-- Subtle header hover/press (WinUI-style), over the rest fill -->
+                    <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackgroundBrush" Color="#0AFFFFFF"/>
+                    <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackgroundBrush" Color="#1FFFFFFF"/>
                     <!-- Window structure -->
                     <SolidColorBrush x:Key="AppWindowBackground"         Color="#202020"/>
                     <SolidColorBrush x:Key="AppTitleBarBackground"       Color="#202020"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -13,6 +13,9 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColorDark2}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#37000000"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
+                    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#09000000"/>
+                    <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#06000000"/>
                     <!-- Accent text (darker accents read better on light bg) -->
                     <SolidColorBrush x:Key="AccentTextFillColorPrimaryBrush"   Color="{DynamicResource SystemAccentColorDark2}"/>
                     <SolidColorBrush x:Key="AccentTextFillColorSecondaryBrush" Color="{DynamicResource SystemAccentColorDark3}"/>
@@ -86,6 +89,9 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColor}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#28FFFFFF"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
+                    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#0FFFFFFF"/>
+                    <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#0AFFFFFF"/>
                     <!-- Accent text -->
                     <SolidColorBrush x:Key="AccentTextFillColorPrimaryBrush"   Color="{DynamicResource SystemAccentColorLight3}"/>
                     <SolidColorBrush x:Key="AccentTextFillColorSecondaryBrush" Color="{DynamicResource SystemAccentColorLight3}"/>
@@ -175,6 +181,96 @@
     </Style>
     <Style Selector="DataGridRow:selected:pointerover /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="{DynamicResource SettingsCardHoverBackground}"/>
+    </Style>
+
+    <!-- Sidebar navigation items: WinUI NavigationViewItem-style selection.
+         Fluent's default fills the selected item with the accent colour; instead use a subtle
+         neutral fill plus a vertical accent pill on the left edge. The content presenter is named
+         ContentHost (not PART_ContentPresenter) so the base theme's accent-fill setters don't apply. -->
+    <Style Selector="ListBoxItem.nav-item">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel>
+                    <ContentPresenter Name="ContentHost"
+                                      Background="{TemplateBinding Background}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      CornerRadius="{TemplateBinding CornerRadius}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Content="{TemplateBinding Content}"
+                                      Padding="{TemplateBinding Padding}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                    <Border Name="SelectionPill"
+                            Width="3" Height="16" CornerRadius="1.5"
+                            Background="{DynamicResource AccentFillColorDefaultBrush}"
+                            HorizontalAlignment="Left" VerticalAlignment="Center"
+                            Opacity="0">
+                        <Border.Transitions>
+                            <Transitions><DoubleTransition Property="Opacity" Duration="0:0:0.1"/></Transitions>
+                        </Border.Transitions>
+                    </Border>
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="ListBoxItem.nav-item:pointerover /template/ ContentPresenter#ContentHost">
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="ListBoxItem.nav-item:pressed /template/ ContentPresenter#ContentHost">
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}"/>
+    </Style>
+    <Style Selector="ListBoxItem.nav-item:selected /template/ ContentPresenter#ContentHost">
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="ListBoxItem.nav-item:selected:pointerover /template/ ContentPresenter#ContentHost">
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}"/>
+    </Style>
+    <Style Selector="ListBoxItem.nav-item:selected /template/ Border#SelectionPill">
+        <Setter Property="Opacity" Value="1"/>
+    </Style>
+
+    <!-- View-mode segmented selector (List / Grid / Icons): WinUI Segmented-style selection — subtle
+         fill plus an accent underline under the selected segment, not Fluent's full-accent fill. -->
+    <Style Selector="ListBoxItem.segment-item">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel>
+                    <ContentPresenter Name="ContentHost"
+                                      Background="{TemplateBinding Background}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      CornerRadius="{TemplateBinding CornerRadius}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Content="{TemplateBinding Content}"
+                                      Padding="{TemplateBinding Padding}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                    <Border Name="SelectionPill"
+                            Height="2" CornerRadius="1"
+                            Background="{DynamicResource AccentFillColorDefaultBrush}"
+                            HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
+                            Margin="5,0,5,2"
+                            Opacity="0">
+                        <Border.Transitions>
+                            <Transitions><DoubleTransition Property="Opacity" Duration="0:0:0.1"/></Transitions>
+                        </Border.Transitions>
+                    </Border>
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="ListBoxItem.segment-item:pointerover /template/ ContentPresenter#ContentHost">
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="ListBoxItem.segment-item:selected /template/ ContentPresenter#ContentHost">
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="ListBoxItem.segment-item:selected:pointerover /template/ ContentPresenter#ContentHost">
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}"/>
+    </Style>
+    <Style Selector="ListBoxItem.segment-item:selected /template/ Border#SelectionPill">
+        <Setter Property="Opacity" Value="1"/>
     </Style>
 
     <!-- SettingsCard appearance -->

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -147,6 +147,10 @@
         <Setter Property="BorderThickness" Value="2"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
     </Style>
+    <!-- Column headers default to Avalonia's 12px bare-TextBlock size; WinUI renders them at 14px. -->
+    <Style Selector="DataGridColumnHeader">
+        <Setter Property="FontSize" Value="14"/>
+    </Style>
     <Style Selector="DataGridRow:selected">
         <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}"/>
     </Style>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
@@ -17,6 +17,8 @@
             <!-- Cards / panels: translucent white layers over the (light) Mica -->
             <SolidColorBrush x:Key="SettingsCardBackground"      Color="#80FFFFFF"/>
             <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#14000000"/>
+            <!-- Package list: near-transparent so Mica shows through, matching WinUI's SystemFillColorNeutralBackground -->
+            <SolidColorBrush x:Key="PackageListBackground"       Color="#06000000"/>
             <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#99FFFFFF"/>
             <SolidColorBrush x:Key="AppSplitterBackground"       Color="#18000000"/>
             <SolidColorBrush x:Key="AppOperationsPanelBackground" Color="#80FFFFFF"/>
@@ -53,6 +55,8 @@
             <!-- Cards / panels: translucent dark layers; ~40% so the wallpaper-tinted Mica bleeds through -->
             <SolidColorBrush x:Key="SettingsCardBackground"      Color="#662D2D2D"/>
             <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#26FFFFFF"/>
+            <!-- Package list: near-transparent so Mica shows through, matching WinUI's SystemFillColorNeutralBackground -->
+            <SolidColorBrush x:Key="PackageListBackground"       Color="#08FFFFFF"/>
             <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#66383838"/>
             <SolidColorBrush x:Key="AppSplitterBackground"       Color="#66000000"/>
             <SolidColorBrush x:Key="AppOperationsPanelBackground" Color="#66202020"/>

--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -65,7 +65,8 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     public string VersionComboString { get; }
     public string ListedNameTooltip { get; private set; } = "";
     public float ListedOpacity { get; private set; } = 1.0f;
-    public string TagIconPath { get; private set; } = "";
+    public string TagBackdropIconPath { get; private set; } = "";
+    public string TagSymbolIconPath { get; private set; } = "";
     public bool TagIconVisible { get; private set; }
 
     public bool InstallerHostChanged { get; private set; }
@@ -248,7 +249,8 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
             UpdateDisplayState();
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ListedOpacity)));
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ListedNameTooltip)));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TagIconPath)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TagBackdropIconPath)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TagSymbolIconPath)));
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TagIconVisible)));
         }
         else if (e.PropertyName == nameof(Package.IsChecked))
@@ -270,20 +272,20 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         };
         ListedNameTooltip = Package.Name;
 
-        string tagName = Package.Tag switch
+        // Match WinUI: an accent-coloured filled disc with the symbol punched out, then the
+        // symbol drawn on top in the default foreground. OnQueue/Unavailable show no badge.
+        (string symbol, string backdrop) = Package.Tag switch
         {
-            PackageTag.AlreadyInstalled => "installed_filled",
-            PackageTag.IsUpgradable => "upgradable_filled",
-            PackageTag.Pinned => "pin_filled",
-            PackageTag.OnQueue => "sandclock",
-            PackageTag.BeingProcessed => "loading_filled",
-            PackageTag.Failed => "warning_filled",
-            _ => "",
+            PackageTag.AlreadyInstalled => ("installed", "installed_filled"),
+            PackageTag.IsUpgradable => ("upgradable", "upgradable_filled"),
+            PackageTag.Pinned => ("pin", "pin_filled"),
+            PackageTag.BeingProcessed => ("loading", "loading_filled"),
+            PackageTag.Failed => ("warning", "warning_filled"),
+            _ => ("", ""),
         };
-        TagIconVisible = tagName.Length > 0;
-        TagIconPath = TagIconVisible
-            ? $"avares://UniGetUI.Avalonia/Assets/Symbols/{tagName}.svg"
-            : "";
+        TagIconVisible = symbol.Length > 0;
+        TagSymbolIconPath = TagIconVisible ? $"avares://UniGetUI.Avalonia/Assets/Symbols/{symbol}.svg" : "";
+        TagBackdropIconPath = TagIconVisible ? $"avares://UniGetUI.Avalonia/Assets/Symbols/{backdrop}.svg" : "";
     }
 
     public void Dispose()

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -130,7 +130,6 @@
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
-        <PackageReference Include="Devolutions.AvaloniaTheme.DevExpress" Version="2026.3.13" />
         <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.3.13" />
         <PackageReference Include="Devolutions.AvaloniaTheme.Linux" Version="2026.3.11" />
         <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3" Condition="'$(EnableAvaloniaDiagnostics)' == 'true'" />

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
@@ -8,11 +8,13 @@ using CommunityToolkit.Mvvm.Input;
 using UniGetUI.Core.Language;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.Serializable;
+using UniGetUI.Avalonia.Views;
 
 namespace UniGetUI.Avalonia.ViewModels;
 
@@ -28,8 +30,11 @@ public partial class InstallOptionsViewModel : ObservableObject
 
     // ── Translated static labels ───────────────────────────────────────────────
     public string DialogTitle { get; }
+    public string PlaceholderText { get; }
+    public string UnlockLabel { get; } = CoreTools.Translate("Change this and unlock");
     public string ProfileLabel { get; } = CoreTools.Translate("Operation profile:");
     public string FollowGlobalLabel { get; } = CoreTools.Translate("Follow the default options when installing, upgrading or uninstalling this package");
+    public string ChangeDefaultOptionsLabel { get; } = CoreTools.Translate("Change default options");
     public string GeneralInfoLabel { get; } = CoreTools.Translate("The following settings will be applied each time this package is installed, updated or removed.");
     public string VersionLabel { get; } = CoreTools.Translate("Version to install:");
     public string ArchLabel { get; } = CoreTools.Translate("Architecture to install:");
@@ -51,11 +56,17 @@ public partial class InstallOptionsViewModel : ObservableObject
     public string AbortUninstallLabel { get; } = CoreTools.Translate("Abort uninstall if pre-uninstall command fails");
     public string CommandPreviewLabel { get; } = CoreTools.Translate("Command-line to run:");
     public string SaveLabel { get; } = CoreTools.Translate("Save and close");
-    public string TabGeneralLabel { get; } = CoreTools.Translate("General");
-    public string TabLocationLabel { get; } = CoreTools.Translate("Architecture & Location");
-    public string TabCLILabel { get; } = CoreTools.Translate("Command-line");
-    public string TabCloseAppsLabel { get; } = CoreTools.Translate("Close apps");
-    public string TabPrePostLabel { get; } = CoreTools.Translate("Pre/Post install");
+    // Tab headers — icon + two text lines, mirroring the WinUI BetterTabViewItem tabs.
+    public string TabGeneralLine1 { get; } = CoreTools.Translate("General");
+    public string TabGeneralLine2 { get; } = CoreTools.Translate("Version");
+    public string TabLocationLine1 { get; } = CoreTools.Translate("Architecture");
+    public string TabLocationLine2 { get; } = CoreTools.Translate("Location and Scope");
+    public string TabCLILine1 { get; } = CoreTools.Translate("Command-line");
+    public string TabCLILine2 { get; } = CoreTools.Translate("Arguments");
+    public string TabCloseAppsLine1 { get; } = CoreTools.Translate("Close apps");
+    public string TabCloseAppsLine2 { get; } = CoreTools.Translate("before installing");
+    public string TabPrePostLine1 { get; } = CoreTools.Translate("Pre-install");
+    public string TabPrePostLine2 { get; } = CoreTools.Translate("Post-install");
 
     // Close-apps tab labels
     public string KillProcessesDescriptionLabel { get; } = CoreTools.Translate(
@@ -72,6 +83,17 @@ public partial class InstallOptionsViewModel : ObservableObject
     public string UninstallPrevCheckBox_Content { get; } = CoreTools.Translate("Uninstall previous versions when updated");
     public string SkipMinorCheckBox_Content { get; } = CoreTools.Translate("Skip minor updates for this package");
     public string AutoUpdateCheckBox_Content { get; } = CoreTools.Translate("Automatically update this package");
+    public string IgnoreUpdatesCheckBox_Content { get; } = CoreTools.Translate("Ignore future updates for this package");
+
+    // ── Security-gated sections (CLI args & pre/post commands), mirrors WinUI ──
+    public bool CliEnabled { get; }
+    public bool CliDisabledWarningVisible => !CliEnabled;
+    public bool PrePostEnabled { get; }
+    public bool PrePostDisabledWarningVisible => !PrePostEnabled;
+    public string CliDisabledLabel { get; } = CoreTools.Translate("For security reasons, custom command-line arguments are disabled by default. Go to UniGetUI security settings to change this.");
+    public string PrePostDisabledLabel { get; } = CoreTools.Translate("For security reasons, pre-operation and post-operation scripts are disabled by default. Go to UniGetUI security settings to change this.");
+    public string PrePostExplainerLabel { get; } = CoreTools.Translate("You can define the commands that will be run before or after this package is installed, updated or uninstalled. They will be run on a command prompt, so CMD scripts will work here.");
+    public string GoToSecurityLabel { get; } = CoreTools.Translate("Go to UniGetUI security settings");
 
     // ── Capability flags (for IsEnabled bindings) ─────────────────────────────
     public bool CanRunAsAdmin { get; }
@@ -122,6 +144,7 @@ public partial class InstallOptionsViewModel : ObservableObject
 
     [ObservableProperty] private bool _skipMinorChecked;
     [ObservableProperty] private bool _autoUpdateChecked;
+    [ObservableProperty] private bool _ignoreUpdatesChecked;
 
     partial void OnAdminCheckedChanged(bool value) => Refresh();
     partial void OnInteractiveCheckedChanged(bool value) => Refresh();
@@ -192,6 +215,9 @@ public partial class InstallOptionsViewModel : ObservableObject
         var caps = package.Manager.Capabilities;
 
         DialogTitle = CoreTools.Translate("{0} installation options", package.Name);
+        PlaceholderText = CoreTools.Translate(
+            "{0} Install options are currently locked because {0} follows the default install options.",
+            package.Name);
 
         // Capability flags
         CanRunAsAdmin = OperatingSystem.IsWindows() && caps.CanRunAsAdmin;
@@ -200,6 +226,10 @@ public partial class InstallOptionsViewModel : ObservableObject
         CanUninstallPrev = caps.CanUninstallPreviousVersionsAfterUpdate;
         HasCustomScopes = caps.SupportsCustomScopes;
         HasCustomLocations = caps.SupportsCustomLocations;
+
+        // Security-gated sections (disabled by default; toggled in security settings)
+        CliEnabled = SecureSettings.Get(SecureSettings.K.AllowCLIArguments);
+        PrePostEnabled = SecureSettings.Get(SecureSettings.K.AllowPrePostOpCommand);
 
         // Profile
         string installLabel = CoreTools.Translate("Install");
@@ -300,7 +330,13 @@ public partial class InstallOptionsViewModel : ObservableObject
         if (caps.SupportsCustomVersions)
             _ = LoadVersionsAsync(options.Version);
 
+        _ = LoadIgnoredUpdatesAsync();
+
         _uiLoaded = true;
+        // Apply the operation-dependent enable gates for the initial operation, matching
+        // WinUI's EnableDisableControls (which runs on load): e.g. Skip-hash/Architecture are
+        // disabled for Uninstall, Version is enabled only for Install.
+        ApplyProfileEnableState();
         _ = RefreshCommandPreviewAsync();
     }
 
@@ -326,6 +362,47 @@ public partial class InstallOptionsViewModel : ObservableObject
 
     [RelayCommand]
     private void ResetLocation() => LocationText = "";
+
+    /// <summary>Unlocks the options by turning off "follow default options" (matches WinUI).</summary>
+    [RelayCommand]
+    private void Unlock() => FollowGlobal = false;
+
+    /// <summary>Closes the dialog and opens the manager's default-options settings (matches WinUI).</summary>
+    [RelayCommand]
+    private void ChangeDefaultOptions()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+        if (MainWindow.Instance?.DataContext is MainWindowViewModel vm)
+            vm.OpenManagerSettings(_package.Manager);
+    }
+
+    /// <summary>Closes the dialog and opens the security settings page (matches WinUI).</summary>
+    [RelayCommand]
+    private void GoToSecuritySettings()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+        if (MainWindow.Instance?.DataContext is MainWindowViewModel vm)
+            vm.OpenSettingsPage(typeof(Views.Pages.SettingsPages.Administrator));
+    }
+
+    // ── Ignore-future-updates state (package-level, like WinUI) ────────────────
+    private async Task LoadIgnoredUpdatesAsync()
+    {
+        try { IgnoreUpdatesChecked = await _package.HasUpdatesIgnoredAsync(); }
+        catch (Exception ex) { Logger.Warn($"[InstallOptionsViewModel] Failed to read ignored-updates state: {ex.Message}"); }
+    }
+
+    private async Task ApplyIgnoredUpdatesAsync()
+    {
+        try
+        {
+            if (IgnoreUpdatesChecked)
+                await _package.AddToIgnoredUpdatesAsync("*");
+            else if (await _package.GetIgnoredUpdatesVersionAsync() == "*")
+                await _package.RemoveFromIgnoredUpdatesAsync();
+        }
+        catch (Exception ex) { Logger.Warn($"[InstallOptionsViewModel] Failed to apply ignored-updates state: {ex.Message}"); }
+    }
 
     // ── Enable/disable based on selected operation profile ────────────────────
     private void ApplyProfileEnableState()
@@ -470,6 +547,7 @@ public partial class InstallOptionsViewModel : ObservableObject
         _options.AbortOnPreUninstallFail = s.AbortOnPreUninstallFail;
         _options.KillBeforeOperation = KillProcessEntries.Select(e => e.Name).ToList();
         Settings.Set(Settings.K.KillProcessesThatRefuseToDie, ForceKillChecked);
+        _ = ApplyIgnoredUpdatesAsync();
     }
 
     private static string ScopeToString(string? selected)

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using UniGetUI.Avalonia.Views;
 using UniGetUI.Core.Language;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
@@ -14,7 +15,6 @@ using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.Serializable;
-using UniGetUI.Avalonia.Views;
 
 namespace UniGetUI.Avalonia.ViewModels;
 

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/CheckboxButtonCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/CheckboxButtonCard.cs
@@ -92,7 +92,7 @@ public sealed partial class CheckboxButtonCard : SettingsCard
             Margin = new Thickness(2, 0, 0, 0),
             VerticalAlignment = VerticalAlignment.Center,
             TextWrapping = TextWrapping.Wrap,
-            FontWeight = FontWeight.Medium,
+            FontSize = 14,
         };
         IS_INVERTED = false;
         AutomationProperties.SetAccessibilityView(Button, AccessibilityView.Control);

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/CheckboxCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/CheckboxCard.cs
@@ -100,6 +100,7 @@ public partial class CheckboxCard : SettingsCard
         {
             VerticalAlignment = VerticalAlignment.Center,
             TextWrapping = TextWrapping.Wrap,
+            FontSize = 14,
         };
         _warningBlock = new TextBlock
         {

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/SecureCheckboxCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/SecureCheckboxCard.cs
@@ -105,6 +105,7 @@ public partial class SecureCheckboxCard : SettingsCard
         {
             VerticalAlignment = VerticalAlignment.Center,
             TextWrapping = TextWrapping.Wrap,
+            FontSize = 14,
         };
         _warningBlock = new TextBlock
         {

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/SettingsCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/SettingsCard.cs
@@ -56,7 +56,7 @@ public class SettingsCard : UserControl
         {
             _rightContent = value;
             _contentPresenter.Content = value is string s
-                ? new TextBlock { Text = s, VerticalAlignment = VerticalAlignment.Center }
+                ? new TextBlock { Text = s, FontSize = 14, VerticalAlignment = VerticalAlignment.Center }
                 : value;
         }
     }
@@ -231,6 +231,7 @@ public class SettingsCard : UserControl
                 ? new TextBlock
                 {
                     Text = s,
+                    FontSize = 14,
                     TextWrapping = TextWrapping.Wrap,
                     VerticalAlignment = VerticalAlignment.Center,
                 }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
@@ -16,7 +16,7 @@
             <!-- Title + description -->
             <StackPanel Spacing="4">
                 <TextBlock Text="{t:Translate UniGetUI has crashed}"
-                           FontSize="22"
+                           FontSize="28"
                            FontWeight="SemiBold"/>
                 <TextBlock Text="{t:Translate Text='Help us fix this by sending a crash report to Devolutions. All fields below are optional.'}"
                            Opacity="0.7"

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -19,14 +19,14 @@
             <TextBlock Grid.Column="1"
                        automation:AutomationProperties.Name="{Binding DialogTitle}"
                        Text="{Binding DialogTitle}"
-                       FontSize="18" FontWeight="Bold"
+                       FontSize="24" FontWeight="Bold"
                        TextWrapping="Wrap"
                        VerticalAlignment="Center"/>
 
             <StackPanel Grid.Column="2" Spacing="3" VerticalAlignment="Center">
                 <TextBlock x:Name="ProfileLabelBlock"
                            Text="{Binding ProfileLabel}"
-                           FontSize="11" Opacity="0.7"/>
+                           FontSize="14" Opacity="0.7"/>
                 <ComboBox x:Name="ProfileSelectorComboBox"
                           ItemsSource="{Binding ProfileOptions}"
                           SelectedItem="{Binding SelectedProfile}"
@@ -174,7 +174,8 @@
                         <TextBox Text="{Binding LocationText}"
                                  IsEnabled="{Binding LocationEnabled}"
                                  automation:AutomationProperties.LabeledBy="{Binding #LocationLabelBlock}"
-                                 FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
+                                 FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                 FontSize="14"
                                  HorizontalAlignment="Stretch"/>
 
                     </StackPanel>
@@ -193,7 +194,8 @@
                         <TextBox Grid.Column="1"
                                  Text="{Binding ParamsInstall}"
                                  automation:AutomationProperties.LabeledBy="{Binding #ParamsInstallLabelBlock}"
-                                 FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                 FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                 FontSize="14"/>
 
                         <TextBlock x:Name="ParamsUpdateLabelBlock" Grid.Row="1"
                                    Text="{Binding ParamsUpdateLabel}"
@@ -201,7 +203,8 @@
                         <TextBox Grid.Row="1" Grid.Column="1"
                                  Text="{Binding ParamsUpdate}"
                                  automation:AutomationProperties.LabeledBy="{Binding #ParamsUpdateLabelBlock}"
-                                 FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                 FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                 FontSize="14"/>
 
                         <TextBlock x:Name="ParamsUninstallLabelBlock" Grid.Row="2"
                                    Text="{Binding ParamsUninstallLabel}"
@@ -209,7 +212,8 @@
                         <TextBox Grid.Row="2" Grid.Column="1"
                                  Text="{Binding ParamsUninstall}"
                                  automation:AutomationProperties.LabeledBy="{Binding #ParamsUninstallLabelBlock}"
-                                 FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                 FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                 FontSize="14"/>
 
                     </Grid>
                 </Border>
@@ -236,7 +240,8 @@
                                     <Grid ColumnDefinitions="*,Auto" Margin="0,2">
                                         <TextBlock Text="{Binding Name}"
                                                    VerticalAlignment="Center"
-                                                   FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                                   FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                                   FontSize="14"/>
                                         <Button Grid.Column="1"
                                                 Content="✕"
                                                 Command="{Binding RemoveCommand}"
@@ -274,12 +279,14 @@
                                      Text="{Binding PreInstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PreInstallLabelBlock}"
-                                     FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                     FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                     FontSize="14"/>
                             <TextBox Grid.Row="1" Grid.Column="1"
                                      Text="{Binding PostInstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PostInstallLabelBlock}"
-                                     FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                     FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                     FontSize="14"/>
                             <CheckBox Grid.Row="2" Grid.ColumnSpan="2"
                                       Content="{Binding AbortInstallLabel}"
                                       automation:AutomationProperties.Name="{Binding AbortInstallLabel}"
@@ -300,12 +307,14 @@
                                      Text="{Binding PreUpdateText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PreUpdateLabelBlock}"
-                                     FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                     FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                     FontSize="14"/>
                             <TextBox Grid.Row="1" Grid.Column="1"
                                      Text="{Binding PostUpdateText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PostUpdateLabelBlock}"
-                                     FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                     FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                     FontSize="14"/>
                             <CheckBox Grid.Row="2" Grid.ColumnSpan="2"
                                       Content="{Binding AbortUpdateLabel}"
                                       automation:AutomationProperties.Name="{Binding AbortUpdateLabel}"
@@ -326,12 +335,14 @@
                                      Text="{Binding PreUninstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PreUninstallLabelBlock}"
-                                     FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                     FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                     FontSize="14"/>
                             <TextBox Grid.Row="1" Grid.Column="1"
                                      Text="{Binding PostUninstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PostUninstallLabelBlock}"
-                                     FontFamily="Cascadia Mono,Consolas,Menlo,monospace"/>
+                                     FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                     FontSize="14"/>
                             <CheckBox Grid.Row="2" Grid.ColumnSpan="2"
                                       Content="{Binding AbortUninstallLabel}"
                                       automation:AutomationProperties.Name="{Binding AbortUninstallLabel}"
@@ -351,8 +362,8 @@
                 <Border Background="{DynamicResource AppDialogDarkBackground}" CornerRadius="4" Padding="8">
                     <TextBlock Text="{Binding CommandPreview}"
                                automation:AutomationProperties.Name="{Binding CommandPreviewLabel}"
-                               FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
-                               FontSize="12"
+                               FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                               FontSize="14"
                                TextWrapping="Wrap"/>
                 </Border>
             </StackPanel>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -3,8 +3,25 @@
              xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
              xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
              xmlns:vmd="using:UniGetUI.Avalonia.ViewModels"
+             xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
              x:Class="UniGetUI.Avalonia.Views.DialogPages.InstallOptionsControl"
              x:DataType="vm:InstallOptionsViewModel">
+
+    <UserControl.Styles>
+        <!-- WinUI-style rich tabs: roomy headers that hold an icon + two text lines. -->
+        <Style Selector="TabItem">
+            <Setter Property="Padding" Value="12,6"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <!-- WinUI tabs have no accent underline; the selected tab is shown by its background. -->
+        <Style Selector="TabItem /template/ #PART_SelectedPipe" x:SetterTargetType="Control">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <Style Selector="TabItem:selected /template/ #PART_SelectedPipe" x:SetterTargetType="Control">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+    </UserControl.Styles>
 
     <StackPanel Spacing="12">
 
@@ -37,12 +54,19 @@
 
         <!-- ── Follow-global-options card ── -->
         <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="8" Padding="16,8">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" ColumnSpacing="8">
                 <TextBlock x:Name="FollowGlobalLabelBlock"
+                           Grid.Row="0" Grid.Column="0"
                            Text="{Binding FollowGlobalLabel}"
                            TextWrapping="Wrap"
                            VerticalAlignment="Center"/>
-                <ToggleSwitch Grid.Column="1"
+                <HyperlinkButton Grid.Row="1" Grid.Column="0"
+                                 Content="{Binding ChangeDefaultOptionsLabel}"
+                                 automation:AutomationProperties.Name="{Binding ChangeDefaultOptionsLabel}"
+                                 Command="{Binding ChangeDefaultOptionsCommand}"
+                                 Padding="0" Margin="0,2,0,0"
+                                 HorizontalAlignment="Left"/>
+                <ToggleSwitch Grid.RowSpan="2" Grid.Column="1"
                               IsChecked="{Binding FollowGlobal}"
                               automation:AutomationProperties.LabeledBy="{Binding #FollowGlobalLabelBlock}"
                               OnContent="" OffContent=""
@@ -50,19 +74,33 @@
             </Grid>
         </Border>
 
-        <!-- ── Options tab panel (dimmed when following global) ── -->
-        <TabControl IsEnabled="{Binding IsCustomMode}"
-                    Opacity="{Binding OptionsOpacity}"
-                    Background="Transparent">
+        <!-- ── Options area + lock overlay ── -->
+        <Grid>
+          <StackPanel Spacing="12">
+
+            <!-- Explainer (applies to every tab, like WinUI) -->
+            <TextBlock Text="{Binding GeneralInfoLabel}"
+                       Opacity="0.7"
+                       TextWrapping="Wrap"
+                       Margin="4,0"/>
+
+            <TabControl IsEnabled="{Binding IsCustomMode}"
+                        Background="Transparent">
 
             <!-- Tab 0: General -->
-            <TabItem Header="{Binding TabGeneralLabel}" FontSize="18">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/settings.svg"
+                                          Width="20" Height="20" VerticalAlignment="Center"/>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{Binding TabGeneralLine1}" FontSize="14"/>
+                            <TextBlock Text="{Binding TabGeneralLine2}" FontSize="12" Opacity="0.7"/>
+                        </StackPanel>
+                    </StackPanel>
+                </TabItem.Header>
                 <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
                     <StackPanel Spacing="8">
-
-                        <TextBlock Text="{Binding GeneralInfoLabel}"
-                                   Opacity="0.7" FontSize="11"
-                                   TextWrapping="Wrap"/>
 
                         <WrapPanel Orientation="Horizontal">
                             <CheckBox Content="{Binding AdminCheckBox_Content, FallbackValue='Run as admin'}"
@@ -108,6 +146,10 @@
                                 automation:AutomationProperties.AccessibilityView="Raw"/>
 
                         <WrapPanel Orientation="Horizontal">
+                            <CheckBox Content="{Binding IgnoreUpdatesCheckBox_Content, FallbackValue='Ignore future updates for this package'}"
+                                      IsChecked="{Binding IgnoreUpdatesChecked}"
+                                      automation:AutomationProperties.Name="{Binding IgnoreUpdatesCheckBox_Content}"
+                                      Margin="0,0,16,4"/>
                             <CheckBox Content="{Binding SkipMinorCheckBox_Content, FallbackValue='Skip minor updates'}"
                                       IsChecked="{Binding SkipMinorChecked}"
                                       automation:AutomationProperties.Name="{Binding SkipMinorCheckBox_Content}"
@@ -123,7 +165,17 @@
             </TabItem>
 
             <!-- Tab 1: Architecture, Scope & Location -->
-            <TabItem Header="{Binding TabLocationLabel}" FontSize="18">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/open_folder.svg"
+                                          Width="20" Height="20" VerticalAlignment="Center"/>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{Binding TabLocationLine1}" FontSize="14"/>
+                            <TextBlock Text="{Binding TabLocationLine2}" FontSize="12" Opacity="0.7"/>
+                        </StackPanel>
+                    </StackPanel>
+                </TabItem.Header>
                 <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
                     <StackPanel Spacing="8">
 
@@ -183,11 +235,34 @@
             </TabItem>
 
             <!-- Tab 2: Custom CLI arguments -->
-            <TabItem Header="{Binding TabCLILabel}" FontSize="18">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/console.svg"
+                                          Width="20" Height="20" VerticalAlignment="Center"/>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{Binding TabCLILine1}" FontSize="14"/>
+                            <TextBlock Text="{Binding TabCLILine2}" FontSize="12" Opacity="0.7"/>
+                        </StackPanel>
+                    </StackPanel>
+                </TabItem.Header>
                 <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
-                    <Grid ColumnDefinitions="*,2*"
-                          RowDefinitions="Auto,Auto,Auto"
-                          ColumnSpacing="8" RowSpacing="8">
+                    <StackPanel Spacing="8">
+
+                      <!-- Security warning shown when custom CLI arguments are disabled -->
+                      <TextBlock Text="{Binding CliDisabledLabel}"
+                                 IsVisible="{Binding CliDisabledWarningVisible}"
+                                 Foreground="{DynamicResource StatusWarningForeground}"
+                                 TextWrapping="Wrap"/>
+                      <HyperlinkButton Content="{Binding GoToSecurityLabel}"
+                                       IsVisible="{Binding CliDisabledWarningVisible}"
+                                       Command="{Binding GoToSecuritySettingsCommand}"
+                                       HorizontalAlignment="Left" Padding="0" FontWeight="SemiBold"/>
+
+                      <Grid ColumnDefinitions="*,2*"
+                            RowDefinitions="Auto,Auto,Auto"
+                            ColumnSpacing="8" RowSpacing="8"
+                            IsEnabled="{Binding CliEnabled}">
 
                         <TextBlock x:Name="ParamsInstallLabelBlock" Text="{Binding ParamsInstallLabel}"
                                    VerticalAlignment="Center"/>
@@ -215,12 +290,23 @@
                                  FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                  FontSize="14"/>
 
-                    </Grid>
+                      </Grid>
+                    </StackPanel>
                 </Border>
             </TabItem>
 
             <!-- Tab 3: Close apps before installing -->
-            <TabItem Header="{Binding TabCloseAppsLabel}" FontSize="18">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/cross.svg"
+                                          Width="20" Height="20" VerticalAlignment="Center"/>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{Binding TabCloseAppsLine1}" FontSize="14"/>
+                            <TextBlock Text="{Binding TabCloseAppsLine2}" FontSize="12" Opacity="0.7"/>
+                        </StackPanel>
+                    </StackPanel>
+                </TabItem.Header>
                 <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
                     <StackPanel Spacing="8">
 
@@ -264,14 +350,36 @@
             </TabItem>
 
             <!-- Tab 4: Pre/Post commands -->
-            <TabItem Header="{Binding TabPrePostLabel}" FontSize="18">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/clipboard_list.svg"
+                                          Width="20" Height="20" VerticalAlignment="Center"/>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{Binding TabPrePostLine1}" FontSize="14"/>
+                            <TextBlock Text="{Binding TabPrePostLine2}" FontSize="12" Opacity="0.7"/>
+                        </StackPanel>
+                    </StackPanel>
+                </TabItem.Header>
                 <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
                     <StackPanel Spacing="10">
 
+                        <!-- Security warning shown when pre/post scripts are disabled -->
+                        <TextBlock Text="{Binding PrePostDisabledLabel}"
+                                   IsVisible="{Binding PrePostDisabledWarningVisible}"
+                                   Foreground="{DynamicResource StatusWarningForeground}"
+                                   TextWrapping="Wrap"/>
+                        <HyperlinkButton Content="{Binding GoToSecurityLabel}"
+                                         IsVisible="{Binding PrePostDisabledWarningVisible}"
+                                         Command="{Binding GoToSecuritySettingsCommand}"
+                                         HorizontalAlignment="Left" Padding="0" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding PrePostExplainerLabel}" TextWrapping="Wrap" Opacity="0.7"/>
+
                         <!-- Install -->
                         <Grid ColumnDefinitions="*,*"
-                              RowDefinitions="Auto,80,Auto"
-                              ColumnSpacing="8" RowSpacing="4">
+                              RowDefinitions="Auto,56,Auto"
+                              ColumnSpacing="8" RowSpacing="4"
+                              IsEnabled="{Binding PrePostEnabled}">
                             <TextBlock x:Name="PreInstallLabelBlock" Text="{Binding PreInstallLabel}" FontSize="12"/>
                             <TextBlock x:Name="PostInstallLabelBlock" Grid.Column="1"
                                        Text="{Binding PostInstallLabel}" FontSize="12"/>
@@ -298,8 +406,9 @@
 
                         <!-- Update -->
                         <Grid ColumnDefinitions="*,*"
-                              RowDefinitions="Auto,80,Auto"
-                              ColumnSpacing="8" RowSpacing="4">
+                              RowDefinitions="Auto,56,Auto"
+                              ColumnSpacing="8" RowSpacing="4"
+                              IsEnabled="{Binding PrePostEnabled}">
                             <TextBlock x:Name="PreUpdateLabelBlock" Text="{Binding PreUpdateLabel}" FontSize="12"/>
                             <TextBlock x:Name="PostUpdateLabelBlock" Grid.Column="1"
                                        Text="{Binding PostUpdateLabel}" FontSize="12"/>
@@ -326,8 +435,9 @@
 
                         <!-- Uninstall -->
                         <Grid ColumnDefinitions="*,*"
-                              RowDefinitions="Auto,80,Auto"
-                              ColumnSpacing="8" RowSpacing="4">
+                              RowDefinitions="Auto,56,Auto"
+                              ColumnSpacing="8" RowSpacing="4"
+                              IsEnabled="{Binding PrePostEnabled}">
                             <TextBlock x:Name="PreUninstallLabelBlock" Text="{Binding PreUninstallLabel}" FontSize="12"/>
                             <TextBlock x:Name="PostUninstallLabelBlock" Grid.Column="1"
                                        Text="{Binding PostUninstallLabel}" FontSize="12"/>
@@ -353,7 +463,27 @@
                 </Border>
             </TabItem>
 
-        </TabControl>
+            </TabControl>
+
+          </StackPanel>
+
+          <!-- Lock overlay shown while following the default options. A translucent solid
+               layer (composites over the in-app tabs so they show faintly behind); Avalonia
+               has no in-app gaussian blur, so this is the closest readable equivalent. -->
+          <Panel IsVisible="{Binding FollowGlobal}">
+            <Border Background="{DynamicResource AppDialogBackground}" Opacity="0.7" IsHitTestVisible="True"/>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
+                        Spacing="12" Margin="24" MaxWidth="420">
+              <TextBlock Text="{Binding PlaceholderText}"
+                         FontSize="20" FontWeight="SemiBold"
+                         TextAlignment="Center" TextWrapping="Wrap"/>
+              <Button Content="{Binding UnlockLabel}"
+                      HorizontalAlignment="Center"
+                      Padding="12,5" CornerRadius="4"
+                      Command="{Binding UnlockCommand}"/>
+            </StackPanel>
+          </Panel>
+        </Grid>
 
         <!-- ── Command-line preview ── -->
         <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="8" Padding="12">

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml
@@ -3,23 +3,41 @@
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
         xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
+        xmlns:chrome="using:Avalonia.Controls.Chrome"
         x:Class="UniGetUI.Avalonia.Views.InstallOptionsWindow"
         x:DataType="vm:InstallOptionsViewModel"
         Width="680" MinWidth="500"
         SizeToContent="Height"
         CanResize="False"
         Background="{DynamicResource AppDialogBackground}"
-        Title="{Binding DialogTitle}">
+        WindowStartupLocation="CenterOwner"
+        Title="">
 
     <Window.KeyBindings>
         <KeyBinding Gesture="Ctrl+S" Command="{Binding SaveCommand}"/>
         <KeyBinding Gesture="Meta+S" Command="{Binding SaveCommand}"/>
     </Window.KeyBindings>
 
-    <ScrollViewer MaxHeight="820"
-                  VerticalScrollBarVisibility="Auto"
-                  HorizontalScrollBarVisibility="Disabled">
-        <StackPanel Margin="16" Spacing="12">
+    <Window.Styles>
+        <!-- Extended client area adds a full-screen caption button; hide it so only the
+             standard window buttons remain (matches the Manage-ignored-updates window). -->
+        <Style Selector=":is(Control)[(chrome|WindowDecorationProperties.ElementRole)=FullScreenButton]">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid RowDefinitions="Auto,Auto">
+
+        <!-- Draggable title-bar strip: the client area is extended over the OS title bar,
+             so this restores window dragging (the ScrollViewer below would otherwise eat it). -->
+        <Border Grid.Row="0" Height="32" Background="Transparent"
+                PointerPressed="TitleBar_PointerPressed"/>
+
+        <ScrollViewer Grid.Row="1"
+                      MaxHeight="820"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Margin="16,4,16,16" Spacing="12">
 
             <dialogs:InstallOptionsControl x:Name="OptionsControl"/>
 
@@ -38,6 +56,7 @@
                         Command="{Binding ProceedCommand}"/>
             </Grid>
 
-        </StackPanel>
-    </ScrollViewer>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </Window>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.PackageEngine.Enums;
@@ -17,7 +19,12 @@ public partial class InstallOptionsWindow : Window
         var vm = new InstallOptionsViewModel(package, operation, options);
         DataContext = vm;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
+
+        // Drop the OS title-bar strip but keep the system min/close buttons, extending the
+        // client area into the title-bar region (matches the Manage-ignored-updates window).
+        ExtendClientAreaToDecorationsHint = true;
+        ExtendClientAreaTitleBarHeightHint = -1;
+
         vm.CloseRequested += (_, _) => Close();
     }
 
@@ -25,5 +32,13 @@ public partial class InstallOptionsWindow : Window
     {
         base.OnOpened(e);
         Dispatcher.UIThread.Post(OptionsControl.FocusProfileSelector, DispatcherPriority.Background);
+    }
+
+    // The client area is extended over the title bar, so provide window dragging from the
+    // transparent strip at the top.
+    private void TitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
     }
 }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml.cs
@@ -1,6 +1,5 @@
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Interactivity;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.PackageEngine.Enums;

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageDesktopShortcutsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageDesktopShortcutsWindow.axaml
@@ -41,6 +41,7 @@
             <StackPanel Orientation="Vertical" Spacing="2">
                 <TextBlock Text="{t:Translate Text='UniGetUI has detected the following desktop shortcuts which can be removed automatically on future upgrades'}"
                            TextWrapping="Wrap"
+                           FontWeight="Bold"
                            Opacity="0.75"/>
                 <TextBlock TextWrapping="Wrap" Opacity="0.75">
                     <TextBlock.Text>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml
@@ -3,28 +3,55 @@
     xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
         xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
+        xmlns:chrome="using:Avalonia.Controls.Chrome"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.ManageIgnoredUpdatesWindow"
         x:DataType="vm:ManageIgnoredUpdatesViewModel"
-        Width="900" MinWidth="520"
+        Width="1100" MinWidth="520"
         Height="500" MinHeight="280"
         CanResize="True"
         ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
+        Background="{DynamicResource IgnoredDialogBackground}"
         WindowStartupLocation="CenterOwner"
-        Title="{Binding Title}">
+        Title="">
+
+    <!-- Solid surfaces defined locally so the app-wide Mica overrides (which make most
+         dialog brushes translucent) can't bleed the desktop through this window. -->
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="IgnoredDialogBackground" Color="#ECECEC"/>
+                    <SolidColorBrush x:Key="IgnoredListBackground"   Color="#F9F9F9"/>
+                    <SolidColorBrush x:Key="IgnoredRowHover"         Color="#14000000"/>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="IgnoredDialogBackground" Color="#2C2C2C"/>
+                    <SolidColorBrush x:Key="IgnoredListBackground"   Color="#1F1F1F"/>
+                    <SolidColorBrush x:Key="IgnoredRowHover"         Color="#18FFFFFF"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
 
     <Window.Styles>
-        <Style Selector="DataGridCell:current /template/ Grid#FocusVisual">
-            <Setter Property="IsVisible" Value="False"/>
+        <!-- WinUI-style row hover highlight. The base Background must be set via a style
+             (not a local value) so the :pointerover setter can override it. -->
+        <Style Selector="Border.row">
+            <Setter Property="Background" Value="Transparent"/>
         </Style>
-        <Style Selector="DataGridCell:current">
-            <Setter Property="BorderBrush" Value="Transparent"/>
+        <Style Selector="Border.row:pointerover">
+            <Setter Property="Background" Value="{DynamicResource IgnoredRowHover}"/>
+        </Style>
+        <!-- Avalonia 12's drawn window decorations add a full-screen caption button; hide it
+             so only minimize/maximize/close remain. -->
+        <Style Selector=":is(Control)[(chrome|WindowDecorationProperties.ElementRole)=FullScreenButton]">
+            <Setter Property="IsVisible" Value="False"/>
         </Style>
     </Window.Styles>
 
     <Grid RowDefinitions="Auto,Auto,*"
-          Margin="16"
+          Margin="16,36,16,16"
           RowSpacing="8">
 
         <!-- ── Title ── -->
@@ -83,140 +110,94 @@
 
         </Grid>
 
-        <!-- ── Package list (DataGrid, mirrors the main package list) ── -->
-        <Border Grid.Row="2"
-                CornerRadius="8"
-                BorderThickness="1"
-                BorderBrush="{DynamicResource AppBorderBrush}"
-                Margin="0,4,0,0">
-            <Panel>
+        <!-- ── Package list (mirrors the WinUI ItemsView: flat rows, no header) ── -->
+        <Border Grid.Row="2" Margin="0,4,0,0" CornerRadius="6"
+                Background="{DynamicResource IgnoredListBackground}">
+          <Panel>
 
-                <!-- Empty state -->
-                <TextBlock Text="{Binding EmptyLabel}"
-                           IsVisible="{Binding ShowEmptyLabel}"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           FontSize="20"
-                           FontWeight="Bold"
-                           Opacity="0.5"/>
+            <!-- Empty state -->
+            <TextBlock Text="{Binding EmptyLabel}"
+                       IsVisible="{Binding ShowEmptyLabel}"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       FontSize="20"
+                       FontWeight="Bold"
+                       Opacity="0.5"/>
 
-                <DataGrid ItemsSource="{Binding Entries}"
-                          x:Name="IgnoredUpdatesGrid"
-                          AutoGenerateColumns="False"
-                          CanUserReorderColumns="True"
-                          CanUserResizeColumns="True"
-                          CanUserSortColumns="True"
-                          SelectionMode="Single"
-                          GridLinesVisibility="Horizontal"
-                          automation:AutomationProperties.Name="{Binding Title}"
-                          automation:AutomationProperties.HelpText="{Binding Description}"
-                          IsVisible="{Binding HasEntries}">
-                    <DataGrid.Columns>
+            <ScrollViewer IsVisible="{Binding HasEntries}"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <ItemsControl ItemsSource="{Binding Entries}"
+                              x:Name="IgnoredUpdatesGrid"
+                              Padding="2,4"
+                              automation:AutomationProperties.Name="{Binding Title}"
+                              automation:AutomationProperties.HelpText="{Binding Description}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Vertical" Spacing="0"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:IgnoredPackageEntryViewModel">
+                          <Border Classes="row" Height="36" Margin="0" CornerRadius="4"
+                                  Padding="8,0">
+                            <Grid ColumnSpacing="4"
+                                  automation:AutomationProperties.Name="{Binding AutomationName}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*" MaxWidth="120"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*" MaxWidth="170"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*" MaxWidth="90"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
 
-                        <DataGridTemplateColumn Header="{Binding $parent[Window].((vm:ManageIgnoredUpdatesViewModel)DataContext).ColName}"
-                                                Width="2*">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate x:DataType="vm:IgnoredPackageEntryViewModel">
-                                    <StackPanel Orientation="Horizontal" Spacing="6"
-                                                automation:AutomationProperties.Name="{Binding AutomationName}"
-                                                VerticalAlignment="Center" Margin="0,0,4,0">
-                                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/package.svg"
-                                                          Width="16" Height="16" VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Name}"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                                <controls:SvgIcon Grid.Column="0" Width="24" Height="24" VerticalAlignment="Center"
+                                                  Path="avares://UniGetUI.Avalonia/Assets/Symbols/package.svg"/>
+                                <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="2,0"
+                                           Text="{Binding Name}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Name}"/>
 
-                        <DataGridTemplateColumn Header="{Binding $parent[Window].((vm:ManageIgnoredUpdatesViewModel)DataContext).ColId}"
-                                                Width="2*">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate x:DataType="vm:IgnoredPackageEntryViewModel">
-                                    <StackPanel Orientation="Horizontal" Spacing="6"
-                                                automation:AutomationProperties.Name="{Binding Id}"
-                                                VerticalAlignment="Center" Margin="0,0,4,0">
-                                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/id.svg"
-                                                          Width="16" Height="16" VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding Id}" VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Id}"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                                <controls:SvgIcon Grid.Column="2" Width="24" Height="24" VerticalAlignment="Center"
+                                                  Path="avares://UniGetUI.Avalonia/Assets/Symbols/id.svg"/>
+                                <TextBlock Grid.Column="3" VerticalAlignment="Center" Margin="2,0"
+                                           Text="{Binding Id}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Id}"/>
 
-                        <DataGridTemplateColumn Header="{Binding $parent[Window].((vm:ManageIgnoredUpdatesViewModel)DataContext).ColVersion}"
-                                                Width="*">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate x:DataType="vm:IgnoredPackageEntryViewModel">
-                                    <StackPanel Orientation="Horizontal" Spacing="6"
-                                                automation:AutomationProperties.Name="{Binding VersionDisplay}"
-                                                VerticalAlignment="Center" Margin="0,0,4,0">
-                                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/version.svg"
-                                                          Width="16" Height="16" VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding VersionDisplay}" VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                                <controls:SvgIcon Grid.Column="4" Width="24" Height="24" VerticalAlignment="Center"
+                                                  Path="avares://UniGetUI.Avalonia/Assets/Symbols/version.svg"/>
+                                <TextBlock Grid.Column="5" VerticalAlignment="Center" Margin="2,0"
+                                           Text="{Binding VersionDisplay}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding VersionDisplay}"/>
 
-                        <DataGridTemplateColumn Header="{Binding $parent[Window].((vm:ManageIgnoredUpdatesViewModel)DataContext).ColNewVersion}"
-                                                Width="*">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate x:DataType="vm:IgnoredPackageEntryViewModel">
-                                    <StackPanel Orientation="Horizontal" Spacing="6"
-                                                automation:AutomationProperties.Name="{Binding NewVersion}"
-                                                VerticalAlignment="Center" Margin="0,0,4,0">
-                                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/upgradable.svg"
-                                                          Width="16" Height="16" VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding NewVersion}" VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                                <controls:SvgIcon Grid.Column="6" Width="24" Height="24" VerticalAlignment="Center"
+                                                  Path="avares://UniGetUI.Avalonia/Assets/Symbols/upgradable.svg"/>
+                                <TextBlock Grid.Column="7" VerticalAlignment="Center" Margin="2,0"
+                                           Text="{Binding NewVersion}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding NewVersion}"/>
 
-                        <DataGridTemplateColumn Header="{Binding $parent[Window].((vm:ManageIgnoredUpdatesViewModel)DataContext).ColManager}"
-                                               Width="*">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate x:DataType="vm:IgnoredPackageEntryViewModel">
-                                    <StackPanel Orientation="Horizontal" Spacing="6"
-                                                automation:AutomationProperties.Name="{Binding Manager}"
-                                                VerticalAlignment="Center" Margin="0,0,4,0">
-                                        <controls:SvgIcon Path="{Binding ManagerIconPath}"
-                                                          Width="16" Height="16"
-                                                          VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding Manager}"
-                                                   VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                                <controls:SvgIcon Grid.Column="8" Width="24" Height="24" VerticalAlignment="Center"
+                                                  Path="{Binding ManagerIconPath}"/>
+                                <TextBlock Grid.Column="9" VerticalAlignment="Center" Margin="2,0"
+                                           Text="{Binding Manager}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Manager}"/>
 
-                        <!-- Remove button column -->
-                        <DataGridTemplateColumn Width="48">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate x:DataType="vm:IgnoredPackageEntryViewModel">
-                                    <Button Width="32" Height="32"
-                                            Padding="0"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            Command="{Binding RemoveCommand}"
-                                            automation:AutomationProperties.Name="{Binding RemoveAutomationName}"
-                                            ToolTip.Tip="{t:Translate Text='Remove from list'}">
-                                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/delete.svg"
-                                                          Width="16" Height="16"/>
-                                    </Button>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                                <Button Grid.Column="10" Width="32" Height="32" Padding="0" Margin="4,0,0,0"
+                                        VerticalAlignment="Center"
+                                        Command="{Binding RemoveCommand}"
+                                        automation:AutomationProperties.Name="{Binding RemoveAutomationName}"
+                                        ToolTip.Tip="{t:Translate Text='Remove from list'}">
+                                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/delete.svg"
+                                                      Width="16" Height="16"/>
+                                </Button>
+                            </Grid>
+                          </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
 
-                    </DataGrid.Columns>
-                </DataGrid>
-
-            </Panel>
+          </Panel>
         </Border>
 
     </Grid>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml.cs
@@ -12,7 +12,14 @@ public partial class ManageIgnoredUpdatesWindow : Window
         var vm = new ManageIgnoredUpdatesViewModel();
         DataContext = vm;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
+
+        // Drop the OS title-bar strip (its background clashed with the dialog) but keep
+        // the system min/max/close buttons floating over the extended client area. Default
+        // WindowDecorations (Full) keeps the system buttons; extending the client area
+        // merges the title-bar region into the content.
+        ExtendClientAreaToDecorationsHint = true;
+        ExtendClientAreaTitleBarHeightHint = -1;
+
         vm.CloseRequested += (_, _) => Close();
     }
 
@@ -21,7 +28,7 @@ public partial class ManageIgnoredUpdatesWindow : Window
         base.OnOpened(e);
         Dispatcher.UIThread.Post(() =>
         {
-            if (IgnoredUpdatesGrid.IsVisible)
+            if (((ManageIgnoredUpdatesViewModel)DataContext!).HasEntries)
                 IgnoredUpdatesGrid.Focus();
             else
                 ResetButton.Focus();

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -142,9 +142,9 @@
                                     VerticalAlignment="Center"
                                     Spacing="4">
                             <TextBlock Text="{Binding PackageName}"
-                                       FontSize="36" FontWeight="Bold"
+                                       FontSize="40" FontWeight="Bold"
+                                       FontFamily="Segoe UI Variable Display"
                                        TextWrapping="Wrap"
-                                       LineHeight="42"
                                        automation:AutomationProperties.HeadingLevel="1"/>
                             <TextBlock Text="{Binding SourceDisplay}"
                                        FontSize="13" Opacity="0.65"/>
@@ -223,7 +223,7 @@
                                                       VerticalAlignment="Center"/>
                                     <TextBlock Grid.Column="1"
                                                Text="{Binding LabelInstallationOptions}"
-                                               FontSize="15"
+                                               FontSize="16"
                                                FontWeight="SemiBold"
                                                VerticalAlignment="Center"/>
                                     <Button x:Name="InstallOptionsSaveButton"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -155,7 +155,7 @@
 
                         <TextBlock Grid.Column="1"
                                    Text="{Binding OperationsHeaderText}"
-                                   FontSize="11" Opacity="0.6"
+                                   FontSize="12" Opacity="0.6"
                                    VerticalAlignment="Center"
                                    Margin="4,0,0,0"/>
 
@@ -215,7 +215,7 @@
 
                                             <TextBlock Text="{Binding Title}"
                                                        FontWeight="SemiBold"
-                                                       FontSize="13"
+                                                       FontSize="14"
                                                        TextTrimming="CharacterEllipsis"/>
 
                                             <Button Content="{Binding LiveLine}"
@@ -471,7 +471,7 @@
                         <TextBox x:Name="GlobalSearchBox"
                                  Grid.Column="0"
                                  MinHeight="20"
-                                 FontSize="15"
+                                 FontSize="14"
                                  CornerRadius="0"
                                  BorderThickness="0"
                                  VerticalContentAlignment="Center"

--- a/src/UniGetUI.Avalonia/Views/Pages/AboutPages/AboutPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/AboutPages/AboutPage.axaml
@@ -13,6 +13,7 @@
         <StackPanel Orientation="Vertical" Spacing="4" Margin="16,8">
 
             <TextBlock Text="{t:Translate About UniGetUI}"
+                       FontFamily="Segoe UI Variable Display"
                        FontSize="24"
                        FontWeight="Bold"/>
 
@@ -23,6 +24,7 @@
                        Margin="0,-4,0,4"/>
 
             <TextBlock Text="{t:Translate Text='UniGetUI is an application that makes managing your software easier, by providing an all-in-one graphical interface for your command-line package managers.'}"
+                       FontSize="14"
                        TextWrapping="Wrap"/>
 
             <TextBlock Text="{Binding VersionText}"
@@ -52,14 +54,17 @@
                     <!-- Text -->
                     <StackPanel Grid.Column="1" Spacing="4">
                         <TextBlock Text="{Binding DisclaimerTitle}"
+                                   FontSize="14"
                                    FontWeight="SemiBold"/>
                         <TextBlock Text="{Binding DisclaimerMessage}"
+                                   FontSize="14"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
             </Border>
 
             <TextBlock Text="{t:Translate Useful links}"
+                       FontFamily="Segoe UI Variable Display"
                        FontSize="24"
                        FontWeight="Bold"
                        Margin="0,10,0,4"/>
@@ -71,6 +76,7 @@
                     HorizontalAlignment="Center"
                     automation:AutomationProperties.Name="{t:Translate UniGetUI Homepage}">
                 <TextBlock Classes="hyperlink"
+                           FontSize="14"
                            Text="{t:Translate UniGetUI Homepage}"
                            automation:AutomationProperties.AccessibilityView="Raw"/>
             </Button>
@@ -82,6 +88,7 @@
                     HorizontalAlignment="Center"
                     automation:AutomationProperties.Name="{t:Translate Report an issue or submit a feature request}">
                 <TextBlock Classes="hyperlink"
+                           FontSize="14"
                            Text="{t:Translate Report an issue or submit a feature request}"
                            automation:AutomationProperties.AccessibilityView="Raw"/>
             </Button>
@@ -93,6 +100,7 @@
                     HorizontalAlignment="Center"
                     automation:AutomationProperties.Name="{t:Translate UniGetUI Repository}">
                 <TextBlock Classes="hyperlink"
+                           FontSize="14"
                            Text="{t:Translate UniGetUI Repository}"
                            automation:AutomationProperties.AccessibilityView="Raw"/>
             </Button>

--- a/src/UniGetUI.Avalonia/Views/Pages/AboutPages/Contributors.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/AboutPages/Contributors.axaml
@@ -13,10 +13,12 @@
         <StackPanel Orientation="Vertical" Spacing="4" Margin="16,8">
 
             <TextBlock Text="{t:Translate Contributors}"
+                       FontFamily="Segoe UI Variable Display"
                        FontSize="24"
                        FontWeight="Bold"/>
 
             <TextBlock Text="{Binding ThanksText}"
+                       FontSize="14"
                        TextWrapping="Wrap"
                        Margin="0,0,0,8"/>
 
@@ -41,6 +43,7 @@
 
                             <TextBlock Grid.Column="1"
                                        Text="{Binding Name}"
+                                       FontSize="14"
                                        VerticalAlignment="Center"/>
 
                             <Button Grid.Column="2"
@@ -52,6 +55,7 @@
                                     Padding="4,0"
                                     automation:AutomationProperties.Name="{Binding Name}">
                                 <TextBlock Classes="hyperlink"
+                                           FontSize="14"
                                            Text="{t:Translate View GitHub Profile}"
                                            automation:AutomationProperties.AccessibilityView="Raw"/>
                             </Button>

--- a/src/UniGetUI.Avalonia/Views/Pages/AboutPages/ThirdPartyLicenses.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/AboutPages/ThirdPartyLicenses.axaml
@@ -13,18 +13,22 @@
         <StackPanel Orientation="Vertical" Spacing="4" Margin="16,8">
 
             <TextBlock Text="{t:Translate UniGetUI License}"
+                       FontFamily="Segoe UI Variable Display"
                        FontSize="24"
                        FontWeight="Bold"/>
 
             <TextBlock Text="{t:Translate Text='Using UniGetUI implies the acceptation of the MIT License'}"
+                       FontSize="14"
                        TextWrapping="Wrap"/>
 
             <TextBlock Text="{t:Translate Third-party licenses}"
+                       FontFamily="Segoe UI Variable Display"
                        FontSize="24"
                        FontWeight="Bold"
                        Margin="0,10,0,0"/>
 
             <TextBlock Text="{Binding LicensesIntro}"
+                       FontSize="14"
                        TextWrapping="Wrap"
                        Margin="0,0,0,8"/>
 
@@ -35,6 +39,7 @@
                               Margin="0,2">
                             <TextBlock Grid.Column="0"
                                        Text="{Binding Name}"
+                                       FontSize="14"
                                        VerticalAlignment="Center"/>
                             <Button Grid.Column="1"
                                     Tag="{Binding LicenseURL}"
@@ -45,6 +50,7 @@
                                     HorizontalAlignment="Center"
                                     automation:AutomationProperties.Name="{Binding License}">
                                 <TextBlock Classes="hyperlink"
+                                           FontSize="14"
                                            Text="{Binding License}"
                                            automation:AutomationProperties.AccessibilityView="Raw"/>
                             </Button>
@@ -57,6 +63,7 @@
                                     HorizontalAlignment="Right"
                                     automation:AutomationProperties.Name="{Binding HomepageText}">
                                 <TextBlock Classes="hyperlink"
+                                           FontSize="14"
                                            Text="{Binding HomepageText}"
                                            automation:AutomationProperties.AccessibilityView="Raw"/>
                             </Button>

--- a/src/UniGetUI.Avalonia/Views/Pages/AboutPages/Translators.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/AboutPages/Translators.axaml
@@ -13,10 +13,12 @@
         <StackPanel Orientation="Vertical" Spacing="4" Margin="16,8">
 
             <TextBlock Text="{t:Translate Translators}"
+                       FontFamily="Segoe UI Variable Display"
                        FontSize="24"
                        FontWeight="Bold"/>
 
             <TextBlock Text="{Binding ThanksText}"
+                       FontSize="14"
                        TextWrapping="Wrap"/>
 
             <Button Click="BecomeTranslatorButton_Click"
@@ -27,6 +29,7 @@
                     Margin="0,4,0,8"
                     automation:AutomationProperties.Name="{t:Translate Become a translator}">
                 <TextBlock Classes="hyperlink"
+                           FontSize="14"
                            Text="{t:Translate Become a translator}"
                            automation:AutomationProperties.AccessibilityView="Raw"/>
             </Button>
@@ -40,6 +43,7 @@
 
                             <TextBlock Grid.Column="0"
                                        Text="{Binding Language}"
+                                       FontSize="14"
                                        VerticalAlignment="Center"/>
 
                             <!-- Avatar -->
@@ -56,6 +60,7 @@
 
                             <TextBlock Grid.Column="2"
                                        Text="{Binding Name}"
+                                       FontSize="14"
                                        VerticalAlignment="Center"/>
 
                             <Button Grid.Column="3"
@@ -67,6 +72,7 @@
                                     Padding="4,0"
                                     automation:AutomationProperties.Name="{Binding Name}">
                                 <TextBlock Classes="hyperlink"
+                                           FontSize="14"
                                            Text="GitHub"
                                            automation:AutomationProperties.AccessibilityView="Raw"/>
                             </Button>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml
@@ -36,6 +36,7 @@
                         VerticalAlignment="Center">
                 <TextBlock x:Name="LogLevelLabel"
                            Text="{t:Translate Log level:}"
+                           FontSize="14"
                            VerticalAlignment="Center"/>
                 <ComboBox Width="250"
                           CornerRadius="6"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Administrator.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Administrator.axaml
@@ -39,10 +39,12 @@
                                    TextWrapping="Wrap"
                                    Margin="0,0,0,4"/>
                         <TextBlock Text="{Binding WarningBody1}"
+                                   FontSize="14"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource WarningBannerSubtext}"
                                    Margin="0,0,0,6"/>
                         <TextBlock Text="{Binding WarningBody2}"
+                                   FontSize="14"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource WarningBannerSubtext}"/>
                     </StackPanel>
@@ -52,6 +54,7 @@
             <!-- Elevation settings (Windows-only) -->
             <StackPanel Orientation="Vertical" IsVisible="{Binding IsWindows}">
                 <settings:TranslatedTextBlock Text="Change how operations request administrator rights"
+                                              FontSize="14"
                                               FontWeight="SemiBold"
                                               Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -79,6 +82,7 @@
             </StackPanel>
 
             <settings:TranslatedTextBlock Text="Restrictions on package operations"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -97,6 +101,7 @@
                                          CornerRadius="0,0,8,8"/>
 
             <settings:TranslatedTextBlock Text="Restrictions on package managers"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -108,6 +113,7 @@
                                          CornerRadius="8"/>
 
             <settings:TranslatedTextBlock Text="Restrictions when importing package bundles"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Backup.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Backup.axaml
@@ -14,6 +14,7 @@
         <StackPanel Orientation="Vertical">
 
             <settings:TranslatedTextBlock Text="Package backup"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -23,7 +24,7 @@
                     <ItemsControl ItemsSource="{Binding InfoLines}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="x:String">
-                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding}" FontSize="14" TextWrapping="Wrap"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
@@ -60,6 +61,7 @@
 
                     <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="2" VerticalAlignment="Center">
                         <TextBlock Text="{Binding GitHubUserTitle}"
+                                   FontSize="14"
                                    FontWeight="SemiBold"
                                    TextWrapping="Wrap"/>
                         <TextBlock Text="{Binding GitHubUserSubtitle}"
@@ -96,6 +98,7 @@
                             BorderThickness="0"
                             Padding="0">
                         <TextBlock Classes="hyperlink"
+                                   FontSize="14"
                                    Text="{t:Translate More details}"
                                    automation:AutomationProperties.AccessibilityView="Raw"/>
                     </Button>
@@ -165,6 +168,7 @@
                                  CommandParameter="{Binding $self}"/>
 
             <settings:TranslatedTextBlock Text="Local backup advanced options"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/General.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/General.axaml
@@ -14,6 +14,7 @@
         <StackPanel Orientation="Vertical">
 
             <settings:TranslatedTextBlock Text="Language"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -22,6 +23,7 @@
                                    CornerRadius="8"/>
 
             <settings:TranslatedTextBlock Text="UniGetUI updater"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -43,6 +45,7 @@
                                    BorderThickness="1,0,1,1"/>
 
             <settings:TranslatedTextBlock Text="Telemetry"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -54,6 +57,7 @@
                                  CommandParameter="{Binding $self}"/>
 
             <settings:TranslatedTextBlock Text="Privacy"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -65,6 +69,7 @@
                                    StateChangedCommand="{Binding ToggleRedactUsernameCommand}"/>
 
             <settings:TranslatedTextBlock Text="Manage UniGetUI settings"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -89,6 +94,7 @@
                                  CommandParameter="{Binding $self}"/>
 
             <settings:TranslatedTextBlock Text="Related settings"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
@@ -21,6 +21,7 @@
                     <TextBlock Grid.Column="0"
                                Text="{Binding HeaderText}"
                                VerticalAlignment="Center"
+                               FontSize="14"
                                TextWrapping="Wrap"/>
                     <Button x:Name="ResetButton"
                             Grid.Column="1"
@@ -87,6 +88,7 @@
                                    Grid.Column="0"
                                    Text="{Binding ArchLabel}"
                                    VerticalAlignment="Center"
+                                   FontSize="14"
                                    Opacity="{Binding ArchOpacity}"/>
                         <ComboBox Grid.Column="1"
                                   ItemsSource="{Binding ArchitectureItems}"
@@ -103,6 +105,7 @@
                                    Grid.Column="0"
                                    Text="{Binding ScopeLabel}"
                                    VerticalAlignment="Center"
+                                   FontSize="14"
                                    Opacity="{Binding ScopeOpacity}"/>
                         <ComboBox Grid.Column="1"
                                   ItemsSource="{Binding ScopeItems}"
@@ -118,6 +121,7 @@
                         <TextBlock Grid.Column="0"
                                    Text="{Binding LocationLabel}"
                                    VerticalAlignment="Center"
+                                   FontSize="14"
                                    Opacity="{Binding LocationOpacity}"/>
                         <Button x:Name="SelectDirButton"
                                 Grid.Column="1"
@@ -132,7 +136,8 @@
                                 IsEnabled="{Binding LocationResetEnabled}"/>
                     </Grid>
                     <TextBlock Text="{Binding LocationText}"
-                               FontFamily="Courier New"
+                               FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                               FontSize="14"
                                Opacity="0.6"
                                TextWrapping="Wrap"/>
 
@@ -163,11 +168,13 @@
                                    Grid.Row="0" Grid.Column="0"
                                    Text="{Binding InstallArgsLabel}"
                                    VerticalAlignment="Center"
+                                   FontSize="14"
                                    Opacity="{Binding CliOpacity}"/>
                         <TextBox   Grid.Row="0" Grid.Column="1"
                                    Text="{Binding CustomInstall}"
                                    IsEnabled="{Binding CliSectionEnabled}"
-                                   FontFamily="Courier New"
+                                   FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                   FontSize="14"
                                    x:Name="CustomInstallBox"
                                    automation:AutomationProperties.LabeledBy="{Binding #InstallArgsLabelBlock}"/>
 
@@ -175,11 +182,13 @@
                                    Grid.Row="1" Grid.Column="0"
                                    Text="{Binding UpdateArgsLabel}"
                                    VerticalAlignment="Center"
+                                   FontSize="14"
                                    Opacity="{Binding CliOpacity}"/>
                         <TextBox   Grid.Row="1" Grid.Column="1"
                                    Text="{Binding CustomUpdate}"
                                    IsEnabled="{Binding CliSectionEnabled}"
-                                   FontFamily="Courier New"
+                                   FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                   FontSize="14"
                                    x:Name="CustomUpdateBox"
                                    automation:AutomationProperties.LabeledBy="{Binding #UpdateArgsLabelBlock}"/>
 
@@ -187,11 +196,13 @@
                                    Grid.Row="2" Grid.Column="0"
                                    Text="{Binding UninstallArgsLabel}"
                                    VerticalAlignment="Center"
+                                   FontSize="14"
                                    Opacity="{Binding CliOpacity}"/>
                         <TextBox   Grid.Row="2" Grid.Column="1"
                                    Text="{Binding CustomUninstall}"
                                    IsEnabled="{Binding CliSectionEnabled}"
-                                   FontFamily="Courier New"
+                                   FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                                   FontSize="14"
                                    x:Name="CustomUninstallBox"
                                    automation:AutomationProperties.LabeledBy="{Binding #UninstallArgsLabelBlock}"/>
                     </Grid>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Interface_P.axaml
@@ -14,6 +14,7 @@
         <StackPanel Orientation="Vertical">
 
             <settings:TranslatedTextBlock Text="Appearance"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -38,6 +39,7 @@
 
              <StackPanel x:Name="SystemTraySection" Orientation="Vertical">
                 <settings:TranslatedTextBlock Text="UniGetUI on the background and system tray"
+                                              FontSize="14"
                                               FontWeight="SemiBold"
                                               Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -57,6 +59,7 @@
             </StackPanel>
 
             <settings:TranslatedTextBlock Text="Package lists"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Internet.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Internet.axaml
@@ -13,6 +13,7 @@
         <StackPanel Orientation="Vertical">
 
             <settings:TranslatedTextBlock Text="Proxy settings"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -48,6 +49,7 @@
             <ContentControl x:Name="ProxyCompatTableHolder"/>
 
             <settings:TranslatedTextBlock Text="Other settings"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Notifications.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Notifications.axaml
@@ -14,12 +14,14 @@
         <StackPanel Orientation="Vertical">
 
             <settings:TranslatedTextBlock Text="Notification preferences"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
 
             <!-- Warning shown when system tray is disabled (Windows-only) -->
             <TextBlock Text="{t:Translate The system tray icon must be enabled in order for notifications to work}"
+                       FontSize="14"
                        Margin="0,0,0,8"
                        HorizontalAlignment="Center"
                        Foreground="OrangeRed"
@@ -32,6 +34,7 @@
                                    IsEnabled="{Binding IsSystemTrayWarningVisible, Converter={x:Static BoolConverters.Not}}"/>
 
             <settings:TranslatedTextBlock Text="Notification types"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Operations.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Operations.axaml
@@ -14,6 +14,7 @@
         <StackPanel Orientation="Vertical">
 
             <settings:TranslatedTextBlock Text="Concurrency and execution"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -39,6 +40,7 @@
                                    CornerRadius="8"/>
 
             <settings:TranslatedTextBlock Text="Automatic desktop shortcut remover"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -50,6 +52,7 @@
                                          CornerRadius="8"/>
 
             <settings:TranslatedTextBlock Text="Related settings"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml
@@ -53,6 +53,7 @@
             <!-- Status section heading -->
             <TextBlock Text="{Binding StatusSectionTitle}"
                        Margin="44,32,4,8"
+                       FontSize="14"
                        FontWeight="SemiBold"/>
 
             <!-- Status banner -->
@@ -79,8 +80,8 @@
                     </Button>
                     <TextBlock Text="{Binding VersionText}"
                                IsVisible="{Binding VersionTextVisible}"
-                               FontFamily="Courier New"
-                               FontSize="12"
+                               FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                               FontSize="14"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
@@ -92,11 +93,11 @@
             <ContentControl x:Name="PathHolder"/>
 
             <!-- Install options heading and panel -->
-            <TextBlock Text="{Binding InstallSectionTitle}" Margin="44,32,4,8" FontWeight="SemiBold"/>
+            <TextBlock Text="{Binding InstallSectionTitle}" Margin="44,32,4,8" FontSize="14" FontWeight="SemiBold"/>
             <ContentControl x:Name="InstallOptionsHolder"/>
 
             <!-- Manager-specific settings heading -->
-            <TextBlock Text="{Binding SettingsSectionTitle}" Margin="44,32,4,8" FontWeight="SemiBold"/>
+            <TextBlock Text="{Binding SettingsSectionTitle}" Margin="44,32,4,8" FontSize="14" FontWeight="SemiBold"/>
 
             <!-- Manager-specific extra controls – built in code-behind -->
             <StackPanel x:Name="ExtraControls"
@@ -105,6 +106,7 @@
 
             <!-- Related settings -->
             <settings:TranslatedTextBlock Text="Related settings"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml.cs
@@ -206,7 +206,7 @@ public sealed partial class PackageManagerPage : UserControl, ISettingsPage
         };
         var pathLabel = new TextBlock
         {
-            FontFamily = new FontFamily("Courier New"),
+            FontFamily = new FontFamily("Consolas,Cascadia Mono,Menlo,monospace"),
             FontSize = 14,
             TextWrapping = TextWrapping.Wrap,
         };

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml
@@ -29,8 +29,8 @@
                                   Path="avares://UniGetUI.Avalonia/Assets/Symbols/backward.svg"/>
             </Button>
             <TextBlock Text="{Binding Title}"
-                       FontSize="26"
-                       FontWeight="SemiBold"
+                       FontSize="24"
+                       FontWeight="Bold"
                        VerticalAlignment="Center"
                        Margin="40,0,0,0"
                        automation:AutomationProperties.HeadingLevel="1"/>
@@ -47,6 +47,7 @@
             <StackPanel Orientation="Horizontal"
                         Margin="8,6">
                 <TextBlock Text="{Binding RestartBannerText}"
+                           FontSize="14"
                            VerticalAlignment="Center"
                            Margin="0,0,16,0"/>
                 <Button Content="{Binding RestartButtonText}"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
@@ -78,7 +78,8 @@
                                               Foreground="{DynamicResource TextControlForeground}"/>
                             <TextBlock Text="{Binding Name}"
                                        VerticalAlignment="Center"
-                                       FontWeight="SemiBold"
+                                       FontSize="14"
+                                       FontWeight="Normal"
                                        MinWidth="120"/>
                         </StackPanel>
                         <!-- URL -->
@@ -86,6 +87,7 @@
                                    Text="{Binding Url}"
                                    VerticalAlignment="Center"
                                    Classes="hyperlink"
+                                   FontSize="14"
                                    TextTrimming="CharacterEllipsis"
                                    Margin="8,0"/>
                         <!-- Delete -->
@@ -123,13 +125,15 @@
                          PlaceholderText="{Binding NameHint}"
                          Text="{Binding NewSourceName}"
                          IsEnabled="{Binding NameUrlEditable}"
-                         FontFamily="Courier New"
+                         FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                         FontSize="14"
                          automation:AutomationProperties.Name="{Binding NameHint}"/>
                 <TextBox Grid.Column="1"
                          PlaceholderText="{Binding UrlHint}"
                          Text="{Binding NewSourceUrl}"
                          IsEnabled="{Binding NameUrlEditable}"
-                         FontFamily="Courier New"
+                         FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                         FontSize="14"
                          automation:AutomationProperties.Name="{Binding UrlHint}"/>
             </Grid>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Updates.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Updates.axaml
@@ -14,6 +14,7 @@
         <StackPanel Orientation="Vertical" Spacing="0">
 
             <settings:TranslatedTextBlock Text="Update checking"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -32,6 +33,7 @@
                                    IsEnabled="{Binding IsAutoCheckEnabled}"/>
 
             <settings:TranslatedTextBlock Text="Automatic updates"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -62,6 +64,7 @@
                                    IsEnabled="{Binding IsAutoCheckEnabled}"/>
 
             <settings:TranslatedTextBlock Text="Update security"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>
@@ -90,6 +93,7 @@
                             Margin="0,8,0,0"/>
 
             <settings:TranslatedTextBlock Text="Related settings"
+                                          FontSize="14"
                                           FontWeight="SemiBold"
                                           Margin="44,32,4,8"
                                           automation:AutomationProperties.HeadingLevel="2"/>

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -27,7 +27,7 @@
                  Padding="8,10,8,0">
 
             <!-- Discover Packages -->
-            <ListBoxItem x:Name="DiscoverNavBtn" Tag="Discover" Padding="4,2" CornerRadius="6"
+            <ListBoxItem x:Name="DiscoverNavBtn" Tag="Discover" Classes="nav-item" Padding="4,2" CornerRadius="6"
                          automation:AutomationProperties.Name="{t:Translate Discover Packages}"
                          automation:AutomationProperties.AcceleratorKey="Ctrl+1"
                          ToolTip.Tip="{t:Translate Discover Packages}">
@@ -52,7 +52,7 @@
             </ListBoxItem>
 
             <!-- Software Updates -->
-            <ListBoxItem x:Name="UpdatesNavBtn" Tag="Updates" Padding="4,2" CornerRadius="6"
+            <ListBoxItem x:Name="UpdatesNavBtn" Tag="Updates" Classes="nav-item" Padding="4,2" CornerRadius="6"
                          automation:AutomationProperties.Name="{t:Translate Software Updates}"
                          automation:AutomationProperties.AcceleratorKey="Ctrl+2"
                          ToolTip.Tip="{t:Translate Software Updates}">
@@ -94,7 +94,7 @@
             </ListBoxItem>
 
             <!-- Installed Packages -->
-            <ListBoxItem x:Name="InstalledNavBtn" Tag="Installed" Padding="4,2" CornerRadius="6"
+            <ListBoxItem x:Name="InstalledNavBtn" Tag="Installed" Classes="nav-item" Padding="4,2" CornerRadius="6"
                          automation:AutomationProperties.Name="{t:Translate Installed Packages}"
                          automation:AutomationProperties.AcceleratorKey="Ctrl+3"
                          ToolTip.Tip="{t:Translate Installed Packages}">
@@ -119,7 +119,7 @@
             </ListBoxItem>
 
             <!-- Package Bundles -->
-            <ListBoxItem x:Name="BundlesNavBtn" Tag="Bundles" Padding="4,2" CornerRadius="6"
+            <ListBoxItem x:Name="BundlesNavBtn" Tag="Bundles" Classes="nav-item" Padding="4,2" CornerRadius="6"
                          automation:AutomationProperties.Name="{t:Translate Package Bundles}"
                          automation:AutomationProperties.AcceleratorKey="Ctrl+4"
                          ToolTip.Tip="{t:Translate Package Bundles}">
@@ -150,58 +150,52 @@
         <StackPanel Grid.Row="1" Margin="8,0,8,12" Spacing="2">
             <controls:UserAvatarControl HorizontalAlignment="Left" Margin="8,4,0,4"/>
 
-            <Button Command="{Binding RequestNavigationCommand}"
-                    CommandParameter="Settings"
-                    HorizontalContentAlignment="Left"
-                    HorizontalAlignment="Stretch"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Padding="12,8"
-                    CornerRadius="6"
-                    automation:AutomationProperties.Name="{t:Translate Settings}"
-                    automation:AutomationProperties.AcceleratorKey="Ctrl+5"
-                    ToolTip.Tip="{t:Translate Settings}">
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                    <TextBlock Text="{t:Translate Settings}" FontSize="14" VerticalAlignment="Center"
-                               IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                </StackPanel>
-            </Button>
+            <!-- Settings & Package Managers are nav targets too, so they live in their own ListBox
+                 (selection coordinated with the main one in code-behind) and share the nav-item look. -->
+            <ListBox x:Name="FooterNavListBox"
+                     SelectionMode="Single"
+                     SelectionChanged="FooterNavListBox_SelectionChanged"
+                     Background="Transparent"
+                     BorderThickness="0"
+                     Padding="0">
 
-            <Button Command="{Binding RequestNavigationCommand}"
-                    CommandParameter="Managers"
-                    HorizontalContentAlignment="Left"
-                    HorizontalAlignment="Stretch"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Padding="12,8"
-                    CornerRadius="6"
-                    automation:AutomationProperties.Name="{t:Translate Package Managers}"
-                    automation:AutomationProperties.AcceleratorKey="Ctrl+6"
-                    ToolTip.Tip="{t:Translate Package Managers}">
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/clipboard_list.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                    <TextBlock Text="{t:Translate Package Managers}" FontSize="14" VerticalAlignment="Center"
-                               IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                </StackPanel>
-            </Button>
+                <!-- Settings -->
+                <ListBoxItem x:Name="SettingsNavBtn" Tag="Settings" Classes="nav-item" Padding="4,2" CornerRadius="6"
+                             automation:AutomationProperties.Name="{t:Translate Settings}"
+                             automation:AutomationProperties.AcceleratorKey="Ctrl+5"
+                             ToolTip.Tip="{t:Translate Settings}">
+                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
+                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center"/>
+                        <TextBlock Text="{t:Translate Settings}" FontSize="14" VerticalAlignment="Center"
+                                   IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
+                    </StackPanel>
+                </ListBoxItem>
 
-            <Button HorizontalContentAlignment="Left"
-                    HorizontalAlignment="Stretch"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Padding="12,8"
-                    CornerRadius="6"
-                    automation:AutomationProperties.Name="{t:Translate More}"
-                    ToolTip.Tip="{t:Translate More}">
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <TextBlock Text="···" FontSize="20" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center"
-                               automation:AutomationProperties.AccessibilityView="Raw"/>
-                    <TextBlock Text="{t:Translate More}" FontSize="14" VerticalAlignment="Center"
-                               IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                </StackPanel>
-                <Button.Flyout>
-                    <MenuFlyout Placement="RightEdgeAlignedTop">
+                <!-- Package Managers -->
+                <ListBoxItem x:Name="ManagersNavBtn" Tag="Managers" Classes="nav-item" Padding="4,2" CornerRadius="6"
+                             automation:AutomationProperties.Name="{t:Translate Package Managers}"
+                             automation:AutomationProperties.AcceleratorKey="Ctrl+6"
+                             ToolTip.Tip="{t:Translate Package Managers}">
+                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
+                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/clipboard_list.svg" Width="24" Height="24" VerticalAlignment="Center"/>
+                        <TextBlock Text="{t:Translate Package Managers}" FontSize="14" VerticalAlignment="Center"
+                                   IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
+                    </StackPanel>
+                </ListBoxItem>
+
+                <!-- More: a nav item visually, but it opens a menu instead of selecting a page,
+                     so code-behind shows its flyout and re-syncs selection rather than highlighting it. -->
+                <ListBoxItem x:Name="MoreNavBtn" Tag="More" Classes="nav-item" Padding="4,2" CornerRadius="6"
+                             automation:AutomationProperties.Name="{t:Translate More}"
+                             ToolTip.Tip="{t:Translate More}">
+                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
+                        <TextBlock Text="···" FontSize="20" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center"
+                                   automation:AutomationProperties.AccessibilityView="Raw"/>
+                        <TextBlock Text="{t:Translate More}" FontSize="14" VerticalAlignment="Center"
+                                   IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
+                    </StackPanel>
+                    <FlyoutBase.AttachedFlyout>
+                        <MenuFlyout Placement="RightEdgeAlignedTop">
                         <MenuItem Header="{t:Translate UniGetUI Log}" Command="{Binding RequestNavigationCommand}" CommandParameter="OwnLog">
                             <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/buggy.svg" Width="16" Height="16"/></MenuItem.Icon>
                         </MenuItem>
@@ -232,9 +226,11 @@
                         <MenuItem Header="{t:Translate Quit UniGetUI}" Command="{Binding RequestNavigationCommand}" CommandParameter="Quit">
                             <MenuItem.Icon><controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/close_round.svg" Width="16" Height="16"/></MenuItem.Icon>
                         </MenuItem>
-                    </MenuFlyout>
-                </Button.Flyout>
-            </Button>
+                        </MenuFlyout>
+                    </FlyoutBase.AttachedFlyout>
+                </ListBoxItem>
+
+            </ListBox>
 
         </StackPanel>
     </Grid>

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -161,11 +161,12 @@
 
                 <!-- Settings -->
                 <ListBoxItem x:Name="SettingsNavBtn" Tag="Settings" Classes="nav-item" Padding="4,2" CornerRadius="6"
+                             Tapped="SettingsNavBtn_Tapped"
                              automation:AutomationProperties.Name="{t:Translate Settings}"
                              automation:AutomationProperties.AcceleratorKey="Ctrl+5"
                              ToolTip.Tip="{t:Translate Settings}">
                     <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
-                        <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center"/>
+                        <controls:SvgIcon x:Name="SettingsIcon" Path="avares://UniGetUI.Avalonia/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center" RenderTransformOrigin="50%,50%"/>
                         <TextBlock Text="{t:Translate Settings}" FontSize="14" VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -35,8 +35,8 @@
                     <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
                         <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/DiscoverPackage.svg" Width="24" Height="24" VerticalAlignment="Center" />
                         <TextBlock Text="{t:Translate Discover Packages}"
-                                   FontSize="16"
-                                   FontWeight="SemiBold"
+                                   FontSize="14"
+                                   FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
@@ -60,7 +60,7 @@
                     <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
                         <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/update.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                         <TextBlock Text="{t:Translate Software Updates}"
-                                   FontSize="16"
+                                   FontSize="14"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
@@ -102,7 +102,7 @@
                     <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
                         <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/InstalledPackages.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                         <TextBlock Text="{t:Translate Installed Packages}"
-                                   FontSize="16"
+                                   FontSize="14"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
@@ -127,7 +127,7 @@
                     <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,6">
                         <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/PackagesBundle.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                         <TextBlock Text="{t:Translate Package Bundles}"
-                                   FontSize="16"
+                                   FontSize="14"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
@@ -163,7 +163,7 @@
                     ToolTip.Tip="{t:Translate Settings}">
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                    <TextBlock Text="{t:Translate Settings}" FontSize="16" VerticalAlignment="Center"
+                    <TextBlock Text="{t:Translate Settings}" FontSize="14" VerticalAlignment="Center"
                                IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                 </StackPanel>
             </Button>
@@ -181,7 +181,7 @@
                     ToolTip.Tip="{t:Translate Package Managers}">
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/clipboard_list.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                    <TextBlock Text="{t:Translate Package Managers}" FontSize="16" VerticalAlignment="Center"
+                    <TextBlock Text="{t:Translate Package Managers}" FontSize="14" VerticalAlignment="Center"
                                IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                 </StackPanel>
             </Button>
@@ -197,7 +197,7 @@
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <TextBlock Text="···" FontSize="20" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center"
                                automation:AutomationProperties.AccessibilityView="Raw"/>
-                    <TextBlock Text="{t:Translate More}" FontSize="16" VerticalAlignment="Center"
+                    <TextBlock Text="{t:Translate More}" FontSize="14" VerticalAlignment="Center"
                                IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                 </StackPanel>
                 <Button.Flyout>

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -1,7 +1,11 @@
 using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Styling;
 using UniGetUI.Avalonia.ViewModels;
 
 namespace UniGetUI.Avalonia.Views;
@@ -87,6 +91,22 @@ public partial class SidebarView : BaseView<SidebarViewModel>
         if (Enum.TryParse<PageType>(tag, out var pageType))
             ViewModel?.RequestNavigation(pageType.ToString());
     }
+
+    // One full gear rotation on click, mirroring the spin of WinUI's AnimatedSettingsVisualSource.
+    // The TransformAnimator manages the icon's RenderTransform, so the animation runs on the Visual itself.
+    private readonly Animation _settingsIconSpin = new()
+    {
+        Duration = TimeSpan.FromSeconds(0.5),
+        Easing = new CubicEaseOut(),
+        Children =
+        {
+            new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(RotateTransform.AngleProperty, 0d) } },
+            new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(RotateTransform.AngleProperty, 360d) } },
+        },
+    };
+
+    private void SettingsNavBtn_Tapped(object? sender, TappedEventArgs e)
+        => _ = _settingsIconSpin.RunAsync(SettingsIcon);
 
     public void FocusSelectedItem()
     {

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using UniGetUI.Avalonia.ViewModels;
 
@@ -32,15 +33,20 @@ public partial class SidebarView : BaseView<SidebarViewModel>
     {
         base.OnDataContextChanged(e);
         if (DataContext is SidebarViewModel vm)
+        {
             vm.PropertyChanged += (_, args) =>
             {
                 if (args.PropertyName == nameof(SidebarViewModel.SelectedPageType))
                     SyncListBoxSelection(vm.SelectedPageType);
             };
+            // The startup page may already be set before this view subscribes, so apply it now.
+            SyncListBoxSelection(vm.SelectedPageType);
+        }
     }
 
     private void SyncListBoxSelection(PageType page)
     {
+        // Selection lives in two ListBoxes (main + footer); only one may hold a selection at a time.
         _lastNavItemSelectionWasAuto = true;
         NavListBox.SelectedItem = page switch
         {
@@ -50,20 +56,41 @@ public partial class SidebarView : BaseView<SidebarViewModel>
             PageType.Bundles => BundlesNavBtn,
             _ => null,
         };
+        FooterNavListBox.SelectedItem = page switch
+        {
+            PageType.Settings => SettingsNavBtn,
+            PageType.Managers => ManagersNavBtn,
+            _ => null,
+        };
         _lastNavItemSelectionWasAuto = false;
     }
 
     private void NavListBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        => HandleNavSelectionChanged(NavListBox.SelectedItem);
+
+    private void FooterNavListBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        => HandleNavSelectionChanged(FooterNavListBox.SelectedItem);
+
+    private void HandleNavSelectionChanged(object? selectedItem)
     {
         if (_lastNavItemSelectionWasAuto) return;
-        if (NavListBox.SelectedItem is ListBoxItem item && item.Tag is string tag
-            && Enum.TryParse<PageType>(tag, out var pageType))
+        if (selectedItem is not ListBoxItem item || item.Tag is not string tag) return;
+
+        if (tag == "More")
+        {
+            // Not a page: re-sync selection so "More" doesn't stay highlighted, then open its menu.
+            SyncListBoxSelection(ViewModel?.SelectedPageType ?? PageType.Null);
+            FlyoutBase.ShowAttachedFlyout(item);
+            return;
+        }
+
+        if (Enum.TryParse<PageType>(tag, out var pageType))
             ViewModel?.RequestNavigation(pageType.ToString());
     }
 
     public void FocusSelectedItem()
     {
-        if (NavListBox.SelectedItem is InputElement item)
+        if ((NavListBox.SelectedItem ?? FooterNavListBox.SelectedItem) is InputElement item)
             item.Focus();
         else
             NavListBox.Focus();

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -21,8 +21,25 @@
       <Style Selector="DataGridCell:current">
          <Setter Property="BorderBrush" Value="Transparent"/>
       </Style>
+      <!-- Remove the DataGrid's built-in line between the header and the rows -->
+      <Style Selector="DataGrid /template/ Rectangle#PART_ColumnHeadersAndRowsSeparator">
+         <Setter Property="IsVisible" Value="False"/>
+      </Style>
+      <!-- Header as one inset, rounded bar (WinUI-style): rounded + inset ends, no borders/separators -->
       <Style Selector="DataGridColumnHeader">
-         <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+         <Setter Property="Background" Value="{DynamicResource PackageListHeaderBackground}"/>
+         <Setter Property="HorizontalContentAlignment" Value="Center"/>
+         <Setter Property="AreSeparatorsVisible" Value="False"/>
+         <Setter Property="SeparatorBrush" Value="Transparent"/>
+         <Setter Property="BorderThickness" Value="0"/>
+         <Setter Property="CornerRadius" Value="0"/>
+         <Setter Property="Margin" Value="0,6,0,6"/>
+      </Style>
+      <Style Selector="DataGridColumnHeader:nth-child(1)">
+         <Setter Property="CornerRadius" Value="4,0,0,4"/>
+      </Style>
+      <Style Selector="DataGridColumnHeader:nth-last-child(1)">
+         <Setter Property="CornerRadius" Value="0,4,4,0"/>
       </Style>
       <Style Selector="Expander /template/ ToggleButton#ExpanderHeader">
          <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
@@ -448,9 +465,8 @@
                 <!-- Package list container -->
                 <Border Margin="0,6,0,6"
                         CornerRadius="8"
-                        BorderThickness="1"
-                        BorderBrush="{DynamicResource AppBorderBrush}"
-                        Background="{DynamicResource SettingsCardBackground}">
+                        BorderThickness="0"
+                        Background="{DynamicResource PackageListBackground}">
                 <Grid RowDefinitions="Auto,*">
                     <!-- Header bar for grid/icons views (select-all) — hidden in list mode, which has its own DataGrid header -->
                     <Border Grid.Row="0"
@@ -470,6 +486,7 @@
                                   IsVisible="{Binding IsListViewMode}"
                                   HorizontalAlignment="Stretch"
                                   VerticalAlignment="Stretch"
+                                  Margin="8,0,8,0"
                                   ItemsSource="{Binding FilteredPackages}"
                                   automation:AutomationProperties.AccessibilityView="Control"
                                   automation:AutomationProperties.Name="{Binding PageTitle}"
@@ -583,7 +600,8 @@
                              origin with the checkbox centered + the same Margin as the rows, so
                              the boxes line up regardless of cell metrics. -->
                         <Border IsVisible="{Binding IsListViewMode}"
-                                Width="40" Height="32"
+                                Width="40" Height="44"
+                                Margin="8,0,0,0"
                                 HorizontalAlignment="Left" VerticalAlignment="Top"
                                 Background="Transparent" ZIndex="10">
                             <CheckBox IsChecked="{Binding AllPackagesChecked, Mode=TwoWay}"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -859,17 +859,17 @@
                         Orientation="Horizontal"
                         Spacing="4"
                         VerticalAlignment="Center">
-                <TextBlock x:Name="OrderByLabel" Text="{t:Translate Order by:}" FontSize="12" VerticalAlignment="Center"/>
+                <TextBlock x:Name="OrderByLabel" Text="{t:Translate Order by:}" FontSize="13" VerticalAlignment="Center"/>
                 <Button x:Name="OrderByButton"
-                        Padding="8,3"
+                        Padding="10,6"
                         CornerRadius="4"
                         Background="Transparent"
                         BorderThickness="1"
                         BorderBrush="{DynamicResource AppBorderBrush}"
                         automation:AutomationProperties.LabeledBy="{Binding #OrderByLabel}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Text="{Binding SortFieldName}" VerticalAlignment="Center" FontSize="13"/>
-                        <Path Data="M 0,0 L 4,4 L 8,0"
+                        <TextBlock Text="{Binding SortFieldName}" VerticalAlignment="Center" FontSize="14"/>
+                        <Path Data="M 0,0 L 5,5 L 10,0"
                               Stroke="{DynamicResource TextFillColorPrimaryBrush}"
                               StrokeThickness="1.5"
                               StrokeJoin="Miter"
@@ -911,45 +911,48 @@
                             <StackPanel Orientation="Horizontal"/>
                         </ItemsPanelTemplate>
                     </ListBox.ItemsPanel>
-                    <ListBoxItem x:Name="Selector_List" Padding="8,3" ToolTip.Tip="List"
+                    <ListBoxItem x:Name="Selector_List" Classes="segment-item" Padding="8,4,8,8" ToolTip.Tip="List"
                                  automation:AutomationProperties.Name="List">
-                        <Grid Width="16" Height="16"
-                              automation:AutomationProperties.AccessibilityView="Raw">
-                            <!-- bullets -->
-                            <Path Data="M 3,3 m -1.2,0 a 1.2,1.2 0 1,0 2.4,0 a 1.2,1.2 0 1,0 -2.4,0
-                                        M 3,8 m -1.2,0 a 1.2,1.2 0 1,0 2.4,0 a 1.2,1.2 0 1,0 -2.4,0
-                                        M 3,13 m -1.2,0 a 1.2,1.2 0 1,0 2.4,0 a 1.2,1.2 0 1,0 -2.4,0"
-                                  Fill="{DynamicResource TextFillColorPrimaryBrush}"/>
-                            <!-- lines -->
-                            <Path Data="M 6,3 H 14 M 6,8 H 14 M 6,13 H 14"
-                                  Stroke="{DynamicResource TextFillColorPrimaryBrush}"
-                                  StrokeThickness="1.5"
-                                  StrokeLineCap="Round"
-                                  Fill="Transparent"/>
-                        </Grid>
+                        <Viewbox Width="18" Height="18" automation:AutomationProperties.AccessibilityView="Raw">
+                            <Grid Width="16" Height="16">
+                                <!-- bullets -->
+                                <Path Data="M 3,3 m -1.2,0 a 1.2,1.2 0 1,0 2.4,0 a 1.2,1.2 0 1,0 -2.4,0
+                                            M 3,8 m -1.2,0 a 1.2,1.2 0 1,0 2.4,0 a 1.2,1.2 0 1,0 -2.4,0
+                                            M 3,13 m -1.2,0 a 1.2,1.2 0 1,0 2.4,0 a 1.2,1.2 0 1,0 -2.4,0"
+                                      Fill="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <!-- lines -->
+                                <Path Data="M 6,3 H 14 M 6,8 H 14 M 6,13 H 14"
+                                      Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                                      StrokeThickness="1.5"
+                                      StrokeLineCap="Round"
+                                      Fill="Transparent"/>
+                            </Grid>
+                        </Viewbox>
                     </ListBoxItem>
-                    <ListBoxItem x:Name="Selector_Grid" Padding="8,3" ToolTip.Tip="Grid"
+                    <ListBoxItem x:Name="Selector_Grid" Classes="segment-item" Padding="8,4,8,8" ToolTip.Tip="Grid"
                                  automation:AutomationProperties.Name="Grid">
                         <!-- Two rows: open "[" bracket on the left + two stacked lines on the right -->
-                        <Path Width="16" Height="16"
-                              Data="M 4,2 H 2 V 6 H 4   M 6,3 H 14   M 6,5 H 14
-                                    M 4,10 H 2 V 14 H 4 M 6,11 H 14  M 6,13 H 14"
-                              Stroke="{DynamicResource TextFillColorPrimaryBrush}"
-                              StrokeThickness="1"
-                              StrokeLineCap="Round"
-                              StrokeJoin="Miter"
-                              Fill="Transparent"
-                              automation:AutomationProperties.AccessibilityView="Raw"/>
+                        <Viewbox Width="18" Height="18" automation:AutomationProperties.AccessibilityView="Raw">
+                            <Path Width="16" Height="16"
+                                  Data="M 4,2 H 2 V 6 H 4   M 6,3 H 14   M 6,5 H 14
+                                        M 4,10 H 2 V 14 H 4 M 6,11 H 14  M 6,13 H 14"
+                                  Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                                  StrokeThickness="1"
+                                  StrokeLineCap="Round"
+                                  StrokeJoin="Miter"
+                                  Fill="Transparent"/>
+                        </Viewbox>
                     </ListBoxItem>
-                    <ListBoxItem x:Name="Selector_Icons" Padding="8,3" ToolTip.Tip="Icons"
+                    <ListBoxItem x:Name="Selector_Icons" Classes="segment-item" Padding="8,4,8,8" ToolTip.Tip="Icons"
                                  automation:AutomationProperties.Name="Icons">
                         <!-- 2x2 hollow squares (WinUI IconView) with extra gap between -->
-                        <Path Width="16" Height="16"
-                              Data="M 2,2 H 6 V 6 H 2 Z M 10,2 H 14 V 6 H 10 Z M 2,10 H 6 V 14 H 2 Z M 10,10 H 14 V 14 H 10 Z"
-                              Stroke="{DynamicResource TextFillColorPrimaryBrush}"
-                              StrokeThickness="1.3"
-                              Fill="Transparent"
-                              automation:AutomationProperties.AccessibilityView="Raw"/>
+                        <Viewbox Width="18" Height="18" automation:AutomationProperties.AccessibilityView="Raw">
+                            <Path Width="16" Height="16"
+                                  Data="M 2,2 H 6 V 6 H 2 Z M 10,2 H 14 V 6 H 10 Z M 2,10 H 6 V 14 H 2 Z M 10,10 H 14 V 14 H 10 Z"
+                                  Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                                  StrokeThickness="1.3"
+                                  Fill="Transparent"/>
+                        </Viewbox>
                     </ListBoxItem>
                 </ListBox>
             </StackPanel>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -97,8 +97,9 @@
                 <TextBlock x:Name="MainTitle"
                            MaxHeight="60"
                            HorizontalAlignment="Left"
-                           FontSize="24"
-                           FontWeight="Bold"
+                           FontSize="28"
+                           FontWeight="SemiBold"
+                           FontFamily="Segoe UI Variable Display"
                            TextWrapping="Wrap"
                            Text="{Binding PageTitle}"/>
                 <TextBlock x:Name="MainSubtitle"
@@ -222,7 +223,7 @@
                             <Expander.Header>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/Sources.svg" Width="16" Height="16" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{t:Translate Sources}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{t:Translate Sources}" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Expander.Header>
                             <StackPanel Orientation="Vertical">
@@ -341,7 +342,7 @@
                             <Expander.Header>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/Filter.svg" Width="16" Height="16" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{t:Translate Filters}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{t:Translate Filters}" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Expander.Header>
                             <StackPanel HorizontalAlignment="Stretch" Orientation="Vertical" Spacing="0">
@@ -373,7 +374,7 @@
                             <Expander.Header>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/search_filled.svg" Width="16" Height="16" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{t:Translate Search mode}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{t:Translate Search mode}" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Expander.Header>
                             <StackPanel HorizontalAlignment="Stretch" Orientation="Vertical" Spacing="0">
@@ -632,7 +633,7 @@
                                                 </Panel>
                                                 <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                                                     <TextBlock Text="{Binding Package.Name}"
-                                                               FontWeight="SemiBold" FontSize="13"
+                                                               FontWeight="SemiBold" FontSize="14"
                                                                TextTrimming="CharacterEllipsis"/>
                                                     <TextBlock Text="{Binding Package.Id}"
                                                                FontSize="11" Opacity="0.7"
@@ -788,7 +789,8 @@
                                          CornerRadius="0"
                                          BorderThickness="0"
                                          Background="Transparent"
-                                         FontSize="40"
+                                         FontSize="28"
+                                         FontWeight="SemiBold"
                                          PlaceholderText="{t:Translate Search for packages}"
                                          automation:AutomationProperties.Name="{t:Translate Search for packages}"
                                          Text="{Binding MegaQueryText, Mode=TwoWay}"
@@ -839,7 +841,7 @@
                         Orientation="Horizontal"
                         Spacing="4"
                         VerticalAlignment="Center">
-                <TextBlock x:Name="OrderByLabel" Text="{t:Translate Order by:}" FontSize="13" VerticalAlignment="Center"/>
+                <TextBlock x:Name="OrderByLabel" Text="{t:Translate Order by:}" FontSize="12" VerticalAlignment="Center"/>
                 <Button x:Name="OrderByButton"
                         Padding="8,3"
                         CornerRadius="4"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -522,8 +522,17 @@
                                                            Stretch="Uniform" IsVisible="{Binding HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/package.svg"
                                                                       Width="24" Height="24" IsVisible="{Binding !HasCustomIcon}"/>
-                                                    <controls:SvgIcon Path="{Binding TagIconPath}"
-                                                                      Width="12" Height="12"
+                                                    <controls:SvgIcon Path="{Binding TagBackdropIconPath}"
+                                                                      Foreground="{DynamicResource SystemAccentColor}"
+                                                                      Width="20" Height="20"
+                                                                      Margin="0,0,-3,-3"
+                                                                      IsVisible="{Binding TagIconVisible}"
+                                                                      HorizontalAlignment="Right"
+                                                                      VerticalAlignment="Bottom"/>
+                                                    <controls:SvgIcon Path="{Binding TagSymbolIconPath}"
+                                                                      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                                      Width="20" Height="20"
+                                                                      Margin="0,0,-3,-3"
                                                                       IsVisible="{Binding TagIconVisible}"
                                                                       HorizontalAlignment="Right"
                                                                       VerticalAlignment="Bottom"/>
@@ -636,8 +645,17 @@
                                                            Stretch="Uniform" IsVisible="{Binding HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/package.svg"
                                                                       Width="44" Height="44" IsVisible="{Binding !HasCustomIcon}"/>
-                                                    <controls:SvgIcon Path="{Binding TagIconPath}"
-                                                                      Width="17" Height="17"
+                                                    <controls:SvgIcon Path="{Binding TagBackdropIconPath}"
+                                                                      Foreground="{DynamicResource SystemAccentColor}"
+                                                                      Width="28" Height="28"
+                                                                      Margin="0,0,-4,-4"
+                                                                      IsVisible="{Binding TagIconVisible}"
+                                                                      HorizontalAlignment="Right"
+                                                                      VerticalAlignment="Bottom"/>
+                                                    <controls:SvgIcon Path="{Binding TagSymbolIconPath}"
+                                                                      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                                      Width="28" Height="28"
+                                                                      Margin="0,0,-4,-4"
                                                                       IsVisible="{Binding TagIconVisible}"
                                                                       HorizontalAlignment="Right"
                                                                       VerticalAlignment="Bottom"/>
@@ -736,8 +754,17 @@
                                                            Stretch="Uniform" IsVisible="{Binding HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="avares://UniGetUI.Avalonia/Assets/Symbols/package.svg"
                                                                       Width="64" Height="64" IsVisible="{Binding !HasCustomIcon}"/>
-                                                    <controls:SvgIcon Path="{Binding TagIconPath}"
-                                                                      Width="24" Height="24"
+                                                    <controls:SvgIcon Path="{Binding TagBackdropIconPath}"
+                                                                      Foreground="{DynamicResource SystemAccentColor}"
+                                                                      Width="38" Height="38"
+                                                                      Margin="0,0,-5,-5"
+                                                                      IsVisible="{Binding TagIconVisible}"
+                                                                      HorizontalAlignment="Right"
+                                                                      VerticalAlignment="Bottom"/>
+                                                    <controls:SvgIcon Path="{Binding TagSymbolIconPath}"
+                                                                      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                                      Width="38" Height="38"
+                                                                      Margin="0,0,-5,-5"
                                                                       IsVisible="{Binding TagIconVisible}"
                                                                       HorizontalAlignment="Right"
                                                                       VerticalAlignment="Bottom"/>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -876,8 +876,7 @@
 
     <!-- ==================== FOOTER STATUS BAR ==================== -->
     <Border Grid.Row="3" Margin="0,-4,0,-8" VerticalAlignment="Center"
-            BorderThickness="0,1,0,0"
-            BorderBrush="{DynamicResource AppBorderBrush}"
+            BorderThickness="0"
             Padding="0,4,0,0">
         <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
 


### PR DESCRIPTION
This pull request introduces several improvements to the application's UI consistency and theming, especially for package lists, navigation, and badges, aligning them more closely with WinUI design patterns. It also refactors how package tag icons are handled in the code, and removes an unused theme package reference.

**The most important changes are:**

### UI Theming and Styles

* Added new brushes and styles in `Styles.Common.axaml` and `Styles.WindowsMica.axaml` for package lists, column headers, and subtle fills, making backgrounds and hover/press states more visually consistent with WinUI. This includes new resources like `PackageListBackground`, `PackageListHeaderBackground`, and subtle fill brushes for both light and dark themes. 
* Introduced custom styles for sidebar navigation items (`ListBoxItem.nav-item`) and segmented view selectors (`ListBoxItem.segment-item`) to use subtle neutral fills and accent selection indicators, instead of full accent fills.
* Set `DataGridColumnHeader` font size to 14px to match WinUI, improving column header appearance.

### Package Tag Icon Refactor

* Changed package tag icon handling in `PackageCollections.cs` to use separate properties for the symbol and backdrop SVGs (`TagSymbolIconPath` and `TagBackdropIconPath`), allowing for a WinUI-style "punched out" badge effect. Updated logic for which icons are shown and when. 
* Updated property change notifications to reflect the new icon property names.

### ViewModel Improvements

* Improved labels and tab headers in `InstallOptionsViewModel` to better match WinUI's two-line tab style and added new translated labels for placeholders and actions.
* Added missing using directives for consistency.

### Dependency Cleanup

* Removed the unused `Devolutions.AvaloniaTheme.DevExpress` package reference from the project file.