### PR TITLE
Add hint and one-click copy for the three independent CLI-argument fields

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -112,6 +112,8 @@
   "Custom install arguments:": "Custom install arguments:",
   "Custom update arguments:": "Custom update arguments:",
   "Custom uninstall arguments:": "Custom uninstall arguments:",
+  "These fields are independent: an argument set for Install won't apply to Update or Uninstall, and vice versa.": "These fields are independent: an argument set for Install won't apply to Update or Uninstall, and vice versa.",
+  "Copy install arguments to update and uninstall": "Copy install arguments to update and uninstall",
   "Pre-install command:": "Pre-install command:",
   "Post-install command:": "Post-install command:",
   "Abort install if pre-install command fails": "Abort install if pre-install command fails",

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
@@ -45,6 +45,8 @@ public partial class InstallOptionsViewModel : ObservableObject
     public string ParamsInstallLabel { get; } = CoreTools.Translate("Custom install arguments:");
     public string ParamsUpdateLabel { get; } = CoreTools.Translate("Custom update arguments:");
     public string ParamsUninstallLabel { get; } = CoreTools.Translate("Custom uninstall arguments:");
+    public string CliArgsHintLabel { get; } = CoreTools.Translate("These fields are independent: an argument set for Install won't apply to Update or Uninstall, and vice versa.");
+    public string CopyInstallArgsLabel { get; } = CoreTools.Translate("Copy install arguments to update and uninstall");
     public string PreInstallLabel { get; } = CoreTools.Translate("Pre-install command:");
     public string PostInstallLabel { get; } = CoreTools.Translate("Post-install command:");
     public string AbortInstallLabel { get; } = CoreTools.Translate("Abort install if pre-install command fails");
@@ -362,6 +364,13 @@ public partial class InstallOptionsViewModel : ObservableObject
 
     [RelayCommand]
     private void ResetLocation() => LocationText = "";
+
+    [RelayCommand]
+    private void CopyInstallArgsToOthers()
+    {
+        ParamsUpdate = ParamsInstall;
+        ParamsUninstall = ParamsInstall;
+    }
 
     /// <summary>Unlocks the options by turning off "follow default options" (matches WinUI).</summary>
     [RelayCommand]

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InstallOptionsPanelViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InstallOptionsPanelViewModel.cs
@@ -77,6 +77,8 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
     public string InstallArgsLabel { get; } = CoreTools.Translate("Custom install arguments:");
     public string UpdateArgsLabel { get; } = CoreTools.Translate("Custom update arguments:");
     public string UninstallArgsLabel { get; } = CoreTools.Translate("Custom uninstall arguments:");
+    public string CliArgsHintLabel { get; } = CoreTools.Translate("These fields are independent: an argument set for Install won't apply to Update or Uninstall, and vice versa.");
+    public string CopyInstallArgsLabel { get; } = CoreTools.Translate("Copy install arguments to update and uninstall");
     public string ResetLabel { get; } = CoreTools.Translate("Reset");
     public string ApplyLabel { get; } = CoreTools.Translate("Apply");
     public string CliDisabledLabel { get; } = CoreTools.Translate("For security reasons, custom command-line arguments are disabled by default. Go to UniGetUI security settings to change this.");
@@ -283,6 +285,16 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
     [RelayCommand]
     private void NavigateToAdministrator() =>
         NavigateToAdministratorRequested?.Invoke(this, EventArgs.Empty);
+
+    // ── CLI args convenience ─────────────────────────────────────────────────
+
+    [RelayCommand]
+    private void CopyInstallArgsToOthers()
+    {
+        CustomUpdate = CustomInstall;
+        CustomUninstall = CustomInstall;
+        HasChanges = true;
+    }
 
     // ── Mark changed ─────────────────────────────────────────────────────────
 

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -259,6 +259,12 @@
                                        Command="{Binding GoToSecuritySettingsCommand}"
                                        HorizontalAlignment="Left" Padding="0" FontWeight="SemiBold"/>
 
+                      <TextBlock Text="{Binding CliArgsHintLabel}"
+                                 IsVisible="{Binding CliEnabled}"
+                                 TextWrapping="Wrap"
+                                 Opacity="0.7"
+                                 FontSize="12"/>
+
                       <Grid ColumnDefinitions="*,2*"
                             RowDefinitions="Auto,Auto,Auto"
                             ColumnSpacing="8" RowSpacing="8"
@@ -291,6 +297,13 @@
                                  FontSize="14"/>
 
                       </Grid>
+
+                      <HyperlinkButton Content="{Binding CopyInstallArgsLabel}"
+                                       IsVisible="{Binding CliEnabled}"
+                                       automation:AutomationProperties.Name="{Binding CopyInstallArgsLabel}"
+                                       Command="{Binding CopyInstallArgsToOthersCommand}"
+                                       Padding="0"
+                                       HorizontalAlignment="Left"/>
                     </StackPanel>
                 </Border>
             </TabItem>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
@@ -159,11 +159,17 @@
                     </Button>
 
                     <!-- CLI arguments: always shown, disabled by security setting -->
+                    <TextBlock Text="{Binding CliArgsHintLabel}"
+                               IsVisible="{Binding CliSectionEnabled}"
+                               TextWrapping="Wrap"
+                               Opacity="0.7"
+                               FontSize="12"
+                               Margin="0,8,0,0"/>
                     <Grid ColumnDefinitions="*,2*"
                           RowDefinitions="Auto,Auto,Auto"
                           RowSpacing="8"
                           ColumnSpacing="8"
-                          Margin="0,8,0,0">
+                          Margin="0,4,0,0">
                         <TextBlock x:Name="InstallArgsLabelBlock"
                                    Grid.Row="0" Grid.Column="0"
                                    Text="{Binding InstallArgsLabel}"
@@ -206,6 +212,18 @@
                                    x:Name="CustomUninstallBox"
                                    automation:AutomationProperties.LabeledBy="{Binding #UninstallArgsLabelBlock}"/>
                     </Grid>
+
+                    <Button IsVisible="{Binding CliSectionEnabled}"
+                            HorizontalAlignment="Left"
+                            Command="{Binding CopyInstallArgsToOthersCommand}"
+                            automation:AutomationProperties.Name="{Binding CopyInstallArgsLabel}"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Padding="0"
+                            Margin="0,4,0,0">
+                        <TextBlock Text="{Binding CopyInstallArgsLabel}" Classes="hyperlink"
+                                   automation:AutomationProperties.AccessibilityView="Raw"/>
+                    </Button>
 
                 </StackPanel>
             </Border>

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -436,7 +436,7 @@ namespace UniGetUI.PackageEngine.Operations
                 + Package.Id
                 + " with Manager="
                 + Package.Manager.Name
-                + "\nInstallation options: "
+                + "\nUpdate options: "
                 + Options.ToString()
                 + "\nOverriden options: "
                 + Package.OverridenOptions.ToString()
@@ -508,7 +508,7 @@ namespace UniGetUI.PackageEngine.Operations
                 + Package.Id
                 + " with Manager="
                 + Package.Manager.Name
-                + "\nInstallation options: "
+                + "\nUninstall options: "
                 + Options.ToString()
                 + "\nOverriden options: "
                 + Package.OverridenOptions.ToString();


### PR DESCRIPTION
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **Have you confirmed that this issue is caused by UniGetUI itself, and not by the package manager or the package involved?**
-----

Follow-up to #5037. That PR fixed a misleading log label; this one addresses the underlying UX gap that caused the confusion in the first place.

`CustomParameters_Install`, `CustomParameters_Update`, and `CustomParameters_Uninstall` are three independent fields, shown as three separate rows on both the per-manager default-options settings panel (`InstallOptionsPanel`) and the per-package install-options dialog (`InstallOptionsControl`). Nothing on either screen indicates that these fields are independent -- a user reaching for "Custom install arguments" (the first row, and the one most naturally filled in first) has no signal that the same argument won't be applied on update or uninstall, and finds out only when an update fails for a reason that looks unrelated.

**Change**, on both screens:
- A short hint text above/near the three fields: "These fields are independent: an argument set for Install won't apply to Update or Uninstall, and vice versa."
- A "Copy install arguments to update and uninstall" link, for users who *do* want the same argument applied everywhere, so they don't have to retype it three times (and so the omission becomes a visible, deliberate non-action rather than an invisible default).

No behavior change to the underlying `InstallOptions` engine -- this only affects the two settings screens. New strings added to `src/Languages/lang_en.json` following the existing convention (see e.g. #4902).

Verified with `dotnet build` on `UniGetUI.Avalonia.csproj` (0 errors) against SDK 10.0.301 -- Avalonia's compiled `x:DataType` bindings fail the build on any binding-name typo, so a clean build confirms the new bindings (`CliArgsHintLabel`, `CopyInstallArgsLabel`, `CopyInstallArgsToOthersCommand`) resolve correctly on both views.

N/A. No existing issue tracks this; not creating one per the PR template guidance.
