### PR TITLE
Reduce Windows publish payload

### DIFF
--- a/src/UniGetUI.Avalonia/Extensions/ObservableSubscriptionExtensions.cs
+++ b/src/UniGetUI.Avalonia/Extensions/ObservableSubscriptionExtensions.cs
@@ -1,0 +1,29 @@
+using System.Runtime.ExceptionServices;
+
+namespace UniGetUI.Avalonia.Extensions;
+
+internal static class ObservableSubscriptionExtensions
+{
+    public static IDisposable SubscribeValue<T>(this IObservable<T> source, Action<T> onNext)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(onNext);
+
+        return source.Subscribe(new ActionObserver<T>(onNext));
+    }
+
+    private sealed class ActionObserver<T>(Action<T> onNext) : IObserver<T>
+    {
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+            ExceptionDispatchInfo.Capture(error).Throw();
+        }
+
+        public void OnNext(T value)
+            => onNext(value);
+    }
+}

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -153,8 +153,8 @@
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
-        <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.3.13" />
-        <PackageReference Include="Devolutions.AvaloniaTheme.Linux" Version="2026.3.11" />
+        <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.3.13" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+        <PackageReference Include="Devolutions.AvaloniaTheme.Linux" Version="2026.3.11" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
         <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3" Condition="'$(EnableAvaloniaDiagnostics)' == 'true'" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
         <PackageReference Include="Octokit" Version="14.0.0" />

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/SecureCheckboxCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/SecureCheckboxCard.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
+using UniGetUI.Avalonia.Extensions;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine.SecureSettings;
@@ -134,7 +135,7 @@ public partial class SecureCheckboxCard : SettingsCard
         _checkbox.IsCheckedChanged += (s, e) => _ = _checkbox_Toggled();
 
         this.GetObservable(IsEnabledProperty)
-            .Subscribe(enabled => _warningBlock.Opacity = enabled ? 1 : 0.2);
+            .SubscribeValue(enabled => _warningBlock.Opacity = enabled ? 1 : 0.2);
 
         // The Devolutions SettingsCard measures the Header with infinite width, so
         // TextWrapping alone won't constrain the warning block. We fix it by updating

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using UniGetUI.Avalonia.Extensions;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.Avalonia.Views.Pages;
@@ -128,7 +129,7 @@ public partial class MainWindow : Window
 
         Resized += (_, _) => _ = SaveGeometryAsync();
         PositionChanged += (_, _) => _ = SaveGeometryAsync();
-        this.GetObservable(WindowStateProperty).Subscribe(state => { _ = SaveGeometryAsync(); });
+        this.GetObservable(WindowStateProperty).SubscribeValue(state => { _ = SaveGeometryAsync(); });
 
         _trayService = new TrayService(this);
         _trayService.UpdateStatus();
@@ -290,7 +291,7 @@ public partial class MainWindow : Window
     // windows give the content full width (the hamburger + sliding flyout still provide nav).
     private void SetupResponsiveRail()
         => MainContentRoot.GetObservable(BoundsProperty)
-            .Subscribe(b =>
+            .SubscribeValue(b =>
             {
                 if (b.Width <= 0) return;
                 NavRail.IsVisible = b.Width >= 800;
@@ -314,7 +315,7 @@ public partial class MainWindow : Window
             // collapses to 0, which would clip the search box and hamburger. Use a fixed
             // title bar height in that state, and drop the traffic-light reservation
             // since the traffic lights aren't shown either.
-            this.GetObservable(WindowStateProperty).Subscribe(state =>
+            this.GetObservable(WindowStateProperty).SubscribeValue(state =>
             {
                 if (state == WindowState.FullScreen)
                 {
@@ -354,7 +355,7 @@ public partial class MainWindow : Window
             HamburgerPanel.Margin = new Thickness(10, 0, 8, 0);
             WindowButtons.IsVisible = true;
             MainContentRoot.Margin = new Thickness(0, 44, 0, 0);
-            this.GetObservable(WindowStateProperty).Subscribe(state =>
+            this.GetObservable(WindowStateProperty).SubscribeValue(state =>
             {
                 UpdateMaximizeButtonState(state == WindowState.Maximized);
             });
@@ -372,7 +373,7 @@ public partial class MainWindow : Window
             WindowButtons.IsVisible = !useNativeDecorations;
             MainContentRoot.Margin = new Thickness(0, 44, 0, 0);
             // Keep maximize icon in sync with window state
-            this.GetObservable(WindowStateProperty).Subscribe(state =>
+            this.GetObservable(WindowStateProperty).SubscribeValue(state =>
             {
                 UpdateMaximizeButtonState(state == WindowState.Maximized);
             });

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Transformation;
 using Avalonia.Threading;
+using UniGetUI.Avalonia.Extensions;
 using UniGetUI.Avalonia.ViewModels.Pages;
 using UniGetUI.Avalonia.Views.Controls;
 using UniGetUI.Core.SettingsEngine;
@@ -95,7 +96,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
         // Using ColumnDefinition.WidthProperty fires every drag step, not just on release.
         FilteringPanel.ColumnDefinitions[0]
             .GetObservable(ColumnDefinition.WidthProperty)
-            .Subscribe(width =>
+            .SubscribeValue(width =>
             {
                 if (_isOverlayMode || !ViewModel.IsFilterPaneOpen) return;
                 if (width.IsAbsolute && width.Value >= 100)
@@ -114,19 +115,19 @@ public abstract partial class AbstractPackagesPage : UserControl,
 
         // Responsive: switch between inline and overlay modes based on content width.
         FilteringPanel.GetObservable(BoundsProperty)
-            .Subscribe(bounds => OnFilteringPanelWidthChanged(bounds.Width));
+            .SubscribeValue(bounds => OnFilteringPanelWidthChanged(bounds.Width));
 
         // Responsive: collapse the menu bar to icon-only on narrow windows so the
         // toolbar buttons stay reachable instead of overflowing (mirrors WinUI).
         this.GetObservable(BoundsProperty)
-            .Subscribe(bounds => ViewModel.SetToolbarLabelsCollapsed(bounds.Width < 900));
+            .SubscribeValue(bounds => ViewModel.SetToolbarLabelsCollapsed(bounds.Width < 900));
 
         // Grid/icons views: stretch cards to fill each row then reflow (mirrors WinUI's
         // UniformGridLayout) instead of leaving wasted space to the right.
         GridViewItems.GetObservable(BoundsProperty)
-            .Subscribe(bounds => UpdateGridCardWidth(bounds.Width));
+            .SubscribeValue(bounds => UpdateGridCardWidth(bounds.Width));
         IconsViewItems.GetObservable(BoundsProperty)
-            .Subscribe(bounds => UpdateIconCardWidth(bounds.Width));
+            .SubscribeValue(bounds => UpdateIconCardWidth(bounds.Width));
 
         // Overlay backdrop dismisses the filter pane when tapped.
         FilterOverlayBackdrop.PointerPressed += (_, _) => ViewModel.IsFilterPaneOpen = false;


### PR DESCRIPTION
## Summary

- Condition the Devolutions macOS and Linux Avalonia theme packages so they are only restored on their target OSes.
- Prevent Windows builds from importing `Devolutions.AvaloniaControls` and its transitive `System.Reactive` dependency, which selected a WindowsDesktop asset and pulled WPF/WinForms runtime files into the self-contained publish.
- Add a small local `SubscribeValue` helper for the app's Avalonia observable callbacks so Windows no longer depends on `System.Reactive` for `Subscribe(Action<T>)` extension methods.
- Keep `PublishReadyToRun` enabled.

## Impact

Windows `win-x64` Release publish no longer contains the WPF/WinForms marker payload (`PresentationFramework.dll`, `PresentationCore.dll`, `System.Windows.Forms*.dll`, `WindowsBase.dll`, `System.Xaml.dll`, `ReachFramework.dll`, `wpfgfx_cor3.dll`).

Measured against the original baseline:

| Metric | Baseline | After | Delta |
|---|---:|---:|---:|
| Files | 925 | 610 | -315 |
| Raw publish size | 317.65 MiB | 216.17 MiB | -101.48 MiB |
| ZIP size | 130.45 MiB | 90.48 MiB | -39.97 MiB |
| WPF/WinForms marker files | 126 | 0 | -126 |

## Validation

- `dotnet publish src\UniGetUI.Avalonia\UniGetUI.Avalonia.csproj /noLogo /p:Configuration=Release /p:Platform=x64 -p:RuntimeIdentifier=win-x64 -v m /m:1`
- `dotnet test src\UniGetUI.Windows.slnx --verbosity q --nologo /p:Platform=x64 /m:1`