### PR TITLE
Collapse carriage-return progress lines in the operation log viewer

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
@@ -18,6 +18,8 @@ public partial class OperationOutputViewModel : ObservableObject
     private readonly IBrush _debugBrush;
     private readonly IBrush _normalBrush;
 
+    private readonly ProgressLineCollapser _collapser = new();
+
     public OperationOutputViewModel(AbstractOperation operation)
     {
         var theme = Application.Current?.ActualThemeVariant ?? ThemeVariant.Default;
@@ -28,10 +30,22 @@ public partial class OperationOutputViewModel : ObservableObject
         Title = operation.Metadata.Title;
 
         foreach (var (text, type) in operation.GetOutput())
-            OutputLines.Add(MakeLine(text, type));
+            AddOrCollapseLine(text, type);
 
         operation.LogLineAdded += (_, ev) =>
-            Dispatcher.UIThread.Post(() => OutputLines.Add(MakeLine(ev.Item1, ev.Item2)));
+            Dispatcher.UIThread.Post(() => AddOrCollapseLine(ev.Item1, ev.Item2));
+    }
+
+    // Progress indicators (carriage-return redraws like installer spinners) overwrite the previous
+    // line instead of stacking up, mirroring how a terminal repaints in place. The first
+    // non-progress line that follows settles into that same line.
+    private void AddOrCollapseLine(string text, AbstractOperation.LineType type)
+    {
+        LogLineItem item = MakeLine(text, type);
+        if (_collapser.Next(type) is ProgressLineCollapser.Fold.ReplaceLast && OutputLines.Count > 0)
+            OutputLines[^1] = item;
+        else
+            OutputLines.Add(item);
     }
 
     private static IBrush LookupBrush(string key, ThemeVariant theme, IBrush fallback)

--- a/src/UniGetUI.Avalonia/Views/Controls/LogTextEditor.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/LogTextEditor.cs
@@ -73,6 +73,21 @@ public class LogTextEditor : TextEditor
         Document.Insert(Document.TextLength, sb.ToString());
     }
 
+    // Overwrites the last physical line in place instead of appending, so carriage-return progress
+    // redraws (installer spinners) repaint a single line rather than flooding the view.
+    public void ReplaceLastLine(LogLineItem line)
+    {
+        if (Document.TextLength == 0 || _lineColors.Count == 0)
+        {
+            AppendLine(line);
+            return;
+        }
+
+        DocumentLine last = Document.GetLineByNumber(Document.LineCount);
+        Document.Replace(last.Offset, last.Length, line.Text);
+        _lineColors[^1] = line.Foreground;
+    }
+
     public void ClearLines()
     {
         _lineColors.Clear();

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
@@ -29,6 +29,12 @@ public partial class OperationOutputWindow : Window
             {
                 OutputText.ClearLines();
             }
+            else if (e.Action == NotifyCollectionChangedAction.Replace && e.NewItems is not null)
+            {
+                // A progress indicator repainting in place: overwrite the last rendered line.
+                foreach (LogLineItem item in e.NewItems)
+                    OutputText.ReplaceLastLine(item);
+            }
             else if (e.NewItems is not null)
             {
                 foreach (LogLineItem item in e.NewItems)

--- a/src/UniGetUI.PackageEngine.Operations/ProgressLineCollapser.cs
+++ b/src/UniGetUI.PackageEngine.Operations/ProgressLineCollapser.cs
@@ -1,0 +1,20 @@
+namespace UniGetUI.PackageOperations;
+
+// Folds a live log stream for in-place display: progress indicators (carriage-return redraws such
+// as installer spinners or download bars) repaint the previous line instead of stacking up,
+// mirroring how a terminal repaints in place. The first non-progress line that follows settles
+// into that same line. Because a progress line is always the most recent one, "replace" always
+// targets the last rendered line.
+public sealed class ProgressLineCollapser
+{
+    public enum Fold { Append, ReplaceLast }
+
+    private bool _lastWasProgress;
+
+    public Fold Next(AbstractOperation.LineType type)
+    {
+        bool wasProgress = _lastWasProgress;
+        _lastWasProgress = type == AbstractOperation.LineType.ProgressIndicator;
+        return wasProgress ? Fold.ReplaceLast : Fold.Append;
+    }
+}

--- a/src/UniGetUI.PackageEngine.Tests/ProgressLineCollapserTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/ProgressLineCollapserTests.cs
@@ -1,0 +1,95 @@
+using UniGetUI.PackageOperations;
+using LineType = UniGetUI.PackageOperations.AbstractOperation.LineType;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public class ProgressLineCollapserTests
+{
+    // Applies the collapser to a stream of (text, type) lines exactly like the live log view does,
+    // returning the lines that would actually be rendered.
+    private static List<string> Render(IEnumerable<(string Text, LineType Type)> stream)
+    {
+        var collapser = new ProgressLineCollapser();
+        var rendered = new List<string>();
+        foreach (var (text, type) in stream)
+        {
+            if (collapser.Next(type) is ProgressLineCollapser.Fold.ReplaceLast && rendered.Count > 0)
+                rendered[^1] = text;
+            else
+                rendered.Add(text);
+        }
+        return rendered;
+    }
+
+    [Fact]
+    public void SpinnerFramesCollapseToASingleLine()
+    {
+        var spinner = new[] { "|", "/", "-", "\\", "|", "/", "-", "\\" }
+            .Select(f => ($"Installing {f}", LineType.ProgressIndicator));
+
+        var rendered = Render(spinner);
+
+        Assert.Single(rendered);
+        Assert.Equal("Installing \\", rendered[0]);   // last frame wins
+    }
+
+    [Fact]
+    public void DownloadProgressCollapsesAndSettlesIntoFinalLine()
+    {
+        var stream = new List<(string, LineType)>
+        {
+            ("Fetching download url...", LineType.Information),
+            ("[=         ] 10 MB/100 MB", LineType.ProgressIndicator),
+            ("[=====     ] 50 MB/100 MB", LineType.ProgressIndicator),
+            ("[==========] 100 MB/100 MB", LineType.ProgressIndicator),
+            ("The file was saved to C:\\out.exe", LineType.Information),
+        };
+
+        var rendered = Render(stream);
+
+        Assert.Equal(
+        [
+            "Fetching download url...",
+            "The file was saved to C:\\out.exe",   // progress bar settled into this line
+        ], rendered);
+    }
+
+    [Fact]
+    public void NonProgressLinesAlwaysAppend()
+    {
+        var stream = new[]
+        {
+            ("line 1", LineType.Information),
+            ("line 2", LineType.VerboseDetails),
+            ("line 3", LineType.Error),
+        };
+
+        var rendered = Render(stream);
+
+        Assert.Equal(["line 1", "line 2", "line 3"], rendered);
+    }
+
+    [Fact]
+    public void ProgressBetweenNormalLinesDoesNotEatThem()
+    {
+        var stream = new[]
+        {
+            ("before", LineType.Information),
+            ("spin 1", LineType.ProgressIndicator),
+            ("spin 2", LineType.ProgressIndicator),
+            ("after", LineType.Information),
+            ("end", LineType.Information),
+        };
+
+        var rendered = Render(stream);
+
+        // "before" kept, two spins collapse and settle into "after", then "end" appends.
+        Assert.Equal(["before", "after", "end"], rendered);
+    }
+
+    [Fact]
+    public void FirstLineNeverReplaces()
+    {
+        Assert.Equal(ProgressLineCollapser.Fold.Append, new ProgressLineCollapser().Next(LineType.ProgressIndicator));
+    }
+}


### PR DESCRIPTION
This pull request introduces a smarter way to handle progress indicator lines (such as spinners or download bars) in the operation output log, making the UI behave more like a terminal by overwriting progress lines in place rather than stacking them. This prevents flooding the view with redundant progress updates and ensures only meaningful output lines are shown. The main changes include the implementation of a `ProgressLineCollapser` utility, integration of this logic into the view model and UI, and comprehensive tests to verify correct behavior.

**Progress Line Collapsing Logic:**

- Added `ProgressLineCollapser` class to detect when progress indicator lines should overwrite the previous line instead of appending a new one, mirroring terminal UI behavior.
- Modified `OperationOutputViewModel` to use `ProgressLineCollapser` and replace or append lines accordingly when handling operation output, both at initialization and during live log updates. 

**UI Integration:**

- Updated `LogTextEditor` with a new `ReplaceLastLine` method, which overwrites the last rendered line in place for progress updates.
- Enhanced the output view event handler to detect replace actions and call `ReplaceLastLine`, ensuring the UI reflects in-place progress updates.

**Testing:**

- Added `ProgressLineCollapserTests` to verify that progress lines collapse correctly, non-progress lines always append, and the logic never incorrectly overwrites the first line or non-progress lines.