### PR TITLE
Support full trim publishing

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -77,3 +77,21 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: dotnet test UniGetUI.Windows.slnx --no-restore --verbosity q --nologo /p:Platform=x64 /p:UseSharedCompilation=false /m:1
+
+    - name: Report full-trim publish warnings
+      working-directory: src
+      shell: pwsh
+      continue-on-error: true
+      run: |
+        dotnet build-server shutdown
+        dotnet publish UniGetUI.Avalonia/UniGetUI.Avalonia.csproj `
+          --no-restore `
+          --configuration Release `
+          --runtime win-x64 `
+          --self-contained true `
+          --output "${{ runner.temp }}\unigetui-full-trim-publish" `
+          /p:Platform=x64 `
+          /p:TrimMode=full `
+          /p:TrimmerSingleWarn=false `
+          /p:UseSharedCompilation=false `
+          --verbosity minimal

--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Threading;
 #if AVALONIA_DIAGNOSTICS_ENABLED
 using Avalonia.Diagnostics;
 #endif
+using UniGetUI.Avalonia.Assets.Styles;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.Views;
 using UniGetUI.Avalonia.Views.DialogPages;
@@ -37,18 +38,9 @@ public partial class App : Application
 #endif
     }
 
-    // ResourceInclude is flagged with RequiresUnreferencedCode because, in general, it can load
-    // resources from other assemblies that trimming might remove. Styles.WindowsMica.axaml is an
-    // avares resource embedded in THIS assembly, so it is never trimmed — the warning is safe to
-    // suppress here. (It can't be declared in XAML because the merge is conditional at runtime.)
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Styles.WindowsMica.axaml is an avares resource in this assembly and is not trimmed.")]
     private void ApplyWindowsMicaStyling()
     {
-        Resources.MergedDictionaries.Add(new ResourceInclude((Uri?)null)
-        {
-            Source = new Uri("avares://UniGetUI/Assets/Styles/Styles.WindowsMica.axaml")
-        });
+        Resources.MergedDictionaries.Add(new WindowsMicaStyles());
         // Give flyouts/menus/tooltips a native acrylic backdrop (DWM) so they blur + tint
         // from behind and adapt to the theme.
         MicaWindowHelper.EnableAcrylicPopups();

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:Class="UniGetUI.Avalonia.Assets.Styles.WindowsMicaStyles">
     <!--
         Windows 11 Mica overrides. Merged into Application.Resources ONLY when Mica is
         actually active (Windows 11 + "Transparency effects" on) — see App.Initialize().

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml.cs
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace UniGetUI.Avalonia.Assets.Styles;
+
+public partial class WindowsMicaStyles : ResourceDictionary
+{
+    public WindowsMicaStyles()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
@@ -1,5 +1,6 @@
 #if WINDOWS
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 using UniGetUI.Core.Logging;
@@ -61,6 +62,10 @@ internal static class AppShortcutAumidStamper
         return File.Exists(commonPath) ? commonPath : null;
     }
 
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2072",
+        Justification = "ShellLink COM activation uses the shell-registered CLSID and COM interfaces declared below; it does not depend on app-owned constructors trimmed from this assembly.")]
     private static void StampIfMissing(string shortcutPath)
     {
         // ShellLink (CLSID 00021401-0000-0000-C000-000000000046) implements IPersistFile and

--- a/src/UniGetUI.Avalonia/Infrastructure/GitHubAuthService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/GitHubAuthService.cs
@@ -1,8 +1,8 @@
-using Octokit;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SecureSettings;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface;
 using CoreSettings = UniGetUI.Core.SettingsEngine.Settings;
 
 namespace UniGetUI.Avalonia.Infrastructure;
@@ -15,25 +15,18 @@ internal sealed class GitHubAuthService
     private readonly string _gitHubClientId = Secrets.GetGitHubClientId();
     private readonly string _gitHubClientSecret = Secrets.GetGitHubClientSecret();
     private const string RedirectUri = "http://127.0.0.1:58642/";
-    private readonly GitHubClient _client;
 
     public static event EventHandler<EventArgs>? AuthStatusChanged;
 
-    public GitHubAuthService()
-    {
-        _client = new GitHubClient(new ProductHeaderValue("UniGetUI", CoreData.VersionName));
-    }
+    public GitHubAuthService() { }
 
-    public static GitHubClient? CreateGitHubClient()
+    public static GitHubApiClient? CreateGitHubClient()
     {
         var token = SecureGHTokenManager.GetToken();
         if (string.IsNullOrEmpty(token))
             return null;
 
-        return new GitHubClient(new ProductHeaderValue("UniGetUI", CoreData.VersionName))
-        {
-            Credentials = new Credentials(token),
-        };
+        return new GitHubApiClient(token);
     }
 
     private GHAuthApiRunner? _loginBackend;
@@ -53,13 +46,11 @@ internal sealed class GitHubAuthService
 
             Logger.Info("Initiating GitHub sign-in process using loopback redirect...");
 
-            var request = new OauthLoginRequest(_gitHubClientId)
-            {
-                Scopes = { "read:user", "gist" },
-                RedirectUri = new Uri(RedirectUri),
-            };
-
-            var oauthLoginUrl = _client.Oauth.GetGitHubLoginUrl(request);
+            var oauthLoginUrl = GitHubApiClient.GetOAuthLoginUrl(
+                _gitHubClientId,
+                new Uri(RedirectUri),
+                ["read:user", "gist"]
+            );
 
             _codeFromApi = null;
             _loginWasCancelled = false;
@@ -141,11 +132,13 @@ internal sealed class GitHubAuthService
     {
         try
         {
-            var tokenRequest = new OauthTokenRequest(_gitHubClientId, _gitHubClientSecret, code)
-            {
-                RedirectUri = new Uri(RedirectUri), // The same redirect_uri must be sent
-            };
-            var token = await _client.Oauth.CreateAccessToken(tokenRequest);
+            using var client = new GitHubApiClient();
+            var token = await client.CreateAccessTokenAsync(
+                _gitHubClientId,
+                _gitHubClientSecret,
+                code,
+                new Uri(RedirectUri)
+            );
 
             if (string.IsNullOrEmpty(token.AccessToken))
             {
@@ -157,11 +150,8 @@ internal sealed class GitHubAuthService
             Logger.Info("GitHub login successful. Storing access token.");
             SecureGHTokenManager.StoreToken(token.AccessToken);
 
-            var userClient = new GitHubClient(new ProductHeaderValue("UniGetUI"))
-            {
-                Credentials = new Credentials(token.AccessToken),
-            };
-            var user = await userClient.User.Current();
+            using var userClient = new GitHubApiClient(token.AccessToken);
+            var user = await userClient.GetCurrentUserAsync();
             if (user is not null)
             {
                 CoreSettings.SetValue(CoreSettings.K.GitHubUserLogin, user.Login);

--- a/src/UniGetUI.Avalonia/Infrastructure/GitHubCloudBackupService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/GitHubCloudBackupService.cs
@@ -1,7 +1,6 @@
-using Octokit;
-using UniGetUI.Core.Data;
 using UniGetUI.Core.SecureSettings;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface;
 
 namespace UniGetUI.Avalonia.Infrastructure;
 
@@ -20,24 +19,21 @@ internal static class GitHubCloudBackupService
         public required string Display { get; init; }
     }
 
-    public static GitHubClient? CreateGitHubClient()
+    public static GitHubApiClient? CreateGitHubClient()
     {
         string? token = SecureGHTokenManager.GetToken();
         if (string.IsNullOrWhiteSpace(token))
             return null;
 
-        return new GitHubClient(new ProductHeaderValue("UniGetUI", CoreData.VersionName))
-        {
-            Credentials = new Credentials(token),
-        };
+        return new GitHubApiClient(token);
     }
 
     public static async Task<(string Login, string DisplayName)> GetCurrentUserAsync()
     {
-        var client = CreateGitHubClient()
+        using var client = CreateGitHubClient()
             ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
 
-        var user = await client.User.Current();
+        var user = await client.GetCurrentUserAsync();
         string login = user.Login ?? string.Empty;
         string displayName = string.IsNullOrWhiteSpace(user.Name) ? login : user.Name;
         return (login, displayName);
@@ -45,31 +41,26 @@ internal static class GitHubCloudBackupService
 
     public static async Task UploadPackageBundleAsync(string bundleContents)
     {
-        var client = CreateGitHubClient()
+        using var client = CreateGitHubClient()
             ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
 
-        var user = await client.User.Current();
-        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: true)
+        var backupGist = await GetBackupGistAsync(client, createIfMissing: true)
             ?? throw new InvalidOperationException(CoreTools.Translate("Backup Failed"));
 
         string fileKey = BuildGistFileKey();
-        var update = new GistUpdate { Description = GistDescription };
-
-        if (backupGist.Files.ContainsKey(fileKey))
-            update.Files[fileKey] = new GistFileUpdate { Content = bundleContents };
-        else
-            update.Files.Add(fileKey, new GistFileUpdate { Content = bundleContents });
-
-        await client.Gist.Edit(backupGist.Id, update);
+        await client.EditGistAsync(
+            backupGist.Id,
+            GistDescription,
+            new Dictionary<string, string> { [fileKey] = bundleContents }
+        );
     }
 
     public static async Task<IReadOnlyList<CloudBackupEntry>> GetAvailableBackupsAsync()
     {
-        var client = CreateGitHubClient()
+        using var client = CreateGitHubClient()
             ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
 
-        var user = await client.User.Current();
-        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: false);
+        var backupGist = await GetBackupGistAsync(client, createIfMissing: false);
         if (backupGist is null)
             return [];
 
@@ -85,16 +76,15 @@ internal static class GitHubCloudBackupService
 
     public static async Task<string> GetBackupContentsAsync(string backupKey)
     {
-        var client = CreateGitHubClient()
+        using var client = CreateGitHubClient()
             ?? throw new InvalidOperationException(CoreTools.Translate("Log in to enable cloud backup"));
 
-        var user = await client.User.Current();
-        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: false);
+        var backupGist = await GetBackupGistAsync(client, createIfMissing: false);
 
         if (backupGist is null)
             throw new KeyNotFoundException(CoreTools.Translate("Log in to enable cloud backup"));
 
-        var fullGist = await client.Gist.Get(backupGist.Id);
+        var fullGist = await client.GetGistAsync(backupGist.Id);
         var file = fullGist.Files.FirstOrDefault(f =>
             f.Key.StartsWith(PackageBackupStartingKey, StringComparison.Ordinal)
             && f.Key.EndsWith(backupKey, StringComparison.Ordinal));
@@ -105,18 +95,23 @@ internal static class GitHubCloudBackupService
         return file.Value.Content;
     }
 
-    private static async Task<Gist?> GetBackupGistAsync(GitHubClient client, string userLogin, bool createIfMissing)
+    private static async Task<GitHubGist?> GetBackupGistAsync(
+        GitHubApiClient client,
+        bool createIfMissing
+    )
     {
-        var candidates = await client.Gist.GetAllForUser(userLogin);
+        var candidates = await client.GetCurrentUserGistsAsync();
         var backupGist = candidates.FirstOrDefault(g =>
             g.Description?.EndsWith(GistDescriptionEndingKey, StringComparison.Ordinal) == true);
 
         if (backupGist is not null || !createIfMissing)
             return backupGist;
 
-        var newGist = new NewGist { Description = GistDescription, Public = false };
-        newGist.Files.Add("- UniGetUI Package Backups", ReadMeContents);
-        return await client.Gist.Create(newGist);
+        return await client.CreateGistAsync(
+            GistDescription,
+            isPublic: false,
+            new Dictionary<string, string> { ["- UniGetUI Package Backups"] = ReadMeContents }
+        );
     }
 
     private static string BuildGistFileKey()

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -22,13 +22,14 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <ApplicationManifest Condition="$([MSBuild]::IsOSPlatform('Windows'))">app.manifest</ApplicationManifest>
         <PublishTrimmed>true</PublishTrimmed>
-        <TrimMode>partial</TrimMode>
+        <TrimMode>full</TrimMode>
         <PublishSingleFile>false</PublishSingleFile>
         <IncludeAvaloniaPublishSymbols>false</IncludeAvaloniaPublishSymbols>
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <NoWarn>$(NoWarn);MVVMTK0045</NoWarn>
+        <!-- Parameterized windows/base views are directly constructed in code, not through the runtime XAML loader. -->
+        <NoWarn>$(NoWarn);MVVMTK0045;AVLN3001</NoWarn>
         <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'arm64'">win-arm64</RuntimeIdentifier>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and ('$(Platform)' == 'x64' or '$(Platform)' == 'x86')">win-$(Platform)</RuntimeIdentifier>
@@ -147,7 +148,6 @@
         <PackageReference Include="Devolutions.AvaloniaTheme.Linux" Version="2026.3.11" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
         <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3" Condition="'$(EnableAvaloniaDiagnostics)' == 'true'" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
-        <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
         <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />

--- a/src/UniGetUI.Avalonia/ViewModels/Controls/UserAvatarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Controls/UserAvatarViewModel.cs
@@ -1,10 +1,10 @@
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
-using Octokit;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface;
 using MvvmRelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace UniGetUI.Avalonia.ViewModels.Controls;
@@ -57,10 +57,10 @@ public class UserAvatarViewModel : ViewModelBase
         {
             try
             {
-                var client = GitHubAuthService.CreateGitHubClient();
+                using var client = GitHubAuthService.CreateGitHubClient();
                 if (client is not null)
                 {
-                    User user = await client.User.Current();
+                    GitHubUser user = await client.GetCurrentUserAsync();
                     displayName = string.IsNullOrEmpty(user.Name)
                         ? $"@{user.Login}"
                         : $"{user.Name} (@{user.Login})";

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/BackupViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/BackupViewModel.cs
@@ -156,20 +156,24 @@ public partial class BackupViewModel : ViewModelBase
 
     private async Task GenerateLogoutState()
     {
-        var client = GitHubAuthService.CreateGitHubClient()
+        using var client = GitHubAuthService.CreateGitHubClient()
             ?? throw new InvalidOperationException("Authenticated but cannot create GitHub client.");
-        var user = await client.User.Current();
+        var user = await client.GetCurrentUserAsync();
 
         IsLoggedIn = true;
-        GitHubUserTitle = CoreTools.Translate("You are logged in as {0} (@{1})", user.Name, user.Login);
+        string displayName = string.IsNullOrWhiteSpace(user.Name) ? user.Login : user.Name;
+        GitHubUserTitle = CoreTools.Translate("You are logged in as {0} (@{1})", displayName, user.Login);
         GitHubUserSubtitle = CoreTools.Translate("Nice! Backups will be uploaded to a private gist on your account");
 
         try
         {
             using var http = new HttpClient(CoreTools.GenericHttpClientParameters);
-            var bytes = await http.GetByteArrayAsync(user.AvatarUrl);
-            using var ms = new MemoryStream(bytes);
-            GitHubAvatarBitmap = new Bitmap(ms);
+            if (!string.IsNullOrWhiteSpace(user.AvatarUrl))
+            {
+                var bytes = await http.GetByteArrayAsync(user.AvatarUrl);
+                using var ms = new MemoryStream(bytes);
+                GitHubAvatarBitmap = new Bitmap(ms);
+            }
         }
         catch (Exception ex)
         {

--- a/src/UniGetUI.Interface.IpcApi/GitHubApiClient.cs
+++ b/src/UniGetUI.Interface.IpcApi/GitHubApiClient.cs
@@ -1,0 +1,393 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Interface;
+
+public sealed class GitHubApiClient : IDisposable
+{
+    private static readonly Uri GitHubBaseUri = new("https://github.com/");
+    private static readonly Uri GitHubApiBaseUri = new("https://api.github.com/");
+    private readonly HttpClient _httpClient;
+
+    public GitHubApiClient(string? token = null)
+    {
+        _httpClient = new HttpClient(CoreTools.GenericHttpClientParameters)
+        {
+            BaseAddress = GitHubApiBaseUri,
+        };
+        _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
+        _httpClient.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        _httpClient.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+
+    public static Uri GetOAuthLoginUrl(
+        string clientId,
+        Uri redirectUri,
+        IEnumerable<string> scopes
+    )
+    {
+        string query = BuildQueryString(
+            new Dictionary<string, string?>
+            {
+                ["client_id"] = clientId,
+                ["redirect_uri"] = redirectUri.ToString(),
+                ["scope"] = string.Join(' ', scopes),
+            }
+        );
+        return new Uri(GitHubBaseUri, "login/oauth/authorize" + query);
+    }
+
+    public Task<GitHubOAuthToken> CreateAccessTokenAsync(
+        string clientId,
+        string clientSecret,
+        string code,
+        Uri redirectUri
+    )
+    {
+        return PostOAuthFormAsync(
+            "login/oauth/access_token",
+            new Dictionary<string, string?>
+            {
+                ["client_id"] = clientId,
+                ["client_secret"] = clientSecret,
+                ["code"] = code,
+                ["redirect_uri"] = redirectUri.ToString(),
+            },
+            GitHubJsonContext.Default.GitHubOAuthToken
+        );
+    }
+
+    public Task<GitHubDeviceFlow> InitiateDeviceFlowAsync(
+        string clientId,
+        IEnumerable<string> scopes,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return PostOAuthFormAsync(
+            "login/device/code",
+            new Dictionary<string, string?>
+            {
+                ["client_id"] = clientId,
+                ["scope"] = string.Join(' ', scopes),
+            },
+            GitHubJsonContext.Default.GitHubDeviceFlow,
+            cancellationToken
+        );
+    }
+
+    public Task<GitHubOAuthToken> CreateAccessTokenForDeviceFlowAsync(
+        string clientId,
+        GitHubDeviceFlow deviceFlow,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return PostOAuthFormAsync(
+            "login/oauth/access_token",
+            new Dictionary<string, string?>
+            {
+                ["client_id"] = clientId,
+                ["device_code"] = deviceFlow.DeviceCode,
+                ["grant_type"] = "urn:ietf:params:oauth:grant-type:device_code",
+            },
+            GitHubJsonContext.Default.GitHubOAuthToken,
+            cancellationToken
+        );
+    }
+
+    public Task<GitHubUser> GetCurrentUserAsync(CancellationToken cancellationToken = default)
+    {
+        return GetJsonAsync("user", GitHubJsonContext.Default.GitHubUser, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<GitHubGist>> GetCurrentUserGistsAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        return GetJsonAsync(
+            "gists",
+            GitHubJsonContext.Default.IReadOnlyListGitHubGist,
+            cancellationToken
+        );
+    }
+
+    public Task<GitHubGist> GetGistAsync(string gistId, CancellationToken cancellationToken = default)
+    {
+        return GetJsonAsync(
+            "gists/" + Uri.EscapeDataString(gistId),
+            GitHubJsonContext.Default.GitHubGist,
+            cancellationToken
+        );
+    }
+
+    public Task<GitHubGist> CreateGistAsync(
+        string description,
+        bool isPublic,
+        IReadOnlyDictionary<string, string> files,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return SendGistAsync(
+            HttpMethod.Post,
+            "gists",
+            description,
+            isPublic,
+            files,
+            cancellationToken
+        );
+    }
+
+    public Task<GitHubGist> EditGistAsync(
+        string gistId,
+        string description,
+        IReadOnlyDictionary<string, string> files,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return SendGistAsync(
+            HttpMethod.Patch,
+            "gists/" + Uri.EscapeDataString(gistId),
+            description,
+            isPublic: false,
+            files,
+            cancellationToken
+        );
+    }
+
+    private async Task<GitHubGist> SendGistAsync(
+        HttpMethod method,
+        string relativeUri,
+        string description,
+        bool isPublic,
+        IReadOnlyDictionary<string, string> files,
+        CancellationToken cancellationToken
+    )
+    {
+        var request = new GitHubGistRequest
+        {
+            Description = description,
+            IsPublic = method == HttpMethod.Post ? isPublic : null,
+            Files = files.ToDictionary(
+                file => file.Key,
+                file => new GitHubGistFileRequest { Content = file.Value },
+                StringComparer.Ordinal
+            ),
+        };
+
+        using var message = new HttpRequestMessage(method, relativeUri)
+        {
+            Content = CreateJsonContent(request, GitHubJsonContext.Default.GitHubGistRequest),
+        };
+        return await SendAsync(message, GitHubJsonContext.Default.GitHubGist, cancellationToken);
+    }
+
+    private async Task<T> GetJsonAsync<T>(
+        string relativeUri,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken cancellationToken
+    )
+    {
+        using var message = new HttpRequestMessage(HttpMethod.Get, relativeUri);
+        return await SendAsync(message, typeInfo, cancellationToken);
+    }
+
+    private async Task<T> PostOAuthFormAsync<T>(
+        string relativeUri,
+        IReadOnlyDictionary<string, string?> values,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using var message = new HttpRequestMessage(HttpMethod.Post, new Uri(GitHubBaseUri, relativeUri))
+        {
+            Content = new FormUrlEncodedContent(
+                values
+                    .Where(value => !string.IsNullOrWhiteSpace(value.Value))
+                    .Select(value => new KeyValuePair<string, string>(value.Key, value.Value!))
+            ),
+        };
+        message.Headers.Accept.Clear();
+        message.Headers.Accept.ParseAdd("application/json");
+        return await SendAsync(message, typeInfo, cancellationToken);
+    }
+
+    private async Task<T> SendAsync<T>(
+        HttpRequestMessage message,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken cancellationToken
+    )
+    {
+        using HttpResponseMessage response = await _httpClient.SendAsync(message, cancellationToken);
+        string content = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"GitHub request failed with HTTP {(int)response.StatusCode} ({response.ReasonPhrase}): {GetErrorMessage(content)}"
+            );
+        }
+
+        return JsonSerializer.Deserialize(content, typeInfo)
+            ?? throw new InvalidOperationException("GitHub returned an empty response.");
+    }
+
+    private static StringContent CreateJsonContent<T>(T value, JsonTypeInfo<T> typeInfo)
+    {
+        return new StringContent(
+            JsonSerializer.Serialize(value, typeInfo),
+            System.Text.Encoding.UTF8,
+            "application/json"
+        );
+    }
+
+    private static string GetErrorMessage(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return "No response body.";
+
+        try
+        {
+            GitHubError? error = JsonSerializer.Deserialize(
+                content,
+                GitHubJsonContext.Default.GitHubError
+            );
+            if (!string.IsNullOrWhiteSpace(error?.ErrorDescription))
+                return error.ErrorDescription;
+            if (!string.IsNullOrWhiteSpace(error?.Error))
+                return error.Error;
+            if (!string.IsNullOrWhiteSpace(error?.Message))
+                return error.Message;
+        }
+        catch (JsonException)
+        {
+            return content;
+        }
+
+        return content;
+    }
+
+    private static string BuildQueryString(IReadOnlyDictionary<string, string?> values)
+    {
+        string query = string.Join(
+            '&',
+            values
+                .Where(value => !string.IsNullOrWhiteSpace(value.Value))
+                .Select(value =>
+                    Uri.EscapeDataString(value.Key) + "=" + Uri.EscapeDataString(value.Value!))
+        );
+        return string.IsNullOrEmpty(query) ? "" : "?" + query;
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}
+
+public sealed class GitHubOAuthToken
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; } = "";
+}
+
+public sealed class GitHubDeviceFlow
+{
+    [JsonPropertyName("device_code")]
+    public string DeviceCode { get; set; } = "";
+
+    [JsonPropertyName("user_code")]
+    public string UserCode { get; set; } = "";
+
+    [JsonPropertyName("verification_uri")]
+    public string VerificationUri { get; set; } = "";
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    [JsonPropertyName("interval")]
+    public int Interval { get; set; }
+}
+
+public sealed class GitHubUser
+{
+    [JsonPropertyName("login")]
+    public string Login { get; set; } = "";
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("avatar_url")]
+    public string? AvatarUrl { get; set; }
+}
+
+public sealed class GitHubGist
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("files")]
+    public Dictionary<string, GitHubGistFile> Files { get; set; } = [];
+}
+
+public sealed class GitHubGistFile
+{
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+}
+
+internal sealed class GitHubGistRequest
+{
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = "";
+
+    [JsonPropertyName("public")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsPublic { get; set; }
+
+    [JsonPropertyName("files")]
+    public Dictionary<string, GitHubGistFileRequest> Files { get; set; } = [];
+}
+
+internal sealed class GitHubGistFileRequest
+{
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = "";
+}
+
+internal sealed class GitHubError
+{
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("error_description")]
+    public string? ErrorDescription { get; set; }
+}
+
+[JsonSourceGenerationOptions]
+[JsonSerializable(typeof(GitHubOAuthToken))]
+[JsonSerializable(typeof(GitHubDeviceFlow))]
+[JsonSerializable(typeof(GitHubUser))]
+[JsonSerializable(typeof(GitHubGist))]
+[JsonSerializable(typeof(GitHubGistFile))]
+[JsonSerializable(typeof(GitHubGistRequest))]
+[JsonSerializable(typeof(GitHubGistFileRequest))]
+[JsonSerializable(typeof(GitHubError))]
+[JsonSerializable(typeof(IReadOnlyList<GitHubGist>))]
+internal sealed partial class GitHubJsonContext : JsonSerializerContext;

--- a/src/UniGetUI.Interface.IpcApi/IpcBackupApi.cs
+++ b/src/UniGetUI.Interface.IpcApi/IpcBackupApi.cs
@@ -1,4 +1,3 @@
-using Octokit;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SecureSettings;
@@ -107,7 +106,7 @@ public static class IpcBackupApi
 
     private sealed class PendingGitHubDeviceFlow
     {
-        public required OauthDeviceFlowResponse DeviceFlow { get; init; }
+        public required GitHubDeviceFlow DeviceFlow { get; init; }
         public required DateTimeOffset ExpiresAtUtc { get; init; }
     }
 
@@ -169,12 +168,10 @@ public static class IpcBackupApi
         request ??= new IpcGitHubDeviceFlowRequest();
         EnsureGitHubClientConfigured();
 
-        var client = CreateAnonymousGitHubClient();
-        var deviceFlow = await client.Oauth.InitiateDeviceFlow(
-            new OauthDeviceFlowRequest(Secrets.GetGitHubClientId())
-            {
-                Scopes = { "read:user", "gist" },
-            },
+        using var client = CreateAnonymousGitHubClient();
+        var deviceFlow = await client.InitiateDeviceFlowAsync(
+            Secrets.GetGitHubClientId(),
+            ["read:user", "gist"],
             CancellationToken.None
         );
 
@@ -218,8 +215,8 @@ public static class IpcBackupApi
 
         try
         {
-            var client = CreateAnonymousGitHubClient();
-            var token = await client.Oauth.CreateAccessTokenForDeviceFlow(
+            using var client = CreateAnonymousGitHubClient();
+            var token = await client.CreateAccessTokenForDeviceFlowAsync(
                 Secrets.GetGitHubClientId(),
                 pending.DeviceFlow,
                 CancellationToken.None
@@ -231,8 +228,8 @@ public static class IpcBackupApi
             }
 
             SecureGHTokenManager.StoreToken(token.AccessToken);
-            var userClient = CreateAuthenticatedGitHubClient(token.AccessToken);
-            var user = await userClient.User.Current();
+            using var userClient = CreateAuthenticatedGitHubClient(token.AccessToken);
+            var user = await userClient.GetCurrentUserAsync();
             Settings.SetValue(Settings.K.GitHubUserLogin, user.Login ?? string.Empty);
             ClearPendingGitHubDeviceFlow();
 
@@ -273,8 +270,9 @@ public static class IpcBackupApi
 
     public static async Task<IReadOnlyList<IpcCloudBackupEntry>> ListCloudBackupsAsync()
     {
-        var (client, user) = await GetAuthenticatedGitHubContextAsync();
-        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: false);
+        using var client = CreateAuthenticatedGitHubClient();
+        await GetAuthenticatedGitHubUserAsync(client);
+        var backupGist = await GetBackupGistAsync(client, createIfMissing: false);
         if (backupGist is null)
         {
             return [];
@@ -300,22 +298,17 @@ public static class IpcBackupApi
     {
         var packages = GetInstalledPackagesForBackup();
         string bundleContents = await IpcBundleApi.CreateBundleAsync(packages);
-        var (client, user) = await GetAuthenticatedGitHubContextAsync();
-        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: true)
+        using var client = CreateAuthenticatedGitHubClient();
+        await GetAuthenticatedGitHubUserAsync(client);
+        var backupGist = await GetBackupGistAsync(client, createIfMissing: true)
             ?? throw new InvalidOperationException("The GitHub backup gist could not be created.");
 
         string fileKey = BuildGistFileKey();
-        var update = new GistUpdate { Description = GistDescription };
-        if (backupGist.Files.ContainsKey(fileKey))
-        {
-            update.Files[fileKey] = new GistFileUpdate { Content = bundleContents };
-        }
-        else
-        {
-            update.Files.Add(fileKey, new GistFileUpdate { Content = bundleContents });
-        }
-
-        await client.Gist.Edit(backupGist.Id, update);
+        await client.EditGistAsync(
+            backupGist.Id,
+            GistDescription,
+            new Dictionary<string, string> { [fileKey] = bundleContents }
+        );
         return new IpcCloudBackupUploadResult
         {
             Status = "success",
@@ -446,8 +439,8 @@ public static class IpcBackupApi
 
         try
         {
-            var client = CreateAuthenticatedGitHubClient();
-            var user = await client.User.Current();
+            using var client = CreateAuthenticatedGitHubClient();
+            var user = await client.GetCurrentUserAsync();
             if (!string.IsNullOrWhiteSpace(user.Login))
             {
                 Settings.SetValue(Settings.K.GitHubUserLogin, user.Login);
@@ -479,12 +472,12 @@ public static class IpcBackupApi
         }
     }
 
-    private static GitHubClient CreateAnonymousGitHubClient()
+    private static GitHubApiClient CreateAnonymousGitHubClient()
     {
-        return new GitHubClient(new ProductHeaderValue("UniGetUI", CoreData.VersionName));
+        return new GitHubApiClient();
     }
 
-    private static GitHubClient CreateAuthenticatedGitHubClient(string? token = null)
+    private static GitHubApiClient CreateAuthenticatedGitHubClient(string? token = null)
     {
         token ??= SecureGHTokenManager.GetToken();
         if (string.IsNullOrWhiteSpace(token))
@@ -492,34 +485,31 @@ public static class IpcBackupApi
             throw new InvalidOperationException("GitHub authentication is required for cloud backups.");
         }
 
-        return new GitHubClient(new ProductHeaderValue("UniGetUI", CoreData.VersionName))
-        {
-            Credentials = new Credentials(token),
-        };
+        return new GitHubApiClient(token);
     }
 
-    private static async Task<(GitHubClient Client, User User)> GetAuthenticatedGitHubContextAsync()
+    private static async Task<GitHubUser> GetAuthenticatedGitHubUserAsync(GitHubApiClient client)
     {
-        var client = CreateAuthenticatedGitHubClient();
-        var user = await client.User.Current();
+        var user = await client.GetCurrentUserAsync();
         if (!string.IsNullOrWhiteSpace(user.Login))
         {
             Settings.SetValue(Settings.K.GitHubUserLogin, user.Login);
         }
 
-        return (client, user);
+        return user;
     }
 
     private static async Task<string> GetCloudBackupContentsAsync(string key)
     {
-        var (client, user) = await GetAuthenticatedGitHubContextAsync();
-        var backupGist = await GetBackupGistAsync(client, user.Login, createIfMissing: false);
+        using var client = CreateAuthenticatedGitHubClient();
+        await GetAuthenticatedGitHubUserAsync(client);
+        var backupGist = await GetBackupGistAsync(client, createIfMissing: false);
         if (backupGist is null)
         {
             throw new InvalidOperationException("No cloud backups are available for the current account.");
         }
 
-        var fullGist = await client.Gist.Get(backupGist.Id);
+        var fullGist = await client.GetGistAsync(backupGist.Id);
         var file = fullGist.Files.FirstOrDefault(candidate =>
             candidate.Key.StartsWith(PackageBackupStartingKey, StringComparison.Ordinal)
             && candidate.Key.EndsWith(key, StringComparison.Ordinal));
@@ -532,13 +522,12 @@ public static class IpcBackupApi
         return file.Value.Content;
     }
 
-    private static async Task<Gist?> GetBackupGistAsync(
-        GitHubClient client,
-        string userLogin,
+    private static async Task<GitHubGist?> GetBackupGistAsync(
+        GitHubApiClient client,
         bool createIfMissing
     )
     {
-        var candidates = await client.Gist.GetAllForUser(userLogin);
+        var candidates = await client.GetCurrentUserGistsAsync();
         var backupGist = candidates.FirstOrDefault(candidate =>
             candidate.Description?.EndsWith(GistDescriptionEndingKey, StringComparison.Ordinal)
             == true
@@ -549,9 +538,11 @@ public static class IpcBackupApi
             return backupGist;
         }
 
-        var newGist = new NewGist { Description = GistDescription, Public = false };
-        newGist.Files.Add("- UniGetUI Package Backups", ReadMeContents);
-        return await client.Gist.Create(newGist);
+        return await client.CreateGistAsync(
+            GistDescription,
+            isPublic: false,
+            new Dictionary<string, string> { ["- UniGetUI Package Backups"] = ReadMeContents }
+        );
     }
 
     private static string BuildGistFileKey()

--- a/src/UniGetUI.Interface.IpcApi/UniGetUI.Interface.IpcApi.csproj
+++ b/src/UniGetUI.Interface.IpcApi/UniGetUI.Interface.IpcApi.csproj
@@ -14,7 +14,6 @@
     <ItemGroup>
         <Compile Remove="Generated Files\**\*.cs" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Switch the Avalonia app default publish mode from `TrimMode=partial` to `TrimMode=full` while keeping self-contained ReadyToRun publishing.
- Replace Octokit usage with a narrow, trim-safe `GitHubApiClient` using `HttpClient` and source-generated `System.Text.Json` DTOs for OAuth, device flow, current user, and gist backup APIs.
- Statically root the conditional Windows Mica styles as a typed `ResourceDictionary`; the first full-trim launch exposed this because the dynamically loaded `Styles.WindowsMica.axaml` resource was trimmed.
- Add targeted handling for app-owned trim warnings: AUMID shortcut COM activation suppression, expected Avalonia constructor warning suppression, and non-blocking CI visibility for full-trim publish warnings.

## Size impact

Measured against same-code x64 Release self-contained ReadyToRun publishes:

| Build | Raw publish | Zipped publish |
|---|---:|---:|
| Partial trim | 135.01 MiB | 59.21 MiB |
| Full trim | 115.62 MiB | 50.31 MiB |
| Savings | 19.39 MiB / 14.4% | 8.90 MiB / 15.0% |

Earlier installer measurement showed a similar gain: `44.56 MiB` -> `36.66 MiB`, about `7.9 MiB` smaller.

## Full-trim warning audit

Full-trim publish succeeds and now leaves 45 trim warnings, all from external dependencies:

| Category | Count | Notes |
|---|---:|---|
| Avalonia DataGrid/Controls | 10 | Reflection/converter paths in Avalonia DataGrid. UniGetUI uses explicit template columns with `AutoGenerateColumns="False"`, but grids still need careful manual validation. |
| WinRT ABI generated code | 35 | CsWinRT/WinRT ABI generic annotation warnings from Windows package manager interop. Review WinGet/native package-manager paths carefully. |
| Octokit/AppShortcut/Mica/AVLN3001 | 0 | App-owned warning categories cleared. |

I intentionally did not blanket-suppress the remaining external warnings so future app-owned trim regressions stay visible.

## Needs careful review

- Package list DataGrid behavior: installed packages, updates, search/discover, sorting, selection, context menus, details dialogs.
- Desktop shortcut manager DataGrid behavior.
- WinGet / Windows Package Manager COM interop paths, including manager initialization and package queries.
- GitHub auth and backup flows using the new API client: loopback OAuth, device flow IPC auth, avatar/current-user loading, gist create/list/get/update, backup upload/download/restore.
- Windows-specific shell paths: AUMID shortcut stamping, toast notifications, tray restore/quit behavior, and Mica/acrylic styling.

## Validation

- `dotnet restore src/UniGetUI.Windows.slnx`
- `dotnet build src/UniGetUI.Windows.slnx --no-restore --verbosity q --nologo /p:Platform=x64 /p:UseSharedCompilation=false /m:1`
- `dotnet test src/UniGetUI.Windows.slnx --no-restore --verbosity q --nologo /p:Platform=x64 /p:UseSharedCompilation=false /m:1`
- `dotnet format whitespace src --folder --verify-no-changes --verbosity minimal`
- `dotnet format style src/UniGetUI.Windows.slnx --no-restore --verify-no-changes --verbosity minimal`
- Full-trim x64 Release publish with `TrimmerSingleWarn=false`
- Launched the full-trim published `UniGetUI.exe` successfully and inspected the backup settings UI path