### PR TITLE
 Smooth package-list scrolling and stop re-parsing SVG icons on every scroll

### DIFF
--- a/src/UniGetUI.Avalonia/Views/Controls/DataGridWheelAnimator.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/DataGridWheelAnimator.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
+using UniGetUI.Avalonia.Infrastructure;
 
 namespace UniGetUI.Avalonia.Views.Controls;
 
@@ -40,7 +41,8 @@ public sealed class DataGridWheelAnimator
 
     private void OnWheel(object? sender, PointerWheelEventArgs e)
     {
-        if (e.Delta.Y == 0 || e.KeyModifiers == KeyModifiers.Shift) return;
+        // Fall back to the native instant scroll for horizontal/shift, or when reduced motion is on.
+        if (e.Delta.Y == 0 || e.KeyModifiers == KeyModifiers.Shift || MotionPreference.ReducedMotion) return;
 
         _pending += e.Delta.Y * WheelStep;
         e.Handled = true;

--- a/src/UniGetUI.Avalonia/Views/Controls/DataGridWheelAnimator.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/DataGridWheelAnimator.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+
+namespace UniGetUI.Avalonia.Views.Controls;
+
+/// <summary>
+/// Eases DataGrid wheel scrolling to a stop (WinUI-like) instead of jumping the whole delta at once.
+/// The grid has no public scroll offset, so we drive its internal UpdateScroll via reflection; if that
+/// ever breaks we never attach and the stock instant behavior stands.
+/// </summary>
+public sealed class DataGridWheelAnimator
+{
+    private static readonly MethodInfo? UpdateScroll =
+        typeof(DataGrid).GetMethod("UpdateScroll", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private const double WheelStep = 50.0;      // matches the DataGrid's own per-notch pixel amount
+    private const double EasePerFrame = 0.4;    // fraction of the remaining distance consumed each frame; higher = snappier
+
+    private readonly DataGrid _grid;
+    private readonly DispatcherTimer _timer;
+    private readonly object?[] _args = new object?[1];
+    private double _pending;
+
+    private DataGridWheelAnimator(DataGrid grid)
+    {
+        _grid = grid;
+        _timer = new DispatcherTimer(TimeSpan.FromMilliseconds(1000.0 / 90), DispatcherPriority.Render, OnTick);
+        grid.AddHandler(InputElement.PointerWheelChangedEvent, OnWheel, RoutingStrategies.Tunnel);
+    }
+
+    public static void Attach(DataGrid grid)
+    {
+        if (UpdateScroll is not null) _ = new DataGridWheelAnimator(grid);
+    }
+
+    private void OnWheel(object? sender, PointerWheelEventArgs e)
+    {
+        if (e.Delta.Y == 0 || e.KeyModifiers == KeyModifiers.Shift) return;
+
+        _pending += e.Delta.Y * WheelStep;
+        e.Handled = true;
+        if (!_timer.IsEnabled) _timer.Start();
+    }
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        double step = _pending * EasePerFrame;
+        if (Math.Abs(step) < 2.0) step = _pending;
+
+        _args[0] = new Vector(0, step);
+        bool scrolled = UpdateScroll!.Invoke(_grid, _args) is true;
+        _pending -= step;
+
+        if (!scrolled || _pending == 0)
+        {
+            _pending = 0;
+            _timer.Stop();
+        }
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
@@ -82,24 +83,44 @@ public class SvgIcon : Control
 
     private void OnThemeChanged(object? sender, EventArgs e) => InvalidateVisual();
 
+    // Parsed SVGs are immutable static assets referenced by a small fixed set of URIs, yet the
+    // same icon is realized thousands of times as the DataGrid recycles rows during scrolling.
+    // Memoizing the parse keeps scrolling from re-opening and re-parsing assets on the UI thread.
+    private sealed record ParsedSvg(IReadOnlyList<Geometry> Geometries, double ViewBoxWidth, double ViewBoxHeight);
+    private static readonly ConcurrentDictionary<string, ParsedSvg> _cache = new();
+
     private void LoadSvg(string? uri)
     {
-        _geometries.Clear();
-        _viewBoxWidth = 24;
-        _viewBoxHeight = 24;
-
         if (string.IsNullOrEmpty(uri))
         {
+            _geometries.Clear();
+            _viewBoxWidth = 24;
+            _viewBoxHeight = 24;
             InvalidateVisual();
             return;
         }
+
+        ParsedSvg parsed = _cache.GetOrAdd(uri, ParseSvg);
+        _geometries.Clear();
+        _geometries.AddRange(parsed.Geometries);
+        _viewBoxWidth = parsed.ViewBoxWidth;
+        _viewBoxHeight = parsed.ViewBoxHeight;
+
+        InvalidateMeasure();
+        InvalidateVisual();
+    }
+
+    private static ParsedSvg ParseSvg(string uri)
+    {
+        var geometries = new List<Geometry>();
+        double viewBoxWidth = 24, viewBoxHeight = 24;
 
         try
         {
             using Stream stream = AssetLoader.Open(new Uri(uri));
             XDocument doc = XDocument.Load(stream);
             XElement? svg = doc.Root;
-            if (svg is null) return;
+            if (svg is null) return new ParsedSvg(geometries, viewBoxWidth, viewBoxHeight);
 
             string? vb = svg.Attribute("viewBox")?.Value;
             if (vb != null)
@@ -111,8 +132,8 @@ public class SvgIcon : Control
                     double.TryParse(parts[3], System.Globalization.NumberStyles.Any,
                         System.Globalization.CultureInfo.InvariantCulture, out double h))
                 {
-                    _viewBoxWidth = w;
-                    _viewBoxHeight = h;
+                    viewBoxWidth = w;
+                    viewBoxHeight = h;
                 }
             }
             else if (
@@ -121,8 +142,8 @@ public class SvgIcon : Control
                 double.TryParse(svg.Attribute("height")?.Value, System.Globalization.NumberStyles.Any,
                     System.Globalization.CultureInfo.InvariantCulture, out double svgH))
             {
-                _viewBoxWidth = svgW;
-                _viewBoxHeight = svgH;
+                viewBoxWidth = svgW;
+                viewBoxHeight = svgH;
             }
 
             XNamespace ns = "http://www.w3.org/2000/svg";
@@ -131,7 +152,7 @@ public class SvgIcon : Control
                 string? d = el.Attribute("d")?.Value;
                 if (!string.IsNullOrEmpty(d))
                 {
-                    try { _geometries.Add(Geometry.Parse(d)); }
+                    try { geometries.Add(Geometry.Parse(d)); }
                     catch { /* skip malformed path data */ }
                 }
             }
@@ -146,7 +167,7 @@ public class SvgIcon : Control
                     double.TryParse(el.Attribute("ry")?.Value, System.Globalization.NumberStyles.Any,
                         System.Globalization.CultureInfo.InvariantCulture, out double ry))
                 {
-                    _geometries.Add(new EllipseGeometry(new Rect(cx - rx, cy - ry, rx * 2, ry * 2)));
+                    geometries.Add(new EllipseGeometry(new Rect(cx - rx, cy - ry, rx * 2, ry * 2)));
                 }
             }
         }
@@ -155,8 +176,7 @@ public class SvgIcon : Control
             // Silently ignore missing or unreadable assets
         }
 
-        InvalidateMeasure();
-        InvalidateVisual();
+        return new ParsedSvg(geometries, viewBoxWidth, viewBoxHeight);
     }
 
     private static readonly IBrush _darkFg = new SolidColorBrush(Color.Parse("#E8E8E8"));

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -92,6 +92,9 @@ public abstract partial class AbstractPackagesPage : UserControl,
         // redirect focus + the typed character to the global search box.
         PackageList.TextInput += PackageList_TextInput;
 
+        // Ease wheel scrolling to a stop instead of jumping per notch (WinUI-like feel).
+        DataGridWheelAnimator.Attach(PackageList);
+
         // Snap-close when splitter is dragged below the minimum (inline mode only).
         // Using ColumnDefinition.WidthProperty fires every drag step, not just on release.
         FilteringPanel.ColumnDefinitions[0]


### PR DESCRIPTION
This pull request introduces two main improvements: smoother DataGrid wheel scrolling and significant performance optimization for SVG icon loading. The new `DataGridWheelAnimator` class provides a WinUI-like eased scroll experience, and the `SvgIcon` control now memoizes parsed SVGs to avoid redundant parsing and asset loading, greatly improving UI responsiveness during heavy DataGrid usage.

**UI/UX Improvements:**
- Added `DataGridWheelAnimator` to enable eased, animated wheel scrolling for `DataGrid`, replacing the default instant jump with a smoother experience. This is achieved by driving the internal scroll method via reflection and gradually applying the scroll delta. (`src/UniGetUI.Avalonia/Views/Controls/DataGridWheelAnimator.cs`, [src/UniGetUI.Avalonia/Views/Controls/DataGridWheelAnimator.csR1-R65](diffhunk://#diff-174cfe85a584d2925d378b92eba9949991a59f8165c3369f6136a1b8450f651fR1-R65))
- Integrated the new scroll animator by attaching it to `PackageList` in the packages page, so users benefit from the improved scrolling immediately. (`src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs`

**Performance Optimizations:**
- Refactored `SvgIcon` to cache parsed SVGs using a thread-safe dictionary, preventing repeated parsing and asset loading for the same icon URI. This greatly reduces UI thread work and improves scrolling performance when icons are reused. (`src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs`
- Moved SVG parsing logic into a static method and record, ensuring that geometry and viewbox calculations are performed once per unique asset and reused efficiently. (`src/UniGetUI.Avalonia/Views/Controls/SvgIcon.cs`