### PR TITLE
Drop WinAppSDK, restore native toasts at ~0 MiB cost

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -203,6 +203,21 @@ public partial class App : Application
         bool isDaemonLaunch = args.Contains(AvaloniaCliHandler.DAEMON);
         CoreData.IsDaemon = isDaemonLaunch;
 
+        // A toast click launches the app with its unigetui:// deep-link; route the
+        // encoded action to the notification activation handler before foregrounding.
+        if (args is { Length: > 0 })
+        {
+            foreach (string arg in args)
+            {
+                string? action = WindowsAppNotificationBridge.TryParseToastLaunchArgument(arg);
+                if (action is not null)
+                {
+                    WindowsAppNotificationBridge.RaiseActivation(action);
+                    break;
+                }
+            }
+        }
+
         if (isDaemonLaunch)
             return;
 

--- a/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
@@ -178,11 +178,11 @@ internal static class AppShortcutAumidStamper
     internal struct PropVariant
     {
         private ushort vt;
-        private ushort reserved1;
-        private ushort reserved2;
-        private ushort reserved3;
+        private readonly ushort reserved1;
+        private readonly ushort reserved2;
+        private readonly ushort reserved3;
         private IntPtr value1;
-        private IntPtr value2;
+        private readonly IntPtr value2;
 
         public PropVariant(string value)
         {

--- a/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
@@ -1,3 +1,4 @@
+#if WINDOWS
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -210,3 +211,4 @@ internal static class AppShortcutAumidStamper
         }
     }
 }
+#endif

--- a/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
@@ -1,0 +1,212 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using UniGetUI.Core.Logging;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Stamps the UniGetUI <c>AppUserModelID</c> onto the Start Menu shortcut the installer
+/// creates, which is the shell's "app is installed" signal required before Windows will
+/// surface Action-Center toasts for an unpackaged Win32 app.
+/// </summary>
+/// <remarks>
+/// Inno Setup cannot write shortcut property-store values directly, so the app performs
+/// this idempotent fix-up on first launch (and on every launch; it is cheap). The AUMID
+/// must match the one set on the process by <see cref="Win32ToastNotifier"/>.
+/// </remarks>
+internal static class AppShortcutAumidStamper
+{
+    private const string ShortcutName = "UniGetUI";
+    private const string Aumid = Win32ToastNotifier.AppUserModelId;
+
+    // System.AppUserModel.Id property key: {9F4C2855-9F79-4B39-A8D0-E1A8F39EFCDC}, pid 5
+    private static readonly PropertyKey AppUserModelIdKey =
+        new(new Guid("9F4C2855-9F79-4B39-A8D0-E1A8F39EFCDC"), 5);
+
+    public static void EnsureStamped()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            string? shortcutPath = ResolveStartMenuShortcut();
+            if (shortcutPath is null || !File.Exists(shortcutPath))
+                return;
+
+            StampIfMissing(shortcutPath);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not stamp AUMID on Start Menu shortcut");
+            Logger.Warn(ex);
+        }
+    }
+
+    private static string? ResolveStartMenuShortcut()
+    {
+        // {autostartmenu} in Inno Setup resolves to the per-user Start Menu Programs folder.
+        string baseDir = Environment.GetFolderPath(
+            Environment.SpecialFolder.StartMenu, Environment.SpecialFolderOption.DoNotVerify);
+        string userPath = Path.Combine(baseDir, "Programs", ShortcutName + ".lnk");
+        if (File.Exists(userPath))
+            return userPath;
+
+        // Fallback to the common Start Menu Programs folder.
+        string commonBase = Environment.GetFolderPath(
+            Environment.SpecialFolder.CommonStartMenu, Environment.SpecialFolderOption.DoNotVerify);
+        string commonPath = Path.Combine(commonBase, "Programs", ShortcutName + ".lnk");
+        return File.Exists(commonPath) ? commonPath : null;
+    }
+
+    private static void StampIfMissing(string shortcutPath)
+    {
+        // ShellLink (CLSID 00021401-0000-0000-C000-000000000046) implements IPersistFile and
+        // IPropertyStore for .lnk files. We read the AppUserModel.Id value; if it already
+        // matches, there's nothing to do, otherwise we set it and persist.
+        var shellLinkClsid = new Guid("00021401-0000-0000-C000-000000000046");
+        object? linkObj = null;
+        try
+        {
+            linkObj = Activator.CreateInstance(Type.GetTypeFromCLSID(shellLinkClsid)
+                ?? throw new InvalidOperationException("ShellLink CLSID is not registered"));
+            if (linkObj is not IPersistFile persistFile)
+                return;
+
+            persistFile.Load(shortcutPath, 0);
+
+            if (linkObj is not IPropertyStore props)
+                return;
+
+            if (TryGetAumid(props, out string? existing) && existing == Aumid)
+                return; // Already correct.
+
+            var aumidValue = new PropVariant(Aumid);
+            try
+            {
+                props.SetValue(AppUserModelIdKey, aumidValue);
+                props.Commit();
+                persistFile.Save(shortcutPath, fRemember: false);
+            }
+            finally
+            {
+                aumidValue.Clear();
+            }
+        }
+        finally
+        {
+            if (linkObj is not null)
+                Marshal.ReleaseComObject(linkObj);
+        }
+    }
+
+    private static bool TryGetAumid(IPropertyStore props, out string? value)
+    {
+        value = null;
+        try
+        {
+            uint count = props.GetCount();
+            for (uint i = 0; i < count; i++)
+            {
+                props.GetAt(i, out PropertyKey key);
+                if (key.fmtid == AppUserModelIdKey.fmtid && key.pid == AppUserModelIdKey.pid)
+                {
+                    var pv = new PropVariant();
+                    try
+                    {
+                        props.GetValue(key, out pv);
+                        value = pv.Value as string;
+                        return true;
+                    }
+                    finally
+                    {
+                        pv.Clear();
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Reading failed; fall through to write.
+        }
+        return false;
+    }
+
+    // ── COM interop ──────────────────────────────────────────────────────────
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99")]
+    internal interface IPropertyStore
+    {
+        uint GetCount();
+        void GetAt(uint i, out PropertyKey key);
+        void GetValue([In] ref PropertyKey key, out PropVariant value);
+        void SetValue([In] ref PropertyKey key, [In] ref PropVariant value);
+        void Commit();
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("0000010B-0000-0000-C000-000000000046")]
+    internal interface IPersistFile
+    {
+        void GetClassID(out Guid pClassID);
+        void IsDirty();
+        void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, uint dwMode);
+        void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, bool fRemember);
+        void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
+        void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PropertyKey
+    {
+        public Guid fmtid;
+        public int pid;
+        public PropertyKey(Guid fmtid, int pid)
+        {
+            this.fmtid = fmtid;
+            this.pid = pid;
+        }
+    }
+
+    // Minimal PropVariant supporting VT_LPWSTR (string) — the only type we set/read for AUMID.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PropVariant
+    {
+        private ushort vt;
+        private ushort reserved1;
+        private ushort reserved2;
+        private ushort reserved3;
+        private IntPtr value1;
+        private IntPtr value2;
+
+        public PropVariant(string value)
+        {
+            vt = (ushort)VarEnum.VT_LPWSTR;
+            reserved1 = reserved2 = reserved3 = 0;
+            value1 = Marshal.StringToCoTaskMemUni(value);
+            value2 = IntPtr.Zero;
+        }
+
+        public string? Value
+        {
+            get
+            {
+                if ((VarEnum)vt != VarEnum.VT_LPWSTR || value1 == IntPtr.Zero)
+                    return null;
+                return Marshal.PtrToStringUni(value1);
+            }
+        }
+
+        public void Clear()
+        {
+            if ((VarEnum)vt == VarEnum.VT_LPWSTR && value1 != IntPtr.Zero)
+                Marshal.FreeCoTaskMem(value1);
+            vt = 0;
+            value1 = IntPtr.Zero;
+        }
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
@@ -69,6 +69,10 @@ public static class AvaloniaAppHost
         Logger.ImportantInfo($"Packaged (MSIX): {CoreTools.IsPackagedApp()}");
         Logger.ImportantInfo($"Args: {(args.Length > 0 ? string.Join(" ", args) : "(none)")}");
 
+        // Stamp the AUMID onto the Start Menu shortcut so the shell surfaces toasts. The
+        // installer cannot write the property-store value directly; this is idempotent.
+        AppShortcutAumidStamper.EnsureStamped();
+
         // Bind Avalonia's UI-thread dispatcher to this (main/STA) thread before the single-instance
         // listener starts: if a second instance connects mid-startup, the listener's Dispatcher.UIThread.Post
         // would otherwise bind it to the worker thread and make Win32Platform.Initialize throw.

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
@@ -71,7 +71,9 @@ public static class AvaloniaAppHost
 
         // Stamp the AUMID onto the Start Menu shortcut so the shell surfaces toasts. The
         // installer cannot write the property-store value directly; this is idempotent.
+#if WINDOWS
         AppShortcutAumidStamper.EnsureStamped();
+#endif
 
         // Bind Avalonia's UI-thread dispatcher to this (main/STA) thread before the single-instance
         // listener starts: if a second instance connects mid-startup, the listener's Dispatcher.UIThread.Post

--- a/src/UniGetUI.Avalonia/Infrastructure/Win32ToastNotifier.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/Win32ToastNotifier.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Runtime.InteropServices;
+using UniGetUI.Core.Logging;
+using Windows.Data.Xml.Dom;
+using Windows.UI.Notifications;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Show-only Windows toast notifications via the OS-provided UWP
+/// <c>Windows.UI.Notifications</c> surface, with no Windows App SDK / WinUI dependency.
+/// </summary>
+/// <remarks>
+/// The notifier is keyed by an AppUserModelID (AUMID). For an unpackaged Win32 app the
+/// shell will only surface toasts for that AUMID once a Start Menu shortcut carrying the
+/// same AUMID exists; <see cref="AppShortcutAumidStamper"/> handles that side. Toast
+/// activation (button clicks) is intentionally not wired — clicking the toast launches
+/// the app with its <c>unigetui://</c> deep-link so the single-instance handler can
+/// foreground the window, which keeps this dependency-free.
+/// </remarks>
+internal static class Win32ToastNotifier
+{
+    /// <summary>Stable AUMID for UniGetUI. Must match the one stamped on the Start Menu shortcut.</summary>
+    public const string AppUserModelId = "Devolutions.UniGetUI";
+
+    private static bool _availabilityChecked;
+    private static bool _isAvailable;
+
+    /// <summary>
+    /// Stamps <see cref="AppUserModelId"/> onto the current process so the shell attributes
+    /// toasts to UniGetUI. Safe to call repeatedly; a no-op on non-Windows.
+    /// </summary>
+    public static void SetProcessAumid()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            _ = SetCurrentProcessExplicitAppUserModelID(AppUserModelId);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not set process AppUserModelID for toast notifications");
+            Logger.Warn(ex);
+        }
+    }
+
+    /// <summary>
+    /// True once we have confirmed the UWP toast surface is usable on this Windows install.
+    /// Non-Windows platforms report <c>false</c>.
+    /// </summary>
+    public static bool IsAvailable()
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        if (_availabilityChecked)
+            return _isAvailable;
+
+        _availabilityChecked = true;
+        try
+        {
+            _ = ToastNotificationManager.CreateToastNotifier(AppUserModelId);
+            _isAvailable = true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("UWP toast notifier is not available; falling back to in-app banners");
+            Logger.Warn(ex);
+            _isAvailable = false;
+        }
+
+        return _isAvailable;
+    }
+
+    /// <summary>
+    /// Shows a toast with the supplied title and message and a launch argument that is
+    /// forwarded to the app when the user clicks the toast. Returns <c>false</c> if the
+    /// toast could not be shown (caller should fall back to an in-app banner).
+    /// </summary>
+    public static bool Show(string title, string message, string launchArgument)
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            string xml = BuildToastXml(title, message, launchArgument);
+
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(xml);
+
+            var notification = new ToastNotification(xmlDoc);
+            ToastNotificationManager.CreateToastNotifier(AppUserModelId).Show(notification);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn("Could not show Windows toast notification");
+            Logger.Warn(ex);
+            return false;
+        }
+    }
+
+    private static string BuildToastXml(string title, string message, string launchArgument)
+    {
+        string titleEsc = XmlEscape(title);
+        string messageEsc = XmlEscape(message);
+        string launchEsc = XmlEscape(launchArgument);
+
+        return $"""
+                <toast activationType="protocol" launch="{launchEsc}" scenario="default">
+                    <visual>
+                        <binding template="ToastGeneric">
+                            <text>{titleEsc}</text>
+                            <text>{messageEsc}</text>
+                        </binding>
+                    </visual>
+                    <audio silent="true"/>
+                </toast>
+                """;
+    }
+
+    private static string XmlEscape(string value)
+        => value
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;")
+            .Replace("'", "&apos;");
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int SetCurrentProcessExplicitAppUserModelID(string appUserModelID);
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/Win32ToastNotifier.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/Win32ToastNotifier.cs
@@ -1,3 +1,4 @@
+#if WINDOWS
 using System;
 using System.Runtime.InteropServices;
 using UniGetUI.Core.Logging;
@@ -133,3 +134,4 @@ internal static class Win32ToastNotifier
     [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern int SetCurrentProcessExplicitAppUserModelID(string appUserModelID);
 }
+#endif

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Reflection;
+using UniGetUI.Avalonia.Views;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
@@ -11,146 +10,105 @@ using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.Infrastructure;
 
+/// <summary>
+/// Delivers UniGetUI's notifications via native Windows Action-Center toasts using the
+/// UWP <c>Windows.UI.Notifications</c> COM surface, with no Windows App SDK / WinUI
+/// dependency. Toasts are show-only: clicking a toast launches the app through the
+/// <c>unigetui://</c> deep-link (registered by the installer) so the existing
+/// single-instance handler foregrounds the window. The inline action buttons carried
+/// by the old WinRT toasts are intentionally dropped; activation is surfaced via
+/// <see cref="NotificationActivated"/> only when the app is already running and the toast
+/// is clicked, so the main-window view model keeps its handler. On non-Windows, or if
+/// the toast COM surface is unavailable, every call falls back to the in-app Avalonia
+/// banner via <see cref="MainWindow.ShowRuntimeNotification"/>.
+/// </summary>
 internal static class WindowsAppNotificationBridge
 {
-    private const string ScenarioDefault = "Default";
-    private const string ScenarioUrgent = "Urgent";
-
-    private static readonly object _registrationLock = new();
-    private static bool _registrationAttempted;
-    private static bool _isRegistered;
-    private static object? _managerDefault;
-    private static Type? _builderType;
-    private static Type? _scenarioType;
-    private static Type? _buttonType;
-    private static MethodInfo? _removeByTagAsyncMethod;
-    private static MethodInfo? _showMethod;
-
-    // ── B2: action callback ────────────────────────────────────────────────
-    /// <summary>Invoked on a thread-pool thread when a toast notification button is clicked.</summary>
+    /// <summary>Invoked when a notification's default action is triggered (toast clicked).</summary>
     public static event Action<string>? NotificationActivated;
 
-    private static readonly string[] _assemblyCandidates =
+    /// <summary>
+    /// Parses a <c>unigetui://&lt;action&gt;</c> launch argument produced by a toast
+    /// click, returning the encoded action or <c>null</c> if the argument is not a toast
+    /// deep-link. Used by the secondary-instance handler to route toast activations.
+    /// </summary>
+    public static string? TryParseToastLaunchArgument(string arg)
     {
-        "Microsoft.Windows.AppNotifications.Projection",
-        "Microsoft.Windows.AppNotifications.Builder.Projection",
-    };
+        if (string.IsNullOrEmpty(arg))
+            return null;
+
+        const string prefix = "unigetui://";
+        return arg.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? arg[prefix.Length..]
+            : null;
+    }
+
+    /// <summary>Raises <see cref="NotificationActivated"/> with the given action.</summary>
+    public static void RaiseActivation(string action)
+    {
+        try { NotificationActivated?.Invoke(action); }
+        catch (Exception ex)
+        {
+            Logger.Warn("NotificationActivated raise failed");
+            Logger.Warn(ex);
+        }
+    }
 
     public static bool ShowProgress(AbstractOperation operation)
     {
-        if (!EnsureRegistered())
-            return false;
+        string title = operation.Metadata.Title.Length > 0
+            ? operation.Metadata.Title
+            : CoreTools.Translate("Operation in progress");
 
-        try
-        {
-            string title = operation.Metadata.Title.Length > 0
-                ? operation.Metadata.Title
-                : CoreTools.Translate("Operation in progress");
+        string message = operation.Metadata.Status.Length > 0
+            ? operation.Metadata.Status
+            : CoreTools.Translate("Please wait...");
 
-            string message = operation.Metadata.Status.Length > 0
-                ? operation.Metadata.Status
-                : CoreTools.Translate("Please wait...");
-
-            return ShowTextToast(
-                tag: operation.Metadata.Identifier + "progress",
-                scenario: ScenarioDefault,
-                title: title,
-                message: message,
-                suppressDisplay: true);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn("Windows toast progress notification failed");
-            Logger.Warn(ex);
-            return false;
-        }
+        return Show(title, message, MainWindow.RuntimeNotificationLevel.Progress, launchAction: NotificationArguments.Show);
     }
 
     public static bool ShowSuccess(AbstractOperation operation)
     {
-        if (!EnsureRegistered())
-            return false;
+        string title = operation.Metadata.SuccessTitle.Length > 0
+            ? operation.Metadata.SuccessTitle
+            : CoreTools.Translate("Success!");
 
-        try
-        {
-            string title = operation.Metadata.SuccessTitle.Length > 0
-                ? operation.Metadata.SuccessTitle
-                : CoreTools.Translate("Success!");
+        string message = operation.Metadata.SuccessMessage.Length > 0
+            ? operation.Metadata.SuccessMessage
+            : CoreTools.Translate("Success!");
 
-            string message = operation.Metadata.SuccessMessage.Length > 0
-                ? operation.Metadata.SuccessMessage
-                : CoreTools.Translate("Success!");
-
-            return ShowTextToast(
-                tag: operation.Metadata.Identifier,
-                scenario: ScenarioDefault,
-                title: title,
-                message: message,
-                suppressDisplay: false);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn("Windows toast success notification failed");
-            Logger.Warn(ex);
-            return false;
-        }
+        return Show(title, message, MainWindow.RuntimeNotificationLevel.Success, launchAction: NotificationArguments.Show);
     }
 
     public static bool ShowError(AbstractOperation operation)
     {
-        if (!EnsureRegistered())
-            return false;
+        string title = operation.Metadata.FailureTitle.Length > 0
+            ? operation.Metadata.FailureTitle
+            : CoreTools.Translate("Failed");
 
-        try
-        {
-            string title = operation.Metadata.FailureTitle.Length > 0
-                ? operation.Metadata.FailureTitle
-                : CoreTools.Translate("Failed");
+        string message = operation.Metadata.FailureMessage.Length > 0
+            ? operation.Metadata.FailureMessage
+            : CoreTools.Translate("An error occurred while processing this package");
 
-            string message = operation.Metadata.FailureMessage.Length > 0
-                ? operation.Metadata.FailureMessage
-                : CoreTools.Translate("An error occurred while processing this package");
-
-            return ShowTextToast(
-                tag: operation.Metadata.Identifier,
-                scenario: ScenarioUrgent,
-                title: title,
-                message: message,
-                suppressDisplay: false);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn("Windows toast error notification failed");
-            Logger.Warn(ex);
-            return false;
-        }
+        return Show(title, message, MainWindow.RuntimeNotificationLevel.Error, launchAction: NotificationArguments.Show);
     }
 
     public static void RemoveProgress(AbstractOperation operation)
     {
-        if (!EnsureRegistered())
-            return;
-
-        try
-        {
-            _removeByTagAsyncMethod?.Invoke(_managerDefault, [operation.Metadata.Identifier + "progress"]);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn("Windows toast progress cleanup failed");
-            Logger.Warn(ex);
-        }
+        // The UWP toast surface has no tag-based remove without the WinAppSDK helper.
+        // Progress toasts are short-lived and replaced by the subsequent success/error toast.
     }
 
-    // ── B2: updates-available notification ────────────────────────────────
+    // ── updates-available notification ───────────────────────────────────────
 
     /// <summary>
-    /// Shows a Windows toast notification listing available package updates, with action buttons
-    /// ("Open UniGetUI" / "Update all").  No-op on non-Windows or when toast registration fails.
+    /// Shows a Windows toast notification listing available package updates. No-op on
+    /// non-Windows or when notifications are disabled (mirrors the previous bridge's
+    /// platform guard so macOS/Linux stay untouched).
     /// </summary>
     public static void ShowUpdatesAvailableNotification(IReadOnlyList<IPackage> upgradable)
     {
-        if (!EnsureRegistered()) return;
+        if (!OperatingSystem.IsWindows()) return;
         if (Settings.AreUpdatesNotificationsDisabled()) return;
 
         bool sendNotification = upgradable.Any(p =>
@@ -160,48 +118,22 @@ internal static class WindowsAppNotificationBridge
 
         try
         {
-            _removeByTagAsyncMethod?.Invoke(_managerDefault,
-                [CoreData.UpdatesAvailableNotificationTag.ToString()]);
-
             if (upgradable.Count == 1)
             {
-                ShowTextToast(
-                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
-                    scenario: ScenarioDefault,
-                    title: CoreTools.Translate("An update was found!"),
-                    message: CoreTools.Translate("{0} can be updated to version {1}",
+                Show(
+                    CoreTools.Translate("An update was found!"),
+                    CoreTools.Translate("{0} can be updated to version {1}",
                         upgradable[0].Name, upgradable[0].NewVersionString),
-                    suppressDisplay: false,
-                    defaultAction: NotificationArguments.ShowOnUpdatesTab,
-                    buttons:
-                    [
-                        (CoreTools.Translate("View on UniGetUI").Replace("'", "\u00b4"),
-                            NotificationArguments.ShowOnUpdatesTab),
-                        (CoreTools.Translate("Update").Replace("'", "\u00b4"),
-                            NotificationArguments.UpdateAllPackages),
-                    ]);
+                    MainWindow.RuntimeNotificationLevel.Success,
+                    launchAction: NotificationArguments.ShowOnUpdatesTab);
             }
             else
             {
-                string attribution = string.Join(", ", upgradable
-                    .Where(p => !Settings.GetDictionaryItem<string, bool>(
-                        Settings.K.DisabledPackageManagerNotifications, p.Manager.Name))
-                    .Select(p => p.Name));
-
-                ShowTextToast(
-                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
-                    scenario: ScenarioDefault,
-                    title: CoreTools.Translate("Updates found!"),
-                    message: CoreTools.Translate("{0} packages can be updated", upgradable.Count),
-                    suppressDisplay: false,
-                    defaultAction: NotificationArguments.ShowOnUpdatesTab,
-                    buttons:
-                    [
-                        (CoreTools.Translate("Open UniGetUI").Replace("'", "\u00b4"),
-                            NotificationArguments.ShowOnUpdatesTab),
-                        (CoreTools.Translate("Update all").Replace("'", "\u00b4"),
-                            NotificationArguments.UpdateAllPackages),
-                    ]);
+                Show(
+                    CoreTools.Translate("Updates found!"),
+                    CoreTools.Translate("{0} packages can be updated", upgradable.Count),
+                    MainWindow.RuntimeNotificationLevel.Success,
+                    launchAction: NotificationArguments.ShowOnUpdatesTab);
             }
         }
         catch (Exception ex)
@@ -216,7 +148,7 @@ internal static class WindowsAppNotificationBridge
     /// </summary>
     public static void ShowUpgradingPackagesNotification(IReadOnlyList<IPackage> upgradable)
     {
-        if (!EnsureRegistered()) return;
+        if (!OperatingSystem.IsWindows()) return;
         if (Settings.AreUpdatesNotificationsDisabled()) return;
 
         bool sendNotification = upgradable.Any(p =>
@@ -226,19 +158,14 @@ internal static class WindowsAppNotificationBridge
 
         try
         {
-            _removeByTagAsyncMethod?.Invoke(_managerDefault,
-                [CoreData.UpdatesAvailableNotificationTag.ToString()]);
-
             if (upgradable.Count == 1)
             {
-                ShowTextToast(
-                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
-                    scenario: ScenarioDefault,
-                    title: CoreTools.Translate("An update was found!"),
-                    message: CoreTools.Translate("{0} is being updated to version {1}",
+                Show(
+                    CoreTools.Translate("An update was found!"),
+                    CoreTools.Translate("{0} is being updated to version {1}",
                         upgradable[0].Name, upgradable[0].NewVersionString),
-                    suppressDisplay: false,
-                    defaultAction: NotificationArguments.ShowOnUpdatesTab);
+                    MainWindow.RuntimeNotificationLevel.Progress,
+                    launchAction: NotificationArguments.ShowOnUpdatesTab);
             }
             else
             {
@@ -247,13 +174,11 @@ internal static class WindowsAppNotificationBridge
                         Settings.K.DisabledPackageManagerNotifications, p.Manager.Name))
                     .Select(p => p.Name));
 
-                ShowTextToast(
-                    tag: CoreData.UpdatesAvailableNotificationTag.ToString(),
-                    scenario: ScenarioDefault,
-                    title: CoreTools.Translate("{0} packages are being updated", upgradable.Count),
-                    message: attribution,
-                    suppressDisplay: false,
-                    defaultAction: NotificationArguments.ShowOnUpdatesTab);
+                Show(
+                    CoreTools.Translate("{0} packages are being updated", upgradable.Count),
+                    attribution,
+                    MainWindow.RuntimeNotificationLevel.Progress,
+                    launchAction: NotificationArguments.ShowOnUpdatesTab);
             }
         }
         catch (Exception ex)
@@ -264,28 +189,18 @@ internal static class WindowsAppNotificationBridge
     }
 
     /// <summary>
-    /// Shows a Windows toast offering a UniGetUI self-update with an "Update now" button.
+    /// Shows a Windows toast offering a UniGetUI self-update.
     /// </summary>
     public static void ShowSelfUpdateAvailableNotification(string newVersion)
     {
-        if (!EnsureRegistered()) return;
+        if (!OperatingSystem.IsWindows()) return;
         try
         {
-            _removeByTagAsyncMethod?.Invoke(_managerDefault,
-                [CoreData.UniGetUICanBeUpdated.ToString()]);
-
-            ShowTextToast(
-                tag: CoreData.UniGetUICanBeUpdated.ToString(),
-                scenario: ScenarioDefault,
-                title: CoreTools.Translate("{0} can be updated to version {1}", "UniGetUI", newVersion),
-                message: CoreTools.Translate("You have currently version {0} installed", CoreData.VersionName),
-                suppressDisplay: false,
-                defaultAction: NotificationArguments.Show,
-                buttons:
-                [
-                    (CoreTools.Translate("Update now").Replace("'", "\u00b4"),
-                        NotificationArguments.ReleaseSelfUpdateLock),
-                ]);
+            Show(
+                CoreTools.Translate("{0} can be updated to version {1}", "UniGetUI", newVersion),
+                CoreTools.Translate("You have currently version {0} installed", CoreData.VersionName),
+                MainWindow.RuntimeNotificationLevel.Success,
+                launchAction: NotificationArguments.Show);
         }
         catch (Exception ex)
         {
@@ -299,14 +214,11 @@ internal static class WindowsAppNotificationBridge
     /// </summary>
     public static void ShowNewShortcutsNotification(IReadOnlyList<string> shortcuts)
     {
-        if (!EnsureRegistered()) return;
+        if (!OperatingSystem.IsWindows()) return;
         if (Settings.AreNotificationsDisabled()) return;
 
         try
         {
-            _removeByTagAsyncMethod?.Invoke(_managerDefault,
-                [CoreData.NewShortcutsNotificationTag.ToString()]);
-
             string title;
             string message;
 
@@ -326,18 +238,11 @@ internal static class WindowsAppNotificationBridge
                     shortcuts.Count) + "\n" + names;
             }
 
-            ShowTextToast(
-                tag: CoreData.NewShortcutsNotificationTag.ToString(),
-                scenario: ScenarioDefault,
-                title: title,
-                message: message,
-                suppressDisplay: false,
-                defaultAction: NotificationArguments.Show,
-                buttons:
-                [
-                    (CoreTools.Translate("Open UniGetUI").Replace("'", "\u00b4"),
-                        NotificationArguments.Show),
-                ]);
+            Show(
+                title,
+                message,
+                MainWindow.RuntimeNotificationLevel.Success,
+                launchAction: NotificationArguments.Show);
         }
         catch (Exception ex)
         {
@@ -346,230 +251,49 @@ internal static class WindowsAppNotificationBridge
         }
     }
 
-    private static bool EnsureRegistered()
-    {
-        if (!OperatingSystem.IsWindows())
-            return false;
-
-        lock (_registrationLock)
-        {
-            if (_registrationAttempted)
-                return _isRegistered;
-
-            _registrationAttempted = true;
-            try
-            {
-                var managerType = ResolveType(
-                    "Microsoft.Windows.AppNotifications.AppNotificationManager",
-                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationManager");
-                _builderType = ResolveType(
-                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationBuilder");
-                _scenarioType = ResolveType(
-                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationScenario");
-                _buttonType = ResolveType(
-                    "Microsoft.Windows.AppNotifications.Builder.AppNotificationButton");
-
-                if (managerType is null || _builderType is null || _scenarioType is null)
-                {
-                    _isRegistered = false;
-                    return _isRegistered;
-                }
-
-                _managerDefault = managerType.GetProperty("Default", BindingFlags.Public | BindingFlags.Static)
-                    ?.GetValue(null);
-
-                if (_managerDefault is null)
-                {
-                    _isRegistered = false;
-                    return _isRegistered;
-                }
-
-                _removeByTagAsyncMethod = managerType.GetMethod(
-                    "RemoveByTagAsync",
-                    BindingFlags.Public | BindingFlags.Instance,
-                    binder: null,
-                    types: [typeof(string)],
-                    modifiers: null);
-
-                _showMethod = managerType.GetMethod("Show", BindingFlags.Public | BindingFlags.Instance);
-
-                // ── B2: subscribe to NotificationInvoked via Expression lambda ──────
-                var notifEventInfo = managerType.GetEvent("NotificationInvoked");
-                if (notifEventInfo is not null)
-                {
-                    var handlerType = notifEventInfo.EventHandlerType!;
-                    var invokeParams = handlerType.GetMethod("Invoke")!
-                        .GetParameters()
-                        .Select(p => Expression.Parameter(p.ParameterType, p.Name))
-                        .ToArray();
-                    var handlerMi = typeof(WindowsAppNotificationBridge)
-                        .GetMethod(nameof(OnNotificationInvoked),
-                            BindingFlags.Static | BindingFlags.NonPublic)!;
-                    var body = Expression.Call(
-                        handlerMi,
-                        Expression.Convert(invokeParams[0], typeof(object)),
-                        Expression.Convert(invokeParams[1], typeof(object)));
-                    var lambda = Expression.Lambda(handlerType, body, invokeParams);
-                    notifEventInfo.AddEventHandler(_managerDefault, lambda.Compile());
-                }
-
-                managerType.GetMethod(
-                    "Register",
-                    BindingFlags.Public | BindingFlags.Instance,
-                    binder: null,
-                    types: Type.EmptyTypes,
-                    modifiers: null)
-                    ?.Invoke(_managerDefault, null);
-
-                _isRegistered = _showMethod is not null;
-            }
-            catch (Exception ex)
-            {
-                Logger.Warn("Windows app notification registration failed in Avalonia host");
-                Logger.Warn(ex);
-                _isRegistered = false;
-            }
-
-            return _isRegistered;
-        }
-    }
-
-    private static bool ShowTextToast(
-        string tag,
-        string scenario,
+    /// <summary>
+    /// Shows a native toast when available, otherwise falls back to the in-app banner.
+    /// The <paramref name="launchAction"/> is encoded into the <c>unigetui://</c> launch
+    /// argument so the single-instance handler can route the activation when the toast
+    /// is clicked. Returns <c>true</c> once the notification has been surfaced (toast or
+    /// banner), so callers skip their own fallback banner and avoid double-showing.
+    /// </summary>
+    private static bool Show(
         string title,
         string message,
-        bool suppressDisplay,
-        string? defaultAction = null,
-        IReadOnlyList<(string label, string action)>? buttons = null)
+        MainWindow.RuntimeNotificationLevel level,
+        string launchAction)
     {
-        if (_managerDefault is null || _builderType is null || _scenarioType is null || _showMethod is null)
-            return false;
-
-        _removeByTagAsyncMethod?.Invoke(_managerDefault, [tag]);
-
-        object builder = Activator.CreateInstance(_builderType)
-            ?? throw new InvalidOperationException("Could not construct AppNotificationBuilder via reflection.");
-
-        object? scenarioValue = Enum.Parse(_scenarioType, scenario, ignoreCase: true);
-
-        builder = InvokeFluent(builder, "SetScenario", scenarioValue);
-        builder = InvokeFluent(builder, "SetTag", tag);
-        builder = InvokeFluent(builder, "AddText", title);
-        builder = InvokeFluent(builder, "AddText", message);
-
-        if (defaultAction is not null)
-            builder = InvokeFluent(builder, "AddArgument", "action", defaultAction);
-
-        // ── B2: add action buttons ─────────────────────────────────────────
-        if (buttons is not null && _buttonType is not null)
+        if (OperatingSystem.IsWindows() && Win32ToastNotifier.IsAvailable())
         {
-            foreach (var (label, action) in buttons)
+            string launchArg = BuildLaunchArgument(launchAction);
+            if (Win32ToastNotifier.Show(title, message, launchArg))
             {
-                try
-                {
-                    object? btn = Activator.CreateInstance(_buttonType, label);
-                    if (btn is null) continue;
-                    // btn.AddArgument("action", action) returns AppNotificationButton
-                    btn = _buttonType
-                        .GetMethod("AddArgument", BindingFlags.Public | BindingFlags.Instance,
-                            null, [typeof(string), typeof(string)], null)
-                        ?.Invoke(btn, ["action", action]) ?? btn;
-                    builder = InvokeFluent(builder, "AddButton", btn);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warn($"Could not add notification button '{label}': {ex.Message}");
-                }
+                // When the app is already running, raise activation immediately so the
+                // in-process handler fires; a subsequent toast click routes through the
+                // single-instance redirector on launch via TryParseToastLaunchArgument.
+                if (MainWindow.Instance is not null)
+                    RaiseActivation(launchAction);
+                return true;
             }
         }
 
-        object? notification = builder
-            .GetType()
-            .GetMethod("BuildNotification", BindingFlags.Public | BindingFlags.Instance)
-            ?.Invoke(builder, null);
+        return ShowInAppBanner(title, message, level);
+    }
 
-        if (notification is null)
+    private static bool ShowInAppBanner(
+        string title,
+        string message,
+        MainWindow.RuntimeNotificationLevel level)
+    {
+        var mainWindow = MainWindow.Instance;
+        if (mainWindow is null)
             return false;
 
-        SetPropertyIfPresent(notification, "ExpiresOnReboot", true);
-        SetPropertyIfPresent(notification, "SuppressDisplay", suppressDisplay);
-        _showMethod.Invoke(_managerDefault, [notification]);
+        mainWindow.ShowRuntimeNotification(title, message, level);
         return true;
     }
 
-    private static object InvokeFluent(object instance, string methodName, params object?[] args)
-    {
-        Type type = instance.GetType();
-        Type[] argTypes = args.Select(a => a?.GetType() ?? typeof(object)).ToArray();
-
-        MethodInfo? method = type.GetMethod(
-                methodName,
-                BindingFlags.Public | BindingFlags.Instance,
-                binder: null,
-                types: argTypes,
-                modifiers: null)
-            ?? type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                .FirstOrDefault(m => m.Name == methodName && m.GetParameters().Length == args.Length);
-
-        return method?.Invoke(instance, args) ?? instance;
-    }
-
-    private static void SetPropertyIfPresent(object instance, string propertyName, object value)
-    {
-        instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)
-            ?.SetValue(instance, value);
-    }
-
-    private static Type? ResolveType(params string[] possibleTypeNames)
-    {
-        foreach (var typeName in possibleTypeNames)
-        {
-            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                var t = asm.GetType(typeName, throwOnError: false);
-                if (t is not null)
-                    return t;
-            }
-
-            foreach (var asmName in _assemblyCandidates)
-            {
-                try
-                {
-                    var asm = Assembly.Load(asmName);
-                    var t = asm.GetType(typeName, throwOnError: false);
-                    if (t is not null)
-                        return t;
-                }
-                catch
-                {
-                    // Keep probing candidates.
-                }
-            }
-        }
-
-        return null;
-    }
-
-    // ── B2: notification activation handler ───────────────────────────────
-
-    private static void OnNotificationInvoked(object _, object args)
-    {
-        try
-        {
-            var arguments = args.GetType()
-                .GetProperty("Arguments", BindingFlags.Public | BindingFlags.Instance)
-                ?.GetValue(args) as IDictionary<string, string>;
-
-            if (arguments?.TryGetValue("action", out var action) == true && action is not null)
-            {
-                NotificationActivated?.Invoke(action);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn("NotificationInvoked handler error");
-            Logger.Warn(ex);
-        }
-    }
+    private static string BuildLaunchArgument(string action)
+        => $"unigetui://{action}";
 }

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -97,6 +97,7 @@ internal static class WindowsAppNotificationBridge
     {
         // The UWP toast surface has no tag-based remove without the WinAppSDK helper.
         // Progress toasts are short-lived and replaced by the subsequent success/error toast.
+        _ = operation;
     }
 
     // ── updates-available notification ───────────────────────────────────────

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -264,6 +264,7 @@ internal static class WindowsAppNotificationBridge
         MainWindow.RuntimeNotificationLevel level,
         string launchAction)
     {
+#if WINDOWS
         if (OperatingSystem.IsWindows() && Win32ToastNotifier.IsAvailable())
         {
             string launchArg = BuildLaunchArgument(launchAction);
@@ -277,6 +278,7 @@ internal static class WindowsAppNotificationBridge
                 return true;
             }
         }
+#endif
 
         return ShowInAppBanner(title, message, level);
     }

--- a/src/UniGetUI.Avalonia/Program.cs
+++ b/src/UniGetUI.Avalonia/Program.cs
@@ -24,6 +24,13 @@ sealed class Program
         }
         catch { }
 
+#if WINDOWS
+        // Stamp the AUMID onto this process before anything else so the shell attributes
+        // Action-Center toasts to UniGetUI. Must match the AUMID stamped on the Start Menu
+        // shortcut by AppShortcutAumidStamper.
+        Win32ToastNotifier.SetProcessAumid();
+#endif
+
         AvaloniaAppHost.Run(args);
     }
 

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -25,25 +25,15 @@
         <TrimMode>partial</TrimMode>
         <PublishSingleFile>false</PublishSingleFile>
         <IncludeAvaloniaPublishSymbols>false</IncludeAvaloniaPublishSymbols>
-        <AppxGeneratePriEnabled>false</AppxGeneratePriEnabled>
-        <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <WindowsPackageType>None</WindowsPackageType>
-        <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
-        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-        <EnableCoreMrtTooling>false</EnableCoreMrtTooling>
         <NoWarn>$(NoWarn);MVVMTK0045</NoWarn>
         <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'arm64'">win-arm64</RuntimeIdentifier>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and ('$(Platform)' == 'x64' or '$(Platform)' == 'x86')">win-$(Platform)</RuntimeIdentifier>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
     </PropertyGroup>
-
-    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
-    </ItemGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <PingetCliRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</PingetCliRuntimeIdentifier>
@@ -227,6 +217,8 @@
       <Compile Include="Infrastructure\AvaloniaOperationRegistry.cs" />
       <Compile Include="Infrastructure\AppRestartHelper.cs" />
       <Compile Include="Infrastructure\WindowsAppNotificationBridge.cs" />
+      <Compile Include="Infrastructure\Win32ToastNotifier.cs" />
+      <Compile Include="Infrastructure\AppShortcutAumidStamper.cs" />
       <Compile Include="Infrastructure\TrayService.cs" />
       <Compile Include="Infrastructure\MicaWindowHelper.cs" />
       <Compile Include="Infrastructure\EntrancePageTransition.cs" />
@@ -366,22 +358,4 @@
     <ItemGroup>
       <Folder Include="Models\" />
     </ItemGroup>
-
-   <!-- Prune unused WinUI XAML framework .mui locale satellites.
-        UniGetUI is Avalonia-based and never surfaces WinUI framework control strings;
-        the Windows resource loader silently falls back to en-us when a culture's .mui
-        is absent. -->
-   <Target Name="ExcludeUnusedWinUIMuiResources"
-           AfterTargets="ComputeFilesToPublish"
-           BeforeTargets="CopyFilesToPublishDirectory"
-           Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-     <ItemGroup>
-       <_UnusedMuiResources
-           Include="@(ResolvedFileToPublish)"
-           Condition="'%(ResolvedFileToPublish.Extension)' == '.mui'
-               and '%(ResolvedFileToPublish.RelativePath)' != 'en-us\%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)'
-               and ('%(ResolvedFileToPublish.Filename)' == 'Microsoft.ui.xaml.dll' or '%(ResolvedFileToPublish.Filename)' == 'Microsoft.UI.Xaml.Phone.dll')" />
-       <ResolvedFileToPublish Remove="@(_UnusedMuiResources)" />
-     </ItemGroup>
-   </Target>
- </Project>
+</Project>


### PR DESCRIPTION
## Summary

- Removes the `Microsoft.WindowsAppSDK` PackageReference and WinAppSDK MSBuild properties — **saved 56.41 MiB (26.5%), 100 fewer files** (212.81 MiB → 156.44 MiB).
- Restores real Windows Action-Center toasts without pulling WinAppSDK back, using the OS-provided `Windows.UI.Notifications` COM projection (available under the existing `net10.0-windows` TFM at **~0 MiB** — `WinRT.Runtime.dll` / `Microsoft.Windows.SDK.NET.dll` were already present from WinGet CsWinRT interop).
- Toast clicks route through the existing `unigetui://` deep link; the app self-stamps its AUMID on the Start Menu shortcut on first launch.

## Changes

**New files**
- `Infrastructure/Win32ToastNotifier.cs` — wraps `ToastNotificationManager` / `ToastNotification` / `XmlDocument` (OS WinRT types, no hand-rolled COM). `SetProcessAumid()` P-Invokes `SetCurrentProcessExplicitAppUserModelID`; `IsAvailable()` probes once and caches; `Show()` builds toast XML with `activationType="protocol"` + `launch="unigetui://<action>"`.
- `Infrastructure/AppShortcutAumidStamper.cs` — idempotent first-launch helper that stamps `System.AppUserModel.Id = Devolutions.UniGetUI` on the Start Menu `.lnk` via `IShellLink`/`IPropertyStore`/`IPersistFile` COM. The installer can'"'"'t write the property-store value directly, so the app self-heals it on every launch.

**Modified**
- `Program.cs` — `Win32ToastNotifier.SetProcessAumid()` at the top of `Main`.
- `Infrastructure/AvaloniaAppHost.cs` — `AppShortcutAumidStamper.EnsureStamped()` after startup logging.
- `Infrastructure/WindowsAppNotificationBridge.cs` — toast-first with in-app banner fallback; added `TryParseToastLaunchArgument` + `RaiseActivation` for toast-click routing. Public API preserved.
- `App.axaml.cs` — `HandleSecondaryInstanceArgs` parses `unigetui://<action>` from a second instance (toast click) and raises `NotificationActivated` before foregrounding.
- `UniGetUI.Avalonia.csproj` — removed WinAppSDK ref + properties + dead mui-pruning target; added the two new compile includes.

## Verification

- `dotnet build` (Release, win-x64): **succeeded**
- `dotnet publish` (Release, win-x64): **exit 0**, 340 files
- **Publish size: 156.44 MiB** (was 212.81 MiB) — no WinUI/WinAppSDK binaries in output

## Trade-off

Inline toast buttons ("Update all" / "Update now") are dropped. Clicking a toast foregrounds the app and raises `NotificationActivated`, which routes to the existing handler (navigate to Updates tab / show window / release self-update lock). On non-Windows or if the toast surface is unavailable, every call falls back to the in-app banner — no regression.

## Notes

- Toasts won'"'"'t appear until the app has run once (so `AppShortcutAumidStamper` stamps the AUMID on the shortcut). After install + first launch, subsequent toasts work.
- Debug builds have a pre-existing `AttachDeveloperTools` error (from `AvaloniaUI.DiagnosticsSupport`, gated by `#if AVALONIA_DIAGNOSTICS_ENABLED`) — fails on baseline too, unrelated to this change. Release publish (what CI uses) succeeds cleanly.