### PR TITLE
Add missing translation key for "Show the release notes after UniGetUI is updated

### DIFF
--- a/src/Languages/lang_af.json
+++ b/src/Languages/lang_af.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Bestuur UniGetUI se outostart-gedrag",
   "Choose how many operations shoulds be performed in parallel": "Kies hoeveel bewerkings parallel uitgevoer moet word",
   "Something went wrong while launching the updater.": "Iets het verkeerd geloop tydens die bekendstelling van die opdaterer.",
-  "Please try again later": "Probeer asseblief weer later"
+  "Please try again later": "Probeer asseblief weer later",
+  "Show the release notes after UniGetUI is updated": "Wys die vrystelling notas nadat UniGetUI opgedateer is"
 }

--- a/src/Languages/lang_ar.json
+++ b/src/Languages/lang_ar.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "إدارة سلوك التشغيل التلقائي لـ UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "اختر عدد العمليات التي يجب تنفيذها بالتوازي",
   "Something went wrong while launching the updater.": "لقد حدث خطأ ما أثناء تشغيل برنامج التحديث.",
-  "Please try again later": "يرجى المحاولة مرة أخرى لاحقًا"
+  "Please try again later": "يرجى المحاولة مرة أخرى لاحقًا",
+  "Show the release notes after UniGetUI is updated": "إظهار ملاحظات الإصدار بعد تحديث UniGetUI"
 }

--- a/src/Languages/lang_be.json
+++ b/src/Languages/lang_be.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Кіраванне аўтазапускам UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Выберыце, колькі аперацый трэба выконваць паралельна",
   "Something went wrong while launching the updater.": "Памылка пры запуску абнаўлення.",
-  "Please try again later": "Паспрабуйце пазней"
+  "Please try again later": "Паспрабуйце пазней",
+  "Show the release notes after UniGetUI is updated": "Паказваць нататкі выпуску пасля абнаўлення UniGetUI"
 }

--- a/src/Languages/lang_bg.json
+++ b/src/Languages/lang_bg.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Управление на поведението при автоматично стартиране на UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Изберете колко операции да се извършват паралелно",
   "Something went wrong while launching the updater.": "Нещо се обърка при стартирането на програмата за актуализиране.",
-  "Please try again later": "Опитайте отново по-късно"
+  "Please try again later": "Опитайте отново по-късно",
+  "Show the release notes after UniGetUI is updated": "Показване на бележките към изданието след актуализиране на UniGetUI"
 }

--- a/src/Languages/lang_bn.json
+++ b/src/Languages/lang_bn.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI-এর স্বয়ংক্রিয় চালু হওয়ার আচরণ পরিচালনা করুন",
   "Choose how many operations shoulds be performed in parallel": "কতগুলো অপারেশন সমান্তরালে চালানো হবে তা নির্বাচন করুন",
   "Something went wrong while launching the updater.": "আপডেটার চালু করার সময় কিছু ভুল হয়েছে।",
-  "Please try again later": "অনুগ্রহ করে পরে আবার চেষ্টা করুন"
+  "Please try again later": "অনুগ্রহ করে পরে আবার চেষ্টা করুন",
+  "Show the release notes after UniGetUI is updated": "UniGetUI আপডেট হওয়ার পর রিলিজ নোট দেখান"
 }

--- a/src/Languages/lang_ca.json
+++ b/src/Languages/lang_ca.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Gestiona el comportament d'inici automàtic de l'UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Trieu quantes operacions s'han de fer en paral·lel",
   "Something went wrong while launching the updater.": "Quelcom ha anat malament en executar l'actualitzador.",
-  "Please try again later": "Proveu-ho més tard"
+  "Please try again later": "Proveu-ho més tard",
+  "Show the release notes after UniGetUI is updated": "Mostra les notes de publicació després d'actualitzar UniGetUI"
 }

--- a/src/Languages/lang_cs.json
+++ b/src/Languages/lang_cs.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Spravovat chování automatického spouštění UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Vyberte, kolik operací se má provádět souběžně",
   "Something went wrong while launching the updater.": "Při spouštění aktualizace se něco pokazilo.",
-  "Please try again later": "Zkuste to prosím později"
+  "Please try again later": "Zkuste to prosím později",
+  "Show the release notes after UniGetUI is updated": "Zobrazit poznámky k vydání po aktualizaci UniGetUI"
 }

--- a/src/Languages/lang_da.json
+++ b/src/Languages/lang_da.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Administrer UniGetUI's autostartadfærd",
   "Choose how many operations shoulds be performed in parallel": "Vælg hvor mange handlinger der skal udføres parallelt",
   "Something went wrong while launching the updater.": "Noget gik galt ved afviklingen af opdateringen.",
-  "Please try again later": "Prøv igen senere"
+  "Please try again later": "Prøv igen senere",
+  "Show the release notes after UniGetUI is updated": "Vis releasenotes efter UniGetUI er opdateret"
 }

--- a/src/Languages/lang_de.json
+++ b/src/Languages/lang_de.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Autostartverhalten von UniGetUI verwalten",
   "Choose how many operations shoulds be performed in parallel": "Wählen Sie aus, wie viele Vorgänge parallel ausgeführt werden sollen",
   "Something went wrong while launching the updater.": "Beim Updater-Start lief etwas schief.",
-  "Please try again later": "Versuchen Sie es bitte später noch einmal"
+  "Please try again later": "Versuchen Sie es bitte später noch einmal",
+  "Show the release notes after UniGetUI is updated": "Versionshinweise anzeigen, nachdem UniGetUI aktualisiert wurde"
 }

--- a/src/Languages/lang_el.json
+++ b/src/Languages/lang_el.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Διαχείριση συμπεριφοράς αυτόματης εκκίνησης του UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Επιλέξτε πόσες λειτουργίες πρέπει να εκτελούνται παράλληλα",
   "Something went wrong while launching the updater.": "Κάτι πήγε στραβά κατά το άνοιγμα του προγράμματος ενημέρωσης.",
-  "Please try again later": "Δοκιμάστε ξανά αργότερα"
+  "Please try again later": "Δοκιμάστε ξανά αργότερα",
+  "Show the release notes after UniGetUI is updated": "Εμφάνιση σημειώσεων έκδοσης μετά την ενημέρωση του UniGetUI"
 }

--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -841,5 +841,6 @@
   "Error": "Error",
   "Log in failed: ": "Log in failed: ",
   "Log out failed: ": "Log out failed: ",
-  "Package backup settings": "Package backup settings"
+  "Package backup settings": "Package backup settings",
+  "Show the release notes after UniGetUI is updated": "Show the release notes after UniGetUI is updated"
 }

--- a/src/Languages/lang_eo.json
+++ b/src/Languages/lang_eo.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Administri la aŭtolanĉan konduton de UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Elektu kiom da operacioj estu plenumataj paralele",
   "Something went wrong while launching the updater.": "Io misfunkciis dum lanĉo de la ĝisdatigilo.",
-  "Please try again later": "Bonvolu reprovi poste"
+  "Please try again later": "Bonvolu reprovi poste",
+  "Show the release notes after UniGetUI is updated": "Montri la eldonajn notojn post kiam UniGetUI estas ĝisdatigita"
 }

--- a/src/Languages/lang_es-MX.json
+++ b/src/Languages/lang_es-MX.json
@@ -841,5 +841,6 @@
   "Error": "Error",
   "Log in failed: ": "Error al iniciar sesión: ",
   "Log out failed: ": "Error al cerrar sesión: ",
-  "Package backup settings": "Ajustes de respaldo de paquetes"
+  "Package backup settings": "Ajustes de respaldo de paquetes",
+  "Show the release notes after UniGetUI is updated": "Mostrar las notas de la versión después de actualizar UniGetUI"
 }

--- a/src/Languages/lang_es.json
+++ b/src/Languages/lang_es.json
@@ -841,5 +841,6 @@
   "Error": "Error",
   "Log in failed: ": "Error al iniciar sesión: ",
   "Log out failed: ": "Error al cerrar sesión: ",
-  "Package backup settings": "Ajustes de copia de seguridad de paquetes"
+  "Package backup settings": "Ajustes de copia de seguridad de paquetes",
+  "Show the release notes after UniGetUI is updated": "Mostrar las notas de la versión después de actualizar UniGetUI"
 }

--- a/src/Languages/lang_et.json
+++ b/src/Languages/lang_et.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Halda UniGetUI automaatkäivituse käitumist",
   "Choose how many operations shoulds be performed in parallel": "Valige, mitu toimingut tehakse paralleelselt",
   "Something went wrong while launching the updater.": "Uuendaja käivitamisel mingi asi ebaõnnestus.",
-  "Please try again later": "Proovige hiljem uuesti"
+  "Please try again later": "Proovige hiljem uuesti",
+  "Show the release notes after UniGetUI is updated": "Kuva väljalaske märkmed pärast UniGetUI uuendamist"
 }

--- a/src/Languages/lang_fa.json
+++ b/src/Languages/lang_fa.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "مدیریت رفتار اجرای خودکار UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "انتخاب کنید چند عملیات به‌صورت هم‌زمان انجام شوند",
   "Something went wrong while launching the updater.": "هنگام اجرای به‌روزرسان، مشکلی پیش آمد.",
-  "Please try again later": "لطفاً بعداً دوباره تلاش کنید"
+  "Please try again later": "لطفاً بعداً دوباره تلاش کنید",
+  "Show the release notes after UniGetUI is updated": "نمایش یادداشت‌های انتشار پس از به‌روزرسانی UniGetUI"
 }

--- a/src/Languages/lang_fi.json
+++ b/src/Languages/lang_fi.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Hallitse UniGetUI:n automaattisen käynnistyksen toimintaa",
   "Choose how many operations shoulds be performed in parallel": "Valitse, kuinka monta toimintoa suoritetaan rinnakkain",
   "Something went wrong while launching the updater.": "Jotain meni pieleen päivitystä käynnistettäessä.",
-  "Please try again later": "Kokeile myöhemmin uudelleen"
+  "Please try again later": "Kokeile myöhemmin uudelleen",
+  "Show the release notes after UniGetUI is updated": "Näytä julkaisutiedot, kun UniGetUI on päivitetty"
 }

--- a/src/Languages/lang_fil.json
+++ b/src/Languages/lang_fil.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Pamahalaan ang awtomatikong pagsisimula ng UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Piliin kung ilang operasyon ang dapat isagawa nang sabay-sabay",
   "Something went wrong while launching the updater.": "Nagkaroon ng problema habang pinapatakbo ang updater.",
-  "Please try again later": "Pakisubukang muli mamaya"
+  "Please try again later": "Pakisubukang muli mamaya",
+  "Show the release notes after UniGetUI is updated": "Ipakita ang mga release note pagkatapos ma-update ang UniGetUI"
 }

--- a/src/Languages/lang_fr.json
+++ b/src/Languages/lang_fr.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Gérer le comportement de démarrage automatique de UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Choisissez combien d'opérations doivent être effectuées en parallèle",
   "Something went wrong while launching the updater.": "Un problème s'est produit lors du lancement de l'outil de mise à jour.",
-  "Please try again later": "Veuillez réessayer plus tard"
+  "Please try again later": "Veuillez réessayer plus tard",
+  "Show the release notes after UniGetUI is updated": "Afficher les notes de publication après la mise à jour de UniGetUI"
 }

--- a/src/Languages/lang_gl.json
+++ b/src/Languages/lang_gl.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Xestionar o comportamento de inicio automático de UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Escolle cantas operacións se deben realizar en paralelo",
   "Something went wrong while launching the updater.": "Algo saíu mal ao iniciar o actualizador.",
-  "Please try again later": "Téntao de novo máis tarde"
+  "Please try again later": "Téntao de novo máis tarde",
+  "Show the release notes after UniGetUI is updated": "Mostrar as notas da versión despois de actualizar UniGetUI"
 }

--- a/src/Languages/lang_gu.json
+++ b/src/Languages/lang_gu.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI autostart વર્તન સંચાલિત કરો",
   "Choose how many operations shoulds be performed in parallel": "કેટલી operations parallel માં ચલાવવી તે પસંદ કરો",
   "Something went wrong while launching the updater.": "updater launch કરતી વખતે કંઈક ખોટું થયું.",
-  "Please try again later": "કૃપા કરીને પછી ફરી પ્રયાસ કરો"
+  "Please try again later": "કૃપા કરીને પછી ફરી પ્રયાસ કરો",
+  "Show the release notes after UniGetUI is updated": "UniGetUI અપડેટ થયા પછી પ્રકાશન નોંધો બતાવો"
 }

--- a/src/Languages/lang_he.json
+++ b/src/Languages/lang_he.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "נהל את אופן ההפעלה האוטומטית של UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "בחר כמה פעולות יבוצעו במקביל",
   "Something went wrong while launching the updater.": "משהו השתבש בעת הפעלת המעדכן.",
-  "Please try again later": "נסה שוב מאוחר יותר"
+  "Please try again later": "נסה שוב מאוחר יותר",
+  "Show the release notes after UniGetUI is updated": "הצג את הערות השחרור לאחר עדכון UniGetUI"
 }

--- a/src/Languages/lang_hi.json
+++ b/src/Languages/lang_hi.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI के ऑटोस्टार्ट व्यवहार को प्रबंधित करें",
   "Choose how many operations shoulds be performed in parallel": "चुनें कि कितनी कार्रवाइयाँ समानांतर में की जानी चाहिए",
   "Something went wrong while launching the updater.": "अपडेटर लॉन्च करते समय कुछ गलत हो गई।",
-  "Please try again later": "कृपया बाद में पुन: प्रयास करें"
+  "Please try again later": "कृपया बाद में पुन: प्रयास करें",
+  "Show the release notes after UniGetUI is updated": "UniGetUI अपडेट होने के बाद रिलीज नोट्स दिखाएं"
 }

--- a/src/Languages/lang_hr.json
+++ b/src/Languages/lang_hr.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Upravljanje ponašanjem automatskog pokretanja UniGetUI-ja",
   "Choose how many operations shoulds be performed in parallel": "Odaberite koliko se operacija treba izvršavati paralelno",
   "Something went wrong while launching the updater.": "Došlo je do pogreške prilikom pokretanja ažuriranja.",
-  "Please try again later": "Molim pokušajte ponovno kasnije"
+  "Please try again later": "Molim pokušajte ponovno kasnije",
+  "Show the release notes after UniGetUI is updated": "Prikaži napomene o izdanju nakon ažuriranja UniGetUI-a"
 }

--- a/src/Languages/lang_hu.json
+++ b/src/Languages/lang_hu.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "A UniGetUI automatikus indításának kezelése",
   "Choose how many operations shoulds be performed in parallel": "Válassza ki, hány művelet fusson párhuzamosan",
   "Something went wrong while launching the updater.": "Valamilyen hiba történt a frissítő indítása közben.",
-  "Please try again later": "Kérjük próbálja később újra"
+  "Please try again later": "Kérjük próbálja később újra",
+  "Show the release notes after UniGetUI is updated": "Kiadási megjegyzések megjelenítése a UniGetUI frissítése után"
 }

--- a/src/Languages/lang_id.json
+++ b/src/Languages/lang_id.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Kelola perilaku mulai otomatis UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Pilih berapa banyak operasi yang harus dilakukan secara paralel",
   "Something went wrong while launching the updater.": "Terjadi kesalahan saat meluncurkan pembaru.",
-  "Please try again later": "Silakan coba lagi nanti"
+  "Please try again later": "Silakan coba lagi nanti",
+  "Show the release notes after UniGetUI is updated": "Tampilkan catatan rilis setelah UniGetUI diperbarui"
 }

--- a/src/Languages/lang_it.json
+++ b/src/Languages/lang_it.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Gestisci il comportamento di avvio automatico di UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Scegli quante operazioni devono essere eseguite in parallelo",
   "Something went wrong while launching the updater.": "Si è verificato un problema durante l'avvio del programma di aggiornamento.",
-  "Please try again later": "Riprova più tardi"
+  "Please try again later": "Riprova più tardi",
+  "Show the release notes after UniGetUI is updated": "Mostra le note sulla versione dopo l'aggiornamento di UniGetUI"
 }

--- a/src/Languages/lang_ja.json
+++ b/src/Languages/lang_ja.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI の自動起動動作を管理する",
   "Choose how many operations shoulds be performed in parallel": "並列で実行する操作数を選択してください",
   "Something went wrong while launching the updater.": "アップデータの起動中に問題が発生しました。",
-  "Please try again later": "後ほどもう一度お試しください。"
+  "Please try again later": "後ほどもう一度お試しください。",
+  "Show the release notes after UniGetUI is updated": "UniGetUIの更新後にリリースノートを表示する"
 }

--- a/src/Languages/lang_ka.json
+++ b/src/Languages/lang_ka.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI-ის ავტომატური გაშვების ქცევის მართვა",
   "Choose how many operations shoulds be performed in parallel": "აირჩიეთ, რამდენი ოპერაცია უნდა შესრულდეს პარალელურად",
   "Something went wrong while launching the updater.": "რაღაც ჩაიშალა განმაახლებლის გაშვებისას",
-  "Please try again later": "გთხოვთ სცადოთ მოგვიანებით"
+  "Please try again later": "გთხოვთ სცადოთ მოგვიანებით",
+  "Show the release notes after UniGetUI is updated": "რელიზის ჩანაწერების ჩვენება UniGetUI-ის განახლების შემდეგ"
 }

--- a/src/Languages/lang_kn.json
+++ b/src/Languages/lang_kn.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI ಸ್ವಯಂಪ್ರಾರಂಭ ವರ್ತನೆಯನ್ನು ನಿರ್ವಹಿಸಿ",
   "Choose how many operations shoulds be performed in parallel": "ಎಷ್ಟು ಕಾರ್ಯಾಚರಣೆಗಳನ್ನು ಸಮಾಂತರವಾಗಿ ನಡೆಸಬೇಕು ಎಂದು ಆಯ್ಕೆಮಾಡಿ",
   "Something went wrong while launching the updater.": "updater ಆರಂಭಿಸುವಾಗ ಏನೋ ತಪ್ಪಾಗಿದೆ.",
-  "Please try again later": "ದಯವಿಟ್ಟು ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ"
+  "Please try again later": "ದಯವಿಟ್ಟು ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ",
+  "Show the release notes after UniGetUI is updated": "UniGetUI ಅಪ್‌ಡೇಟ್ ಆದ ನಂತರ ಬಿಡುಗಡೆ ಟಿಪ್ಪಣಿಗಳನ್ನು ತೋರಿಸಿ"
 }

--- a/src/Languages/lang_ko.json
+++ b/src/Languages/lang_ko.json
@@ -841,5 +841,6 @@
   "Error": "오류",
   "Log in failed: ": "로그인 실패: ",
   "Log out failed: ": "로그아웃 실패: ",
-  "Package backup settings": "패키지 백업 설정"
+  "Package backup settings": "패키지 백업 설정",
+  "Show the release notes after UniGetUI is updated": "UniGetUI 업데이트 후 릴리스 노트 표시"
 }

--- a/src/Languages/lang_ku.json
+++ b/src/Languages/lang_ku.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "هەڵسوکەوتی خۆکار دەستپێکردنی UniGetUI بەڕێوەبەرە",
   "Choose how many operations shoulds be performed in parallel": "هەڵبژێرە چەند کردارێک دەبێت بە هاوکات ئەنجام بدرێن",
   "Something went wrong while launching the updater.": "کاتێک نوێکەرەوەکە دەستپێدەکرا شتێک هەڵە ڕوویدا.",
-  "Please try again later": "تکایە دواتر دووبارە هەوڵ بدەوە"
+  "Please try again later": "تکایە دواتر دووبارە هەوڵ بدەوە",
+  "Show the release notes after UniGetUI is updated": "پیشاندانی تێبینییەکانی وەشاندن دوای نوێکردنەوەی UniGetUI"
 }

--- a/src/Languages/lang_lt.json
+++ b/src/Languages/lang_lt.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Valdyti „UniGetUI“ automatinio paleidimo elgseną",
   "Choose how many operations shoulds be performed in parallel": "Pasirinkite, kiek operacijų turi būti vykdoma lygiagrečiai",
   "Something went wrong while launching the updater.": "Kažkas įvyko negerai, bandant paleisti naujinį.",
-  "Please try again later": "Prašome pabandyti dar kartą, vėlesniu laiku"
+  "Please try again later": "Prašome pabandyti dar kartą, vėlesniu laiku",
+  "Show the release notes after UniGetUI is updated": "Rodyti išleidimo užrašus po UniGetUI atnaujinimo"
 }

--- a/src/Languages/lang_mk.json
+++ b/src/Languages/lang_mk.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Управувај со однесувањето на автоматското стартување на UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Избери колку операции треба да се извршуваат паралелно",
   "Something went wrong while launching the updater.": "Нешто тргна наопаку при стартување на ажурирачот.",
-  "Please try again later": "Обидете се повторно подоцна"
+  "Please try again later": "Обидете се повторно подоцна",
+  "Show the release notes after UniGetUI is updated": "Прикажи ги белешките за изданието по ажурирањето на UniGetUI"
 }

--- a/src/Languages/lang_mr.json
+++ b/src/Languages/lang_mr.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI च्या स्वयंप्रारंभ वर्तनाचे व्यवस्थापन करा",
   "Choose how many operations shoulds be performed in parallel": "किती क्रिया समांतरपणे करायच्या ते निवडा",
   "Something went wrong while launching the updater.": "Updater सुरू करताना काहीतरी चुकले.",
-  "Please try again later": "कृपया नंतर पुन्हा प्रयत्न करा"
+  "Please try again later": "कृपया नंतर पुन्हा प्रयत्न करा",
+  "Show the release notes after UniGetUI is updated": "UniGetUI अद्यतनित झाल्यानंतर प्रकाशन नोंदी दर्शवा"
 }

--- a/src/Languages/lang_nb.json
+++ b/src/Languages/lang_nb.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Administrer UniGetUIs autostartoppførsel",
   "Choose how many operations shoulds be performed in parallel": "Velg hvor mange handlinger som skal utføres parallelt",
   "Something went wrong while launching the updater.": "Noe gikk galt under oppstart av oppdateringsprogrammet.",
-  "Please try again later": "Vennligst prøv igjen senere"
+  "Please try again later": "Vennligst prøv igjen senere",
+  "Show the release notes after UniGetUI is updated": "Vis utgivelsesnotater etter at UniGetUI er oppdatert"
 }

--- a/src/Languages/lang_nl.json
+++ b/src/Languages/lang_nl.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Automatisch opstartgedrag van UniGetUI beheren",
   "Choose how many operations shoulds be performed in parallel": "Kies hoeveel bewerkingen parallel moeten worden uitgevoerd",
   "Something went wrong while launching the updater.": "Er ging iets mis bij het starten van de updater.",
-  "Please try again later": "Probeer het later nog eens"
+  "Please try again later": "Probeer het later nog eens",
+  "Show the release notes after UniGetUI is updated": "Toon de release-opmerkingen nadat UniGetUI is bijgewerkt"
 }

--- a/src/Languages/lang_nn.json
+++ b/src/Languages/lang_nn.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Handsam autostartåtferda til UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Vel kor mange handlingar som skal utførast parallelt",
   "Something went wrong while launching the updater.": "Noko gjekk gale ved oppstart av oppdateraren.",
-  "Please try again later": "Venlegst prøv igjen seinare"
+  "Please try again later": "Venlegst prøv igjen seinare",
+  "Show the release notes after UniGetUI is updated": "Vis utgivingsnotata etter at UniGetUI er oppdatert"
 }

--- a/src/Languages/lang_pl.json
+++ b/src/Languages/lang_pl.json
@@ -845,5 +845,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Zarządzaj zachowaniem autostartu UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Wybierz, ile operacji ma być wykonywanych równolegle",
   "Something went wrong while launching the updater.": "Wystąpił błąd podczas uruchamiania aktualizatora.",
-  "Please try again later": "Proszę spróbować ponownie później"
+  "Please try again later": "Proszę spróbować ponownie później",
+  "Show the release notes after UniGetUI is updated": "Pokaż informacje o wydaniu po aktualizacji UniGetUI"
 }

--- a/src/Languages/lang_pt_BR.json
+++ b/src/Languages/lang_pt_BR.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Gerenciar o comportamento de inicialização automática do UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Escolha quantas operações devem ser executadas em paralelo",
   "Something went wrong while launching the updater.": "Algo deu errado ao iniciar o atualizador.",
-  "Please try again later": "Por favor, tente novamente mais tarde"
+  "Please try again later": "Por favor, tente novamente mais tarde",
+  "Show the release notes after UniGetUI is updated": "Mostrar as notas de lançamento após a atualização do UniGetUI"
 }

--- a/src/Languages/lang_pt_PT.json
+++ b/src/Languages/lang_pt_PT.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Gerir o comportamento de arranque automático do UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Escolha quantas operações devem ser executadas em paralelo",
   "Something went wrong while launching the updater.": "Algo correu mal ao iniciar o atualizador.",
-  "Please try again later": "Por favor tente novamente mais tarde"
+  "Please try again later": "Por favor tente novamente mais tarde",
+  "Show the release notes after UniGetUI is updated": "Mostrar as notas de lançamento após a atualização do UniGetUI"
 }

--- a/src/Languages/lang_ro.json
+++ b/src/Languages/lang_ro.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Gestionează comportamentul de pornire automată al UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Alege câte operații să fie efectuate în paralel",
   "Something went wrong while launching the updater.": "Ceva nu a funcționat la lansarea actualizatorului.",
-  "Please try again later": "Te rog încearcă din nou mai târziu"
+  "Please try again later": "Te rog încearcă din nou mai târziu",
+  "Show the release notes after UniGetUI is updated": "Afișează informațiile versiunii după actualizarea UniGetUI"
 }

--- a/src/Languages/lang_ru.json
+++ b/src/Languages/lang_ru.json
@@ -847,5 +847,6 @@
   "Choose how many operations shoulds be performed in parallel": "Выберите, сколько операций должно выполняться параллельно",
   "Something went wrong while launching the updater.": "Что-то пошло не так при запуске программы обновления.",
   "Please try again later": "Пожалуйста, попробуйте ещё раз позже",
-  "Show the release notes after UnigetUI is updated": "Показать список изменений после обновления UnigetUI"
+  "Show the release notes after UnigetUI is updated": "Показать список изменений после обновления UnigetUI",
+  "Show the release notes after UniGetUI is updated": "Показывать примечания к выпуску после обновления UniGetUI"
 }

--- a/src/Languages/lang_sa.json
+++ b/src/Languages/lang_sa.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI स्वयमारम्भ-व्यवहारं प्रबन्धय",
   "Choose how many operations shoulds be performed in parallel": "कियत् क्रियाः समकालिकरूपेण क्रियेरन् इति चयनय",
   "Something went wrong while launching the updater.": "updater आरम्भयन् किमपि विपरीतं जातम्।",
-  "Please try again later": "कृपया पश्चात् पुनः प्रयतस्व"
+  "Please try again later": "कृपया पश्चात् पुनः प्रयतस्व",
+  "Show the release notes after UniGetUI is updated": "UniGetUI नवीनीकृते सति प्रकाशन-टिप्पण्यः दर्शयतु"
 }

--- a/src/Languages/lang_si.json
+++ b/src/Languages/lang_si.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI ස්වයං ආරම්භ හැසිරීම කළමනාකරණය කරන්න",
   "Choose how many operations shoulds be performed in parallel": "එකවර ක්‍රියාත්මක කළ යුතු මෙහෙයුම් ගණන තෝරන්න",
   "Something went wrong while launching the updater.": "updater ආරම්භ කිරීමේදී යම් දෙයක් වැරදී ගියේය.",
-  "Please try again later": "කරුණාකර පසුව නැවත උත්සාහ කරන්න"
+  "Please try again later": "කරුණාකර පසුව නැවත උත්සාහ කරන්න",
+  "Show the release notes after UniGetUI is updated": "UniGetUI යාවත්කාලීන වූ පසු නිකුතු සටහන් පෙන්වන්න"
 }

--- a/src/Languages/lang_sk.json
+++ b/src/Languages/lang_sk.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Spravovať správanie automatického spúšťania UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Vyberte, koľko operácií sa má vykonávať súbežne",
   "Something went wrong while launching the updater.": "Pri spustení aktualizácie sa niečo pokazilo.",
-  "Please try again later": "Skúste to prosím neskôr"
+  "Please try again later": "Skúste to prosím neskôr",
+  "Show the release notes after UniGetUI is updated": "Zobraziť poznámky k vydaniu po aktualizácii UniGetUI"
 }

--- a/src/Languages/lang_sl.json
+++ b/src/Languages/lang_sl.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Upravljaj vedenje samodejnega zagona UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Izberite, koliko operacij naj se izvaja vzporedno",
   "Something went wrong while launching the updater.": "Pri zagonu posodobitvenega programa je prišlo do napake.",
-  "Please try again later": "Poskusite znova pozneje"
+  "Please try again later": "Poskusite znova pozneje",
+  "Show the release notes after UniGetUI is updated": "Pokaži opombe ob izdaji po posodobitvi UniGetUI"
 }

--- a/src/Languages/lang_sq.json
+++ b/src/Languages/lang_sq.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Menaxho sjelljen e nisjes automatike të UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Zgjidh sa operacione duhet të kryhen paralelisht",
   "Something went wrong while launching the updater.": "Diçka shkoi gabim gjatë nisjes së përditësuesit.",
-  "Please try again later": "Të lutem provo përsëri më vonë"
+  "Please try again later": "Të lutem provo përsëri më vonë",
+  "Show the release notes after UniGetUI is updated": "Shfaq shënimet e botimit pasi UniGetUI të jetë përditësuar"
 }

--- a/src/Languages/lang_sr.json
+++ b/src/Languages/lang_sr.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Управљај понашањем аутоматског покретања UniGetUI-а",
   "Choose how many operations shoulds be performed in parallel": "Изабери колико операција треба да се извршава паралелно",
   "Something went wrong while launching the updater.": "Нешто је пошло наопако при покретању ажурирача.",
-  "Please try again later": "Покушај поново касније"
+  "Please try again later": "Покушај поново касније",
+  "Show the release notes after UniGetUI is updated": "Прикажи белешке о верзијама након ажурирања UniGetUI-а"
 }

--- a/src/Languages/lang_sv.json
+++ b/src/Languages/lang_sv.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Hantera UniGetUI:s autostartbeteende",
   "Choose how many operations shoulds be performed in parallel": "Välj hur många åtgärder som ska utföras parallellt",
   "Something went wrong while launching the updater.": "Något gick fel vid starten av uppdateraren",
-  "Please try again later": "Försök igen senare"
+  "Please try again later": "Försök igen senare",
+  "Show the release notes after UniGetUI is updated": "Visa versionsinformation efter att UniGetUI har uppdaterats"
 }

--- a/src/Languages/lang_ta.json
+++ b/src/Languages/lang_ta.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI தானியங்கி தொடக்க நடத்தையை நிர்வகி",
   "Choose how many operations shoulds be performed in parallel": "ஒரே நேரத்தில் எத்தனை செயல்பாடுகள் மேற்கொள்ளப்பட வேண்டும் என்பதைத் தேர்ந்தெடுக்கவும்",
   "Something went wrong while launching the updater.": "updater ஐ தொடங்கும் போது ஏதோ தவறாகிவிட்டது.",
-  "Please try again later": "பின்னர் மீண்டும் முயற்சிக்கவும்"
+  "Please try again later": "பின்னர் மீண்டும் முயற்சிக்கவும்",
+  "Show the release notes after UniGetUI is updated": "UniGetUI புதுப்பிக்கப்பட்ட பிறகு வெளியீட்டு குறிப்புகளைக் காட்டு"
 }

--- a/src/Languages/lang_th.json
+++ b/src/Languages/lang_th.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "จัดการพฤติกรรมการเริ่มอัตโนมัติของ UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "เลือกจำนวนการดำเนินการที่ควรทำพร้อมกัน",
   "Something went wrong while launching the updater.": "มีข้อผิดพลาดขณะเปิดตัวอัปเดต",
-  "Please try again later": "กรุณาลองใหม่ในภายหลัง"
+  "Please try again later": "กรุณาลองใหม่ในภายหลัง",
+  "Show the release notes after UniGetUI is updated": "แสดงรายละเอียดการปรับปรุงหลังจากอัปเดต UniGetUI"
 }

--- a/src/Languages/lang_tl.json
+++ b/src/Languages/lang_tl.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Pamahalaan ang awtomatikong pagsisimula ng UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Piliin kung ilang operasyon ang dapat isagawa nang sabay-sabay",
   "Something went wrong while launching the updater.": "May nangyaring mali habang inilulunsad ang updater.",
-  "Please try again later": "Pakisubukan muli mamaya"
+  "Please try again later": "Pakisubukan muli mamaya",
+  "Show the release notes after UniGetUI is updated": "Ipakita ang mga tala sa release pagkatapos ma-update ang UniGetUI"
 }

--- a/src/Languages/lang_tr.json
+++ b/src/Languages/lang_tr.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI otomatik başlatma davranışını yönet",
   "Choose how many operations shoulds be performed in parallel": "Aynı anda kaç işlemin yürütüleceğini seçin",
   "Something went wrong while launching the updater.": "Güncelleyici başlatılırken bir şeyler ters gitti.",
-  "Please try again later": "Lütfen daha sonra tekrar deneyin"
+  "Please try again later": "Lütfen daha sonra tekrar deneyin",
+  "Show the release notes after UniGetUI is updated": "UniGetUI güncellendikten sonra sürüm notlarını göster"
 }

--- a/src/Languages/lang_uk.json
+++ b/src/Languages/lang_uk.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Керування автозапуском UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Виберіть, скільки операцій слід виконувати паралельно",
   "Something went wrong while launching the updater.": "Щось пішло не так при запуску програми оновлення.",
-  "Please try again later": "Будь ласка, спробуйте ще раз пізніше"
+  "Please try again later": "Будь ласка, спробуйте ще раз пізніше",
+  "Show the release notes after UniGetUI is updated": "Показувати нотатки про випуск після оновлення UniGetUI"
 }

--- a/src/Languages/lang_ur.json
+++ b/src/Languages/lang_ur.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "UniGetUI کے خودکار آغاز کے رویے کا نظم کریں",
   "Choose how many operations shoulds be performed in parallel": "منتخب کریں کہ کتنی کارروائیاں بیک وقت انجام دی جائیں",
   "Something went wrong while launching the updater.": "اپڈیٹر لانچ کرتے وقت کچھ غلط ہو گیا۔",
-  "Please try again later": "براہ کرم بعد میں دوبارہ کوشش کریں۔"
+  "Please try again later": "براہ کرم بعد میں دوبارہ کوشش کریں۔",
+  "Show the release notes after UniGetUI is updated": "UniGetUI اپ ڈیٹ ہونے کے بعد ریلیز نوٹس دکھائیں"
 }

--- a/src/Languages/lang_vi.json
+++ b/src/Languages/lang_vi.json
@@ -846,5 +846,6 @@
   "Manage UniGetUI autostart behaviour from the Settings app": "Quản lý hành vi tự khởi động của UniGetUI",
   "Choose how many operations shoulds be performed in parallel": "Chọn số thao tác nên được thực hiện song song",
   "Something went wrong while launching the updater.": "Đã xảy ra sự cố khi khởi động trình cập nhật.",
-  "Please try again later": "Vui lòng thử lại sau"
+  "Please try again later": "Vui lòng thử lại sau",
+  "Show the release notes after UniGetUI is updated": "Hiển thị ghi chú phát hành sau khi UniGetUI được cập nhật"
 }

--- a/src/Languages/lang_zh_CN.json
+++ b/src/Languages/lang_zh_CN.json
@@ -845,5 +845,6 @@
   "Package managers": "软件包管理器",
   "Manage UniGetUI autostart behaviour from the Settings app": "管理 UniGetUI 自动启动行为",
   "Something went wrong while launching the updater.": "在启动更新程序时出错。",
-  "Please try again later": "请稍后再试"
+  "Please try again later": "请稍后再试",
+  "Show the release notes after UniGetUI is updated": "在 UniGetUI 更新后显示发布说明"
 }

--- a/src/Languages/lang_zh_TW.json
+++ b/src/Languages/lang_zh_TW.json
@@ -847,5 +847,6 @@
   "Choose how many operations shoulds be performed in parallel": "選擇要同時執行的操作數量",
   "Something went wrong while launching the updater.": "啟動更新程式時發生錯誤。",
   "Please try again later": "請稍後再試",
-  "Installer host changed since the installed version.\nOld: {0}\nNew: {1}\n\nThis is usually harmless (the publisher moved hosting), but can also indicate a hijacked package manifest. Verify the new source before upgrading.": "安裝程式主機在已安裝版本之後變更。\n舊版: {0}\n新版: {1}\n\n這通常無害（發布者移動了主機），但也可能表示套件描述檔已被劫持。更新前請驗證新來源。"
+  "Installer host changed since the installed version.\nOld: {0}\nNew: {1}\n\nThis is usually harmless (the publisher moved hosting), but can also indicate a hijacked package manifest. Verify the new source before upgrading.": "安裝程式主機在已安裝版本之後變更。\n舊版: {0}\n新版: {1}\n\n這通常無害（發布者移動了主機），但也可能表示套件描述檔已被劫持。更新前請驗證新來源。",
+  "Show the release notes after UniGetUI is updated": "在 UniGetUI 更新後顯示版本更新說明"
 }


### PR DESCRIPTION
This pull request adds a new translation string, "Show the release notes after UniGetUI is updated", to the English language file and updates translations for this string across multiple other language files. This ensures that the new UI feature for displaying release notes post-update is localized for a broad set of users.

Localization updates:

* Added the "Show the release notes after UniGetUI is updated" string to `lang_en.json` and provided corresponding translations in the following language files: `lang_af.json`, `lang_ar.json`, `lang_be.json`, `lang_bg.json`, `lang_bn.json`, `lang_ca.json`, `lang_cs.json`, `lang_da.json`, `lang_de.json`, `lang_el.json`, `lang_eo.json`, `lang_es-MX.json`, `lang_es.json`, `lang_et.json`, `lang_fa.json`, `lang_fi.json`, `lang_fil.json`, `lang_fr.json`, `lang_gl.json`. 