### PR TITLE
Make NativeAOT the default for UniGetUI release packages on all targets

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -194,7 +194,13 @@ jobs:
             throw "Could not resolve the Avalonia target framework from MSBuild"
           }
 
-          dotnet publish src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj /noLogo /p:Configuration=Release /p:Platform=$Platform -p:RuntimeIdentifier=win-$Platform -v m
+          dotnet publish src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj `
+            /noLogo `
+            /p:Configuration=Release `
+            /p:Platform=$Platform `
+            /p:RuntimeIdentifier=win-$Platform `
+            /p:PublishProfile=Win-$Platform-NativeAot `
+            -v m
           if ($LASTEXITCODE -ne 0) { throw "dotnet publish Avalonia failed" }
 
           # Stage binaries
@@ -285,6 +291,26 @@ jobs:
           Compress-Archive -Path "unigetui_bin/*" -DestinationPath "output/UniGetUI.$Platform.zip" -CompressionLevel Optimal
 
           # Installer is created in output during the previous step
+
+      - name: Capture artifact sizes
+        shell: pwsh
+        run: |
+          $Platform = '${{ matrix.platform }}'
+          $SizesFile = "output/sizes.$Platform.json"
+          $UncompressedSize = (Get-ChildItem "unigetui_bin" -Recurse -File | Measure-Object -Property Length -Sum).Sum
+          $Artifacts = Get-ChildItem "output" -File | Where-Object { $_.Name -ne "sizes.$Platform.json" } | ForEach-Object {
+            @{ Name = $_.Name; SizeBytes = $_.Length }
+          }
+          $Report = @{
+            Platform = $Platform
+            RuntimeIdentifier = "win-$Platform"
+            UncompressedSizeBytes = $UncompressedSize
+            Artifacts = $Artifacts
+            Timestamp = [DateTimeOffset]::UtcNow.ToString("o")
+          }
+          $Report | ConvertTo-Json -Depth 4 | Set-Content $SizesFile -Encoding UTF8
+          Write-Host "Artifact sizes saved to $SizesFile"
+          Get-Content $SizesFile
 
       - name: Code-sign installer
         if: ${{ fromJSON(needs.preflight.outputs.dry-run) == false }}
@@ -377,6 +403,7 @@ jobs:
             --configuration Release \
             --runtime ${{ matrix.runtime }} \
             --self-contained true \
+            /p:PublishProfile=${{ matrix.runtime }}-NativeAot \
             --output ../bin/${{ matrix.name }}
 
       - name: Install macOS packaging tools
@@ -534,6 +561,28 @@ jobs:
               -Iteration    $RpmIteration `
               -Architecture $RpmArch
 
+      - name: Capture artifact sizes
+        shell: pwsh
+        run: |
+          $Name = '${{ matrix.name }}'
+          $Runtime = '${{ matrix.runtime }}'
+          $SizesFile = "output/sizes.$Name.json"
+          $SourceDir = if ('${{ runner.os }}' -eq 'macOS') { "UniGetUI.app/Contents/MacOS" } else { "bin/$Name" }
+          $UncompressedSize = (Get-ChildItem $SourceDir -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
+          $Artifacts = Get-ChildItem "output" -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -ne "sizes.$Name.json" } | ForEach-Object {
+            @{ Name = $_.Name; SizeBytes = $_.Length }
+          }
+          $Report = @{
+            Platform = $Name
+            RuntimeIdentifier = $Runtime
+            UncompressedSizeBytes = $UncompressedSize
+            Artifacts = $Artifacts
+            Timestamp = [DateTimeOffset]::UtcNow.ToString("o")
+          }
+          $Report | ConvertTo-Json -Depth 4 | Set-Content $SizesFile -Encoding UTF8
+          Write-Host "Artifact sizes saved to $SizesFile"
+          Get-Content $SizesFile
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -586,6 +635,39 @@ jobs:
 
           echo "::group::checksums"
           Get-Content $ChecksumFile
+          echo "::endgroup::"
+
+      - name: Generate consolidated size report
+        shell: pwsh
+        working-directory: output
+        run: |
+          $SizeFiles = Get-ChildItem -Path . -Recurse -File -Filter "sizes.*.json" | Sort-Object Name
+          if (-not $SizeFiles) {
+            Write-Host "No size files found."
+            return
+          }
+
+          $Rows = foreach ($file in $SizeFiles) {
+            $data = Get-Content $file.FullName -Raw | ConvertFrom-Json
+            $uncompressedMiB = [math]::Round($data.UncompressedSizeBytes / 1MB, 2)
+            foreach ($artifact in $data.Artifacts) {
+              [PSCustomObject]@{
+                Platform = $data.Platform
+                RID = $data.RuntimeIdentifier
+                Artifact = $artifact.Name
+                CompressedMiB = [math]::Round($artifact.SizeBytes / 1MB, 2)
+                UncompressedMiB = $uncompressedMiB
+              }
+            }
+          }
+
+          $SizeReportFile = Join-Path $PWD "sizes.md"
+          $Lines = @("# UniGetUI Release Artifact Sizes", "")
+          $Lines += $Rows | Format-Table -AutoSize | Out-String -Stream | Where-Object { $_.Trim() -ne '' }
+          Set-Content -Path $SizeReportFile -Value $Lines -Encoding utf8NoBOM
+
+          echo "::group::sizes"
+          Get-Content $SizeReportFile
           echo "::endgroup::"
 
       - name: Create GitHub Release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -783,3 +783,54 @@ jobs:
           remote: releases
           source_path: Devolutions.UniGetUI.*
           working_directory: onedrive-staging
+
+  size-report:
+    name: Consolidated Size Report
+    runs-on: ubuntu-latest
+    needs: [preflight, build, build-avalonia]
+    if: always() && needs.build.result != 'cancelled' && needs.build-avalonia.result != 'cancelled'
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: output
+
+      - name: Generate consolidated size report
+        shell: pwsh
+        working-directory: output
+        run: |
+          $SizeFiles = Get-ChildItem -Path . -Recurse -File -Filter "sizes.*.json" | Sort-Object Name
+          if (-not $SizeFiles) {
+            Write-Host "No size files found."
+            return
+          }
+
+          $Rows = foreach ($file in $SizeFiles) {
+            $data = Get-Content $file.FullName -Raw | ConvertFrom-Json
+            $uncompressedMiB = [math]::Round($data.UncompressedSizeBytes / 1MB, 2)
+            foreach ($artifact in $data.Artifacts) {
+              [PSCustomObject]@{
+                Platform = $data.Platform
+                RID = $data.RuntimeIdentifier
+                Artifact = $artifact.Name
+                CompressedMiB = [math]::Round($artifact.SizeBytes / 1MB, 2)
+                UncompressedMiB = $uncompressedMiB
+              }
+            }
+          }
+
+          $SizeReportFile = Join-Path $PWD "sizes.md"
+          $Lines = @("# UniGetUI Release Artifact Sizes", "")
+          $Lines += $Rows | Format-Table -AutoSize | Out-String -Stream | Where-Object { $_.Trim() -ne '' }
+          Set-Content -Path $SizeReportFile -Value $Lines -Encoding utf8NoBOM
+
+          echo "::group::sizes"
+          Get-Content $SizeReportFile
+          echo "::endgroup::"
+
+      - name: Upload size report
+        uses: actions/upload-artifact@v7
+        with:
+          name: UniGetUI-size-report
+          path: output/sizes.md

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -359,15 +359,21 @@ jobs:
           - os: macos-latest
             name: macos-arm64
             runtime: osx-arm64
+            publish_profile: osx-arm64-NativeAot
           - os: macos-latest
             name: macos-x64
             runtime: osx-x64
+            publish_profile: osx-x64-NativeAot
           - os: ubuntu-latest
             name: linux-x64
             runtime: linux-x64
+            publish_profile: linux-x64-NativeAot
           - os: ubuntu-latest
             name: linux-arm64
             runtime: linux-arm64
+            # linux-arm64 is built on an x64 runner; NativeAOT cross-compilation is not
+            # available in the default runner image, so fall back to ReadyToRun/full-trim.
+            publish_profile: ''
 
     steps:
       - name: Checkout
@@ -399,12 +405,23 @@ jobs:
       - name: Publish
         working-directory: src
         run: |
-          dotnet publish UniGetUI.Avalonia/UniGetUI.Avalonia.csproj \
-            --configuration Release \
-            --runtime ${{ matrix.runtime }} \
-            --self-contained true \
-            /p:PublishProfile=${{ matrix.runtime }}-NativeAot \
-            --output ../bin/${{ matrix.name }}
+          $PublishProfile = '${{ matrix.publish_profile }}'
+          $PublishArgs = @(
+            'publish',
+            'UniGetUI.Avalonia/UniGetUI.Avalonia.csproj',
+            '--configuration', 'Release',
+            '--runtime', '${{ matrix.runtime }}',
+            '--self-contained', 'true',
+            '--output', '../bin/${{ matrix.name }}'
+          )
+          if ($PublishProfile) {
+            $PublishArgs += "/p:PublishProfile=$PublishProfile"
+          }
+          else {
+            # Fallback: explicitly disable NativeAOT so the ReadyToRun release default is used.
+            $PublishArgs += '/p:PublishAot=false'
+          }
+          dotnet @PublishArgs
 
       - name: Install macOS packaging tools
         if: runner.os == 'macOS'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -371,9 +371,7 @@ jobs:
           - os: ubuntu-latest
             name: linux-arm64
             runtime: linux-arm64
-            # linux-arm64 is built on an x64 runner; NativeAOT cross-compilation is not
-            # available in the default runner image, so fall back to ReadyToRun/full-trim.
-            publish_profile: ''
+            publish_profile: linux-arm64-NativeAot
 
     steps:
       - name: Checkout
@@ -391,6 +389,53 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('global.json', 'src/**/*.csproj', 'src/**/*.props', 'src/**/*.targets', 'src/**/*.sln', 'src/**/*.slnx') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
+
+      - name: Install Linux arm64 NativeAOT toolchain
+        if: matrix.runtime == 'linux-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          . /etc/os-release
+          sudo dpkg --add-architecture arm64
+
+          # Keep the runner's default Ubuntu feeds bound to amd64, then add the
+          # Ubuntu Ports arm64 feed that provides the target CRT and zlib objects.
+          if compgen -G "/etc/apt/sources.list.d/*.sources" > /dev/null; then
+            for source in /etc/apt/sources.list.d/*.sources; do
+              if ! grep -q '^Architectures:' "$source"; then
+                sudo sed -i '/^Types: deb$/a Architectures: amd64' "$source"
+              fi
+            done
+          fi
+
+          if [ -f /etc/apt/sources.list ]; then
+            sudo sed -i -E '/^deb /s/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+          fi
+
+          sudo tee /etc/apt/sources.list.d/ubuntu-arm64.sources >/dev/null <<EOF
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports/
+          Suites: ${VERSION_CODENAME} ${VERSION_CODENAME}-updates ${VERSION_CODENAME}-backports
+          Components: main restricted universe multiverse
+          Architectures: arm64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports/
+          Suites: ${VERSION_CODENAME}-security
+          Components: main restricted universe multiverse
+          Architectures: arm64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
+
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            llvm \
+            binutils-aarch64-linux-gnu \
+            gcc-aarch64-linux-gnu \
+            zlib1g-dev:arm64
 
       - name: Set version
         shell: pwsh
@@ -417,11 +462,6 @@ jobs:
           )
           if ($PublishProfile) {
             $PublishArgs += "/p:PublishProfile=$PublishProfile"
-          }
-          else {
-            # Fallback: explicitly disable NativeAOT. The hosted x64 runner cannot cross-compile
-            # NativeAOT for linux-arm64, so we keep the previous non-NativeAOT self-contained path.
-            $PublishArgs += '/p:PublishAot=false'
           }
           dotnet @PublishArgs
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -200,6 +200,7 @@ jobs:
             /p:Platform=$Platform `
             /p:RuntimeIdentifier=win-$Platform `
             /p:PublishProfile=Win-$Platform-NativeAot `
+            /p:UseSharedCompilation=false `
             -v m
           if ($LASTEXITCODE -ne 0) { throw "dotnet publish Avalonia failed" }
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -465,6 +465,22 @@ jobs:
           }
           dotnet @PublishArgs
 
+      - name: Remove oversized Linux debug symbols
+        if: runner.os == 'Linux'
+        shell: pwsh
+        run: |
+          $PublishDir = "bin/${{ matrix.name }}"
+          $MaxDebugSymbolSizeBytes = 1MB
+          $DebugSymbolsToRemove = @(Get-ChildItem $PublishDir -Include "*.dbg", "*.pdb" -File -Recurse | Where-Object {
+            $_.Length -gt $MaxDebugSymbolSizeBytes
+          })
+
+          if ($DebugSymbolsToRemove.Count -gt 0) {
+            $RemovedDebugSymbolBytes = ($DebugSymbolsToRemove | Measure-Object -Property Length -Sum).Sum
+            $DebugSymbolsToRemove | Remove-Item -Force
+            Write-Host ("Removed {0} oversized Linux debug symbols above {1:N2} MiB ({2:N2} MiB total)." -f $DebugSymbolsToRemove.Count, ($MaxDebugSymbolSizeBytes / 1MB), ($RemovedDebugSymbolBytes / 1MB))
+          }
+
       - name: Install macOS packaging tools
         if: runner.os == 'macOS'
         run: brew install create-dmg

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -419,7 +419,8 @@ jobs:
             $PublishArgs += "/p:PublishProfile=$PublishProfile"
           }
           else {
-            # Fallback: explicitly disable NativeAOT so the ReadyToRun release default is used.
+            # Fallback: explicitly disable NativeAOT. The hosted x64 runner cannot cross-compile
+            # NativeAOT for linux-arm64, so we keep the previous non-NativeAOT self-contained path.
             $PublishArgs += '/p:PublishAot=false'
           }
           dotnet @PublishArgs

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -201,6 +201,8 @@ jobs:
             /p:RuntimeIdentifier=win-$Platform `
             /p:PublishProfile=Win-$Platform-NativeAot `
             /p:UseSharedCompilation=false `
+            /p:BuildInParallel=false `
+            /m:1 `
             -v m
           if ($LASTEXITCODE -ne 0) { throw "dotnet publish Avalonia failed" }
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -404,6 +404,7 @@ jobs:
 
       - name: Publish
         working-directory: src
+        shell: pwsh
         run: |
           $PublishProfile = '${{ matrix.publish_profile }}'
           $PublishArgs = @(

--- a/.github/workflows/cli-headless-e2e.yml
+++ b/.github/workflows/cli-headless-e2e.yml
@@ -27,12 +27,26 @@ jobs:
             daemon_project: UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
             daemon_build_args: '-p:Platform=x64'
             manifest: testing/automation/cli-e2e.manifest.windows.json
+          - name: Windows (NativeAOT)
+            os: windows-latest
+            solution: UniGetUI.Windows.slnx
+            daemon_project: UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+            daemon_publish_profile: Win-x64-NativeAot
+            daemon_build_args: '-p:Platform=x64'
+            manifest: testing/automation/cli-e2e.manifest.windows.json
           - name: Linux (Avalonia)
             os: ubuntu-latest
             solution: UniGetUI.Avalonia.slnx
             daemon_project: UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
             daemon_build_args: ''
             manifest: testing/automation/cli-e2e.manifest.linux.json
+          - name: Linux (NativeAOT)
+            os: ubuntu-latest
+            solution: UniGetUI.Avalonia.slnx
+            daemon_project: UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+            daemon_publish_profile: linux-x64-NativeAot
+            daemon_build_args: ''
+            manifest: testing/automation/cli-e2e.manifest.linux-nativeaot.json
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -76,22 +90,66 @@ jobs:
         working-directory: src
         shell: pwsh
         run: |
-          $args = @(
-            'build',
-            '${{ matrix.daemon_project }}',
-            '--no-restore',
-            '--configuration',
-            '${{ env.CONFIGURATION }}',
-            '--verbosity',
-            'minimal',
-            '/p:UseSharedCompilation=false',
-            '/m:1'
-          )
-          if ('${{ matrix.daemon_build_args }}') {
-            $args += '${{ matrix.daemon_build_args }}'
-          }
+          $PublishProfile = '${{ matrix.daemon_publish_profile }}'
+          $BuildArgs = '${{ matrix.daemon_build_args }}'
+
           dotnet build-server shutdown
-          dotnet @args
+
+          if ($PublishProfile) {
+            $RuntimeIdentifier = $PublishProfile -replace '-NativeAot$', '' -replace '^Win-', 'win-' -replace '^linux-', 'linux-' -replace '^osx-', 'osx-'
+            $OutputPath = Join-Path (Resolve-Path '..') "artifacts/e2e-nativeaot/$RuntimeIdentifier"
+            New-Item -ItemType Directory -Force -Path $OutputPath | Out-Null
+
+            $args = @(
+              'publish',
+              '${{ matrix.daemon_project }}',
+              '--no-restore',
+              '--configuration',
+              '${{ env.CONFIGURATION }}',
+              '--runtime',
+              $RuntimeIdentifier,
+              '--self-contained',
+              'true',
+              '--output',
+              $OutputPath,
+              '--verbosity',
+              'minimal',
+              '/p:UseSharedCompilation=false',
+              '/m:1',
+              "/p:PublishProfile=$PublishProfile"
+            )
+            if ($BuildArgs) {
+              $args += $BuildArgs
+            }
+            dotnet @args
+
+            $exeName = if ('${{ runner.os }}' -eq 'Windows') { 'UniGetUI.exe' } else { 'UniGetUI' }
+            $daemonExe = Join-Path $OutputPath $exeName
+            if (-not (Test-Path $daemonExe)) {
+              throw "NativeAOT daemon executable was not produced at $daemonExe"
+            }
+            if ('${{ runner.os }}' -ne 'Windows') {
+              chmod +x $daemonExe
+            }
+            echo "UNIGETUI_DAEMON_EXE=$daemonExe" >> $Env:GITHUB_ENV
+          }
+          else {
+            $args = @(
+              'build',
+              '${{ matrix.daemon_project }}',
+              '--no-restore',
+              '--configuration',
+              '${{ env.CONFIGURATION }}',
+              '--verbosity',
+              'minimal',
+              '/p:UseSharedCompilation=false',
+              '/m:1'
+            )
+            if ($BuildArgs) {
+              $args += $BuildArgs
+            }
+            dotnet @args
+          }
 
       - name: Upgrade pip tooling
         shell: pwsh

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -99,7 +99,6 @@ jobs:
     - name: Report NativeAOT publish warnings
       working-directory: src
       shell: pwsh
-      continue-on-error: true
       run: |
         dotnet build-server shutdown
         dotnet publish UniGetUI.Avalonia/UniGetUI.Avalonia.csproj `

--- a/README.md
+++ b/README.md
@@ -91,14 +91,15 @@ scoop install extras/unigetui
 choco install unigetui
 ```
 
-### Experimental NativeAOT build (Windows)
-For contributors and advanced validation, the repository includes an opt-in NativeAOT publish profile and a helper script:
+### NativeAOT builds
+
+Release packages are compiled with NativeAOT on all supported platforms (Windows, macOS, and Linux) for improved startup performance and a reduced attack surface. If you want to build the same configuration locally, the repository includes helper publish profiles and a script:
 
 ```powershell
-pwsh ./scripts/publish-nativeaot.ps1
+pwsh ./scripts/publish-nativeaot.ps1 -Platform x64   # or arm64
 ```
 
-This publishes `src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj` for `win-x64` as a self-contained NativeAOT build into `artifacts/nativeaot/win-x64/`. It does not replace the existing Release or installer flows.
+This publishes `src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj` as a self-contained NativeAOT build into `artifacts/nativeaot/win-<platform>/`.
 
 ### macOS
 

--- a/scripts/package-linux.ps1
+++ b/scripts/package-linux.ps1
@@ -79,7 +79,7 @@ param(
     [string] $Description   = 'UniGetUI - GUI for package managers',
     [string] $Maintainer    = 'Devolutions Inc. <support@devolutions.net>',
     [string] $Url           = 'https://github.com/Devolutions/UniGetUI',
-    [string] $AppExecutableName = 'UniGetUI.Avalonia',
+    [string] $AppExecutableName = 'UniGetUI',
     [string] $LauncherName      = 'unigetui',
     [string] $IconSourcePath    = (Join-Path $PSScriptRoot '..' 'src' 'SharedAssets' 'Assets' 'Images' 'icon.png')
 )
@@ -111,6 +111,11 @@ function New-LinuxIntegrationAssets {
     New-Item -ItemType Directory -Path $payloadDir -Force | Out-Null
     & /bin/cp -a "$SourceDir/." $payloadDir
     if ($LASTEXITCODE -ne 0) { throw "cp (payload staging) exited $LASTEXITCODE" }
+
+    $appExecutableFullPath = Join-Path $payloadDir $AppExecutableName
+    if (-not (Test-Path $appExecutableFullPath -PathType Leaf)) {
+        throw "App executable '$AppExecutableName' was not found in package payload '$payloadDir'"
+    }
 
     $launcherFullPath = Join-Path $StageRoot $LauncherPath.TrimStart('/')
     New-Item -ItemType Directory -Path (Split-Path $launcherFullPath -Parent) -Force | Out-Null

--- a/scripts/publish-nativeaot.ps1
+++ b/scripts/publish-nativeaot.ps1
@@ -7,20 +7,21 @@
     Build configuration. Default: Release.
 
 .PARAMETER Platform
-    Target platform. Default: x64.
+    Target platform. Default: x64. Supported: x64, arm64.
 
 .PARAMETER OutputPath
     Directory for the published output. Default: ./artifacts/nativeaot/win-<platform>.
 
 .PARAMETER PublishProfileName
-    NativeAOT publish profile name. Default: Win-x64-NativeAot.
+    NativeAOT publish profile name. Default: Win-<platform>-NativeAot.
 #>
 [CmdletBinding()]
 param(
     [string] $Configuration = "Release",
+    [ValidateSet("x64", "arm64")]
     [string] $Platform = "x64",
     [string] $OutputPath = (Join-Path (Join-Path $PSScriptRoot "..") "artifacts/nativeaot/win-$Platform"),
-    [string] $PublishProfileName = "Win-x64-NativeAot"
+    [string] $PublishProfileName = "Win-$Platform-NativeAot"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -54,7 +54,8 @@
         <Optimize>true</Optimize>
         <WholeProgramOptimization>true</WholeProgramOptimization>
         <TieredCompilation>true</TieredCompilation>
-        <PublishReadyToRun>true</PublishReadyToRun>
+        <!-- NativeAOT and ReadyToRun are mutually exclusive; ReadyToRun is only enabled when NativeAOT is not. -->
+        <PublishReadyToRun Condition="'$(PublishAot)' != 'true'">true</PublishReadyToRun>
         <EnableProfileOptimization>true</EnableProfileOptimization>
     </PropertyGroup>
 

--- a/src/UniGetUI.Avalonia/Properties/PublishProfiles/Win-arm64-NativeAot.pubxml
+++ b/src/UniGetUI.Avalonia/Properties/PublishProfiles/Win-arm64-NativeAot.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>arm64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <PublishSingleFile>false</PublishSingleFile>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
+</Project>

--- a/src/UniGetUI.Avalonia/Properties/PublishProfiles/linux-arm64-NativeAot.pubxml
+++ b/src/UniGetUI.Avalonia/Properties/PublishProfiles/linux-arm64-NativeAot.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>arm64</Platform>
+    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <PublishSingleFile>false</PublishSingleFile>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
+</Project>

--- a/src/UniGetUI.Avalonia/Properties/PublishProfiles/linux-x64-NativeAot.pubxml
+++ b/src/UniGetUI.Avalonia/Properties/PublishProfiles/linux-x64-NativeAot.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <PublishSingleFile>false</PublishSingleFile>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
+</Project>

--- a/src/UniGetUI.Avalonia/Properties/PublishProfiles/osx-arm64-NativeAot.pubxml
+++ b/src/UniGetUI.Avalonia/Properties/PublishProfiles/osx-arm64-NativeAot.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>arm64</Platform>
+    <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <PublishSingleFile>false</PublishSingleFile>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
+</Project>

--- a/src/UniGetUI.Avalonia/Properties/PublishProfiles/osx-x64-NativeAot.pubxml
+++ b/src/UniGetUI.Avalonia/Properties/PublishProfiles/osx-x64-NativeAot.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <PublishSingleFile>false</PublishSingleFile>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
+</Project>

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -27,6 +27,13 @@
         <IncludeAvaloniaPublishSymbols>false</IncludeAvaloniaPublishSymbols>
     </PropertyGroup>
 
+    <!-- NativeAOT is the default for release packages on all platforms. -->
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <PublishAot>true</PublishAot>
+        <!-- NativeAOT and ReadyToRun are mutually exclusive. -->
+        <PublishReadyToRun>false</PublishReadyToRun>
+    </PropertyGroup>
+
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <!-- Parameterized windows/base views are directly constructed in code, not through the runtime XAML loader. -->
         <NoWarn>$(NoWarn);MVVMTK0045;AVLN3001</NoWarn>

--- a/testing/automation/cli-e2e.manifest.linux-nativeaot.json
+++ b/testing/automation/cli-e2e.manifest.linux-nativeaot.json
@@ -1,0 +1,99 @@
+{
+  "name": "linux-headless-ipc",
+  "daemon": {
+    "kind": "avalonia-native",
+    "project": "UniGetUI.Avalonia\\UniGetUI.Avalonia.csproj",
+    "assemblyName": "UniGetUI"
+  },
+  "transport": {
+    "kind": "named-pipe",
+    "verifyNoTcpListener": false
+  },
+  "secureSettings": {
+    "allowSet": true,
+    "toggleKey": "AllowCustomManagerPaths",
+    "managerForExecutableOverride": "npm"
+  },
+  "uninstallValidationManagers": [
+    "pip"
+  ],
+  "packageManagers": [
+    {
+      "manager": "pip",
+      "sourceName": "pip",
+      "query": "cowsay",
+      "packageId": "cowsay",
+      "installVersion": "5.0",
+      "scope": "User",
+      "roles": [
+        "specific-update"
+      ]
+    },
+    {
+      "manager": "npm",
+      "sourceName": "npm",
+      "query": "cowsay",
+      "packageId": "cowsay",
+      "installVersion": "1.5.0",
+      "scope": "Global",
+      "roles": [
+        "bundle",
+        "update-manager",
+        "reinstall",
+        "repair",
+        "toggle-manager",
+        "update-all"
+      ]
+    }
+  ],
+  "queueOperations": [
+    {
+      "manager": "pip",
+      "sourceName": "pip",
+      "packageId": "awscli",
+      "target": "download",
+      "query": "awscli"
+    },
+    {
+      "manager": "npm",
+      "sourceName": "npm",
+      "packageId": "typescript",
+      "target": "download",
+      "query": "typescript"
+    }
+  ],
+  "excludedCommands": [
+    {
+      "command": "manager action",
+      "reason": "Current manager actions are Windows-specific and system-changing, so they are intentionally excluded from Linux CI."
+    },
+    {
+      "command": "source add",
+      "reason": "The deterministic Linux manager matrix does not include a manager with reliable CI-safe custom source mutation."
+    },
+    {
+      "command": "source remove",
+      "reason": "The deterministic Linux manager matrix does not include a manager with reliable CI-safe custom source mutation."
+    },
+    {
+      "command": "operation cancel",
+      "reason": "Queued package downloads complete too quickly on current Linux CI runners to guarantee a stable cancellable operation window."
+    },
+    {
+      "command": "operation retry",
+      "reason": "A deterministic retry scenario depends on first forcing a stable failed or canceled operation, which is not yet reliable in CI."
+    },
+    {
+      "command": "operation reorder",
+      "reason": "Queued package downloads complete too quickly on current Linux CI runners to guarantee a stable reorderable operation window."
+    },
+    {
+      "command": "backup github *",
+      "reason": "GitHub device-flow authentication is intentionally excluded from deterministic CI."
+    },
+    {
+      "command": "backup cloud *",
+      "reason": "Cloud backup flows depend on external authenticated GitHub state and are intentionally excluded from deterministic CI."
+    }
+  ]
+}

--- a/testing/automation/run-cli-e2e.ps1
+++ b/testing/automation/run-cli-e2e.ps1
@@ -244,6 +244,23 @@ function Get-DaemonCommand {
                 PrefixArguments = @($resolvedDll)
             }
         }
+        'avalonia-native' {
+            $fileName = if ($runningOnWindows) { "$($manifest.daemon.assemblyName).exe" } else { $manifest.daemon.assemblyName }
+            $daemonNative = if ($env:UNIGETUI_DAEMON_EXE) {
+                $env:UNIGETUI_DAEMON_EXE
+            }
+            else {
+                Find-BuiltArtifact -ProjectDirectory (Split-Path $daemonProject -Parent) -FileName $fileName
+            }
+            if ([string]::IsNullOrWhiteSpace($daemonNative) -or -not (Test-Path $daemonNative)) {
+                throw "NativeAOT headless executable was not found. Expected $fileName under $(Split-Path $daemonProject -Parent)\bin\$configuration"
+            }
+
+            return @{
+                FilePath = (Resolve-Path $daemonNative).Path
+                WorkingDirectory = Split-Path (Resolve-Path $daemonNative).Path -Parent
+            }
+        }
         default {
             throw "Unsupported daemon kind $($manifest.daemon.kind)"
         }


### PR DESCRIPTION
This change promotes the opt-in NativeAOT path added in #5057 to the default release packaging path for every UniGetUI target: Windows, macOS, and Linux on x64 and arm64.

## What changed

- **Release defaults**: `PublishAot=true` is now enabled for `Release` publishes in `UniGetUI.Avalonia.csproj`, while Debug/local development builds remain non-AOT by default.
- **ReadyToRun conflict handling**: `PublishReadyToRun` is disabled whenever NativeAOT is active.
- **Publish profiles**: added NativeAOT publish profiles for Windows arm64, macOS x64/arm64, and Linux x64/arm64.
- **Release workflow**: `build-release.yml` now publishes NativeAOT packages for all release targets.
- **Linux arm64 cross-compilation**: the Ubuntu x64 runner installs the arm64 target toolchain (`clang`/LLVM, `gcc-aarch64-linux-gnu`, `binutils-aarch64-linux-gnu`, `zlib1g-dev:arm64`) before publishing `linux-arm64-NativeAot`.
- **Linux package size fix**: oversized `.dbg`/`.pdb` files are removed from Linux release payloads before packaging, matching the existing Windows oversized-PDB pruning behavior.
- **Linux launcher fix**: Linux package launchers now point to the actual app host, `/opt/unigetui/UniGetUI`, and package staging validates that the executable exists.
- **Windows CI hardening**: Windows NativeAOT publish disables shared compilation and project parallelism to avoid intermittent intermediate-output file locks in CI.
- **CI hardening**: the NativeAOT publish warning report in `dotnet-test.yml` no longer uses `continue-on-error`, so publish failures block CI.
- **Size reporting**: release dry runs now upload a consolidated `UniGetUI-size-report` artifact.
- **E2E coverage**: headless CLI E2E now includes Windows NativeAOT and Linux NativeAOT variants; the runner supports the `avalonia-native` daemon kind for Linux NativeAOT executables.
- **Docs/scripts**: `publish-nativeaot.ps1` supports arm64 and the README documents NativeAOT as the release default.

## Validation

- ✅ `.NET Tests` passed.
- ✅ `CLI Headless E2E` passed for:
  - Windows Avalonia
  - Windows NativeAOT
  - Linux Avalonia
  - Linux NativeAOT
- ✅ `build-release.yml` dry-run passed for all release targets:
  - Windows x64/arm64 NativeAOT
  - macOS x64/arm64 NativeAOT
  - Linux x64/arm64 NativeAOT
- ✅ Verified the CI-produced Linux `.deb` launcher points to `/opt/unigetui/UniGetUI`, matching the packaged app host.

Latest successful release dry run: https://github.com/Devolutions/UniGetUI/actions/runs/28967170760

## Final dry-run package sizes

| Target | Uncompressed | Compressed artifact(s) |
|---|---:|---:|
| Windows x64 | 95.1 MiB | 28.6 MiB installer / 39.5 MiB zip |
| Windows arm64 | 93.3 MiB | 27.4 MiB installer / 37.5 MiB zip |
| macOS x64 | 216.9 MiB | 48.9 MiB dmg / 49.1 MiB tar.gz |
| macOS arm64 | 207.7 MiB | 45.1 MiB dmg / 45.2 MiB tar.gz |
| Linux x64 | 66.2 MiB | 27.8 MiB deb / 27.7 MiB rpm / 27.8 MiB tar.gz |
| Linux arm64 | 66.5 MiB | 26.4 MiB deb / 26.3 MiB rpm / 26.4 MiB tar.gz |

## Same-branch Linux comparison

The initial Linux size increase came from shipping the NativeAOT debug-symbol file (`UniGetUI.dbg`, about 105.8 MiB). After pruning oversized symbols, NativeAOT is smaller than the same-branch non-AOT/R2R Linux publish:

| Linux x64 build | Uncompressed | tar.gz |
|---|---:|---:|
| Non-AOT/R2R (`PublishAot=false`, `PublishReadyToRun=true`) | 92.0 MiB | 38.1 MiB |
| NativeAOT before symbol pruning | 171.9 MiB | 54.6 MiB |
| NativeAOT after symbol pruning | 66.2 MiB | 27.8 MiB |

## Notes

- Avalonia `DataGrid` still produces known third-party trim/AOT warnings; no new UniGetUI-specific warnings were introduced.
- One Linux E2E run hit the known transient `Collection was modified` package-download error; the rerun passed.