### PR TITLE
fix for runtime error at startup

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -387,9 +387,14 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
         internal IWinGetManagerHelper CreateCliHelperForSelectedCliTool()
         {
+            return CreateCliHelperForSelectedCliTool(Status.ExecutablePath);
+        }
+
+        internal IWinGetManagerHelper CreateCliHelperForSelectedCliTool(string executablePath)
+        {
             return SelectedCliToolKind == WinGetCliToolKind.BundledPinget
-                ? new PingetCliHelper(this, Status.ExecutablePath)
-                : new WinGetCliHelper(this, Status.ExecutablePath);
+                ? new PingetCliHelper(this, executablePath)
+                : new WinGetCliHelper(this, executablePath);
         }
 
         protected override void _loadManagerExecutableFile(
@@ -449,7 +454,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                 }
 
                 Logger.Warn("WinGet will resort to using WinGetCliHelper()");
-                WinGetHelper.Instance = CreateCliHelperForSelectedCliTool();
+                WinGetHelper.Instance = CreateCliHelperForSelectedCliTool(path);
             }
         }
 

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -501,6 +501,25 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void CreateCliHelperForSelectedCliToolUsesExplicitExecutablePath()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+
+        IWinGetManagerHelper helper = manager.CreateCliHelperForSelectedCliTool(
+            @"C:\WindowsApps\winget.exe"
+        );
+
+        var pathField = typeof(WinGetCliHelper).GetField(
+            "_cliExecutablePath",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
+        );
+
+        Assert.NotNull(pathField);
+        Assert.Equal(@"C:\WindowsApps\winget.exe", pathField.GetValue(helper));
+    }
+
+    [Fact]
     public void NativeWinGetHelperUsesSystemCliFallbackForInstalledPackagesWhenCompositeCatalogFails()
     {
         var manager = new TestableWinGet();


### PR DESCRIPTION
Same failure in two call paths (installed packages and updates): Process.Start receives an empty FileName in WinGetCliHelper.

System.InvalidOperationException: Cannot start process because a file name has not been provided. at System.Diagnostics.Process.Start()
at UniGetUI.PackageEngine.Managers.WingetManager.WinGetCliHelper.GetInstalledPackages_UnSafe() at UniGetUI.PackageEngine.Managers.WingetManager.WinGet.GetInstalledPackages_UnSafe()

