### PR TITLE
Preserve autostart choice across installer updates

### DIFF
--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -97,6 +97,21 @@ Name: "Ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 #include "InstallerExtras\CustomMessages.iss"
 
 [Code]
+var
+  PreserveAutostartDisabled: Boolean;
+
+// StartupApproved stores the on/off state in the first byte's low bit (03 = off).
+function IsAutostartDisabledByUser: Boolean;
+var
+  Data: AnsiString;
+begin
+  Result := False;
+  if RegQueryBinaryValue(HKEY_CURRENT_USER,
+       'Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run',
+       'WingetUI', Data) then
+    Result := (Length(Data) >= 1) and ((Ord(Data[1]) and 1) = 1);
+end;
+
 procedure InitializeWizard;
 begin
   WizardForm.Bevel.Visible := False;
@@ -157,6 +172,8 @@ end;
 // Runs before any file is copied: shut everything down, then mark the copy window.
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
+    // Capture before [Registry] rewrites the Run key, so updates keep the user's choice.
+    PreserveAutostartDisabled := IsAutostartDisabledByUser;
     KillRunningApps;
     WriteUpdateMarker;
     Result := '';
@@ -204,7 +221,7 @@ end;
 
 function ShouldSuppressRunOnStartup: Boolean;
 begin
-  Result := CmdLineParamExists('/NoRunOnStartup') or IsMSStoreInstall;
+  Result := CmdLineParamExists('/NoRunOnStartup') or IsMSStoreInstall or PreserveAutostartDisabled;
 end;
 
 var CustomExitCode: integer;


### PR DESCRIPTION
This pull request improves how the installer preserves the user's choice to disable autostart for the application during updates. The main changes ensure that if a user has previously disabled autostart, this preference is detected and maintained even after an update.  

**Autostart preference preservation:**

* Added the `PreserveAutostartDisabled` variable and logic to capture whether autostart was disabled by the user before installation starts, by reading the `StartupApproved\Run` registry key.
* Updated the `PrepareToInstall` function to set `PreserveAutostartDisabled` before any registry changes, ensuring the user's preference is remembered during updates.
* Modified `ShouldSuppressRunOnStartup` to also suppress autostart if `PreserveAutostartDisabled` is true, so the user's choice persists after update.
