### PR TITLE
Fix log text color for dark mode and live theme switch

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/ThemeHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ThemeHelper.cs
@@ -1,0 +1,27 @@
+using Avalonia;
+using Avalonia.Platform;
+using Avalonia.Styling;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+// Reliable theme resolution for code that bakes colors in C# (log/output views). ActualThemeVariant
+// can read back as Default before it settles; resolve that against the OS theme so a resource lookup
+// never falls back to the light-theme (near-black) value on a dark background (#5032).
+public static class ThemeHelper
+{
+    public static ThemeVariant Variant
+    {
+        get
+        {
+            var app = Application.Current;
+            var variant = app?.ActualThemeVariant;
+            if (variant == ThemeVariant.Dark) return ThemeVariant.Dark;
+            if (variant == ThemeVariant.Light) return ThemeVariant.Light;
+            return app?.PlatformSettings?.GetColorValues().ThemeVariant == PlatformThemeVariant.Dark
+                ? ThemeVariant.Dark
+                : ThemeVariant.Light;
+        }
+    }
+
+    public static bool IsDark => Variant == ThemeVariant.Dark;
+}

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
@@ -22,7 +22,7 @@ public partial class OperationOutputViewModel : ObservableObject
 
     public OperationOutputViewModel(AbstractOperation operation)
     {
-        var theme = Application.Current?.ActualThemeVariant ?? ThemeVariant.Default;
+        var theme = Infrastructure.ThemeHelper.Variant;
         _errorBrush = LookupBrush("StatusErrorForeground", theme, new SolidColorBrush(Color.Parse("#c62828")));
         _debugBrush = LookupBrush("LogOutputVerboseForeground", theme, new SolidColorBrush(Color.Parse("#767676")));
         _normalBrush = LookupBrush("SystemControlForegroundBaseHighBrush", theme, Brushes.White);

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationOutputViewModel.cs
@@ -14,26 +14,37 @@ public partial class OperationOutputViewModel : ObservableObject
     [ObservableProperty] private string _title = "";
     public ObservableCollection<LogLineItem> OutputLines { get; } = new();
 
-    private readonly IBrush _errorBrush;
-    private readonly IBrush _debugBrush;
-    private readonly IBrush _normalBrush;
+    private IBrush _errorBrush = Brushes.Transparent;
+    private IBrush _debugBrush = Brushes.Transparent;
+    private IBrush _normalBrush = Brushes.Transparent;
 
-    private readonly ProgressLineCollapser _collapser = new();
+    private readonly AbstractOperation _operation;
+    private ProgressLineCollapser _collapser = new();
 
     public OperationOutputViewModel(AbstractOperation operation)
+    {
+        _operation = operation;
+        Title = operation.Metadata.Title;
+
+        Rebuild();
+
+        operation.LogLineAdded += (_, ev) =>
+            Dispatcher.UIThread.Post(() => AddOrCollapseLine(ev.Item1, ev.Item2));
+    }
+
+    // Rebuilds every line with brushes for the current theme; called on construction and whenever
+    // the theme changes, so already-rendered output follows a live light/dark switch.
+    public void Rebuild()
     {
         var theme = Infrastructure.ThemeHelper.Variant;
         _errorBrush = LookupBrush("StatusErrorForeground", theme, new SolidColorBrush(Color.Parse("#c62828")));
         _debugBrush = LookupBrush("LogOutputVerboseForeground", theme, new SolidColorBrush(Color.Parse("#767676")));
         _normalBrush = LookupBrush("SystemControlForegroundBaseHighBrush", theme, Brushes.White);
 
-        Title = operation.Metadata.Title;
-
-        foreach (var (text, type) in operation.GetOutput())
+        OutputLines.Clear();
+        _collapser = new();
+        foreach (var (text, type) in _operation.GetOutput())
             AddOrCollapseLine(text, type);
-
-        operation.LogLineAdded += (_, ev) =>
-            Dispatcher.UIThread.Post(() => AddOrCollapseLine(ev.Item1, ev.Item2));
     }
 
     // Progress indicators (carriage-return redraws like installer spinners) overwrite the previous

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/LogPages/BaseLogPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/LogPages/BaseLogPageViewModel.cs
@@ -1,7 +1,5 @@
 using System.Collections.ObjectModel;
-using Avalonia;
 using Avalonia.Media;
-using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using UniGetUI.Core.Logging;
@@ -40,8 +38,7 @@ public abstract partial class BaseLogPageViewModel : ViewModels.ViewModelBase
 
     public void ClearLog() => LogLines.Clear();
 
-    protected static bool IsDark =>
-        Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+    protected static bool IsDark => Infrastructure.ThemeHelper.IsDark;
 
     protected static IBrush GetSeverityBrush(LogEntry.SeverityLevel severity, bool isDark)
     {

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -14,8 +14,11 @@ namespace UniGetUI.Avalonia.Views.DialogPages;
 
 public partial class OperationFailedDialog : Window
 {
+    private readonly AbstractOperation _operation;
+
     public OperationFailedDialog(AbstractOperation operation)
     {
+        _operation = operation;
         InitializeComponent();
         UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         Title = operation.Metadata.FailureMessage;
@@ -26,25 +29,9 @@ public partial class OperationFailedDialog : Window
                 "Please see the Command-line Output or refer to the Operation History for further information about the issue."
             );
 
-        // Resolve against the actual theme variant; bare FindResource picks the light-theme
-        // foreground (near-black) even in dark mode, making normal lines unreadable (#5032).
-        var theme = Infrastructure.ThemeHelper.Variant;
-        var errorBrush = new SolidColorBrush(Color.Parse("#FF6B6B"));
-        var debugBrush = new SolidColorBrush(Color.Parse("#888888"));
-        var normalBrush = LookupBrush("SystemControlForegroundBaseHighBrush", theme, Brushes.White);
-
-        var lines = new List<LogLineItem>();
-        foreach (var (text, type) in operation.GetOutput())
-        {
-            IBrush brush = type switch
-            {
-                AbstractOperation.LineType.Error => errorBrush,
-                AbstractOperation.LineType.VerboseDetails => debugBrush,
-                _ => normalBrush,
-            };
-            lines.Add(new LogLineItem(text, brush));
-        }
-        OutputText.SetLines(lines);
+        PopulateOutput();
+        // Line brushes are baked per theme; recolor so they follow a live theme switch.
+        ActualThemeVariantChanged += (_, _) => PopulateOutput();
 
         var closeButton = new Button
         {
@@ -60,6 +47,29 @@ public partial class OperationFailedDialog : Window
         ButtonsLayout.Children.Add(closeButton);
         Grid.SetColumn(retryButton, 0);
         Grid.SetColumn(closeButton, 1);
+    }
+
+    private void PopulateOutput()
+    {
+        // Resolve against the actual theme variant; bare FindResource picks the light-theme
+        // foreground (near-black) even in dark mode, making normal lines unreadable (#5032).
+        var theme = Infrastructure.ThemeHelper.Variant;
+        var errorBrush = new SolidColorBrush(Color.Parse("#FF6B6B"));
+        var debugBrush = new SolidColorBrush(Color.Parse("#888888"));
+        var normalBrush = LookupBrush("SystemControlForegroundBaseHighBrush", theme, Brushes.White);
+
+        var lines = new List<LogLineItem>();
+        foreach (var (text, type) in _operation.GetOutput())
+        {
+            IBrush brush = type switch
+            {
+                AbstractOperation.LineType.Error => errorBrush,
+                AbstractOperation.LineType.VerboseDetails => debugBrush,
+                _ => normalBrush,
+            };
+            lines.Add(new LogLineItem(text, brush));
+        }
+        OutputText.SetLines(lines);
     }
 
     private static IBrush LookupBrush(string key, ThemeVariant theme, IBrush fallback)

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels.Pages.LogPages;
 using UniGetUI.Core.Tools;
@@ -25,10 +26,12 @@ public partial class OperationFailedDialog : Window
                 "Please see the Command-line Output or refer to the Operation History for further information about the issue."
             );
 
+        // Resolve against the actual theme variant; bare FindResource picks the light-theme
+        // foreground (near-black) even in dark mode, making normal lines unreadable (#5032).
+        var theme = Infrastructure.ThemeHelper.Variant;
         var errorBrush = new SolidColorBrush(Color.Parse("#FF6B6B"));
         var debugBrush = new SolidColorBrush(Color.Parse("#888888"));
-        var normalBrush = Application.Current?.FindResource("SystemControlForegroundBaseHighBrush") as IBrush
-                          ?? Brushes.White;
+        var normalBrush = LookupBrush("SystemControlForegroundBaseHighBrush", theme, Brushes.White);
 
         var lines = new List<LogLineItem>();
         foreach (var (text, type) in operation.GetOutput())
@@ -57,6 +60,13 @@ public partial class OperationFailedDialog : Window
         ButtonsLayout.Children.Add(closeButton);
         Grid.SetColumn(retryButton, 0);
         Grid.SetColumn(closeButton, 1);
+    }
+
+    private static IBrush LookupBrush(string key, ThemeVariant theme, IBrush fallback)
+    {
+        if (Application.Current?.TryGetResource(key, theme, out var resource) == true && resource is IBrush brush)
+            return brush;
+        return fallback;
     }
 
     protected override void OnOpened(EventArgs e)

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
@@ -18,6 +18,9 @@ public partial class OperationOutputWindow : Window
 
         OutputText.SetLines(vm.OutputLines);
         vm.OutputLines.CollectionChanged += OnOutputLinesChanged;
+
+        // Recolor already-rendered output when the theme changes at runtime.
+        ActualThemeVariantChanged += (_, _) => vm.Rebuild();
     }
 
     private void OnOutputLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/BaseLogPage.axaml.cs
@@ -24,6 +24,9 @@ public partial class BaseLogPage : UserControl, IEnterLeaveListener, IKeyboardSh
         ViewModel.ScrollToBottomRequested += OnScrollToBottomRequested;
         ViewModel.LogLines.CollectionChanged += OnLogLinesChanged;
 
+        // Line brushes are baked per theme at load time; reload so they follow a live theme switch.
+        ActualThemeVariantChanged += (_, _) => ViewModel.LoadLog();
+
         LogEditor.SetLines(ViewModel.LogLines);
     }
 


### PR DESCRIPTION
This pull request improves how the application handles theming for log and output views, ensuring that colors and brushes adapt correctly to theme changes (such as switching between light and dark mode) at runtime. The changes introduce a new `ThemeHelper` utility, refactor brush resolution logic, and update UI components to recolor output lines dynamically when the theme changes.

The most important changes are:

**Theme detection and brush resolution improvements:**
* Added a new static class `ThemeHelper` in `src/UniGetUI.Avalonia/Infrastructure/ThemeHelper.cs` to reliably determine the current theme variant and whether the app is in dark mode, resolving issues where theme detection could be inconsistent.
* Refactored all theme and brush lookups in log/output-related view models and dialogs to use `ThemeHelper` for consistent theme resolution, replacing direct use of `Application.Current.ActualThemeVariant`. 

**Dynamic theme switching support:**
* Updated `OperationOutputViewModel`, `OperationFailedDialog`, `OperationOutputWindow`, and `BaseLogPage` to listen for theme changes (`ActualThemeVariantChanged`) and rebuild or reload their output lines with the correct brushes, so already-rendered output adapts instantly to theme switches. 

**Code cleanup and reliability:**
* Removed redundant or direct resource lookups in favor of the new centralized brush lookup logic, and cleaned up unused imports related to Avalonia theming.

These changes make the application's log and output views more visually reliable and responsive to theme changes, addressing previous issues with incorrect colors in dark mode.