### PR TITLE
Prune unused WinUI locale resources

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -363,4 +363,22 @@
     <ItemGroup>
       <Folder Include="Models\" />
     </ItemGroup>
+
+   <!-- Prune unused WinUI XAML framework .mui locale satellites.
+        UniGetUI is Avalonia-based and never surfaces WinUI framework control strings;
+        the Windows resource loader silently falls back to en-us when a culture's .mui
+        is absent. -->
+   <Target Name="ExcludeUnusedWinUIMuiResources"
+           AfterTargets="ComputeFilesToPublish"
+           BeforeTargets="CopyFilesToPublishDirectory"
+           Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+     <ItemGroup>
+       <_UnusedMuiResources
+           Include="@(ResolvedFileToPublish)"
+           Condition="'%(ResolvedFileToPublish.Extension)' == '.mui'
+               and '%(ResolvedFileToPublish.RelativePath)' != 'en-us\%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)'
+               and ('%(ResolvedFileToPublish.Filename)' == 'Microsoft.ui.xaml.dll' or '%(ResolvedFileToPublish.Filename)' == 'Microsoft.UI.Xaml.Phone.dll')" />
+       <ResolvedFileToPublish Remove="@(_UnusedMuiResources)" />
+     </ItemGroup>
+   </Target>
  </Project>


### PR DESCRIPTION
## Summary
- Remove non-`en-us` WinUI XAML framework `.mui` satellite resources from the publish file list
- Keep the `en-us` neutral fallback files
- Leave self-contained deployment and ReadyToRun unchanged

## Validation
- Reviewed the initial GLM 5.2 implementation and found it did not affect the release zip path
- Updated the MSBuild target to prune `ResolvedFileToPublish` after `ComputeFilesToPublish` and before `CopyFilesToPublishDirectory`
- Ran Release x64 publish with `RuntimeIdentifier=win-x64`; publish output contains only:
  - `en-us/Microsoft.ui.xaml.dll.mui`
  - `en-us/Microsoft.UI.Xaml.Phone.dll.mui`
- Recreated the release zip staging path; zip contains only those 2 `.mui` files
- Integrity tree refresh succeeded for the slimmed `unigetui_bin` output

## Size impact
- Removes 170 `.mui` files (~3.37 MB uncompressed)
- Release zip measured at 88.75 MB after pruning