### PR TITLE
Fix misleading "Installation options" label on Update/Uninstall operation logs

### DIFF
--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -436,7 +436,7 @@ namespace UniGetUI.PackageEngine.Operations
                 + Package.Id
                 + " with Manager="
                 + Package.Manager.Name
-                + "\nInstallation options: "
+                + "\nUpdate options: "
                 + Options.ToString()
                 + "\nOverriden options: "
                 + Package.OverridenOptions.ToString()
@@ -508,7 +508,7 @@ namespace UniGetUI.PackageEngine.Operations
                 + Package.Id
                 + " with Manager="
                 + Package.Manager.Name
-                + "\nInstallation options: "
+                + "\nUninstall options: "
                 + Options.ToString()
                 + "\nOverriden options: "
                 + Package.OverridenOptions.ToString();


### PR DESCRIPTION
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **Have you confirmed that this issue is caused by UniGetUI itself, and not by the package manager or the package involved?**
-----

`UpdatePackageOperation.Initialize()` and `UninstallPackageOperation.Initialize()` in `PackageOperations.cs` both logged their `Options.ToString()` dump under the header `"Installation options: "`, copy-pasted from `InstallPackageOperation`. Since `InstallOptions` already has three independent fields (`CustomParameters_Install`, `CustomParameters_Update`, `CustomParameters_Uninstall`) that are correctly applied per operation type (see `NpmPkgOperationHelper._getOperationParameters`), the mislabeled header was purely cosmetic, but it's actively misleading during debugging: a user who only set "Custom Install Arguments" sees that value echoed under an `"Installation options:"` banner during an *update* run, which reads as confirmation that the flag applies, when in fact it's `CustomParameters_Update` (a separate, empty field) that actually gets appended to the update command.

This surfaced while diagnosing why `--legacy-peer-deps` wasn't being applied to `npm` package updates: the engine behavior was correct, but the log was telling a different story.

**Change:** rename the header to `"Update options: "` and `"Uninstall options: "` in their respective operation classes. No behavior change, no new abstraction; matches the existing per-class string literal style already used for `Metadata.Title`/`Metadata.Status`/etc. in the same file.

Verified with `dotnet build` (0 errors) and `dotnet test` on `UniGetUI.PackageEngine.Tests` (252/252 passing, no regressions) against SDK 10.0.301.

N/A. No existing issue tracks this; not creating one per the PR template guidance.
