### PR TITLE
Stop console auto-scroll from fighting manual scroll-up

### DIFF
--- a/src/UniGetUI.Avalonia/Views/Controls/LogTextEditor.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/LogTextEditor.cs
@@ -81,6 +81,9 @@ public class LogTextEditor : TextEditor
 
     public void ScrollToBottom() => ScrollToEnd();
 
+    // True when the view is pinned to the last line; used to keep auto-scroll from fighting a manual scroll-up.
+    public bool IsScrolledToBottom => ExtentHeight - ViewportHeight - VerticalOffset <= 1.0;
+
     // AvaloniaEdit auto-links URLs; its default link brush is too dark to read on the dark theme.
     private void UpdateLinkColor()
     {

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
@@ -24,6 +24,7 @@ public partial class OperationOutputWindow : Window
     {
         Dispatcher.UIThread.Post(() =>
         {
+            bool wasAtBottom = OutputText.IsScrolledToBottom;
             if (e.Action == NotifyCollectionChangedAction.Reset)
             {
                 OutputText.ClearLines();
@@ -33,7 +34,9 @@ public partial class OperationOutputWindow : Window
                 foreach (LogLineItem item in e.NewItems)
                     OutputText.AppendLine(item);
             }
-            OutputText.ScrollToBottom();
+            // Only follow new output if the user hadn't scrolled up to read earlier lines.
+            if (wasAtBottom)
+                OutputText.ScrollToBottom();
         }, DispatcherPriority.Background);
     }
 


### PR DESCRIPTION
This pull request improves the user experience of the log output window by ensuring that auto-scrolling to the bottom only occurs if the user hasn't manually scrolled up to read earlier lines. This prevents the view from fighting user-initiated scrolls when new output is appended.

**Improvements to log output window scrolling behavior:**

* Added an `IsScrolledToBottom` property to `LogTextEditor` to detect if the view is currently pinned to the last line.
* Updated `OperationOutputWindow` so that auto-scroll to the bottom only happens if the user was already at the bottom before new log lines were added, preserving manual scroll position. 