### PR TITLE
Fix/5009 titlebar search text styling

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -27,6 +27,10 @@
                     <SolidColorBrush x:Key="TextFillColorPrimaryBrush"   Color="#E4000000"/>
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#9E000000"/>
                     <SolidColorBrush x:Key="TextFillColorTertiaryBrush"  Color="#72000000"/>
+                    <!-- Search-box placeholders. The big Discover field uses larger (thicker-stroked) text, so it
+                         gets a lighter light-theme value to read as the same weight as the compact title-bar field. -->
+                    <SolidColorBrush x:Key="SearchBoxPlaceholderForeground"   Color="#72000000"/>
+                    <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#52000000"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5C000000"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#FFFFFFFF"/>
                     <!-- Text on accent -->
@@ -102,6 +106,10 @@
                     <SolidColorBrush x:Key="TextFillColorPrimaryBrush"   Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#C5FFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorTertiaryBrush"  Color="#87FFFFFF"/>
+                    <!-- Search-box placeholders. Dark theme keeps the brighter value that matched WinUI; both fields
+                         share it since thick-stroke heaviness only reads as darker on light backgrounds. -->
+                    <SolidColorBrush x:Key="SearchBoxPlaceholderForeground"   Color="#C5FFFFFF"/>
+                    <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#C5FFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5DFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#E4000000"/>
                     <!-- Text on accent -->

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -410,8 +410,8 @@
                         VerticalAlignment="Center"
                         Orientation="Horizontal"
                         Margin="65,0,8,0"
-                        Spacing="8"
-                        Opacity="0.6">
+                        Spacing="8">
+                <!-- Opacity follows window focus (see SetupTitleBarFocusOpacity): white title when active, dimmed when not. -->
                 <!-- Back button — appears once there is navigation history (mirrors WinUI's title-bar back). -->
                 <Button x:Name="BackButton"
                         Width="32" Height="32"
@@ -477,6 +477,7 @@
                                  VerticalContentAlignment="Center"
                                  Padding="12,0,4,0"
                                  Background="Transparent"
+                                 PlaceholderForeground="{DynamicResource SearchBoxPlaceholderForeground}"
                                  PlaceholderText="{Binding GlobalSearchPlaceholder}"
                                  IsEnabled="{Binding GlobalSearchEnabled}"
                                  automation:AutomationProperties.Name="{Binding GlobalSearchPlaceholder}"
@@ -492,6 +493,8 @@
                                 <SolidColorBrush x:Key="TextControlBackground" Color="Transparent"/>
                                 <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="Transparent"/>
                                 <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="Transparent"/>
+                                <!-- Fluent dims placeholders to 0.5; WinUI showed them at full secondary-text brightness. -->
+                                <x:Double x:Key="TextControlPlaceholderOpacity">1</x:Double>
                             </TextBox.Resources>
                         </TextBox>
                         <Button Grid.Column="1"
@@ -528,7 +531,6 @@
                             VerticalAlignment="Center"
                             Margin="0,0,4,0"
                             Spacing="0"
-                            Opacity="0.55"
                             IsVisible="False">
                     <!-- Minimize: horizontal line -->
                     <Button Width="46" Height="32" Padding="0"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -115,6 +115,7 @@ public partial class MainWindow : Window
         DataContext = new MainWindowViewModel();
         InitializeComponent();
         SetupTitleBar();
+        SetupTitleBarFocusOpacity();
         SetupResponsiveRail();
 
         RestoreGeometry();
@@ -299,6 +300,14 @@ public partial class MainWindow : Window
     // Light-dismiss: clicking outside the open flyout closes it (no darkening — the layer is transparent).
     private void FlyoutDismiss_PointerPressed(object? sender, PointerPressedEventArgs e)
         => ViewModel.Sidebar.IsPaneOpen = false;
+
+    // Title-bar caption follows window focus (WinUI behaviour): full opacity — white title — when active, dimmed when not.
+    private void SetupTitleBarFocusOpacity()
+        => this.GetObservable(IsActiveProperty).SubscribeValue(active =>
+        {
+            HamburgerPanel.Opacity = active ? 1.0 : 0.6;
+            WindowButtons.Opacity = active ? 1.0 : 0.55;
+        });
 
     private void SetupTitleBar()
     {

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -61,7 +61,7 @@
                         <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/update.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                         <TextBlock Text="{t:Translate Software Updates}"
                                    FontSize="14"
-                                   FontWeight="SemiBold"
+                                   FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
@@ -103,7 +103,7 @@
                         <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/InstalledPackages.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                         <TextBlock Text="{t:Translate Installed Packages}"
                                    FontSize="14"
-                                   FontWeight="SemiBold"
+                                   FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
@@ -128,7 +128,7 @@
                         <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/PackagesBundle.svg" Width="24" Height="24" VerticalAlignment="Center"/>
                         <TextBlock Text="{t:Translate Package Bundles}"
                                    FontSize="14"
-                                   FontWeight="SemiBold"
+                                   FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -848,7 +848,8 @@
                                          BorderThickness="0"
                                          Background="Transparent"
                                          FontSize="28"
-                                         FontWeight="SemiBold"
+                                         FontWeight="Normal"
+                                         PlaceholderForeground="{DynamicResource MegaQueryPlaceholderForeground}"
                                          PlaceholderText="{t:Translate Search for packages}"
                                          automation:AutomationProperties.Name="{t:Translate Search for packages}"
                                          Text="{Binding MegaQueryText, Mode=TwoWay}"
@@ -860,6 +861,8 @@
                                         <SolidColorBrush x:Key="TextControlBackground" Color="Transparent"/>
                                         <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="Transparent"/>
                                         <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="Transparent"/>
+                                        <!-- Fluent dims placeholders to 0.5; WinUI showed them at full secondary-text brightness. -->
+                                        <x:Double x:Key="TextControlPlaceholderOpacity">1</x:Double>
                                     </TextBox.Resources>
                                 </TextBox>
                                 <Button x:Name="MegaFindButton"


### PR DESCRIPTION
This pull request improves the visual consistency and accessibility of placeholder text and title bar elements in the UI, aligning them more closely with WinUI standards. The main changes include introducing theme-specific placeholder colors, making placeholder opacity consistent, and updating title bar and sidebar styling for better focus indication and readability.

**Placeholder Text Styling Improvements:**

* Added `SearchBoxPlaceholderForeground` and `MegaQueryPlaceholderForeground` resources in `Styles.Common.axaml` for both light and dark themes, ensuring appropriate placeholder color contrast and weight matching WinUI conventions. 
* Applied the new placeholder foreground resources to the global search box and the main "mega query" search box, ensuring consistent placeholder appearance across the app. 
* Set `TextControlPlaceholderOpacity` to `1` in relevant `TextBox` resources, so placeholder text displays at full intended brightness, matching WinUI behavior. 

**Title Bar and Window Focus Enhancements:**

* Removed hard-coded opacity from title bar elements and sidebar window buttons, and implemented `SetupTitleBarFocusOpacity()` in `MainWindow.axaml.cs` to dynamically adjust opacity based on window focus, giving a clear visual cue when the window is active or inactive. 
**Sidebar and Search Box Font Weight Adjustments:**

* Changed several sidebar and search box text elements from `SemiBold` to `Normal` font weight for improved consistency and readability. 