### PR TITLE
Fix mangled accents in Chocolatey output by decoding with the system console code page

### DIFF
--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -18,6 +18,29 @@ namespace UniGetUI.Core.Data
         {
             get => __code_page ??= GetCodePage();
         }
+
+        private static Encoding? __console_encoding;
+        // The encoding CLIs that don't force UTF-8 (e.g. Chocolatey) actually emit their console output in.
+        public static Encoding ConsoleEncoding
+        {
+            get
+            {
+                if (__console_encoding is not null)
+                    return __console_encoding;
+                try
+                {
+                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                    __console_encoding = Encoding.GetEncoding(CODE_PAGE);
+                }
+                catch (Exception e)
+                {
+                    Logger.Warn($"Could not resolve console code page {CODE_PAGE}, falling back to UTF-8");
+                    Logger.Warn(e);
+                    __console_encoding = Encoding.UTF8;
+                }
+                return __console_encoding;
+            }
+        }
         public const string VersionName = "2026.1.0"; // Do not modify this line, use file scripts/set-version.ps1
         public const int BuildNumber = 106; // Do not modify this line, use file scripts/set-version.ps1
 

--- a/src/UniGetUI.Core.Data/UniGetUI.Core.Data.csproj
+++ b/src/UniGetUI.Core.Data/UniGetUI.Core.Data.csproj
@@ -19,5 +19,6 @@
 
     <ItemGroup>
         <PackageReference Include="YamlDotNet" Version="17.0.1" />
+        <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.5" />
     </ItemGroup>
 </Project>

--- a/src/UniGetUI.PackageEngine.Interfaces/IPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.Interfaces/IPackageManager.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using UniGetUI.PackageEngine.Classes.Manager.Classes;
 using UniGetUI.PackageEngine.Classes.Manager.ManagerHelpers;
 using UniGetUI.PackageEngine.Interfaces.ManagerProviders;
@@ -20,6 +21,12 @@ namespace UniGetUI.PackageEngine.Interfaces
         public IPackageDetailsHelper DetailsHelper { get; }
         public IPackageOperationHelper OperationHelper { get; }
         public IReadOnlyList<ManagerDependency> Dependencies { get; }
+
+        /// <summary>
+        /// The text encoding this manager's CLI emits its output in. Defaults to UTF-8; managers
+        /// whose CLI emits in the system console code page (e.g. Chocolatey) must override this.
+        /// </summary>
+        public Encoding OutputEncoding { get; }
 
         /// <summary>
         /// Initializes the Package Manager (asynchronously). Must be run before using any other method of the manager.

--- a/src/UniGetUI.PackageEngine.Managers.Chocolatey/Chocolatey.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Chocolatey/Chocolatey.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
@@ -18,6 +19,9 @@ namespace UniGetUI.PackageEngine.Managers.ChocolateyManager
 {
     public class Chocolatey : BaseNuGet
     {
+        // Chocolatey emits its output in the system console code page, not UTF-8.
+        public override Encoding OutputEncoding => CoreData.ConsoleEncoding;
+
         public static readonly string[] FALSE_PACKAGE_IDS =
         [
             "Directory",
@@ -265,7 +269,8 @@ namespace UniGetUI.PackageEngine.Managers.ChocolateyManager
                     RedirectStandardInput = true,
                     UseShellExecute = false,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                    StandardOutputEncoding = OutputEncoding,
+                    StandardErrorEncoding = OutputEncoding,
                 },
             };
 
@@ -300,7 +305,8 @@ namespace UniGetUI.PackageEngine.Managers.ChocolateyManager
                     RedirectStandardInput = true,
                     UseShellExecute = false,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                    StandardOutputEncoding = OutputEncoding,
+                    StandardErrorEncoding = OutputEncoding,
                 },
             };
 
@@ -368,7 +374,8 @@ namespace UniGetUI.PackageEngine.Managers.ChocolateyManager
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                    StandardOutputEncoding = OutputEncoding,
+                    StandardErrorEncoding = OutputEncoding,
                 },
             };
             process.Start();

--- a/src/UniGetUI.PackageEngine.Managers.Chocolatey/Helpers/ChocolateyDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Chocolatey/Helpers/ChocolateyDetailsHelper.cs
@@ -42,7 +42,8 @@ namespace UniGetUI.PackageEngine.Managers.Choco
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                    StandardOutputEncoding = Manager.OutputEncoding,
+                    StandardErrorEncoding = Manager.OutputEncoding,
                 },
             };
 

--- a/src/UniGetUI.PackageEngine.Managers.Chocolatey/Helpers/ChocolateySourceHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Chocolatey/Helpers/ChocolateySourceHelper.cs
@@ -65,7 +65,8 @@ namespace UniGetUI.PackageEngine.Managers.ChocolateyManager
                     RedirectStandardInput = true,
                     UseShellExecute = false,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                    StandardOutputEncoding = Manager.OutputEncoding,
+                    StandardErrorEncoding = Manager.OutputEncoding,
                 },
             };
 

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -139,6 +139,8 @@ namespace UniGetUI.PackageEngine.Operations
 
             process.StartInfo.FileName = FileName;
             process.StartInfo.Arguments = Arguments;
+            process.StartInfo.StandardOutputEncoding = Package.Manager.OutputEncoding;
+            process.StartInfo.StandardErrorEncoding = Package.Manager.OutputEncoding;
 
             ApplyCapabilities(
                 IsAdmin,

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using UniGetUI.Core.IconEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
@@ -19,6 +20,7 @@ namespace UniGetUI.PackageEngine.Classes.Manager
         public ManagerProperties Properties { get; }
         public ManagerCapabilities Capabilities { get; }
         public ManagerStatus Status { get; }
+        public Encoding OutputEncoding => Encoding.UTF8;
         public string Id
         {
             get => string.IsNullOrWhiteSpace(Properties.Id) ? Properties.Name : Properties.Id;

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.SettingsEngine.SecureSettings;
@@ -41,6 +42,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         public IMultiSourceHelper SourcesHelper { get; protected set; } = new NullSourceHelper();
         public IPackageDetailsHelper DetailsHelper { get; protected set; } = null!;
         public IPackageOperationHelper OperationHelper { get; protected set; } = null!;
+        public virtual Encoding OutputEncoding => Encoding.UTF8;
 
         private readonly bool _baseConstructorCalled;
         private bool _ready;


### PR DESCRIPTION
This pull request improves how the application handles CLI output encodings for package managers, ensuring correct reading of console output from tools like Chocolatey that do not emit UTF-8. The main changes introduce a configurable `OutputEncoding` property for package managers, defaulting to UTF-8 but allowing overrides for managers that use the system console code page. The process start logic is updated to use this encoding, preventing character corruption in CLI output.

**Encoding handling improvements:**

* Added a `ConsoleEncoding` property to `CoreData` that detects and caches the system console code page, with a fallback to UTF-8 if detection fails.
* Updated the `IPackageManager` interface to include an `OutputEncoding` property, defaulting to UTF-8 but overridable by specific managers.
* The base `PackageManager` class and `NullPackageManager` now provide a default implementation for `OutputEncoding`. 
**Chocolatey-specific changes:**

* The `Chocolatey` package manager overrides `OutputEncoding` to use `CoreData.ConsoleEncoding`, ensuring correct output decoding for its CLI.
* All process invocations in Chocolatey and its helpers now use the manager's `OutputEncoding` for both standard output and error streams. 

**Dependency updates:**

* Added the `System.Text.Encoding.CodePages` NuGet package to enable support for non-UTF-8 code pages.

**Process invocation updates:**

* All package operation process invocations now consistently use the package manager's `OutputEncoding` for output and error streams.
