### PR TITLE
Fix maximized title-bar search clipping (#5013) and Discover hero-search overlap (#5014)

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -83,7 +83,7 @@
             <Grid x:Name="ContentRoot" Grid.Column="1" RowDefinitions="*,4,Auto">
 
             <!-- ── Banners + page content ── -->
-            <Grid Grid.Row="0" RowDefinitions="Auto,*" Margin="0,10">
+            <Grid Grid.Row="0" RowDefinitions="Auto,*" Margin="0,0,0,10">
                 <StackPanel Grid.Row="0"
                             Spacing="0"
                             automation:AutomationProperties.AccessibilityView="Control">

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -362,10 +362,10 @@ public partial class MainWindow : Window
             if (MicaWindowHelper.IsMicaEnabled())
                 TransparencyLevelHint = new[] { WindowTransparencyLevel.Mica };
             TitleBarGrid.ClearValue(HeightProperty);
-            TitleBarGrid.Height = 44;
+            TitleBarGrid.Height = 50;
             HamburgerPanel.Margin = new Thickness(10, 0, 8, 0);
             WindowButtons.IsVisible = true;
-            MainContentRoot.Margin = new Thickness(0, 44, 0, 0);
+            MainContentRoot.Margin = new Thickness(0, 50, 0, 0);
             this.GetObservable(WindowStateProperty).SubscribeValue(state =>
             {
                 UpdateMaximizeButtonState(state == WindowState.Maximized);
@@ -871,6 +871,27 @@ public partial class MainWindow : Window
         // the top inset, leaving the WS_THICKFRAME left/right/bottom resize border as glass.
         if (msg == WM_NCCALCSIZE && wParam.ToInt64() != 0)
         {
+            // When maximized, Windows places the window so its resize border sits offscreen
+            // (top-left near (-frame, -frame)). Claiming the whole window rect as client then
+            // pushes the title bar's top few pixels off the monitor, clipping the search box
+            // so it hugs the top edge (#5013). While maximized, inset the client rect by the
+            // frame thickness so it fills exactly the visible monitor; keep the full-rect
+            // (borderless, extended) client otherwise.
+            if (NativeMethods.IsZoomed(hWnd))
+            {
+                uint dpi = NativeMethods.GetDpiForWindow(hWnd);
+                if (dpi == 0) dpi = 96;
+                var border = default(NativeMethods.RECT);
+                if (NativeMethods.AdjustWindowRectExForDpi(ref border, WS_THICKFRAME, false, 0, dpi))
+                {
+                    var p = Marshal.PtrToStructure<NativeMethods.NCCALCSIZE_PARAMS>(lParam);
+                    p.rgrc0.Left -= border.Left;
+                    p.rgrc0.Top -= border.Top;
+                    p.rgrc0.Right -= border.Right;
+                    p.rgrc0.Bottom -= border.Bottom;
+                    Marshal.StructureToPtr(p, lParam, false);
+                }
+            }
             handled = true;
             return 0;
         }
@@ -980,6 +1001,10 @@ public partial class MainWindow : Window
         [DllImport("user32.dll")]
         public static extern nint MonitorFromWindow(nint hwnd, uint dwFlags);
 
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsZoomed(nint hWnd);
+
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetMonitorInfo(nint hMonitor, ref MONITORINFO lpmi);
@@ -1036,6 +1061,16 @@ public partial class MainWindow : Window
             public RECT rcMonitor;
             public RECT rcWork;
             public uint dwFlags;
+        }
+
+        // rgrc is a RECT[3] laid out inline; only rgrc[0] (the proposed client rect) is needed here.
+        [StructLayout(LayoutKind.Sequential)]
+        public struct NCCALCSIZE_PARAMS
+        {
+            public RECT rgrc0;
+            public RECT rgrc1;
+            public RECT rgrc2;
+            public nint lppos;
         }
     }
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -462,8 +462,11 @@
                              HorizontalAlignment="Stretch"
                              Margin="1,0,1,0"/>
 
-                <!-- Package list container -->
+                <!-- Package list container. Hidden while the Discover hero search (MegaQuery) is
+                     shown: the list is empty then, and its column headers would otherwise collide
+                     with the centred search box when a banner + operations pane shrink the area (#5014). -->
                 <Border Margin="0,6,0,6"
+                        IsVisible="{Binding !MegaQueryVisible}"
                         CornerRadius="8"
                         BorderThickness="0"
                         Background="{DynamicResource PackageListBackground}">

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -91,7 +91,7 @@
       </Style>
    </UserControl.Styles>
 
-   <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="8,8,8,8">
+   <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="8,6,8,8">
 
         <!-- ==================== HEADER ==================== -->
         <Grid Name="MainHeader"


### PR DESCRIPTION
Fixes two Windows title-bar / search layout bugs in the Avalonia UI, plus a small related spacing cleanup.
### #5013 — Global search box clipped when maximized                                                                                                                                          
                                                                                                                                                                                                
The `WM_NCCALCSIZE` handler returns 0 to claim the whole window rect as the client area (the borderless extended-client look). When the window is maximized, Windows positions it with the `WS_THICKFRAME` resize border offscreen (top-left near `(-frame, -frame)`), so claiming the full rect pushes the title bar's top few pixels off the monitor and clips the search pill against the top edge (worse at higher DPI).                                                                                                                                                   
                                                                                                                                                                                                
While maximized (`IsZoomed`), we now inset the client rect by the DPI-scaled frame thickness so it fills exactly the visible monitor; the full-rect extended client is kept when windowed. Verified via Win32: the maximized client top went from 6px offscreen → ~0.                                                                                                                                                                      
                                                                                                                                                                                                
  ### #5014 — Discover search overlaps the package list header                                                                                                                           
                                                                                                                                                                                                
On the Discover page the centred MegaQuery and the package list share one overlay cell. When a banner and the operations pane shrink the area, the MegaQuery lands on the DataGrid column headers and they bleed through it.                                                                                                                                                                             
                                                                                                                                                                                                
`MegaQueryVisible` is only true on Discover in the pristine empty-query state, where the list is already cleared — so the list container is now hidden while thequery is shown, and reappears (with results) as soon as the user types or submits. 