### PR TITLE
Add icon for @bbk1ng/agent-orch (npm)

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -7,6 +7,10 @@
     "total_screenshots": 4140
   },
   "icons_and_screenshots": {
+    "bbk1ng/agent-orch": {
+      "icon": "https://raw.githubusercontent.com/bbk1ng/agent-orch/main/docs/assets/orch-avatar.png",
+      "images": []
+    },
     "__test_entry_DO_NOT_EDIT_PLEASE": {
       "icon": "https://this.is.a.test/url/used_for/automated_unit_testing.png",
       "images": [


### PR DESCRIPTION
Adds an icon entry for the npm package [`@bbk1ng/agent-orch`](https://www.npmjs.com/package/@bbk1ng/agent-orch), which currently shows no icon in UniGetUI.

- **Normalized ID:** `bbk1ng/agent-orch` (scope `@` stripped, `/` kept, lowercase)
- **Icon:** square 512×512 PNG hosted in the package repo, referenced by raw URL (same pattern as existing external entries like `google/gemini-cli`)

Verified `screenshot-database-v2.json` remains valid JSON after the addition.