### PR TITLE
Use max installer compression for release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -260,7 +260,13 @@ jobs:
             Set-Content $IssPath $issContentNoSign -NoNewline
 
             $InstallerBaseName = "UniGetUI.Installer.$Platform"
-            & ISCC.exe $IssPath /F"$InstallerBaseName" /O"$OutputDir"
+            $IsccArgs = @($IssPath, "/F$InstallerBaseName", "/O$OutputDir")
+            if ([System.Boolean]::Parse('${{ needs.preflight.outputs.dry-run }}') -eq $false) {
+              Write-Host "Using lzma/ultra64 installer compression for release build."
+              $IsccArgs = @('/DInstallerCompression=lzma/ultra64') + $IsccArgs
+            }
+
+            & ISCC.exe @IsccArgs
             if ($LASTEXITCODE -ne 0) { throw "Inno Setup failed with exit code $LASTEXITCODE" }
           }
           finally {

--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -6,6 +6,9 @@
 #define MyAppPublisher "Devolutions Inc."
 #define MyAppURL "https://github.com/Devolutions/UniGetUI"
 #define MyAppExeName "UniGetUI.exe"
+#ifndef InstallerCompression
+#define InstallerCompression "lzma"
+#endif
 
 #define public Dependency_Path_NetCoreCheck "InstallerExtras\"
 #include "InstallerExtras\CodeDependencies.iss"
@@ -46,7 +49,7 @@ SignedUninstallerDir=InstallerExtras\
 MinVersion=10.0
 SetupIconFile=src\SharedAssets\Assets\Images\icon.ico
 UninstallDisplayIcon={app}\UniGetUI.exe
-Compression=lzma
+Compression={#InstallerCompression}
 SolidCompression=yes
 WizardStyle=modern dynamic
 WizardImageFile=InstallerExtras\installer-banner.png

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -21,8 +21,10 @@
 .PARAMETER Version
     Version string to stamp into the build (e.g. "3.3.7"). If not provided,
     the current version from SharedAssemblyInfo.cs is used.
-#>
 
+.PARAMETER MaxInstallerCompression
+    Use the strongest Inno Setup compression settings for the installer.
+#>
 [CmdletBinding()]
 param(
     [string] $Configuration = "Release",
@@ -30,6 +32,7 @@ param(
     [string] $OutputPath = (Join-Path $PSScriptRoot ".." "output"),
     [switch] $SkipTests,
     [switch] $SkipInstaller,
+    [switch] $MaxInstallerCompression,
     [string] $Version
 )
 
@@ -143,7 +146,13 @@ if (-not $SkipInstaller) {
             $IssContentNoSign = $IssContentNoSign -Replace '(?m)^SignedUninstaller=yes', 'SignedUninstaller=no'
             Set-Content $IssPath $IssContentNoSign -NoNewline
 
-            & $IsccPath $IssPath /F"$InstallerBaseName" /O"$OutputPath"
+            $IsccArgs = @($IssPath, "/F$InstallerBaseName", "/O$OutputPath")
+            if ($MaxInstallerCompression) {
+                Write-Host "Using lzma/ultra64 installer compression."
+                $IsccArgs = @('/DInstallerCompression=lzma/ultra64') + $IsccArgs
+            }
+
+            & $IsccPath @IsccArgs
             if ($LASTEXITCODE -ne 0) {
                 throw "Inno Setup failed with exit code $LASTEXITCODE"
             }


### PR DESCRIPTION
## Summary

- Adds an Inno Setup `InstallerCompression` preprocessor value that defaults to the current `lzma` setting.
- Adds `scripts\build.ps1 -MaxInstallerCompression` to opt into `lzma/ultra64` for local/manual release-style builds.
- Updates the release workflow to use `lzma/ultra64` only when `dry-run` is `false`, so dry runs keep the faster default compression.

## Size measurements

Measured against the local Windows x64 package baseline from the existing release payload:

| Compression | Installer size | Gain vs current | Compile time |
|---|---:|---:|---:|
| current `lzma` default max | 88.96 MiB | baseline | 41.9s |
| `lzma/ultra64` | 86.79 MiB | 2.17 MiB / 2.44% | 71.5s |
| `lzma2/ultra64` | 86.79 MiB | 2.17 MiB / 2.44% | 76.1s |
| `lzma/ultra` | 87.46 MiB | 1.51 MiB / 1.69% | 58.4s |
| `lzma2/max` | 88.97 MiB | -0.01 MiB | 42.1s |

`lzma/ultra64` was the smallest measured output, narrowly beating `lzma2/ultra64` by about 2.8 KB. The gain is modest but free for real release artifacts, while dry runs avoid the extra build time.

## Validation

- Compiled the default installer path against the x64 baseline payload: 88.96 MiB.
- Compiled the release override path with `/DInstallerCompression=lzma/ultra64`: 86.79 MiB.
- Confirmed the branch was pushed cleanly.