### PR TITLE
Optimize package icon loading and memory management

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/MemoryTrimmer.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MemoryTrimmer.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using UniGetUI.Core.Logging;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Returns reclaimable memory to the OS once a package load has settled. .NET and the native
+/// allocator keep freed memory committed for reuse, so a search/refresh leaves the working set high
+/// even after the app goes idle. This collects the managed heap and hands the freed pages back so
+/// the reported footprint drops once the list has finished loading. Windows-only, best-effort.
+///
+/// Debounced: a trim is scheduled when a load finishes and cancelled if another load starts, so it
+/// only runs when everything is quiet (and never mid-load).
+/// </summary>
+internal static class MemoryTrimmer
+{
+    private static readonly TimeSpan SettleDelay = TimeSpan.FromSeconds(3);
+    private static DispatcherTimer? _timer;
+
+    /// <summary>Schedule a trim once loading has been quiet for a moment.</summary>
+    public static void RequestTrimAfterIdle()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(RequestTrimAfterIdle);
+            return;
+        }
+
+        _timer ??= CreateTimer();
+        _timer.Stop();
+        _timer.Start();
+    }
+
+    /// <summary>Cancel a pending trim because a new load has started.</summary>
+    public static void CancelPending()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(CancelPending);
+            return;
+        }
+
+        _timer?.Stop();
+    }
+
+    private static DispatcherTimer CreateTimer()
+    {
+        var timer = new DispatcherTimer { Interval = SettleDelay };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            Trim();
+        };
+        return timer;
+    }
+
+    private static void Trim() => _ = Task.Run(() =>
+    {
+        try
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            NativeMethods.SetProcessWorkingSetSize(NativeMethods.GetCurrentProcess(), -1, -1);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Post-load working-set trim failed: {ex.Message}");
+        }
+    });
+
+    private static class NativeMethods
+    {
+        [DllImport("kernel32.dll")]
+        public static extern nint GetCurrentProcess();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetProcessWorkingSetSize(
+            nint hProcess,
+            nint dwMinimumWorkingSetSize,
+            nint dwMaximumWorkingSetSize
+        );
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/MemoryTrimmer.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MemoryTrimmer.cs
@@ -6,21 +6,14 @@ using UniGetUI.Core.Logging;
 
 namespace UniGetUI.Avalonia.Infrastructure;
 
-/// <summary>
-/// Returns reclaimable memory to the OS once a package load has settled. .NET and the native
-/// allocator keep freed memory committed for reuse, so a search/refresh leaves the working set high
-/// even after the app goes idle. This collects the managed heap and hands the freed pages back so
-/// the reported footprint drops once the list has finished loading. Windows-only, best-effort.
-///
-/// Debounced: a trim is scheduled when a load finishes and cancelled if another load starts, so it
-/// only runs when everything is quiet (and never mid-load).
-/// </summary>
+// Collects and returns the working set to the OS once loading has settled — neither .NET nor the
+// native allocator hand freed memory back on their own. Debounced so it never runs mid-load.
+// Windows-only, best-effort.
 internal static class MemoryTrimmer
 {
     private static readonly TimeSpan SettleDelay = TimeSpan.FromSeconds(3);
     private static DispatcherTimer? _timer;
 
-    /// <summary>Schedule a trim once loading has been quiet for a moment.</summary>
     public static void RequestTrimAfterIdle()
     {
         if (!OperatingSystem.IsWindows()) return;
@@ -35,7 +28,6 @@ internal static class MemoryTrimmer
         _timer.Start();
     }
 
-    /// <summary>Cancel a pending trim because a new load has started.</summary>
     public static void CancelPending()
     {
         if (!OperatingSystem.IsWindows()) return;

--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -1,7 +1,7 @@
-using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Net.Http;
+using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
@@ -27,8 +27,70 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     {
         Timeout = TimeSpan.FromSeconds(8),
     };
-    private static readonly ConcurrentDictionary<long, Bitmap?> _iconCache = new();
     private static readonly SemaphoreSlim _iconLoadSemaphore = new(4, 4);
+
+    // List icons render at 24-64px; decoding/caching them at native resolution (often 256-512px)
+    // wastes ~10-60x the memory. Cap the cached side to cover 64px at 2x DPI.
+    private const int MaxIconSide = 128;
+
+    // Bounded LRU of decoded icons keyed by package hash. Was previously an unbounded static
+    // dictionary that kept every icon ever shown resident for the whole session. Entries are not
+    // disposed on eviction: the same Bitmap may still be bound to a visible row, and any wrapper
+    // still referencing it keeps it alive; dropping it here only makes it eligible for GC.
+    private const int MaxIconCacheEntries = 512;
+    private static readonly object _iconCacheLock = new();
+    private static readonly Dictionary<long, LinkedListNode<(long Hash, Bitmap? Bitmap)>> _iconCache = new();
+    private static readonly LinkedList<(long Hash, Bitmap? Bitmap)> _iconCacheOrder = new();
+
+    private static bool TryGetCachedIcon(long hash, out Bitmap? bitmap)
+    {
+        lock (_iconCacheLock)
+        {
+            if (_iconCache.TryGetValue(hash, out var node))
+            {
+                _iconCacheOrder.Remove(node);
+                _iconCacheOrder.AddFirst(node);
+                bitmap = node.Value.Bitmap;
+                return true;
+            }
+        }
+        bitmap = null;
+        return false;
+    }
+
+    private static void CacheIcon(long hash, Bitmap? bitmap)
+    {
+        lock (_iconCacheLock)
+        {
+            if (_iconCache.TryGetValue(hash, out var existing))
+            {
+                existing.Value = (hash, bitmap);
+                _iconCacheOrder.Remove(existing);
+                _iconCacheOrder.AddFirst(existing);
+                return;
+            }
+
+            var node = new LinkedListNode<(long, Bitmap?)>((hash, bitmap));
+            _iconCache[hash] = node;
+            _iconCacheOrder.AddFirst(node);
+
+            while (_iconCache.Count > MaxIconCacheEntries && _iconCacheOrder.Last is { } last)
+            {
+                _iconCacheOrder.RemoveLast();
+                _iconCache.Remove(last.Value.Hash);
+            }
+        }
+    }
+
+    /// <summary>Drops all cached decoded icons. Bound bitmaps stay alive via their own references.</summary>
+    public static void ClearIconCache()
+    {
+        lock (_iconCacheLock)
+        {
+            _iconCache.Clear();
+            _iconCacheOrder.Clear();
+        }
+    }
 
     public IPackage Package { get; }
     public PackageWrapper Self => this;
@@ -184,7 +246,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     private async Task LoadIconAsync()
     {
         long hash = Package.GetHash();
-        if (_iconCache.TryGetValue(hash, out Bitmap? cached))
+        if (TryGetCachedIcon(hash, out Bitmap? cached))
         {
             if (cached is not null)
                 IconBitmap = cached;
@@ -198,7 +260,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
             try
             {
                 var uri = await Task.Run(Package.GetIconUrlIfAny).ConfigureAwait(false);
-                if (uri is null) { _iconCache[hash] = null; return; }
+                if (uri is null) { CacheIcon(hash, null); return; }
 
                 Bitmap? decoded;
                 if (uri.IsFile)
@@ -207,7 +269,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
                     {
                         // Avalonia's Bitmap (Skia) can't decode SVG/AVIF/ICO/TIFF — the
                         // icon cache may produce those. Reject upfront so we don't throw.
-                        _iconCache[hash] = null;
+                        CacheIcon(hash, null);
                         return;
                     }
                     decoded = await Task.Run(() => TryDecodeIcon(uri.LocalPath)).ConfigureAwait(false);
@@ -217,11 +279,11 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
                     var bytes = await _iconHttpClient.GetByteArrayAsync(uri).ConfigureAwait(false);
                     decoded = TryDecodeIcon(bytes, uri.Host);
                 }
-                else { _iconCache[hash] = null; return; }
+                else { CacheIcon(hash, null); return; }
 
-                if (decoded is null) { _iconCache[hash] = null; return; }
+                if (decoded is null) { CacheIcon(hash, null); return; }
                 bitmap = decoded;
-                _iconCache[hash] = bitmap;
+                CacheIcon(hash, bitmap);
             }
             finally
             {
@@ -230,7 +292,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
 
             await Dispatcher.UIThread.InvokeAsync(() => IconBitmap = bitmap);
         }
-        catch { _iconCache[hash] = null; }
+        catch { CacheIcon(hash, null); }
     }
 
     // Icons come from a shared on-disk cache that can hold empty or partial entries after an
@@ -239,16 +301,40 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     {
         var info = new FileInfo(filePath);
         if (!info.Exists || info.Length == 0) return null;
-        return TryDecodeIcon(() => new Bitmap(filePath), filePath);
+        return TryDecodeIcon(() => { using var fs = File.OpenRead(filePath); return DecodeDownscaled(fs); }, filePath);
     }
 
     private static Bitmap? TryDecodeIcon(byte[] bytes, string source)
-        => bytes.Length == 0 ? null : TryDecodeIcon(() => new Bitmap(new MemoryStream(bytes)), source);
+        => bytes.Length == 0 ? null : TryDecodeIcon(() => { using var ms = new MemoryStream(bytes); return DecodeDownscaled(ms); }, source);
 
     private static Bitmap? TryDecodeIcon(Func<Bitmap> decode, string source)
     {
         try { return decode(); }
         catch (Exception ex) { Logger.Debug($"Discarding undecodable icon '{source}': {ex.Message}"); return null; }
+    }
+
+    // Decodes at native resolution, then downscales to MaxIconSide if oversized so only the small
+    // bitmap is retained. Small icons are returned as-is (never upscaled) to preserve crispness.
+    private static Bitmap DecodeDownscaled(Stream stream)
+    {
+        var bitmap = new Bitmap(stream);
+        PixelSize size = bitmap.PixelSize;
+        if (size.Width <= MaxIconSide && size.Height <= MaxIconSide)
+            return bitmap;
+
+        double scale = (double)MaxIconSide / Math.Max(size.Width, size.Height);
+        var target = new PixelSize(
+            Math.Max(1, (int)Math.Round(size.Width * scale)),
+            Math.Max(1, (int)Math.Round(size.Height * scale)));
+
+        try
+        {
+            return bitmap.CreateScaledBitmap(target, BitmapInterpolationMode.HighQuality);
+        }
+        finally
+        {
+            bitmap.Dispose();
+        }
     }
 
     private static bool IsSkiaDecodableExtension(string path)

--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -135,6 +135,10 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     public string InstallerHostChangeTooltip { get; private set; } = "";
 
     private CancellationTokenSource? _installerHostCheckCts;
+    // Cancelled when the row is discarded (e.g. a new search). Icon loads are throttled, so a large
+    // result set queues many; without this, a discarded row's queued load keeps its async state
+    // machine — and the wrapper/package/bitmap it roots — alive, so RAM climbs with each search.
+    private readonly CancellationTokenSource _lifetimeCts = new();
 
     public string SourceIconPath => IconTypeToSvgPath(Package.Source.IconId);
 
@@ -245,6 +249,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
 
     private async Task LoadIconAsync()
     {
+        CancellationToken token = _lifetimeCts.Token;
         long hash = Package.GetHash();
         if (TryGetCachedIcon(hash, out Bitmap? cached))
         {
@@ -255,11 +260,13 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
 
         try
         {
-            await _iconLoadSemaphore.WaitAsync().ConfigureAwait(false);
+            // Cancellable wait: if the row is discarded while queued behind the throttle, the load
+            // bails here instead of eventually running and rooting this wrapper.
+            await _iconLoadSemaphore.WaitAsync(token).ConfigureAwait(false);
             Bitmap bitmap;
             try
             {
-                var uri = await Task.Run(Package.GetIconUrlIfAny).ConfigureAwait(false);
+                var uri = await Task.Run(Package.GetIconUrlIfAny, token).ConfigureAwait(false);
                 if (uri is null) { CacheIcon(hash, null); return; }
 
                 Bitmap? decoded;
@@ -272,11 +279,11 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
                         CacheIcon(hash, null);
                         return;
                     }
-                    decoded = await Task.Run(() => TryDecodeIcon(uri.LocalPath)).ConfigureAwait(false);
+                    decoded = await Task.Run(() => TryDecodeIcon(uri.LocalPath), token).ConfigureAwait(false);
                 }
                 else if (uri.Scheme is "http" or "https")
                 {
-                    var bytes = await _iconHttpClient.GetByteArrayAsync(uri).ConfigureAwait(false);
+                    var bytes = await _iconHttpClient.GetByteArrayAsync(uri, token).ConfigureAwait(false);
                     decoded = TryDecodeIcon(bytes, uri.Host);
                 }
                 else { CacheIcon(hash, null); return; }
@@ -290,8 +297,13 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
                 _iconLoadSemaphore.Release();
             }
 
-            await Dispatcher.UIThread.InvokeAsync(() => IconBitmap = bitmap);
+            if (token.IsCancellationRequested) return;
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (!token.IsCancellationRequested) IconBitmap = bitmap;
+            });
         }
+        catch (OperationCanceledException) { /* row discarded before its icon finished loading */ }
         catch { CacheIcon(hash, null); }
     }
 
@@ -400,6 +412,9 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         _installerHostCheckCts?.Cancel();
         _installerHostCheckCts?.Dispose();
         _installerHostCheckCts = null;
+        // Cancel any queued/in-flight icon load so it stops rooting this wrapper. Not disposed:
+        // a background load may still hold the token; the source is tiny and has no handle to leak.
+        _lifetimeCts.Cancel();
     }
 }
 

--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -29,14 +29,11 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     };
     private static readonly SemaphoreSlim _iconLoadSemaphore = new(8, 8);
 
-    // List icons render at 24-64px; decoding/caching them at native resolution (often 256-512px)
-    // wastes ~10-60x the memory. Cap the cached side to cover 64px at 2x DPI.
+    // Cap decoded icon size; the list shows icons at ≤64px (128 covers 2x DPI).
     private const int MaxIconSide = 128;
 
-    // Bounded LRU of decoded icons keyed by package hash. Was previously an unbounded static
-    // dictionary that kept every icon ever shown resident for the whole session. Entries are not
-    // disposed on eviction: the same Bitmap may still be bound to a visible row, and any wrapper
-    // still referencing it keeps it alive; dropping it here only makes it eligible for GC.
+    // Bounded LRU by package hash. Evicted entries aren't disposed: a visible row may still
+    // reference the bitmap, so dropping it here only makes it GC-eligible.
     private const int MaxIconCacheEntries = 512;
     private static readonly object _iconCacheLock = new();
     private static readonly Dictionary<long, LinkedListNode<(long Hash, Bitmap? Bitmap)>> _iconCache = new();
@@ -82,7 +79,6 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         }
     }
 
-    /// <summary>Drops all cached decoded icons. Bound bitmaps stay alive via their own references.</summary>
     public static void ClearIconCache()
     {
         lock (_iconCacheLock)
@@ -135,9 +131,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     public string InstallerHostChangeTooltip { get; private set; } = "";
 
     private CancellationTokenSource? _installerHostCheckCts;
-    // Cancelled when the row is discarded (e.g. a new search). Icon loads are throttled, so a large
-    // result set queues many; without this, a discarded row's queued load keeps its async state
-    // machine — and the wrapper/package/bitmap it roots — alive, so RAM climbs with each search.
+    // Cancels this row's queued/in-flight icon load on disposal so it stops rooting the wrapper.
     private readonly CancellationTokenSource _lifetimeCts = new();
 
     public string SourceIconPath => IconTypeToSvgPath(Package.Source.IconId);
@@ -168,18 +162,13 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         Package.PropertyChanged += Package_PropertyChanged;
         UpdateDisplayState();
 
-        // Icon loading is deferred until the row is actually shown (see EnsureIconLoaded). Starting
-        // it here would eagerly load an icon for every result — thousands for a broad search — when
-        // the virtualized list only ever displays a few dozen at once.
+        // Icons load lazily per visible row (see EnsureIconLoaded), not eagerly for every result.
         MaybeStartInstallerHostCheck();
     }
 
     private int _iconLoadStarted;
 
-    /// <summary>
-    /// Starts loading this row's icon, at most once. Called when the row becomes visible so that
-    /// only on-screen rows load icons (see PackageIconLoader).
-    /// </summary>
+    /// <summary>Loads this row's icon at most once; called when the row becomes visible.</summary>
     public void EnsureIconLoaded()
     {
         if (Settings.Get(Settings.K.DisableIconsOnPackageLists)) return;
@@ -273,8 +262,6 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
 
         try
         {
-            // Cancellable wait: if the row is discarded while queued behind the throttle, the load
-            // bails here instead of eventually running and rooting this wrapper.
             await _iconLoadSemaphore.WaitAsync(token).ConfigureAwait(false);
             Bitmap bitmap;
             try
@@ -338,8 +325,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         catch (Exception ex) { Logger.Debug($"Discarding undecodable icon '{source}': {ex.Message}"); return null; }
     }
 
-    // Decodes at native resolution, then downscales to MaxIconSide if oversized so only the small
-    // bitmap is retained. Small icons are returned as-is (never upscaled) to preserve crispness.
+    // Downscales oversized icons to MaxIconSide; small icons pass through (never upscaled).
     private static Bitmap DecodeDownscaled(Stream stream)
     {
         var bitmap = new Bitmap(stream);
@@ -425,9 +411,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         _installerHostCheckCts?.Cancel();
         _installerHostCheckCts?.Dispose();
         _installerHostCheckCts = null;
-        // Cancel any queued/in-flight icon load so it stops rooting this wrapper. Not disposed:
-        // a background load may still hold the token; the source is tiny and has no handle to leak.
-        _lifetimeCts.Cancel();
+        _lifetimeCts.Cancel(); // not disposed: a background load may still hold the token
     }
 }
 

--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -27,7 +27,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     {
         Timeout = TimeSpan.FromSeconds(8),
     };
-    private static readonly SemaphoreSlim _iconLoadSemaphore = new(4, 4);
+    private static readonly SemaphoreSlim _iconLoadSemaphore = new(8, 8);
 
     // List icons render at 24-64px; decoding/caching them at native resolution (often 256-512px)
     // wastes ~10-60x the memory. Cap the cached side to cover 64px at 2x DPI.
@@ -168,10 +168,23 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         Package.PropertyChanged += Package_PropertyChanged;
         UpdateDisplayState();
 
-        if (!Settings.Get(Settings.K.DisableIconsOnPackageLists))
-            _ = LoadIconAsync();
-
+        // Icon loading is deferred until the row is actually shown (see EnsureIconLoaded). Starting
+        // it here would eagerly load an icon for every result — thousands for a broad search — when
+        // the virtualized list only ever displays a few dozen at once.
         MaybeStartInstallerHostCheck();
+    }
+
+    private int _iconLoadStarted;
+
+    /// <summary>
+    /// Starts loading this row's icon, at most once. Called when the row becomes visible so that
+    /// only on-screen rows load icons (see PackageIconLoader).
+    /// </summary>
+    public void EnsureIconLoaded()
+    {
+        if (Settings.Get(Settings.K.DisableIconsOnPackageLists)) return;
+        if (Interlocked.Exchange(ref _iconLoadStarted, 1) != 0) return;
+        _ = LoadIconAsync();
     }
 
     /// <summary>

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -35,9 +35,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <!-- The app spends most of its life idle in the background. Have the GC decommit unused
-             heap segments back to the OS instead of retaining them (we measured ~40 MB of idle
-             reserve). Trades slightly more frequent collections for a smaller resident footprint. -->
+        <!-- Let the GC decommit unused heap back to the OS; the app is idle most of the time. -->
         <RuntimeHostConfigurationOption Include="System.GC.ConserveMemory" Value="5" Trim="false" />
     </ItemGroup>
 

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -34,6 +34,13 @@
         <PublishReadyToRun>false</PublishReadyToRun>
     </PropertyGroup>
 
+    <ItemGroup>
+        <!-- The app spends most of its life idle in the background. Have the GC decommit unused
+             heap segments back to the OS instead of retaining them (we measured ~40 MB of idle
+             reserve). Trades slightly more frequent collections for a smaller resident footprint. -->
+        <RuntimeHostConfigurationOption Include="System.GC.ConserveMemory" Value="5" Trim="false" />
+    </ItemGroup>
+
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <!-- Parameterized windows/base views are directly constructed in code, not through the runtime XAML loader. -->
         <NoWarn>$(NoWarn);MVVMTK0045;AVLN3001</NoWarn>

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -236,6 +236,7 @@
       <Compile Include="Infrastructure\AppShortcutAumidStamper.cs" />
       <Compile Include="Infrastructure\TrayService.cs" />
       <Compile Include="Infrastructure\MicaWindowHelper.cs" />
+      <Compile Include="Infrastructure\MemoryTrimmer.cs" />
       <Compile Include="Infrastructure\EntrancePageTransition.cs" />
       <Compile Include="Infrastructure\DirectionalSlideTransition.cs" />
       <Compile Include="Infrastructure\MacOsNotificationBridge.cs" />

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -201,8 +201,7 @@ public partial class MainWindowViewModel : ViewModelBase
             loader.FinishedLoading += (_, _) =>
             {
                 Dispatcher.UIThread.Post(() => Sidebar.SetNavItemLoading(pt, false));
-                // A load (search/refresh) balloons the working set; once it settles, return the
-                // reclaimable memory to the OS so the footprint drops back down.
+                // Return the load's memory to the OS once it settles.
                 Infrastructure.MemoryTrimmer.RequestTrimAfterIdle();
             };
             loader.StartedLoading += (_, _) =>

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -199,9 +199,17 @@ public partial class MainWindowViewModel : ViewModelBase
             if (loader is null) continue;
             var pt = pageType;
             loader.FinishedLoading += (_, _) =>
+            {
                 Dispatcher.UIThread.Post(() => Sidebar.SetNavItemLoading(pt, false));
+                // A load (search/refresh) balloons the working set; once it settles, return the
+                // reclaimable memory to the OS so the footprint drops back down.
+                Infrastructure.MemoryTrimmer.RequestTrimAfterIdle();
+            };
             loader.StartedLoading += (_, _) =>
+            {
                 Dispatcher.UIThread.Post(() => Sidebar.SetNavItemLoading(pt, true));
+                Infrastructure.MemoryTrimmer.CancelPending();
+            };
             Sidebar.SetNavItemLoading(pt, loader.IsLoading);
         }
 

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/Interface_PViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/Interface_PViewModel.cs
@@ -34,6 +34,7 @@ public partial class Interface_PViewModel : ViewModelBase
     {
         try { Directory.Delete(CoreData.UniGetUICacheDirectory_Icons, true); }
         catch (Exception ex) { Logger.Error(ex); }
+        global::UniGetUI.PackageEngine.PackageClasses.PackageWrapper.ClearIconCache();
         RestartRequired?.Invoke(this, EventArgs.Empty);
         await LoadIconCacheSize();
     }

--- a/src/UniGetUI.Avalonia/Views/Controls/PackageIconLoader.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/PackageIconLoader.cs
@@ -1,0 +1,54 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using UniGetUI.PackageEngine.PackageClasses;
+
+namespace UniGetUI.Avalonia.Views.Controls;
+
+/// <summary>
+/// Attached behaviour that calls <see cref="PackageWrapper.EnsureIconLoaded"/> when the icon element
+/// attaches to the visual tree or is rebound to a new wrapper. In the virtualized list only the
+/// realized (visible) rows attach, so only those load their icons — instead of every result eagerly
+/// loading one in the wrapper constructor (thousands for a broad search).
+/// </summary>
+public static class PackageIconLoader
+{
+    public static readonly AttachedProperty<bool> TrackProperty =
+        AvaloniaProperty.RegisterAttached<Control, bool>("Track", typeof(PackageIconLoader));
+
+    public static void SetTrack(Control control, bool value) => control.SetValue(TrackProperty, value);
+    public static bool GetTrack(Control control) => control.GetValue(TrackProperty);
+
+    static PackageIconLoader()
+    {
+        TrackProperty.Changed.AddClassHandler<Control>((control, e) =>
+        {
+            if (e.GetNewValue<bool>())
+            {
+                control.AttachedToVisualTree += OnAttached;
+                control.DataContextChanged += OnDataContextChanged;
+                if (control.IsLoaded) TryLoad(control);
+            }
+            else
+            {
+                control.AttachedToVisualTree -= OnAttached;
+                control.DataContextChanged -= OnDataContextChanged;
+            }
+        });
+    }
+
+    private static void OnAttached(object? sender, VisualTreeAttachmentEventArgs e)
+        => TryLoad((Control)sender!);
+
+    private static void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        var control = (Control)sender!;
+        // Only when realized: a recycled container fires this while detached too.
+        if (control.IsLoaded) TryLoad(control);
+    }
+
+    private static void TryLoad(Control control)
+    {
+        if (control.DataContext is PackageWrapper wrapper) wrapper.EnsureIconLoaded();
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/Controls/PackageIconLoader.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/PackageIconLoader.cs
@@ -5,12 +5,8 @@ using UniGetUI.PackageEngine.PackageClasses;
 
 namespace UniGetUI.Avalonia.Views.Controls;
 
-/// <summary>
-/// Attached behaviour that calls <see cref="PackageWrapper.EnsureIconLoaded"/> when the icon element
-/// attaches to the visual tree or is rebound to a new wrapper. In the virtualized list only the
-/// realized (visible) rows attach, so only those load their icons — instead of every result eagerly
-/// loading one in the wrapper constructor (thousands for a broad search).
-/// </summary>
+// Calls PackageWrapper.EnsureIconLoaded when the icon element attaches or is rebound, so only
+// realized (visible) rows in the virtualized list load their icons.
 public static class PackageIconLoader
 {
     public static readonly AttachedProperty<bool> TrackProperty =
@@ -43,7 +39,7 @@ public static class PackageIconLoader
     private static void OnDataContextChanged(object? sender, EventArgs e)
     {
         var control = (Control)sender!;
-        // Only when realized: a recycled container fires this while detached too.
+        // A recycled container also fires this while detached; only load when realized.
         if (control.IsLoaded) TryLoad(control);
     }
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -525,7 +525,8 @@
                                             <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0"
                                                         automation:AutomationProperties.Name="{Binding Package.AutomationName}"
                                                         automation:AutomationProperties.ItemType="{t:Translate Package}">
-                                                <Panel Width="24" Height="24" VerticalAlignment="Center">
+                                                <Panel Width="24" Height="24" VerticalAlignment="Center"
+                                                       controls:PackageIconLoader.Track="True">
                                                     <Image Source="{Binding IconBitmap}" Width="24" Height="24"
                                                            Stretch="Uniform" IsVisible="{Binding HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/package.svg"
@@ -648,7 +649,8 @@
                                                 BorderBrush="{DynamicResource SettingsCardBorderBrush}" BorderThickness="1" Padding="4">
                                             <Grid ColumnDefinitions="48,*,28" ColumnSpacing="4">
                                                 <Panel Grid.Column="0" Width="44" Height="44"
-                                                       VerticalAlignment="Center" HorizontalAlignment="Center">
+                                                       VerticalAlignment="Center" HorizontalAlignment="Center"
+                                                       controls:PackageIconLoader.Track="True">
                                                     <Image Source="{Binding IconBitmap}" Width="44" Height="44"
                                                            Stretch="Uniform" IsVisible="{Binding HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/package.svg"
@@ -757,7 +759,8 @@
                                                 </Button>
                                                 <Panel Grid.Row="1" Width="64" Height="64"
                                                        Margin="0,-8,0,4"
-                                                       VerticalAlignment="Center" HorizontalAlignment="Center">
+                                                       VerticalAlignment="Center" HorizontalAlignment="Center"
+                                                       controls:PackageIconLoader.Track="True">
                                                     <Image Source="{Binding IconBitmap}" Width="64" Height="64"
                                                            Stretch="Uniform" IsVisible="{Binding HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/package.svg"

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
@@ -13,6 +13,11 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager;
 
 internal sealed class WinGetCliHelper : IWinGetManagerHelper
 {
+    // "winget search a" returns ~12k results; parsing each into a Package and pushing them to the
+    // UI freezes the app for seconds and spikes RAM. Cap to the most relevant matches (winget
+    // orders by relevance), matching the bundled pinget's default behaviour.
+    private const int MAX_SEARCH_RESULTS = 100;
+
     private readonly WinGet Manager;
     private readonly string _cliExecutablePath;
     private readonly IPingetPackageDetailsProvider _packageDetailsProvider;
@@ -320,7 +325,9 @@ internal sealed class WinGetCliHelper : IWinGetManagerHelper
                     Manager.Status.ExecutableCallArgs
                     + " search \""
                     + query
-                    + "\"  --accept-source-agreements "
+                    + "\" --count "
+                    + MAX_SEARCH_RESULTS
+                    + " --accept-source-agreements "
                     + WinGet.GetProxyArgument(),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
@@ -13,9 +13,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager;
 
 internal sealed class WinGetCliHelper : IWinGetManagerHelper
 {
-    // "winget search a" returns ~12k results; parsing each into a Package and pushing them to the
-    // UI freezes the app for seconds and spikes RAM. Cap to the most relevant matches (winget
-    // orders by relevance), matching the bundled pinget's default behaviour.
+    // "winget search a" returns ~12k results; cap to the most relevant to avoid the freeze/RAM spike.
     private const int MAX_SEARCH_RESULTS = 100;
 
     private readonly WinGet Manager;

--- a/src/UniGetUI.PackageEngine.PackageLoader/DiscoverablePackagesLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/DiscoverablePackagesLoader.cs
@@ -8,6 +8,12 @@ namespace UniGetUI.PackageEngine.PackageLoader
     {
         public static DiscoverablePackagesLoader Instance = null!;
 
+        // A broad query (e.g. "a") makes each manager return thousands of results; aggregated across
+        // every enabled manager that is thousands of packages to wrap, tag (per-package upgradable/
+        // installed lookups) and render, which freezes the UI and spikes RAM. Keep only the most
+        // relevant matches per manager — nobody scrolls thousands of results.
+        private const int MAX_RESULTS_PER_MANAGER = 100;
+
         private string QUERY_TEXT = string.Empty;
         private volatile bool _pendingReload;
 
@@ -70,7 +76,10 @@ namespace UniGetUI.PackageEngine.PackageLoader
                 return [];
             }
 
-            return manager.FindPackages(text);
+            IReadOnlyList<IPackage> found = manager.FindPackages(text);
+            return found.Count > MAX_RESULTS_PER_MANAGER
+                ? found.Take(MAX_RESULTS_PER_MANAGER).ToArray()
+                : found;
         }
 
         protected override Task WhenAddingPackage(IPackage package)

--- a/src/UniGetUI.PackageEngine.PackageLoader/DiscoverablePackagesLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/DiscoverablePackagesLoader.cs
@@ -8,10 +8,8 @@ namespace UniGetUI.PackageEngine.PackageLoader
     {
         public static DiscoverablePackagesLoader Instance = null!;
 
-        // A broad query (e.g. "a") makes each manager return thousands of results; aggregated across
-        // every enabled manager that is thousands of packages to wrap, tag (per-package upgradable/
-        // installed lookups) and render, which freezes the UI and spikes RAM. Keep only the most
-        // relevant matches per manager — nobody scrolls thousands of results.
+        // Cap results per manager; a broad query across every enabled manager otherwise wraps,
+        // tags and renders thousands of packages, freezing the UI and spiking RAM.
         private const int MAX_RESULTS_PER_MANAGER = 100;
 
         private string QUERY_TEXT = string.Empty;

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/ManagerLogger.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/ManagerLogger.cs
@@ -9,9 +9,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
     {
         private readonly IPackageManager Manager;
 
-        // Every task (search, list, install, ...) is retained here for the manager-log viewer. Left
-        // unbounded, a session's worth of operations — each holding its full output — grows without
-        // limit (a broad search alone spawns one per manager). Keep only the most recent.
+        // Keep only recent operations; retained unbounded, each holds its full output and grows forever.
         private const int MAX_RETAINED_OPERATIONS = 100;
         private readonly List<TaskLogger> operations = [];
         public IReadOnlyList<ITaskLogger> Operations
@@ -63,9 +61,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
 
     public abstract class TaskLogger : ITaskLogger
     {
-        // Cap retained output per stream. A broad "search" can emit thousands of lines per manager;
-        // keeping them all across every operation is what makes memory climb with each search. The
-        // manager-log viewer only needs the tail. Trimmed in chunks to keep appending O(1).
+        // Cap retained output per stream (chunk-trimmed to keep appending O(1)); a search can emit thousands of lines.
         protected const int MaxRetainedLines = 1000;
         private const int TrimSlack = 256;
 

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/ManagerLogger.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/ManagerLogger.cs
@@ -9,15 +9,29 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
     {
         private readonly IPackageManager Manager;
 
+        // Every task (search, list, install, ...) is retained here for the manager-log viewer. Left
+        // unbounded, a session's worth of operations — each holding its full output — grows without
+        // limit (a broad search alone spawns one per manager). Keep only the most recent.
+        private const int MAX_RETAINED_OPERATIONS = 100;
         private readonly List<TaskLogger> operations = [];
         public IReadOnlyList<ITaskLogger> Operations
         {
-            get => (IReadOnlyList<ITaskLogger>)operations;
+            get { lock (operations) return operations.ToArray(); }
         }
 
         public ManagerLogger(IPackageManager manager)
         {
             Manager = manager;
+        }
+
+        private void Register(TaskLogger operation)
+        {
+            lock (operations)
+            {
+                operations.Add(operation);
+                if (operations.Count > MAX_RETAINED_OPERATIONS)
+                    operations.RemoveRange(0, operations.Count - MAX_RETAINED_OPERATIONS);
+            }
         }
 
         public IProcessTaskLogger CreateNew(LoggableTaskType type, Process process)
@@ -35,20 +49,33 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
                 process.StartInfo.FileName,
                 process.StartInfo.Arguments
             );
-            operations.Add(operation);
+            Register(operation);
             return operation;
         }
 
         public INativeTaskLogger CreateNew(LoggableTaskType type)
         {
             NativeTaskLogger operation = new(Manager, type);
-            operations.Add(operation);
+            Register(operation);
             return operation;
         }
     }
 
     public abstract class TaskLogger : ITaskLogger
     {
+        // Cap retained output per stream. A broad "search" can emit thousands of lines per manager;
+        // keeping them all across every operation is what makes memory climb with each search. The
+        // manager-log viewer only needs the tail. Trimmed in chunks to keep appending O(1).
+        protected const int MaxRetainedLines = 1000;
+        private const int TrimSlack = 256;
+
+        protected static void AppendCapped(List<string> target, string line)
+        {
+            target.Add(line);
+            if (target.Count > MaxRetainedLines + TrimSlack)
+                target.RemoveRange(0, target.Count - MaxRetainedLines);
+        }
+
         protected DateTime StartTime;
         protected DateTime? EndTime;
         protected bool isComplete;
@@ -167,7 +194,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
             {
                 if (line != "")
                 {
-                    StdOut.Add(line);
+                    AppendCapped(StdOut, line);
                 }
             }
         }
@@ -193,7 +220,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
             {
                 if (line != "")
                 {
-                    StdErr.Add(line);
+                    AppendCapped(StdErr, line);
                 }
             }
         }
@@ -325,7 +352,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
             {
                 if (line != "")
                 {
-                    Info.Add(line);
+                    AppendCapped(Info, line);
                 }
             }
         }
@@ -351,7 +378,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
             {
                 if (line != "")
                 {
-                    Errors.Add(line);
+                    AppendCapped(Errors, line);
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces significant improvements to memory usage and icon loading efficiency in the application. The changes implement a memory trimming mechanism for Windows, overhaul the package icon loading and caching system to be more performant and memory-friendly, and add logic to only load icons for visible rows. Additionally, icons are now downscaled to reduce memory usage, and the icon cache can be reset more reliably. The most important changes are grouped below:

**Memory Management Improvements:**

* Added a `MemoryTrimmer` utility for Windows that returns unused memory to the OS after UI loads settle, reducing the app's working set. This is triggered after loading completes and can be canceled if a new load starts (`MemoryTrimmer.cs`, `MainWindowViewModel.cs`, `UniGetUI.Avalonia.csproj`). 
* Enabled .NET's GC memory conservation mode in the project file to further reduce idle memory usage (`UniGetUI.Avalonia.csproj`).

**Icon Loading and Caching Overhaul:**

* Replaced the old concurrent dictionary icon cache with a custom LRU cache, capped at 512 entries, to reduce memory pressure and avoid rooting unused bitmaps. The cache can now be cleared programmatically (`PackageCollections.cs`). 
* Increased icon loading concurrency and added per-row cancellation tokens to ensure that icon loads for discarded rows are canceled, preventing memory leaks (`PackageCollections.cs`). 
* Icons are now loaded lazily only when their row becomes visible, rather than preloading for all results. This is coordinated via a new `PackageIconLoader` attached property and corresponding XAML changes (`PackageIconLoader.cs`, `AbstractPackagesPage.axaml`). 
**Icon Decoding and Memory Usage:**

* Added logic to downscale oversized icons to a maximum of 128x128 pixels before caching, reducing memory usage for large icon files (`PackageCollections.cs`).
* Improved error handling and cancellation support during icon decoding and loading, making the UI more responsive and robust (`PackageCollections.cs`). 

**Other Improvements:**

* Limited the number of results returned by WinGet search to 100 to avoid UI freezes and memory spikes (`WinGetCliHelper.cs`).

These changes collectively result in a more responsive UI, lower memory footprint, and improved user experience, especially when browsing large package lists or running the app for extended periods.