### PR TITLE
Add opt-in NativeAOT publish path

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -95,3 +95,22 @@ jobs:
           /p:TrimmerSingleWarn=false `
           /p:UseSharedCompilation=false `
           --verbosity minimal
+
+    - name: Report NativeAOT publish warnings
+      working-directory: src
+      shell: pwsh
+      continue-on-error: true
+      run: |
+        dotnet build-server shutdown
+        dotnet publish UniGetUI.Avalonia/UniGetUI.Avalonia.csproj `
+          --no-restore `
+          --configuration Release `
+          --runtime win-x64 `
+          --self-contained true `
+          --output "${{ runner.temp }}\unigetui-nativeaot-publish" `
+          /m:1 `
+          /p:Platform=x64 `
+          /p:PublishProfile=Win-x64-NativeAot `
+          /p:TrimmerSingleWarn=false `
+          /p:UseSharedCompilation=false `
+          --verbosity minimal

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ UniGetUI Store.exe
 UniGetUI.exe
 installer.iss
 output/
+/artifacts/
 *.old
 vcredist.exe
 unigetui_bin/

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ scoop install extras/unigetui
 choco install unigetui
 ```
 
+### Experimental NativeAOT build (Windows)
+For contributors and advanced validation, the repository includes an opt-in NativeAOT publish profile and a helper script:
+
+```powershell
+pwsh ./scripts/publish-nativeaot.ps1
+```
+
+This publishes `src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj` for `win-x64` as a self-contained NativeAOT build into `artifacts/nativeaot/win-x64/`. It does not replace the existing Release or installer flows.
+
 ### macOS
 
 macOS builds are available from GitHub Releases. Use the `.dmg` for the standard installer experience, or the `.tar.gz` archive for a portable app bundle.

--- a/scripts/publish-nativeaot.ps1
+++ b/scripts/publish-nativeaot.ps1
@@ -1,0 +1,56 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Publishes UniGetUI as a NativeAOT self-contained Windows build.
+
+.PARAMETER Configuration
+    Build configuration. Default: Release.
+
+.PARAMETER Platform
+    Target platform. Default: x64.
+
+.PARAMETER OutputPath
+    Directory for the published output. Default: ./artifacts/nativeaot/win-<platform>.
+
+.PARAMETER PublishProfileName
+    NativeAOT publish profile name. Default: Win-x64-NativeAot.
+#>
+[CmdletBinding()]
+param(
+    [string] $Configuration = "Release",
+    [string] $Platform = "x64",
+    [string] $OutputPath = (Join-Path (Join-Path $PSScriptRoot "..") "artifacts/nativeaot/win-$Platform"),
+    [string] $PublishProfileName = "Win-x64-NativeAot"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$ProjectPath = Join-Path $RepoRoot "src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj"
+
+if (Test-Path $OutputPath) {
+    Remove-Item $OutputPath -Recurse -Force
+}
+
+New-Item $OutputPath -ItemType Directory -Force | Out-Null
+
+Write-Host "Publishing NativeAOT build for win-$Platform to $OutputPath" -ForegroundColor Cyan
+
+dotnet publish $ProjectPath `
+    --configuration $Configuration `
+    --runtime "win-$Platform" `
+    --self-contained true `
+    --output $OutputPath `
+    /m:1 `
+    /p:Platform=$Platform `
+    /p:PublishProfile=$PublishProfileName `
+    /p:TrimmerSingleWarn=false `
+    /p:UseSharedCompilation=false `
+    --nologo `
+    --verbosity minimal
+
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "NativeAOT publish complete." -ForegroundColor Green

--- a/src/UniGetUI.Avalonia/Properties/PublishProfiles/Win-x64-NativeAot.pubxml
+++ b/src/UniGetUI.Avalonia/Properties/PublishProfiles/Win-x64-NativeAot.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <PublishSingleFile>false</PublishSingleFile>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
+</Project>

--- a/src/UniGetUI.Core.Settings/SettingsJson.cs
+++ b/src/UniGetUI.Core.Settings/SettingsJson.cs
@@ -70,6 +70,10 @@ internal static class SettingsJson
         "Trimming",
         "IL2026",
         Justification = "Runtime settings use generated metadata for known app types; this fallback preserves generic settings tests and extension scenarios outside trimmed app paths.")]
+    [UnconditionalSuppressMessage(
+        "AotCompatibility",
+        "IL3050",
+        Justification = "This reflection fallback is only used when generated metadata is unavailable; NativeAOT app paths rely on source-generated metadata for the known settings types.")]
     private static string SerializeListWithReflection<T>(List<T> value)
     {
         return JsonSerializer.Serialize(value, Settings.SerializationOptions);
@@ -79,6 +83,10 @@ internal static class SettingsJson
         "Trimming",
         "IL2026",
         Justification = "Runtime settings use generated metadata for known app types; this fallback preserves generic settings tests and extension scenarios outside trimmed app paths.")]
+    [UnconditionalSuppressMessage(
+        "AotCompatibility",
+        "IL3050",
+        Justification = "This reflection fallback is only used when generated metadata is unavailable; NativeAOT app paths rely on source-generated metadata for the known settings types.")]
     private static List<T>? DeserializeListWithReflection<T>(string json)
     {
         return JsonSerializer.Deserialize<List<T>>(json, Settings.SerializationOptions);
@@ -88,6 +96,10 @@ internal static class SettingsJson
         "Trimming",
         "IL2026",
         Justification = "Runtime settings use generated metadata for known app types; this fallback preserves generic settings tests and extension scenarios outside trimmed app paths.")]
+    [UnconditionalSuppressMessage(
+        "AotCompatibility",
+        "IL3050",
+        Justification = "This reflection fallback is only used when generated metadata is unavailable; NativeAOT app paths rely on source-generated metadata for the known settings types.")]
     private static string SerializeDictionaryWithReflection<KeyT, ValueT>(
         Dictionary<KeyT, ValueT> value
     )
@@ -100,6 +112,10 @@ internal static class SettingsJson
         "Trimming",
         "IL2026",
         Justification = "Runtime settings use generated metadata for known app types; this fallback preserves generic settings tests and extension scenarios outside trimmed app paths.")]
+    [UnconditionalSuppressMessage(
+        "AotCompatibility",
+        "IL3050",
+        Justification = "This reflection fallback is only used when generated metadata is unavailable; NativeAOT app paths rely on source-generated metadata for the known settings types.")]
     private static Dictionary<KeyT, ValueT>? DeserializeDictionaryWithReflection<KeyT, ValueT>(
         string json
     )

--- a/src/UniGetUI.Core.Tools/DWMThreadHelper.cs
+++ b/src/UniGetUI.Core.Tools/DWMThreadHelper.cs
@@ -123,7 +123,7 @@ public class DWMThreadHelper
             hThread,
             ThreadQuerySetWin32StartAddress,
             ref adress,
-            Marshal.SizeOf(typeof(IntPtr)),
+            Marshal.SizeOf<IntPtr>(),
             out _
         );
         if (status != 0)

--- a/src/UniGetUI.Interface.IpcApi/IpcJson.cs
+++ b/src/UniGetUI.Interface.IpcApi/IpcJson.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
+using System.Threading;
 
 namespace UniGetUI.Interface;
 
@@ -24,6 +25,14 @@ internal static class IpcJson
         return JsonSerializer.Deserialize(json, GetTypeInfo<T>());
     }
 
+    internal static JsonTypeInfo<T> GetTypeInfo<T>()
+    {
+        return (JsonTypeInfo<T>?)IpcJsonContext.Default.GetTypeInfo(typeof(T))
+            ?? throw new InvalidOperationException(
+                $"IPC JSON metadata for {typeof(T).FullName} was not generated."
+            );
+    }
+
     public static HttpContent CreateContent<T>(T value)
     {
         return new StringContent(
@@ -38,13 +47,21 @@ internal static class IpcJson
         response.ContentType = "application/json; charset=utf-8";
         return response.WriteAsync(Serialize(value));
     }
+}
 
-    private static JsonTypeInfo<T> GetTypeInfo<T>()
+internal static class IpcHttpResponseJsonExtensions
+{
+    internal static Task WriteAsJsonAsync<TValue>(
+        this HttpResponse response,
+        TValue value,
+        JsonSerializerOptions? options,
+        CancellationToken cancellationToken = default)
     {
-        return (JsonTypeInfo<T>?)IpcJsonContext.Default.GetTypeInfo(typeof(T))
-            ?? throw new InvalidOperationException(
-                $"IPC JSON metadata for {typeof(T).FullName} was not generated."
-            );
+        ArgumentNullException.ThrowIfNull(response);
+        JsonTypeInfo<TValue>? typeInfo = options?.GetTypeInfo(typeof(TValue)) as JsonTypeInfo<TValue>;
+        string json = JsonSerializer.Serialize(value, typeInfo ?? IpcJson.GetTypeInfo<TValue>());
+        response.ContentType = "application/json; charset=utf-8";
+        return response.WriteAsync(json, cancellationToken);
     }
 }
 

--- a/src/UniGetUI.Interface.IpcApi/IpcJson.cs
+++ b/src/UniGetUI.Interface.IpcApi/IpcJson.cs
@@ -2,8 +2,8 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using Microsoft.AspNetCore.Http;
 using System.Threading;
+using Microsoft.AspNetCore.Http;
 
 namespace UniGetUI.Interface;
 


### PR DESCRIPTION
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [ ] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **Have you confirmed that this issue is caused by UniGetUI itself, and not by the package manager or the package involved?**
If the same issue can be reproduced outside UniGetUI with the relevant package manager or with the package itself, please report it there first. UniGetUI should only be used to track issues that are specific to UniGetUI's behavior or integration.
-----

Adds an opt-in Windows x64 NativeAOT publish path without changing the existing Release/default publish flow.

Changes:
- Adds `Win-x64-NativeAot.pubxml` for explicit NativeAOT publishing.
- Adds `scripts/publish-nativeaot.ps1` as the repeatable developer entry point.
- Adds CI coverage to publish with the NativeAOT profile and report warnings.
- Updates IPC JSON response writing to use source-generated metadata.
- Documents the experimental NativeAOT workflow.
- Ignores generated `artifacts/` output.

Validation:
- `dotnet test src\UniGetUI.Windows.slnx --no-restore --verbosity q --nologo /p:Platform=x64 /p:UseSharedCompilation=false /m:1`
- `pwsh .\scripts\publish-nativeaot.ps1`
- Smoke-launched `artifacts\nativeaot\win-x64\UniGetUI.exe --help`

-----
Relates to NativeAOT build validation work.