### PR TITLE
Make copy-worthy text selectable in Avalonia

### DIFF
--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -490,7 +490,7 @@
             <StackPanel Spacing="6">
                 <TextBlock Text="{Binding CommandPreviewLabel}" Opacity="0.7"/>
                 <Border Background="{DynamicResource AppDialogDarkBackground}" CornerRadius="4" Padding="8">
-                    <TextBlock Text="{Binding CommandPreview}"
+                    <SelectableTextBlock Text="{Binding CommandPreview}"
                                automation:AutomationProperties.Name="{Binding CommandPreviewLabel}"
                                FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                FontSize="14"

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -146,7 +146,7 @@
                                        FontFamily="Segoe UI Variable Display"
                                        TextWrapping="Wrap"
                                        automation:AutomationProperties.HeadingLevel="1"/>
-                            <TextBlock Text="{Binding SourceDisplay}"
+                            <SelectableTextBlock Text="{Binding SourceDisplay}"
                                        FontSize="13" Opacity="0.65"/>
                         </StackPanel>
                     </Grid>

--- a/src/UniGetUI.Avalonia/Views/Pages/AboutPages/AboutPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/AboutPages/AboutPage.axaml
@@ -27,7 +27,7 @@
                        FontSize="14"
                        TextWrapping="Wrap"/>
 
-            <TextBlock Text="{Binding VersionText}"
+            <SelectableTextBlock Text="{Binding VersionText}"
                        FontSize="15"
                        FontWeight="SemiBold"
                        Margin="0,10"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
@@ -135,7 +135,7 @@
                                 Command="{Binding ResetLocationCommand}"
                                 IsEnabled="{Binding LocationResetEnabled}"/>
                     </Grid>
-                    <TextBlock Text="{Binding LocationText}"
+                    <SelectableTextBlock Text="{Binding LocationText}"
                                FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                FontSize="14"
                                Opacity="0.6"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/PackageManagerPage.axaml
@@ -78,7 +78,7 @@
                         <TextBlock Text="{Binding ShowVersionLabel}" Classes="hyperlink"
                                    automation:AutomationProperties.AccessibilityView="Raw"/>
                     </Button>
-                    <TextBlock Text="{Binding VersionText}"
+                    <SelectableTextBlock Text="{Binding VersionText}"
                                IsVisible="{Binding VersionTextVisible}"
                                FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                FontSize="14"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
@@ -83,7 +83,7 @@
                                        MinWidth="120"/>
                         </StackPanel>
                         <!-- URL -->
-                        <TextBlock Grid.Column="2"
+                        <SelectableTextBlock Grid.Column="2"
                                    Text="{Binding Url}"
                                    VerticalAlignment="Center"
                                    Classes="hyperlink"


### PR DESCRIPTION
This pull request updates several UI components to improve text selection capabilities across the application. The main change is replacing instances of `TextBlock` with `SelectableTextBlock` in various views, allowing users to select and copy text where previously it was not possible.

**UI Improvements:**

* Replaced `TextBlock` with `SelectableTextBlock` for the command preview in `InstallOptionsControl.axaml`, enabling users to select and copy the command text.
* Updated `PackageDetailsWindow.axaml` to use `SelectableTextBlock` for the source display, making the source information selectable.
* Changed the version text in `AboutPage.axaml` to a `SelectableTextBlock`, allowing users to select the version string.
* Updated `InstallOptionsPanel.axaml` to use `SelectableTextBlock` for the location text, improving usability for copying install locations.
* Modified `PackageManagerPage.axaml` to make the version text selectable by switching to `SelectableTextBlock`.
* Changed the URL display in `SourceManagerCard.axaml` to a `SelectableTextBlock`, so repository URLs can be easily copied.