### PR TITLE
Fix visuals for Avalonia components and bump pinget to 0.10.0

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -161,7 +161,7 @@
         <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
         <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.9.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.10.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
@@ -27,7 +27,10 @@
 
     <Border x:Name="BodyBorder"
             IsVisible="{Binding IsOpen}"
-            BorderThickness="0,1,0,1"
+            BorderThickness="1"
+            CornerRadius="6"
+            ClipToBounds="True"
+            Margin="12,4"
             automation:AutomationProperties.AccessibilityView="Control"
             automation:AutomationProperties.Name="{Binding Title}"
             automation:AutomationProperties.HelpText="{Binding Message}"

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/SettingsCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/SettingsCard.cs
@@ -118,10 +118,31 @@ public class SettingsCard : UserControl
         set => _border.CornerRadius = value;
     }
 
+    // Base (unfocused) thickness as assigned by the consumer. Grouped cards use a
+    // partial thickness like "1,0,1,1" to share a divider with the card above; we
+    // must remember it so we can restore it when focus leaves.
+    private Thickness _baseBorderThickness = new(1);
+
     public new Thickness BorderThickness
     {
         get => _border.BorderThickness;
-        set => _border.BorderThickness = value;
+        set
+        {
+            _baseBorderThickness = value;
+            // While focused the border is forced complete (see GotFocus); don't clobber it.
+            if (!_border.Classes.Contains("settings-card-focused"))
+                _border.BorderThickness = value;
+        }
+    }
+
+    // A focused card needs a border on all four sides, even when its base thickness omits
+    // the top (grouped cards). The accent focus style can't supply this: BorderThickness is
+    // a local value on _border, which wins over the style setter — so we set it here instead.
+    private static Thickness FocusedBorderThickness(Thickness baseThickness)
+    {
+        double t = Math.Max(Math.Max(baseThickness.Left, baseThickness.Right),
+                            Math.Max(baseThickness.Top, baseThickness.Bottom));
+        return new Thickness(Math.Max(t, 1));
     }
 
     // ── Constructor ────────────────────────────────────────────────────────
@@ -216,8 +237,17 @@ public class SettingsCard : UserControl
 
         PointerPressed += OnPointerPressed;
         KeyDown += OnKeyDown;
-        GotFocus += (_, _) => { if (_isClickEnabled) _border.Classes.Add("settings-card-focused"); };
-        LostFocus += (_, _) => _border.Classes.Remove("settings-card-focused");
+        GotFocus += (_, _) =>
+        {
+            if (!_isClickEnabled) return;
+            _border.Classes.Add("settings-card-focused");
+            _border.BorderThickness = FocusedBorderThickness(_baseBorderThickness);
+        };
+        LostFocus += (_, _) =>
+        {
+            _border.Classes.Remove("settings-card-focused");
+            _border.BorderThickness = _baseBorderThickness;
+        };
         SyncAutomationProperties();
     }
 

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
@@ -158,7 +158,6 @@ public partial class PackageDetailsWindow : Window
             MainGrid.ColumnDefinitions[1].Width = new GridLength(1, GridUnitType.Star);
 
             ScreenshotsBorder.Height = _vm.HasScreenshots ? 320 : 150;
-            InstallOptionsExpander.IsExpanded = true;
         }
         else
         {
@@ -169,7 +168,6 @@ public partial class PackageDetailsWindow : Window
             MainGrid.ColumnDefinitions[1].Width = new GridLength(0);
 
             ScreenshotsBorder.Height = _vm.HasScreenshots ? 225 : 130;
-            InstallOptionsExpander.IsExpanded = false;
         }
     }
 

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -22,7 +22,7 @@
              via styles (opacity) so the .focus-within setter wins over the base. -->
         <Style Selector="Border#SearchFocusUnderline">
             <Setter Property="Opacity" Value="0"/>
-            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Background" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
             <Setter Property="Transitions">
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.12"/>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -72,7 +72,7 @@
            full-border accent or the field swapping to its focused (black) background. -->
       <Style Selector="Border#MegaQueryUnderline">
          <Setter Property="Opacity" Value="0"/>
-         <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+         <Setter Property="Background" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
          <Setter Property="Transitions">
             <Transitions>
                <DoubleTransition Property="Opacity" Duration="0:0:0.12"/>


### PR DESCRIPTION
This pull request includes several UI improvements and a dependency update. The most significant changes enhance the visual consistency and focus handling of card controls, update the appearance of underlines to use a more neutral color, and update a package dependency. Additionally, some redundant code related to the expansion state of the install options expander has been removed.

**UI Improvements:**

* Improved focus handling and border rendering for `SettingsCard` controls, ensuring focused cards always have a complete border and restoring the original border thickness when focus is lost (`SettingsCard.cs`). 
* Refined the appearance of the `InfoBar` control by adding rounded corners, a uniform border, and margin for a more modern look (`InfoBar.axaml`).
* Changed the underline color for search and query fields from the accent color to a secondary text fill color for better visual consistency (`MainWindow.axaml`, `AbstractPackagesPage.axaml`).

**Dependency Updates:**

* Updated the `Devolutions.Pinget.Cli.Rust` package from version 0.9.0 to 0.10.0 (`UniGetUI.Avalonia.csproj`).

**Code Cleanup:**

* Removed code that explicitly set the expanded state of the install options expander, likely to allow for more flexible or user-driven control (`PackageDetailsWindow.axaml.cs`). 
