### PR TITLE
Fix high GPU usage from always-running indeterminate ProgressBar animations

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InternetViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InternetViewModel.cs
@@ -34,7 +34,7 @@ public partial class InternetViewModel : ViewModelBase
     {
         _savingIndicator = new ProgressBar
         {
-            IsIndeterminate = true,
+            IsIndeterminate = false,
             Opacity = 0,
             Margin = new Thickness(0, -8, 0, 0),
         };
@@ -172,6 +172,7 @@ public partial class InternetViewModel : ViewModelBase
     {
         if (_usernameBox is null || _passwordBox is null || _savingIndicator is null) return;
         _savingIndicator.Opacity = 1;
+        _savingIndicator.IsIndeterminate = true;
         string u = _usernameBox.Text ?? "";
         string p = _passwordBox.Text ?? "";
         await Task.Delay(500);
@@ -180,6 +181,7 @@ public partial class InternetViewModel : ViewModelBase
         CoreSettings.SetProxyCredentials(u, p);
         InternetViewModel.ApplyProxyToProcess();
         _savingIndicator.Opacity = 0;
+        _savingIndicator.IsIndeterminate = false;
     }
 
     [RelayCommand]

--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/SecureCheckboxCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/SecureCheckboxCard.cs
@@ -96,12 +96,14 @@ public partial class SecureCheckboxCard : SettingsCard
         };
         _loading = new ProgressBar
         {
-            IsIndeterminate = true,
+            IsIndeterminate = false,
             IsVisible = false,
             Width = 20,
             Height = 20,
             Margin = new Thickness(0, 0, 4, 0),
         };
+        // Keep the indeterminate clock off while hidden so it doesn't pin the render loop.
+        _loading.Bind(ProgressBar.IsIndeterminateProperty, _loading.GetObservable(Visual.IsVisibleProperty));
         _textblock = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -101,7 +101,7 @@
 
     <Grid>
         <!-- Loading indicator across the very top -->
-        <ProgressBar IsIndeterminate="True"
+        <ProgressBar IsIndeterminate="{Binding IsLoading}"
                      IsVisible="{Binding IsLoading}"
                      automation:AutomationProperties.Name="{Binding PackageName}"
                      VerticalAlignment="Top"

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
@@ -91,7 +91,7 @@
         <!-- Progress bar shown while navigating -->
         <ProgressBar Grid.Row="1"
                      x:Name="NavProgressBar"
-                     IsIndeterminate="True"
+                     IsIndeterminate="{Binding IsVisible, RelativeSource={RelativeSource Self}}"
                      IsVisible="False"
                      Height="2"
                      CornerRadius="0"

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
@@ -36,7 +36,7 @@
         <!-- Progress bar shown while navigating -->
         <ProgressBar Grid.Row="1"
                      x:Name="NavProgressBar"
-                     IsIndeterminate="True"
+                     IsIndeterminate="{Binding IsVisible, RelativeSource={RelativeSource Self}}"
                      IsVisible="False"
                      Height="2"
                      CornerRadius="0"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
@@ -38,7 +38,7 @@
                             IsEnabled="{Binding !IsLoading}"
                             Margin="4,0,0,0"/>
                 </Grid>
-                <ProgressBar IsIndeterminate="True"
+                <ProgressBar IsIndeterminate="{Binding IsLoading}"
                              IsVisible="{Binding IsLoading}"
                              Height="4"/>
             </StackPanel>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
@@ -46,7 +46,7 @@
         </Grid>
 
         <!-- Loading indicator -->
-        <ProgressBar IsIndeterminate="True"
+        <ProgressBar IsIndeterminate="{Binding IsLoading}"
                      IsVisible="{Binding IsLoading}"
                      Height="4"/>
 

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -40,7 +40,7 @@
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
-                    <ProgressBar IsIndeterminate="True"
+                    <ProgressBar IsIndeterminate="{Binding DiscoverIsLoading}"
                                  IsVisible="{Binding DiscoverIsLoading}"
                                  Height="2"
                                  Width="32"
@@ -82,7 +82,7 @@
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"/>
                     </Border>
-                    <ProgressBar IsIndeterminate="True"
+                    <ProgressBar IsIndeterminate="{Binding UpdatesIsLoading}"
                                  IsVisible="{Binding UpdatesIsLoading}"
                                  Height="2"
                                  Width="32"
@@ -107,7 +107,7 @@
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
-                    <ProgressBar IsIndeterminate="True"
+                    <ProgressBar IsIndeterminate="{Binding InstalledIsLoading}"
                                  IsVisible="{Binding InstalledIsLoading}"
                                  Height="2"
                                  Width="32"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -459,7 +459,7 @@
 
                 <!-- Loading indicator -->
                 <ProgressBar x:Name="LoadingProgressBar"
-                             IsIndeterminate="True"
+                             IsIndeterminate="{Binding IsLoading}"
                              IsVisible="{Binding IsLoading}"
                              automation:AutomationProperties.Name="{t:Translate Loading}"
                              Height="4"


### PR DESCRIPTION
The cause is that every indeterminate ProgressBar in the app was declared with a static IsIndeterminate="True" and only toggled via IsVisible (or Opacity). An indeterminate bar runs an infinite animation, and that animation clock keeps running for the control's entire lifetime — hiding the control doesn't stop it. A live animation keeps Avalonia's compositor render loop producing a new frame at the display's refresh rate instead of going idle.                                                                                                 
                                                                                                                                                                                         
By itself that's cheap. But on a transparent Mica window the compositor loses cheap partial (dirty-rect) presents — each committed frame forces a full-window present plus a DWM blend against the backdrop. On a high-refresh, high-DPI laptop panel driven by an integrated GPU, doing that 120–165×/second is what spikes GPU usage.                                                                                          
                                                                                                                                                                                         
### Fix                                                                                                                                                                                    
                                                                                                                                                                                         
Bind IsIndeterminate to the same flag that controls the bar's visibility, so the animation clock actually stops when the bar is hidden and the render loop can go idle.
this fix dropped the GPU usage to 0.1% on my computer when idle 