### PR TITLE
Fix deterministic resource lifetimes

### DIFF
--- a/src/ExternalLibraries.FilePickers/Classes/Helper.cs
+++ b/src/ExternalLibraries.FilePickers/Classes/Helper.cs
@@ -17,6 +17,7 @@ internal static class Helper
     internal static string ShowOpen(nint windowHandle, FOS fos, List<string>? typeFilters = null)
     {
         FileOpenDialog dialog = new();
+        IShellItem item = null!;
         try
         {
             dialog.SetOptions(fos);
@@ -36,13 +37,15 @@ internal static class Helper
                 return string.Empty;
             }
 
-            dialog.GetResult(out IShellItem item);
+            dialog.GetResult(out item);
             item.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out string path);
             return path;
         }
         finally
         {
 #pragma warning disable CA1416
+            if (item is not null)
+                Marshal.ReleaseComObject(item);
             Marshal.ReleaseComObject(dialog);
 #pragma warning restore CA1416
         }
@@ -56,6 +59,7 @@ internal static class Helper
     )
     {
         FileSaveDialog dialog = new();
+        IShellItem item = null!;
         try
         {
             dialog.SetOptions(fos);
@@ -79,7 +83,7 @@ internal static class Helper
                 return string.Empty;
             }
 
-            dialog.GetResult(out IShellItem item);
+            dialog.GetResult(out item);
             item.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out string path);
 
             dialog.GetFileTypeIndex(out uint selection);
@@ -92,6 +96,8 @@ internal static class Helper
         finally
         {
 #pragma warning disable CA1416
+            if (item is not null)
+                Marshal.ReleaseComObject(item);
             Marshal.ReleaseComObject(dialog);
 #pragma warning restore CA1416
         }

--- a/src/UniGetUI.Avalonia/ViewModels/Controls/UserAvatarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Controls/UserAvatarViewModel.cs
@@ -9,8 +9,13 @@ using MvvmRelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace UniGetUI.Avalonia.ViewModels.Controls;
 
-public class UserAvatarViewModel : ViewModelBase
+public class UserAvatarViewModel : ViewModelBase, IDisposable
 {
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
+    private readonly CancellationToken _lifetimeToken;
+    private int _isDisposed;
+    private long _refreshGeneration;
+
     private bool _isAuthenticated;
     public bool IsAuthenticated
     {
@@ -38,15 +43,32 @@ public class UserAvatarViewModel : ViewModelBase
 
     public UserAvatarViewModel()
     {
+        _lifetimeToken = _lifetimeCancellation.Token;
         LoginCommand = new AsyncRelayCommand(LoginAsync);
         LogoutCommand = new MvvmRelayCommand(Logout);
         MoreDetailsCommand = new MvvmRelayCommand(() => CoreTools.Launch("https://devolutions.net/unigetui"));
-        GitHubAuthService.AuthStatusChanged += (_, _) => _ = RefreshAsync();
+        GitHubAuthService.AuthStatusChanged += OnAuthStatusChanged;
         _ = RefreshAsync();
+    }
+
+    private bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+    private bool CanApplyRefresh(long generation) =>
+        !IsDisposed
+        && !_lifetimeToken.IsCancellationRequested
+        && generation == Volatile.Read(ref _refreshGeneration);
+
+    private void OnAuthStatusChanged(object? sender, EventArgs e)
+    {
+        if (!IsDisposed)
+            _ = RefreshAsync();
     }
 
     private async Task RefreshAsync()
     {
+        if (IsDisposed) return;
+
+        long generation = Interlocked.Increment(ref _refreshGeneration);
         var service = new GitHubAuthService();
         bool authenticated = GitHubAuthService.IsAuthenticated();
 
@@ -61,6 +83,8 @@ public class UserAvatarViewModel : ViewModelBase
                 if (client is not null)
                 {
                     GitHubUser user = await client.GetCurrentUserAsync();
+                    if (!CanApplyRefresh(generation)) return;
+
                     displayName = string.IsNullOrEmpty(user.Name)
                         ? $"@{user.Login}"
                         : $"{user.Name} (@{user.Login})";
@@ -68,26 +92,47 @@ public class UserAvatarViewModel : ViewModelBase
                     if (!string.IsNullOrEmpty(user.AvatarUrl))
                     {
                         using var http = new HttpClient(CoreTools.GenericHttpClientParameters);
-                        byte[] bytes = await http.GetByteArrayAsync(user.AvatarUrl);
+                        byte[] bytes = await http.GetByteArrayAsync(user.AvatarUrl, _lifetimeToken);
+                        if (!CanApplyRefresh(generation)) return;
+
                         using var ms = new MemoryStream(bytes);
                         bitmap = new Bitmap(ms);
                     }
                 }
             }
+            catch (OperationCanceledException) when (_lifetimeToken.IsCancellationRequested)
+            {
+                return;
+            }
             catch (Exception ex)
             {
-                Logger.Warn("UserAvatarViewModel: failed to fetch GitHub user info");
-                Logger.Warn(ex);
+                if (!IsDisposed)
+                {
+                    Logger.Warn("UserAvatarViewModel: failed to fetch GitHub user info");
+                    Logger.Warn(ex);
+                }
                 authenticated = false;
             }
         }
 
+        if (!CanApplyRefresh(generation))
+        {
+            bitmap?.Dispose();
+            return;
+        }
+
         await Dispatcher.UIThread.InvokeAsync(() =>
         {
+            if (!CanApplyRefresh(generation)) return;
+
             IsAuthenticated = authenticated;
             UserDisplayName = displayName;
             AvatarBitmap = bitmap;
+            bitmap = null;
         });
+
+        // A queued UI update can become obsolete while it is waiting to run.
+        bitmap?.Dispose();
     }
 
     private async Task LoginAsync()
@@ -98,8 +143,11 @@ public class UserAvatarViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            Logger.Error("UserAvatarViewModel: login failed");
-            Logger.Error(ex);
+            if (!IsDisposed)
+            {
+                Logger.Error("UserAvatarViewModel: login failed");
+                Logger.Error(ex);
+            }
         }
     }
 
@@ -108,8 +156,21 @@ public class UserAvatarViewModel : ViewModelBase
         try { new GitHubAuthService().SignOut(); }
         catch (Exception ex)
         {
-            Logger.Error("UserAvatarViewModel: logout failed");
-            Logger.Error(ex);
+            if (!IsDisposed)
+            {
+                Logger.Error("UserAvatarViewModel: logout failed");
+                Logger.Error(ex);
+            }
         }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0) return;
+
+        GitHubAuthService.AuthStatusChanged -= OnAuthStatusChanged;
+        // In-flight HTTP work can still observe this token. Cancelling is sufficient;
+        // disposing the source here could race with that work.
+        _lifetimeCancellation.Cancel();
     }
 }

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/BackupViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/BackupViewModel.cs
@@ -17,7 +17,7 @@ using CoreSettings = UniGetUI.Core.SettingsEngine.Settings;
 
 namespace UniGetUI.Avalonia.ViewModels.Pages.SettingsPages;
 
-public partial class BackupViewModel : ViewModelBase
+public partial class BackupViewModel : ViewModelBase, IDisposable
 {
     public event EventHandler? RestartRequired;
 
@@ -43,15 +43,33 @@ public partial class BackupViewModel : ViewModelBase
     [ObservableProperty] private IImage? _gitHubAvatarBitmap;
 
     private readonly GitHubAuthService _authService = new();
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
+    private readonly CancellationToken _lifetimeToken;
     private bool _isLoading;
+    private int _isDisposed;
+    private long _statusGeneration;
 
     public BackupViewModel()
     {
+        _lifetimeToken = _lifetimeCancellation.Token;
         _isLocalBackupEnabled = CoreSettings.Get(CoreSettings.K.EnablePackageBackup_LOCAL);
         RefreshDirectoryLabel();
 
-        GitHubAuthService.AuthStatusChanged += (_, _) => _ = UpdateGitHubLoginStatus();
+        GitHubAuthService.AuthStatusChanged += OnAuthStatusChanged;
         _ = UpdateGitHubLoginStatus();
+    }
+
+    private bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+    private bool CanApplyStatus(long generation) =>
+        !IsDisposed
+        && !_lifetimeToken.IsCancellationRequested
+        && generation == Volatile.Read(ref _statusGeneration);
+
+    private void OnAuthStatusChanged(object? sender, EventArgs e)
+    {
+        if (!IsDisposed)
+            _ = UpdateGitHubLoginStatus();
     }
 
     /* ─────────────── Local backup ─────────────── */
@@ -59,12 +77,14 @@ public partial class BackupViewModel : ViewModelBase
     [RelayCommand]
     private void EnableLocalBackupChanged()
     {
+        if (IsDisposed) return;
         IsLocalBackupEnabled = CoreSettings.Get(CoreSettings.K.EnablePackageBackup_LOCAL);
         RestartRequired?.Invoke(this, EventArgs.Empty);
     }
 
     private void RefreshDirectoryLabel()
     {
+        if (IsDisposed) return;
         string dir = CoreSettings.GetValue(CoreSettings.K.ChangeBackupOutputDirectory);
         BackupDirectoryLabel = string.IsNullOrEmpty(dir) ? CoreData.UniGetUI_DefaultBackupDirectory : dir;
     }
@@ -72,12 +92,12 @@ public partial class BackupViewModel : ViewModelBase
     [RelayCommand]
     private async Task PickBackupDirectory(Visual? visual)
     {
-        if (visual is null || TopLevel.GetTopLevel(visual) is not { } topLevel) return;
+        if (IsDisposed || visual is null || TopLevel.GetTopLevel(visual) is not { } topLevel) return;
         var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
         {
             AllowMultiple = false,
         });
-        if (folders is not [{ } folder]) return;
+        if (IsDisposed || folders is not [{ } folder]) return;
         var path = folder.TryGetLocalPath();
         if (path is null) return;
         CoreSettings.SetValue(CoreSettings.K.ChangeBackupOutputDirectory, path);
@@ -129,36 +149,51 @@ public partial class BackupViewModel : ViewModelBase
 
     private async Task UpdateGitHubLoginStatus()
     {
+        if (IsDisposed) return;
+
+        long generation = Interlocked.Increment(ref _statusGeneration);
         if (GitHubAuthService.IsAuthenticated())
         {
-            try { await GenerateLogoutState(); }
+            try { await GenerateLogoutState(generation); }
+            catch (OperationCanceledException) when (_lifetimeToken.IsCancellationRequested)
+            {
+                return;
+            }
             catch (Exception ex)
             {
-                Logger.Error("An error occurred while attempting to generate settings login UI:");
-                Logger.Error(ex);
-                GenerateLoginState();
+                if (!IsDisposed)
+                {
+                    Logger.Error("An error occurred while attempting to generate settings login UI:");
+                    Logger.Error(ex);
+                }
+                GenerateLoginState(generation);
             }
         }
         else
         {
-            GenerateLoginState();
+            GenerateLoginState(generation);
         }
-        UpdateCloudControlsEnabled();
+
+        if (CanApplyStatus(generation))
+            UpdateCloudControlsEnabled();
     }
 
-    private void GenerateLoginState()
+    private void GenerateLoginState(long generation)
     {
+        if (!CanApplyStatus(generation)) return;
+
         IsLoggedIn = false;
         GitHubUserTitle = CoreTools.Translate("Current status: Not logged in");
         GitHubUserSubtitle = CoreTools.Translate("Log in to enable cloud backup");
-        GitHubAvatarBitmap = null;
+        SetGitHubAvatarBitmap(null);
     }
 
-    private async Task GenerateLogoutState()
+    private async Task GenerateLogoutState(long generation)
     {
         using var client = GitHubAuthService.CreateGitHubClient()
             ?? throw new InvalidOperationException("Authenticated but cannot create GitHub client.");
         var user = await client.GetCurrentUserAsync();
+        if (!CanApplyStatus(generation)) return;
 
         IsLoggedIn = true;
         string displayName = string.IsNullOrWhiteSpace(user.Name) ? user.Login : user.Name;
@@ -170,20 +205,36 @@ public partial class BackupViewModel : ViewModelBase
             using var http = new HttpClient(CoreTools.GenericHttpClientParameters);
             if (!string.IsNullOrWhiteSpace(user.AvatarUrl))
             {
-                var bytes = await http.GetByteArrayAsync(user.AvatarUrl);
+                var bytes = await http.GetByteArrayAsync(user.AvatarUrl, _lifetimeToken);
+                if (!CanApplyStatus(generation)) return;
+
                 using var ms = new MemoryStream(bytes);
-                GitHubAvatarBitmap = new Bitmap(ms);
+                var bitmap = new Bitmap(ms);
+                if (CanApplyStatus(generation))
+                    SetGitHubAvatarBitmap(bitmap);
+                else
+                    bitmap.Dispose();
             }
+        }
+        catch (OperationCanceledException) when (_lifetimeToken.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
-            Logger.Error("Failed to load GitHub avatar:");
-            Logger.Error(ex);
+            if (!IsDisposed)
+            {
+                Logger.Error("Failed to load GitHub avatar:");
+                Logger.Error(ex);
+            }
         }
     }
 
+    private void SetGitHubAvatarBitmap(IImage? bitmap) => GitHubAvatarBitmap = bitmap;
+
     private void UpdateCloudControlsEnabled()
     {
+        if (IsDisposed) return;
+
         IsLoginButtonEnabled = !_isLoading;
         IsCloudControlsEnabled = IsLoggedIn && !_isLoading;
         IsCloudBackupNowEnabled = IsLoggedIn && !_isLoading
@@ -193,6 +244,7 @@ public partial class BackupViewModel : ViewModelBase
     [RelayCommand]
     private void EnableCloudBackupChanged()
     {
+        if (IsDisposed) return;
         RestartRequired?.Invoke(this, EventArgs.Empty);
         UpdateCloudControlsEnabled();
     }
@@ -200,13 +252,15 @@ public partial class BackupViewModel : ViewModelBase
     [RelayCommand]
     private async Task Login()
     {
+        if (IsDisposed) return;
         _isLoading = true;
         UpdateCloudControlsEnabled();
 
         bool success = await _authService.SignInAsync();
-        if (!success)
+        if (!success && !IsDisposed)
             Logger.Error("An error occurred while logging in to GitHub.");
 
+        if (IsDisposed) return;
         _isLoading = false;
         UpdateCloudControlsEnabled();
     }
@@ -214,6 +268,7 @@ public partial class BackupViewModel : ViewModelBase
     [RelayCommand]
     private void Logout()
     {
+        if (IsDisposed) return;
         _isLoading = true;
         UpdateCloudControlsEnabled();
 
@@ -226,6 +281,7 @@ public partial class BackupViewModel : ViewModelBase
     [RelayCommand]
     private async Task DoCloudBackup()
     {
+        if (IsDisposed) return;
         _isLoading = true;
         UpdateCloudControlsEnabled();
         try { await DoCloudBackupStatic(); }
@@ -337,5 +393,15 @@ public partial class BackupViewModel : ViewModelBase
     private static void MoreDetails()
     {
         CoreTools.Launch("https://devolutions.net/unigetui");
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0) return;
+
+        GitHubAuthService.AuthStatusChanged -= OnAuthStatusChanged;
+        // In-flight HTTP work can still observe this token. Cancelling is sufficient;
+        // disposing the source here could race with that work.
+        _lifetimeCancellation.Cancel();
     }
 }

--- a/src/UniGetUI.Avalonia/Views/Controls/UserAvatarControl.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/UserAvatarControl.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using UniGetUI.Avalonia.ViewModels.Controls;
 
@@ -5,9 +6,20 @@ namespace UniGetUI.Avalonia.Views.Controls;
 
 public partial class UserAvatarControl : UserControl
 {
+    private readonly UserAvatarViewModel _viewModel;
+
     public UserAvatarControl()
     {
-        DataContext = new UserAvatarViewModel();
+        _viewModel = new UserAvatarViewModel();
+        DataContext = _viewModel;
         InitializeComponent();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        // This control belongs to a SidebarView data template, which Avalonia can recreate as
+        // the navigation layout changes. Its visual lifetime—not page navigation—is the owner.
+        _viewModel.Dispose();
+        base.OnDetachedFromVisualTree(e);
     }
 }

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Backup.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/Backup.axaml.cs
@@ -4,8 +4,10 @@ using UniGetUI.Core.Tools;
 
 namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
 
-public sealed partial class Backup : UserControl, ISettingsPage
+public sealed partial class Backup : UserControl, ISettingsPage, IDisposable
 {
+    private readonly BackupViewModel _viewModel;
+
     public bool CanGoBack => true;
     public string ShortTitle => CoreTools.Translate("Backup and Restore");
 
@@ -14,9 +16,18 @@ public sealed partial class Backup : UserControl, ISettingsPage
 
     public Backup()
     {
-        DataContext = new BackupViewModel();
+        _viewModel = new BackupViewModel();
+        DataContext = _viewModel;
         InitializeComponent();
 
-        ((BackupViewModel)DataContext).RestartRequired += (s, e) => RestartRequired?.Invoke(s, e);
+        _viewModel.RestartRequired += OnRestartRequired;
+    }
+
+    private void OnRestartRequired(object? sender, EventArgs e) => RestartRequired?.Invoke(sender, e);
+
+    public void Dispose()
+    {
+        _viewModel.RestartRequired -= OnRestartRequired;
+        _viewModel.Dispose();
     }
 }

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml.cs
@@ -83,8 +83,11 @@ public partial class SettingsBasePage : UserControl, IInnerNavigationPage, IEnte
     private void NavigateBack()
     {
         if (_history.Count == 0) return;
-        var prev = _history.Pop();
-        NavigateToPage(prev, forward: false);
+
+        var discardedPage = _currentContent;
+        var previousPage = _history.Pop();
+        NavigateToPage(previousPage, forward: false);
+        DisposePage(discardedPage);
     }
 
     private void Page_NavigationRequested(object? sender, Type e)
@@ -159,12 +162,11 @@ public partial class SettingsBasePage : UserControl, IInnerNavigationPage, IEnte
 
     public void OnEnter()
     {
-        _history.Clear();
-        NavigateToPage(_isManagers ? GetManagersHomepage() : GetSettingsHomepage());
+        ResetToHomepage();
         VM.IsRestartBannerVisible = false;
     }
 
-    public void OnLeave() { }
+    public void OnLeave() => ResetToHomepage();
 
     // ── IInnerNavigationPage extra overloads ──────────────────────────────
 
@@ -185,6 +187,27 @@ public partial class SettingsBasePage : UserControl, IInnerNavigationPage, IEnte
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────
+
+    private void ResetToHomepage()
+    {
+        UserControl homepage = _isManagers ? GetManagersHomepage() : GetSettingsHomepage();
+
+        while (_history.TryPop(out var page))
+            if (!ReferenceEquals(page, homepage))
+                DisposePage(page);
+
+        if (ReferenceEquals(_currentContent, homepage)) return;
+
+        var discardedPage = _currentContent;
+        NavigateToPage(homepage);
+        DisposePage(discardedPage);
+    }
+
+    private static void DisposePage(UserControl? page)
+    {
+        if (page is IDisposable disposable)
+            disposable.Dispose();
+    }
 
     private MainWindowViewModel? GetMainWindowViewModel() =>
         (TopLevel.GetTopLevel(this) is Window { DataContext: MainWindowViewModel vm }) ? vm : null;

--- a/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
+++ b/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
@@ -130,6 +130,27 @@ public class TaskRecyclerTests
     }
 
     [Fact]
+    public async Task FaultedTaskIsEvictedBeforeTheNextCall()
+    {
+        int calls = 0;
+        Func<int> method = () =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+                throw new InvalidOperationException("Expected first attempt failure");
+            return 42;
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await TaskRecycler<int>.RunOrAttachAsync(method)
+        );
+
+        int result = await TaskRecycler<int>.RunOrAttachAsync(method);
+
+        Assert.Equal(42, result);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
     public async Task TestTaskRecycler_Class_String()
     {
         var class1 = new TestClass();

--- a/src/UniGetUI.Core.Classes/TaskRecycler.cs
+++ b/src/UniGetUI.Core.Classes/TaskRecycler.cs
@@ -21,22 +21,18 @@ public static class TaskRecycler<ReturnT>
     private static readonly ConcurrentDictionary<int, Task<ReturnT>> _tasks = new();
     private static readonly ConcurrentDictionary<int, Task> _tasks_VOID = new();
 
-    // ---------------------------------------------------------------------------------------------------------------
-
     public static Task RunOrAttachAsync_VOID(Action method, int cacheTimeSecs = 0)
     {
         int hash = method.GetHashCode();
         return _runTaskAndWait_VOID(new Task(method), hash, cacheTimeSecs);
     }
 
-    /// Asynchronous entry point for 0 parameters
     public static Task<ReturnT> RunOrAttachAsync(Func<ReturnT> method, int cacheTimeSecs = 0)
     {
         int hash = method.GetHashCode();
         return _runTaskAndWait(new Task<ReturnT>(method), hash, cacheTimeSecs);
     }
 
-    /// Asynchronous entry point for 1 parameter
     public static Task<ReturnT> RunOrAttachAsync<ParamT>(
         Func<ParamT, ReturnT> method,
         ParamT arg1,
@@ -47,7 +43,6 @@ public static class TaskRecycler<ReturnT>
         return _runTaskAndWait(new Task<ReturnT>(() => method(arg1)), hash, cacheTimeSecs);
     }
 
-    /// Asynchronous entry point for 2 parameters
     public static Task<ReturnT> RunOrAttachAsync<Param1T, Param2T>(
         Func<Param1T, Param2T, ReturnT> method,
         Param1T arg1,
@@ -59,7 +54,6 @@ public static class TaskRecycler<ReturnT>
         return _runTaskAndWait(new Task<ReturnT>(() => method(arg1, arg2)), hash, cacheTimeSecs);
     }
 
-    /// Asynchronous entry point for 3 parameters
     public static Task<ReturnT> RunOrAttachAsync<Param1T, Param2T, Param3T>(
         Func<Param1T, Param2T, Param3T, ReturnT> method,
         Param1T arg1,
@@ -80,20 +74,15 @@ public static class TaskRecycler<ReturnT>
         );
     }
 
-    // ---------------------------------------------------------------------------------------------------------------
-
-    /// Synchronous entry point for 0 parameters
     public static ReturnT RunOrAttach(Func<ReturnT> method, int cacheTimeSecs = 0) =>
         RunOrAttachAsync(method, cacheTimeSecs).GetAwaiter().GetResult();
 
-    /// Synchronous entry point for 1 parameter1
     public static ReturnT RunOrAttach<ParamT>(
         Func<ParamT, ReturnT> method,
         ParamT arg1,
         int cacheTimeSecs = 0
     ) => RunOrAttachAsync(method, arg1, cacheTimeSecs).GetAwaiter().GetResult();
 
-    /// Synchronous entry point for 2 parameters
     public static ReturnT RunOrAttach<Param1T, Param2T>(
         Func<Param1T, Param2T, ReturnT> method,
         Param1T arg1,
@@ -101,7 +90,6 @@ public static class TaskRecycler<ReturnT>
         int cacheTimeSecs = 0
     ) => RunOrAttachAsync(method, arg1, arg2, cacheTimeSecs).GetAwaiter().GetResult();
 
-    /// Synchronous entry point for 3 parameters
     public static ReturnT RunOrAttach<Param1T, Param2T, Param3T>(
         Func<Param1T, Param2T, Param3T, ReturnT> method,
         Param1T arg1,
@@ -110,104 +98,80 @@ public static class TaskRecycler<ReturnT>
         int cacheTimeSecs = 0
     ) => RunOrAttachAsync(method, arg1, arg2, arg3, cacheTimeSecs).GetAwaiter().GetResult();
 
-    // ---------------------------------------------------------------------------------------------------------------
-
     /// <summary>
     /// Instantly removes a function call from the cache, even if the associated task has not
-    /// finished yet. Any previous call will finish as expected. New calls won't attach to any
+    /// finished yet. Any previous call will finish as expected. New calls will not attach to any
     /// preexisting Tasks, and a new Task will be created instead.
-    /// If the given function call is not present in the cache, nothing will be done.
     /// </summary>
-    /// <param name="method"></param>
     public static void RemoveFromCache(Func<ReturnT> method) =>
-        _removeFromCache(method.GetHashCode(), 0);
+        _tasks.TryRemove(method.GetHashCode(), out _);
 
-    // ---------------------------------------------------------------------------------------------------------------
-
-    /// <summary>
-    /// Handles running the task if no such task was found on cache, and returning the cached task if it was found.
-    /// </summary>
-    private static async Task _runTaskAndWait_VOID(Task task, int hash, int cacheTimeSecsSecs)
+    private static Task _runTaskAndWait_VOID(Task task, int hash, int cacheTimeSecs)
     {
-        if (_tasks_VOID.TryGetValue(hash, out Task? _task))
+        Task cachedTask = _tasks_VOID.GetOrAdd(hash, task);
+        if (ReferenceEquals(cachedTask, task))
         {
-            // Get the cached task, which is either running or finished
-            task = _task;
-        }
-        else if (!_tasks_VOID.TryAdd(hash, task))
-        {
-            // Race condition, an equivalent task got added from another thread between the TryGetValue and TryAdd,
-            // so we are going to restart the call to _runTaskAndWait in order for TryGetValue to return the new task again
-            await _runTaskAndWait_VOID(task, hash, cacheTimeSecsSecs).ConfigureAwait(false);
-            return;
+            task.Start();
+            _ = _scheduleCacheRemoval_VOID(hash, task, cacheTimeSecs);
         }
         else
         {
-            // Now that the new task is in the cache, run the task.
-            task.Start();
+            Interlocked.Increment(ref TaskRecyclerTelemetry.DeduplicatedCalls);
         }
 
-        // Wait for the task to finish
-        await task.ConfigureAwait(false);
-
-        // Schedule the task for removal after the cache time expires
-        _removeFromCache_VOID(hash, cacheTimeSecsSecs);
+        return cachedTask;
     }
 
-    /// <summary>
-    /// Handles running the task if no such task was found on cache, and returning the cached task if it was found.
-    /// </summary>
-    private static async Task<ReturnT> _runTaskAndWait(
-        Task<ReturnT> task,
-        int hash,
-        int cacheTimeSecsSecs
-    )
+    private static Task<ReturnT> _runTaskAndWait(Task<ReturnT> task, int hash, int cacheTimeSecs)
     {
-        if (_tasks.TryGetValue(hash, out Task<ReturnT>? _task))
+        Task<ReturnT> cachedTask = _tasks.GetOrAdd(hash, task);
+        if (ReferenceEquals(cachedTask, task))
         {
-            // Get the cached task, which is either running or finished
-            task = _task;
-        }
-        else if (!_tasks.TryAdd(hash, task))
-        {
-            // Race condition, an equivalent task got added from another thread between the TryGetValue and TryAdd,
-            // so we are going to restart the call to _runTaskAndWait in order for TryGetValue to return the new task again
-            return await _runTaskAndWait(task, hash, cacheTimeSecsSecs).ConfigureAwait(false);
+            task.Start();
+            _ = _scheduleCacheRemoval(hash, task, cacheTimeSecs);
         }
         else
         {
-            // Now that the new task is in the cache, run the task.
-            task.Start();
+            Interlocked.Increment(ref TaskRecyclerTelemetry.DeduplicatedCalls);
         }
 
-        // Wait for the task to finish
-        ReturnT result = await task.ConfigureAwait(false);
-
-        // Schedule the task for removal after the cache time expires
-        _removeFromCache(hash, cacheTimeSecsSecs);
-
-        return result;
+        return cachedTask;
     }
 
-    /// <summary>
-    /// Removes the task associated with the given hash from the cache after the given period of time
-    /// If the given hash is not present, nothing will be done.
-    /// </summary>
-    private static async void _removeFromCache(int hash, int cacheTimeSecsSecs)
+    private static Task _scheduleCacheRemoval(int hash, Task<ReturnT> task, int cacheTimeSecs) =>
+        task.ContinueWith(
+                completedTask => _removeFromCache(hash, completedTask, cacheTimeSecs),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+            )
+            .Unwrap();
+
+    private static Task _scheduleCacheRemoval_VOID(int hash, Task task, int cacheTimeSecs) =>
+        task.ContinueWith(
+                completedTask => _removeFromCache_VOID(hash, completedTask, cacheTimeSecs),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+            )
+            .Unwrap();
+
+    private static async Task _removeFromCache(int hash, Task<ReturnT> task, int cacheTimeSecs)
     {
-        if (cacheTimeSecsSecs > 0)
-            await Task.Delay(cacheTimeSecsSecs * 1000);
+        if (task.IsCompletedSuccessfully && cacheTimeSecs > 0)
+            await Task.Delay(TimeSpan.FromSeconds(cacheTimeSecs)).ConfigureAwait(false);
 
-        _tasks.Remove(hash, out _);
+        ((ICollection<KeyValuePair<int, Task<ReturnT>>>)_tasks).Remove(new(hash, task));
     }
 
-    private static async void _removeFromCache_VOID(int hash, int cacheTimeSecsSecs)
+    private static async Task _removeFromCache_VOID(int hash, Task task, int cacheTimeSecs)
     {
-        if (cacheTimeSecsSecs > 0)
-            await Task.Delay(cacheTimeSecsSecs * 1000);
+        if (task.IsCompletedSuccessfully && cacheTimeSecs > 0)
+            await Task.Delay(TimeSpan.FromSeconds(cacheTimeSecs)).ConfigureAwait(false);
 
-        _tasks_VOID.Remove(hash, out _);
+        ((ICollection<KeyValuePair<int, Task>>)_tasks_VOID).Remove(new(hash, task));
     }
+
 }
 
 public static class TaskRecyclerTelemetry

--- a/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
+++ b/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
@@ -217,7 +217,8 @@ namespace UniGetUI.Core.IconEngine
                 using HttpClient client = new(CoreTools.GenericHttpClientParameters);
                 client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
 
-                HttpResponseMessage response = client.GetAsync(icon.Url).GetAwaiter().GetResult();
+                using var request = new HttpRequestMessage(HttpMethod.Get, icon.Url);
+                using HttpResponseMessage response = client.Send(request);
                 if (!response.IsSuccessStatusCode)
                 {
                     Logger.Warn(
@@ -309,25 +310,27 @@ namespace UniGetUI.Core.IconEngine
                 if (width > MAX_SIDE || height > MAX_SIDE)
                 {
                     File.Move(cachedIconFile, $"{cachedIconFile}.copy");
-                    var image = MagicImageProcessor.BuildPipeline(
-                        $"{cachedIconFile}.copy",
-                        new ProcessImageSettings
-                        {
-                            Width = MAX_SIDE,
-                            Height = MAX_SIDE,
-                            ResizeMode = CropScaleMode.Contain,
-                        }
-                    );
-
-                    // Apply changes and save the image to disk
-                    using (FileStream fileStream = File.Create(cachedIconFile))
+                    using (
+                        var image = MagicImageProcessor.BuildPipeline(
+                            $"{cachedIconFile}.copy",
+                            new ProcessImageSettings
+                            {
+                                Width = MAX_SIDE,
+                                Height = MAX_SIDE,
+                                ResizeMode = CropScaleMode.Contain,
+                            }
+                        )
+                    )
                     {
-                        image.WriteOutput(fileStream);
+                        // Apply changes and save the image to disk
+                        using (FileStream fileStream = File.Create(cachedIconFile))
+                        {
+                            image.WriteOutput(fileStream);
+                        }
+                        Logger.Debug(
+                            $"File {cachedIconFile} was downsized from {width}x{height} to {image.Settings.Width}x{image.Settings.Height}"
+                        );
                     }
-                    Logger.Debug(
-                        $"File {cachedIconFile} was downsized from {width}x{height} to {image.Settings.Width}x{image.Settings.Height}"
-                    );
-                    image.Dispose();
                     File.Delete($"{cachedIconFile}.copy");
                 }
                 else

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -149,7 +149,7 @@ namespace UniGetUI.Core.Tools
             string command =
                 $"Wait-Process -Id {currentProcessId}; Start-Process -FilePath '{escapedExecutablePath}'";
 
-            Process.Start(
+            using var process = Process.Start(
                 new ProcessStartInfo
                 {
                     FileName = "powershell.exe",
@@ -356,9 +356,8 @@ namespace UniGetUI.Core.Tools
             try
             {
                 using HttpClient client = new(CoreTools.GenericHttpClientParameters);
-                HttpResponseMessage response = client.Send(
-                    new HttpRequestMessage(HttpMethod.Head, url)
-                );
+                using var request = new HttpRequestMessage(HttpMethod.Head, url);
+                using HttpResponseMessage response = client.Send(request);
                 return response.Content.Headers.ContentLength ?? 0;
             }
             catch (Exception e)
@@ -377,9 +376,8 @@ namespace UniGetUI.Core.Tools
                 var handler = CoreTools.GenericHttpClientParameters;
                 handler.AllowAutoRedirect = false;
                 using HttpClient client = new(handler);
-                HttpResponseMessage response = client.Send(
-                    new HttpRequestMessage(HttpMethod.Head, url)
-                );
+                using var request = new HttpRequestMessage(HttpMethod.Head, url);
+                using HttpResponseMessage response = client.Send(request);
 
                 if (
                     response.StatusCode
@@ -935,7 +933,7 @@ namespace UniGetUI.Core.Tools
                     return;
                 }
 
-                Process p = new()
+                using Process p = new()
                 {
                     StartInfo = new()
                     {
@@ -947,7 +945,6 @@ namespace UniGetUI.Core.Tools
                 };
                 p.Start();
                 await p.WaitForExitAsync();
-                p.Dispose();
             }
             catch (Exception ex)
             {
@@ -962,7 +959,7 @@ namespace UniGetUI.Core.Tools
                 if (path is null)
                     return;
 
-                var p = new Process()
+                using var p = new Process()
                 {
                     StartInfo = new() { FileName = path, UseShellExecute = true, CreateNoWindow = true, },
                 };

--- a/src/UniGetUI.Interface.Telemetry.Tests/TelemetryHandlerTests.cs
+++ b/src/UniGetUI.Interface.Telemetry.Tests/TelemetryHandlerTests.cs
@@ -90,6 +90,33 @@ public sealed class TelemetryHandlerTests : IDisposable
     }
 
     [Fact]
+    public async Task Posts_DisposeResponsesReturnedByInjectionSeam()
+    {
+        TelemetryHandler.Configure("telemetry-user", "telemetry-pass");
+        var activityResponse = new TrackingHttpResponseMessage(HttpStatusCode.OK);
+        TelemetryHandler.TestSendAsyncOverride = _ => Task.FromResult<HttpResponseMessage>(activityResponse);
+
+        await TelemetryHandler.InitializeAsync();
+
+        Assert.True(activityResponse.IsDisposed);
+
+        var packageResponse = new TrackingHttpResponseMessage(HttpStatusCode.BadRequest);
+        TelemetryHandler.TestSendAsyncOverride = _ => Task.FromResult<HttpResponseMessage>(packageResponse);
+        var package = new Package(
+            "Telemetry Package",
+            "Telemetry.Package",
+            "1.0.0",
+            new NullSource("Telemetry Source"),
+            NullPackageManager.Instance
+        );
+        TelemetryHandler.UpdatePackage(package, TEL_OP_RESULT.SUCCESS);
+
+        await TelemetryHandler.FlushPackageEventsAsync();
+
+        Assert.True(packageResponse.IsDisposed);
+    }
+
+    [Fact]
     public void ComputeActiveSettingsBitmask_IncludesDeterministicSettingsAndSpecialPaths()
     {
         Settings.Set(Settings.K.DisableAutoUpdateWingetUI, false);
@@ -351,6 +378,18 @@ public sealed class TelemetryHandlerTests : IDisposable
         FieldInfo field = typeof(Settings).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)!;
         object dictionary = field.GetValue(null)!;
         dictionary.GetType().GetMethod("Clear")!.Invoke(dictionary, null);
+    }
+
+    private sealed class TrackingHttpResponseMessage(HttpStatusCode statusCode)
+        : HttpResponseMessage(statusCode)
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
     }
 
     private sealed record CapturedRequest(

--- a/src/UniGetUI.Interface.Telemetry/TelemetryHandler.cs
+++ b/src/UniGetUI.Interface.Telemetry/TelemetryHandler.cs
@@ -280,7 +280,7 @@ public static class TelemetryHandler
             };
             request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
 
-            HttpResponseMessage response = TestSendAsyncOverride is { } sendAsync
+            using HttpResponseMessage response = TestSendAsyncOverride is { } sendAsync
                 ? await sendAsync(request)
                 : await _httpClient.SendAsync(request);
 
@@ -357,7 +357,7 @@ public static class TelemetryHandler
             };
             request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
 
-            HttpResponseMessage response = TestSendAsyncOverride is { } sendAsync
+            using HttpResponseMessage response = TestSendAsyncOverride is { } sendAsync
                 ? await sendAsync(request)
                 : await _httpClient.SendAsync(request);
 

--- a/src/UniGetUI.PackageEngine.Managers.Bun/Bun.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Bun/Bun.cs
@@ -222,7 +222,7 @@ namespace UniGetUI.PackageEngine.Managers.BunManager
 
         protected override void _loadManagerVersion(out string version)
         {
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.Cargo/CratesIOClient.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Cargo/CratesIOClient.cs
@@ -91,10 +91,13 @@ internal sealed class CratesIOClient
 
     internal static T Fetch<T>(Uri url)
     {
-        HttpClient client = new(CoreTools.GenericHttpClientParameters);
+        using HttpClient client = new(CoreTools.GenericHttpClientParameters);
         client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        using HttpResponseMessage response = client.Send(request);
+        response.EnsureSuccessStatusCode();
 
-        var manifestStr = client.GetStringAsync(url).GetAwaiter().GetResult();
+        string manifestStr = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
         var manifest =
             CargoJson.Deserialize<T>(manifestStr)

--- a/src/UniGetUI.PackageEngine.Managers.Chocolatey/Chocolatey.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Chocolatey/Chocolatey.cs
@@ -369,7 +369,7 @@ namespace UniGetUI.PackageEngine.Managers.ChocolateyManager
 
         protected override void _loadManagerVersion(out string version)
         {
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
@@ -106,10 +106,8 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
                     while (SearchUrl is not null)
                     {
-                        HttpResponseMessage response = client
-                            .GetAsync(SearchUrl)
-                            .GetAwaiter()
-                            .GetResult();
+                        using var request = new HttpRequestMessage(HttpMethod.Get, SearchUrl);
+                        using HttpResponseMessage response = client.Send(request);
 
                         if (!response.IsSuccessStatusCode)
                         {
@@ -246,10 +244,8 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
                     using HttpClient client = new(CoreTools.GenericHttpClientParameters);
                     client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
-                    HttpResponseMessage response = client
-                        .GetAsync(SearchUrl)
-                        .GetAwaiter()
-                        .GetResult();
+                    using var request = new HttpRequestMessage(HttpMethod.Get, SearchUrl);
+                    using HttpResponseMessage response = client.Send(request);
 
                     if (!response.IsSuccessStatusCode)
                     {

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
@@ -266,10 +266,10 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
             List<string> results = [];
 
-            HttpClient client = new(CoreTools.GenericHttpClientParameters);
+            using HttpClient client = new(CoreTools.GenericHttpClientParameters);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
-
-            HttpResponseMessage response = client.GetAsync(SearchUrl).GetAwaiter().GetResult();
+            using var request = new HttpRequestMessage(HttpMethod.Get, SearchUrl);
+            using HttpResponseMessage response = client.Send(request);
             if (!response.IsSuccessStatusCode)
             {
                 Logger.Warn(

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetManifestLoader.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetManifestLoader.cs
@@ -45,7 +45,6 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
                 return manifest;
             }
 
-            string? PackageManifestContent = "";
             string PackageManifestUrl = GetManifestUrl(package).ToString();
 
             try
@@ -53,33 +52,24 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
                 using (HttpClient client = new(CoreTools.GenericHttpClientParameters))
                 {
                     client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
-                    HttpResponseMessage response = client
-                        .GetAsync(PackageManifestUrl)
-                        .GetAwaiter()
-                        .GetResult();
-                    if (!response.IsSuccessStatusCode && package.VersionString.EndsWith(".0"))
-                    {
-                        response = client
-                            .GetAsync(new Uri(PackageManifestUrl.ToString().Replace(".0')", "')")))
-                            .GetAwaiter()
-                            .GetResult();
-                    }
+                    using var initialRequest = new HttpRequestMessage(
+                        HttpMethod.Get,
+                        PackageManifestUrl
+                    );
+                    using HttpResponseMessage initialResponse = client.Send(initialRequest);
 
-                    if (!response.IsSuccessStatusCode)
+                    if (!initialResponse.IsSuccessStatusCode && package.VersionString.EndsWith(".0"))
                     {
-                        Logger.Warn(
-                            $"Failed to download the {package.Manager.Name} manifest at Url={PackageManifestUrl.ToString()} with status code {response.StatusCode}"
+                        using var fallbackRequest = new HttpRequestMessage(
+                            HttpMethod.Get,
+                            new Uri(PackageManifestUrl.ToString().Replace(".0')", "')"))
                         );
-                        return null;
+                        using HttpResponseMessage fallbackResponse = client.Send(fallbackRequest);
+                        return CacheManifestContent(package, PackageManifestUrl, fallbackResponse);
                     }
 
-                    PackageManifestContent = response
-                        .Content.ReadAsStringAsync()
-                        .GetAwaiter()
-                        .GetResult();
+                    return CacheManifestContent(package, PackageManifestUrl, initialResponse);
                 }
-                BaseNuGet.Manifests[package.GetHash()] = PackageManifestContent;
-                return PackageManifestContent;
             }
             catch (Exception e)
             {
@@ -89,6 +79,25 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
                 Logger.Warn(e);
                 return null;
             }
+        }
+
+        private static string? CacheManifestContent(
+            IPackage package,
+            string packageManifestUrl,
+            HttpResponseMessage response
+        )
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                Logger.Warn(
+                    $"Failed to download the {package.Manager.Name} manifest at Url={packageManifestUrl} with status code {response.StatusCode}"
+                );
+                return null;
+            }
+
+            string packageManifestContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            BaseNuGet.Manifests[package.GetHash()] = packageManifestContent;
+            return packageManifestContent;
         }
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.Npm/Npm.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Npm/Npm.cs
@@ -208,7 +208,7 @@ namespace UniGetUI.PackageEngine.Managers.NpmManager
 
         protected override void _loadManagerVersion(out string version)
         {
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.Pip/Helpers/PipPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pip/Helpers/PipPkgDetailsHelper.cs
@@ -21,13 +21,15 @@ namespace UniGetUI.PackageEngine.Managers.PipManager
                 LoggableTaskType.LoadPackageDetails
             );
 
-            string JsonString;
-            HttpClient client = new(CoreTools.GenericHttpClientParameters);
+            using HttpClient client = new(CoreTools.GenericHttpClientParameters);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
-            JsonString = client
-                .GetStringAsync($"https://pypi.org/pypi/{details.Package.Id}/json")
-                .GetAwaiter()
-                .GetResult();
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"https://pypi.org/pypi/{details.Package.Id}/json"
+            );
+            using HttpResponseMessage response = client.Send(request);
+            response.EnsureSuccessStatusCode();
+            string JsonString = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             JsonObject? contents = JsonNode.Parse(JsonString) as JsonObject;
 

--- a/src/UniGetUI.PackageEngine.Managers.Pip/Pip.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pip/Pip.cs
@@ -195,7 +195,8 @@ namespace UniGetUI.PackageEngine.Managers.PipManager
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
             client.DefaultRequestHeaders.Add("Accept", "application/vnd.pypi.simple.v1+json");
 
-            HttpResponseMessage response = client.GetAsync("https://pypi.org/simple/").GetAwaiter().GetResult();
+            using var request = new HttpRequestMessage(HttpMethod.Get, "https://pypi.org/simple/");
+            using HttpResponseMessage response = client.Send(request);
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException($"PyPI simple index returned {(int)response.StatusCode} {response.ReasonPhrase}");
 
@@ -251,9 +252,15 @@ namespace UniGetUI.PackageEngine.Managers.PipManager
             await _versionFetchSemaphore.WaitAsync().ConfigureAwait(false);
             try
             {
-                string json = await _httpClient
-                    .GetStringAsync($"https://pypi.org/pypi/{Uri.EscapeDataString(packageName)}/json")
+                using var request = new HttpRequestMessage(
+                    HttpMethod.Get,
+                    $"https://pypi.org/pypi/{Uri.EscapeDataString(packageName)}/json"
+                );
+                using HttpResponseMessage response = await _httpClient
+                    .SendAsync(request)
                     .ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+                string json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return (JsonNode.Parse(json) as JsonObject)?["info"]?["version"]?.GetValue<string>();
             }
             catch
@@ -489,7 +496,7 @@ namespace UniGetUI.PackageEngine.Managers.PipManager
 
         protected override void _loadManagerVersion(out string version)
         {
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell/PowerShell.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell/PowerShell.cs
@@ -138,7 +138,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
         protected override void _loadManagerVersion(out string version)
         {
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
@@ -181,7 +181,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShell7Manager
 
         protected override void _loadManagerVersion(out string version)
         {
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
@@ -374,7 +374,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             var (found, path) = CoreTools.Which("scoop-search.exe");
             if (!found)
             {
-                Process proc = new()
+                using Process proc = new()
                 {
                     StartInfo = new ProcessStartInfo
                     {
@@ -553,7 +553,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
 
         protected override void _loadManagerVersion(out string version)
         {
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.Vcpkg/Helpers/VcpkgPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Vcpkg/Helpers/VcpkgPkgDetailsHelper.cs
@@ -27,15 +27,15 @@ namespace UniGetUI.PackageEngine.Managers.VcpkgManager
             string PackagePrefix = details.Package.Id.Split(":")[0];
             string PackageName = PackagePrefix.Split("[")[0];
 
-            string JsonString;
-            HttpClient client = new(CoreTools.GenericHttpClientParameters);
+            using HttpClient client = new(CoreTools.GenericHttpClientParameters);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
-            JsonString = client
-                .GetStringAsync(
-                    $"https://raw.githubusercontent.com/{VCPKG_REPO}/refs/heads/{VCPKG_PORT_PATH}/{PackageName}/{VCPKG_PORT_FILE}"
-                )
-                .GetAwaiter()
-                .GetResult();
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"https://raw.githubusercontent.com/{VCPKG_REPO}/refs/heads/{VCPKG_PORT_PATH}/{PackageName}/{VCPKG_PORT_FILE}"
+            );
+            using HttpResponseMessage response = client.Send(request);
+            response.EnsureSuccessStatusCode();
+            string JsonString = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             JsonObject? contents = JsonNode.Parse(JsonString) as JsonObject;
 

--- a/src/UniGetUI.PackageEngine.Managers.Vcpkg/Vcpkg.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Vcpkg/Vcpkg.cs
@@ -366,7 +366,7 @@ namespace UniGetUI.PackageEngine.Managers.VcpkgManager
         {
             var (_, rootPath) = GetVcpkgRoot();
 
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetIconsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetIconsHelper.cs
@@ -38,7 +38,7 @@ internal static class WinGetIconsHelper
         using (StreamWriter streamWriter = new(httpRequest.GetRequestStream()))
             streamWriter.Write(data);
 
-        var httpResponse = httpRequest.GetResponse() as HttpWebResponse;
+        using var httpResponse = httpRequest.GetResponse() as HttpWebResponse;
         if (httpResponse is null)
         {
             Logger.Warn($"Null MS Store response for uri={url} and data={data}");

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -589,7 +589,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             bool usesCliHelper = WinGetHelper.Instance is WinGetCliHelper;
             bool usesPingetHelper = WinGetHelper.Instance is PingetCliHelper;
 
-            Process process = new()
+            using Process process = new()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
@@ -23,6 +23,11 @@ public abstract partial class AbstractOperation : IDisposable
     protected bool QUEUE_ENABLED;
     protected bool FORCE_HOLD_QUEUE;
     private bool IsInnerOperation;
+    private readonly object CancellationLock = new();
+    private CancellationTokenSource? RunCancellationSource;
+    private AbstractOperation? ActiveInnerOperation;
+    private volatile bool IsExecutingOperation;
+    private bool Disposed;
 
     private readonly List<(string, LineType)> LogList = [];
     private OperationStatus _status = OperationStatus.InQueue;
@@ -73,28 +78,84 @@ public abstract partial class AbstractOperation : IDisposable
 
     public void Cancel()
     {
-        switch (_status)
+        if (_status is OperationStatus.Canceled or OperationStatus.Failed or OperationStatus.Succeeded)
+            return;
+
+        bool wasRunning = _status is OperationStatus.Running;
+        bool hasActiveWork = IsExecutingOperation;
+        Status = OperationStatus.Canceled;
+        CancellationTokenSource? cancellationSource;
+        lock (CancellationLock)
+            cancellationSource = RunCancellationSource;
+        cancellationSource?.Cancel();
+        AbstractOperation? activeInnerOperation;
+        lock (CancellationLock)
+            activeInnerOperation = ActiveInnerOperation;
+        activeInnerOperation?.Cancel();
+
+        if (wasRunning)
+            CancelRequested?.Invoke(this, EventArgs.Empty);
+
+        // A queued operation has no active work to clean up. A running operation stays on the
+        // queue until MainThread has awaited its task and completed its cleanup.
+        if (!hasActiveWork)
         {
-            case OperationStatus.Canceled:
-                break;
-            case OperationStatus.Failed:
-                break;
-            case OperationStatus.Running:
-                Status = OperationStatus.Canceled;
-                while (OperationQueue.Remove(this))
-                    ;
-                CancelRequested?.Invoke(this, EventArgs.Empty);
-                Status = OperationStatus.Canceled;
-                break;
-            case OperationStatus.InQueue:
-                Status = OperationStatus.Canceled;
-                while (OperationQueue.Remove(this))
-                    ;
-                Status = OperationStatus.Canceled;
-                break;
-            case OperationStatus.Succeeded:
-                break;
+            while (OperationQueue.Remove(this))
+                ;
         }
+    }
+
+    protected CancellationToken CancellationToken
+    {
+        get
+        {
+            lock (CancellationLock)
+                return RunCancellationSource?.Token ?? global::System.Threading.CancellationToken.None;
+        }
+    }
+
+    private CancellationTokenSource StartRunCancellation()
+    {
+        var cancellationSource = new CancellationTokenSource();
+        lock (CancellationLock)
+            RunCancellationSource = cancellationSource;
+        return cancellationSource;
+    }
+
+    private bool TrySetActiveInnerOperation(AbstractOperation operation)
+    {
+        bool cancellationRequested;
+        lock (CancellationLock)
+        {
+            cancellationRequested =
+                RunCancellationSource?.IsCancellationRequested is true
+                || Status is OperationStatus.Canceled;
+            if (!cancellationRequested)
+                ActiveInnerOperation = operation;
+        }
+
+        if (cancellationRequested)
+            operation.Cancel();
+
+        return !cancellationRequested;
+    }
+
+    private void ClearActiveInnerOperation(AbstractOperation operation)
+    {
+        lock (CancellationLock)
+            if (ReferenceEquals(ActiveInnerOperation, operation))
+                ActiveInnerOperation = null;
+    }
+
+    private void EndRunCancellation(CancellationTokenSource cancellationSource)
+    {
+        lock (CancellationLock)
+        {
+            if (!ReferenceEquals(RunCancellationSource, cancellationSource))
+                return;
+            RunCancellationSource = null;
+        }
+        cancellationSource.Dispose();
     }
 
     protected void Line(string line, LineType type)
@@ -116,6 +177,7 @@ public abstract partial class AbstractOperation : IDisposable
 
     public async Task MainThread()
     {
+        CancellationTokenSource runCancellation = StartRunCancellation();
         try
         {
             if (Metadata.Status == "")
@@ -176,7 +238,16 @@ public abstract partial class AbstractOperation : IDisposable
             }
             // END QUEUE HANDLER
 
-            var result = await _runOperation();
+            IsExecutingOperation = true;
+            OperationVeredict result;
+            try
+            {
+                result = await _runOperation();
+            }
+            finally
+            {
+                IsExecutingOperation = false;
+            }
             while (OperationQueue.Remove(this))
                 ;
 
@@ -250,8 +321,16 @@ public abstract partial class AbstractOperation : IDisposable
         }
         finally
         {
-            if (OperationQueue.Count == 0)
-                QueueDrained?.Invoke(null, EventArgs.Empty);
+            try
+            {
+                OnRunCompleted();
+            }
+            finally
+            {
+                EndRunCancellation(runCancellation);
+                if (OperationQueue.Count == 0)
+                    QueueDrained?.Invoke(null, EventArgs.Empty);
+            }
         }
     }
 
@@ -266,13 +345,27 @@ public abstract partial class AbstractOperation : IDisposable
             Line("", LineType.VerboseDetails);
         foreach (var preReq in PreOperations)
         {
+            if (Status is OperationStatus.Canceled || CancellationToken.IsCancellationRequested)
+                return OperationVeredict.Canceled;
+
             i++;
             Line(
                     CoreTools.Translate("Running PreOperation ({0}/{1})...", i, count),
                 LineType.Information
             );
             preReq.Operation.LogLineAdded += (_, line) => Line(line.Item1, line.Item2);
-            await preReq.Operation.MainThread();
+            if (!TrySetActiveInnerOperation(preReq.Operation))
+                return OperationVeredict.Canceled;
+            try
+            {
+                await preReq.Operation.MainThread();
+            }
+            finally
+            {
+                ClearActiveInnerOperation(preReq.Operation);
+            }
+            if (Status is OperationStatus.Canceled || CancellationToken.IsCancellationRequested)
+                return OperationVeredict.Canceled;
             if (preReq.Operation.Status is not OperationStatus.Succeeded && preReq.MustSucceed)
             {
                 Line(
@@ -305,29 +398,26 @@ public abstract partial class AbstractOperation : IDisposable
 
         do
         {
+            if (Status is OperationStatus.Canceled || CancellationToken.IsCancellationRequested)
+            {
+                result = OperationVeredict.Canceled;
+                break;
+            }
+
             OperationStarting?.Invoke(this, EventArgs.Empty);
 
             try
             {
-                // Check if the operation was canceled
-                if (Status is OperationStatus.Canceled)
-                {
-                    result = OperationVeredict.Canceled;
-                    break;
-                }
-
                 Task<OperationVeredict> op = PerformOperation();
-                while (Status != OperationStatus.Canceled && !op.IsCompleted)
-                    await Task.Delay(100);
-
-                if (Status is OperationStatus.Canceled)
+                result = await op.ConfigureAwait(false);
+                if (Status is OperationStatus.Canceled || CancellationToken.IsCancellationRequested)
                     result = OperationVeredict.Canceled;
-                else
-                    result = op.GetAwaiter().GetResult();
             }
             catch (Exception e)
             {
-                result = OperationVeredict.Failure;
+                result = CancellationToken.IsCancellationRequested
+                    ? OperationVeredict.Canceled
+                    : OperationVeredict.Failure;
                 Logger.Error(e);
                 foreach (string l in e.ToString().Split("\n"))
                 {
@@ -351,8 +441,22 @@ public abstract partial class AbstractOperation : IDisposable
                 CoreTools.Translate("Running PostOperation ({0}/{1})...", i, count),
                 LineType.Information
             );
+            if (Status is OperationStatus.Canceled || CancellationToken.IsCancellationRequested)
+                return OperationVeredict.Canceled;
+
             postReq.Operation.LogLineAdded += (_, line) => Line(line.Item1, line.Item2);
-            await postReq.Operation.MainThread();
+            if (!TrySetActiveInnerOperation(postReq.Operation))
+                return OperationVeredict.Canceled;
+            try
+            {
+                await postReq.Operation.MainThread();
+            }
+            finally
+            {
+                ClearActiveInnerOperation(postReq.Operation);
+            }
+            if (Status is OperationStatus.Canceled || CancellationToken.IsCancellationRequested)
+                return OperationVeredict.Canceled;
             if (postReq.Operation.Status is not OperationStatus.Succeeded && postReq.MustSucceed)
             {
                 Line(
@@ -437,9 +541,25 @@ public abstract partial class AbstractOperation : IDisposable
     protected abstract Task<OperationVeredict> PerformOperation();
     public abstract Task<Uri> GetOperationIcon();
 
+    protected virtual void OnRunCompleted() { }
+
     public void Dispose()
     {
-        while (OperationQueue.Remove(this))
-            ;
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing || Disposed)
+            return;
+
+        Disposed = true;
+        Cancel();
+        if (!IsExecutingOperation)
+        {
+            while (OperationQueue.Remove(this))
+                ;
+        }
     }
 }

--- a/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
@@ -26,6 +26,9 @@ public abstract partial class AbstractOperation : IDisposable
     private readonly object CancellationLock = new();
     private CancellationTokenSource? RunCancellationSource;
     private AbstractOperation? ActiveInnerOperation;
+    private Task? ActiveRunTask;
+    private TaskCompletionSource? ScheduledRetryCompletionSource;
+    private bool ActiveRunIsStarting;
     private volatile bool IsExecutingOperation;
     private bool Disposed;
 
@@ -78,19 +81,27 @@ public abstract partial class AbstractOperation : IDisposable
 
     public void Cancel()
     {
-        if (_status is OperationStatus.Canceled or OperationStatus.Failed or OperationStatus.Succeeded)
-            return;
-
-        bool wasRunning = _status is OperationStatus.Running;
-        bool hasActiveWork = IsExecutingOperation;
-        Status = OperationStatus.Canceled;
-        CancellationTokenSource? cancellationSource;
-        lock (CancellationLock)
-            cancellationSource = RunCancellationSource;
-        cancellationSource?.Cancel();
         AbstractOperation? activeInnerOperation;
+        bool wasRunning;
+        bool hasActiveWork;
         lock (CancellationLock)
+        {
+            if (
+                _status
+                    is OperationStatus.Canceled
+                        or OperationStatus.Failed
+                        or OperationStatus.Succeeded
+                && !ActiveRunIsStarting
+            )
+                return;
+
+            wasRunning = _status is OperationStatus.Running;
+            hasActiveWork = IsExecutingOperation;
+            RunCancellationSource?.Cancel();
             activeInnerOperation = ActiveInnerOperation;
+        }
+
+        Status = OperationStatus.Canceled;
         activeInnerOperation?.Cancel();
 
         if (wasRunning)
@@ -112,14 +123,6 @@ public abstract partial class AbstractOperation : IDisposable
             lock (CancellationLock)
                 return RunCancellationSource?.Token ?? global::System.Threading.CancellationToken.None;
         }
-    }
-
-    private CancellationTokenSource StartRunCancellation()
-    {
-        var cancellationSource = new CancellationTokenSource();
-        lock (CancellationLock)
-            RunCancellationSource = cancellationSource;
-        return cancellationSource;
     }
 
     private bool TrySetActiveInnerOperation(AbstractOperation operation)
@@ -154,6 +157,7 @@ public abstract partial class AbstractOperation : IDisposable
             if (!ReferenceEquals(RunCancellationSource, cancellationSource))
                 return;
             RunCancellationSource = null;
+            ActiveRunIsStarting = false;
         }
         cancellationSource.Dispose();
     }
@@ -175,9 +179,49 @@ public abstract partial class AbstractOperation : IDisposable
         return LogList.Select(l => (Logger.Redact(l.Item1), l.Item2)).ToList();
     }
 
-    public async Task MainThread()
+    public Task MainThread()
     {
-        CancellationTokenSource runCancellation = StartRunCancellation();
+        TaskCompletionSource completionSource;
+        CancellationTokenSource cancellationSource;
+        lock (CancellationLock)
+        {
+            ObjectDisposedException.ThrowIf(Disposed, this);
+
+            if (ActiveRunTask is { IsCompleted: false })
+                return ActiveRunTask;
+
+            if (ScheduledRetryCompletionSource is not null)
+                return ScheduledRetryCompletionSource.Task;
+
+            completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            cancellationSource = new();
+            ActiveRunTask = completionSource.Task;
+            RunCancellationSource = cancellationSource;
+            ActiveRunIsStarting = true;
+        }
+
+        _ = ExecuteRunAsync(completionSource, cancellationSource);
+        return completionSource.Task;
+    }
+
+    private async Task ExecuteRunAsync(
+        TaskCompletionSource completionSource,
+        CancellationTokenSource cancellationSource
+    )
+    {
+        try
+        {
+            await MainThreadCore(cancellationSource).ConfigureAwait(false);
+            completionSource.SetResult();
+        }
+        catch (Exception ex)
+        {
+            completionSource.SetException(ex);
+        }
+    }
+
+    private async Task MainThreadCore(CancellationTokenSource runCancellation)
+    {
         try
         {
             if (Metadata.Status == "")
@@ -200,17 +244,44 @@ public abstract partial class AbstractOperation : IDisposable
             if (OperationQueue.Contains(this))
                 throw new InvalidOperationException("This operation was already on the queue");
 
+            if (runCancellation.IsCancellationRequested)
+            {
+                MarkRunAsStarted(runCancellation);
+                CompleteCanceledRun();
+                return;
+            }
+
             Status = OperationStatus.InQueue;
+            MarkRunAsStarted(runCancellation);
+            if (runCancellation.IsCancellationRequested)
+            {
+                CompleteCanceledRun();
+                return;
+            }
+
             Line(Metadata.OperationInformation, LineType.VerboseDetails);
             Line(Metadata.Status, LineType.ProgressIndicator);
 
             Enqueued?.Invoke(this, EventArgs.Empty);
+            if (runCancellation.IsCancellationRequested)
+            {
+                CompleteCanceledRun();
+                return;
+            }
 
             if (QUEUE_ENABLED && !IsInnerOperation)
             {
                 // QUEUE HANDLER
                 SKIP_QUEUE = false;
                 OperationQueue.Add(this);
+                if (runCancellation.IsCancellationRequested)
+                {
+                    while (OperationQueue.Remove(this))
+                        ;
+                    CompleteCanceledRun();
+                    return;
+                }
+
                 int lastPos = -2;
 
                 while (
@@ -293,6 +364,7 @@ public abstract partial class AbstractOperation : IDisposable
             while (OperationQueue.Remove(this))
                 ;
 
+            MarkRunAsStarted(runCancellation);
             Status = OperationStatus.Failed;
             try
             {
@@ -331,6 +403,22 @@ public abstract partial class AbstractOperation : IDisposable
                 if (OperationQueue.Count == 0)
                     QueueDrained?.Invoke(null, EventArgs.Empty);
             }
+        }
+    }
+
+    private void CompleteCanceledRun()
+    {
+        Status = OperationStatus.Canceled;
+        OperationFinished?.Invoke(this, EventArgs.Empty);
+        Line(CoreTools.Translate("Operation canceled by user"), LineType.Error);
+    }
+
+    private void MarkRunAsStarted(CancellationTokenSource cancellationSource)
+    {
+        lock (CancellationLock)
+        {
+            if (ReferenceEquals(RunCancellationSource, cancellationSource))
+                ActiveRunIsStarting = false;
         }
     }
 
@@ -527,14 +615,98 @@ public abstract partial class AbstractOperation : IDisposable
         if (retryMode is RetryMode.NoRetry)
             throw new InvalidOperationException("We weren't supposed to reach this, weren't we?");
 
+        Task? previousRun = null;
+        TaskCompletionSource? scheduledRetry = null;
+        bool applyImmediately = false;
+        lock (CancellationLock)
+        {
+            if (Disposed)
+                return;
+
+            if (Status is OperationStatus.Running)
+                return;
+
+            if (Status is OperationStatus.InQueue)
+            {
+                applyImmediately = true;
+            }
+            else
+            {
+                if (ScheduledRetryCompletionSource is not null)
+                    return;
+
+                scheduledRetry = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                ScheduledRetryCompletionSource = scheduledRetry;
+                previousRun = ActiveRunTask ?? Task.CompletedTask;
+            }
+        }
+
+        if (applyImmediately)
+        {
+            ApplyRetryActionAndLog(retryMode);
+            return;
+        }
+
+        _ = RetryAfterRunAsync(previousRun!, scheduledRetry!, retryMode);
+    }
+
+    private async Task RetryAfterRunAsync(
+        Task previousRun,
+        TaskCompletionSource scheduledRetry,
+        string retryMode
+    )
+    {
+        CancellationTokenSource? cancellationSource = null;
+        try
+        {
+            await previousRun.ConfigureAwait(false);
+
+            lock (CancellationLock)
+            {
+                if (!ReferenceEquals(ScheduledRetryCompletionSource, scheduledRetry))
+                    return;
+
+                if (Disposed)
+                {
+                    ScheduledRetryCompletionSource = null;
+                    scheduledRetry.TrySetCanceled();
+                    return;
+                }
+
+                cancellationSource = new();
+                RunCancellationSource = cancellationSource;
+                ActiveRunTask = scheduledRetry.Task;
+                ScheduledRetryCompletionSource = null;
+                ActiveRunIsStarting = true;
+            }
+
+            ApplyRetryActionAndLog(retryMode);
+            await ExecuteRunAsync(scheduledRetry, cancellationSource).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            if (cancellationSource is not null)
+                EndRunCancellation(cancellationSource);
+
+            lock (CancellationLock)
+            {
+                if (ReferenceEquals(ScheduledRetryCompletionSource, scheduledRetry))
+                    ScheduledRetryCompletionSource = null;
+                if (ReferenceEquals(ActiveRunTask, scheduledRetry.Task))
+                    ActiveRunTask = null;
+            }
+            scheduledRetry.TrySetException(ex);
+            Logger.Error(ex);
+        }
+    }
+
+    private void ApplyRetryActionAndLog(string retryMode)
+    {
         ApplyRetryAction(retryMode);
         Line($"", LineType.VerboseDetails);
         Line($"-----------------------", LineType.VerboseDetails);
         Line($"Retrying operation with RetryMode={retryMode}", LineType.VerboseDetails);
         Line($"", LineType.VerboseDetails);
-        if (Status is OperationStatus.Running or OperationStatus.InQueue)
-            return;
-        _ = MainThread();
     }
 
     protected abstract void ApplyRetryAction(string retryMode);
@@ -551,10 +723,21 @@ public abstract partial class AbstractOperation : IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        if (!disposing || Disposed)
+        if (!disposing)
             return;
 
-        Disposed = true;
+        TaskCompletionSource? scheduledRetry;
+        lock (CancellationLock)
+        {
+            if (Disposed)
+                return;
+
+            Disposed = true;
+            scheduledRetry = ScheduledRetryCompletionSource;
+            ScheduledRetryCompletionSource = null;
+        }
+
+        scheduledRetry?.TrySetCanceled();
         Cancel();
         if (!IsExecutingOperation)
         {

--- a/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
@@ -20,23 +20,10 @@ public abstract class AbstractProcessOperation : AbstractOperation
         : base(queue_enabled, preOps, postOps)
     {
         process = new();
-        CancelRequested += (_, _) =>
-        {
-            try
-            {
-                process.Kill();
-                ProcessKilled = true;
-            }
-            catch (InvalidOperationException e)
-            {
-                Line(
-                    "Attempted to cancel a process that hasn't ben created yet: " + e.Message,
-                    LineType.Error
-                );
-            }
-        };
+        CancelRequested += (_, _) => StopProcess();
         OperationStarting += (_, _) =>
         {
+            DisposeProcess();
             ProcessKilled = false;
             process = new();
             process.StartInfo.UseShellExecute = false;
@@ -56,12 +43,10 @@ public abstract class AbstractProcessOperation : AbstractOperation
             {
                 if (e.Data is null)
                     return;
-                string line = e.Data.ToString().Trim();
+                string line = e.Data.Trim();
                 var lineType = LineType.Error;
                 if (line.Length < 6 || line.Contains("Waiting for another install..."))
-                {
                     lineType = LineType.ProgressIndicator;
-                }
 
                 Line(line, lineType);
             };
@@ -98,12 +83,11 @@ public abstract class AbstractProcessOperation : AbstractOperation
         if (process.StartInfo.Arguments == "lol")
             throw new InvalidOperationException("StartInfo.Arguments has not been set");
 
-        Line($"Executing process with StartInfo:", LineType.VerboseDetails);
+        Line("Executing process with StartInfo:", LineType.VerboseDetails);
         Line($" - FileName: \"{process.StartInfo.FileName.Trim()}\"", LineType.VerboseDetails);
         Line($" - Arguments: \"{process.StartInfo.Arguments.Trim()}\"", LineType.VerboseDetails);
         Line($"Start Time: \"{DateTime.Now}\"", LineType.VerboseDetails);
 
-        // An empty FileName means elevation was required but no elevator (UniGetUI Elevator/GSudo) is available
         if (string.IsNullOrWhiteSpace(process.StartInfo.FileName))
         {
             Line(
@@ -121,18 +105,25 @@ public abstract class AbstractProcessOperation : AbstractOperation
             await CoreTools.CacheUACForCurrentProcess();
         }
 
+        CancellationToken.ThrowIfCancellationRequested();
         process.Start();
+        if (CancellationToken.IsCancellationRequested)
+        {
+            StopProcess();
+            await process.WaitForExitAsync().ConfigureAwait(false);
+            return OperationVeredict.Canceled;
+        }
+
         if (!Settings.Get(Settings.K.DisableNewProcessLineHandler))
         {
-            await process.StandardInput.WriteLineAsync("\r\n\r\n\r\n\r\n");
+            await process.StandardInput.WriteLineAsync("\r\n\r\n\r\n\r\n".AsMemory(), CancellationToken);
             process.StandardInput.Close();
         }
-        // process.BeginOutputReadLine();
         try
         {
             process.BeginErrorReadLine();
         }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
         {
             Logger.Error(ex);
         }
@@ -140,41 +131,56 @@ public abstract class AbstractProcessOperation : AbstractOperation
         StringBuilder currentLine = new();
         char[] buffer = new char[1];
         string? lastStringBeforeLF = null;
-
-        while ((await process.StandardOutput.ReadBlockAsync(buffer)) > 0)
+        try
         {
-            char c = buffer[0];
-            if (c == '\n')
+            while ((await process.StandardOutput.ReadAsync(buffer.AsMemory(), CancellationToken)) > 0)
             {
-                if (currentLine.Length == 0)
+                char c = buffer[0];
+                if (c == 10)
                 {
-                    if (lastStringBeforeLF is not null)
+                    if (currentLine.Length == 0)
                     {
-                        Line(lastStringBeforeLF, LineType.Information);
-                        lastStringBeforeLF = null;
+                        if (lastStringBeforeLF is not null)
+                        {
+                            Line(lastStringBeforeLF, LineType.Information);
+                            lastStringBeforeLF = null;
+                        }
+                        continue;
                     }
-                    continue;
-                }
 
-                string line = currentLine.ToString();
-                Line(line, LineType.Information);
-                currentLine.Clear();
-            }
-            else if (c == '\r')
-            {
-                if (currentLine.Length == 0)
-                    continue;
-                lastStringBeforeLF = currentLine.ToString();
-                Line(lastStringBeforeLF, LineType.ProgressIndicator);
-                currentLine.Clear();
-            }
-            else
-            {
-                currentLine.Append(c);
+                    string line = currentLine.ToString();
+                    Line(line, LineType.Information);
+                    currentLine.Clear();
+                }
+                else if (c == 13)
+                {
+                    if (currentLine.Length == 0)
+                        continue;
+                    lastStringBeforeLF = currentLine.ToString();
+                    Line(lastStringBeforeLF, LineType.ProgressIndicator);
+                    currentLine.Clear();
+                }
+                else
+                {
+                    currentLine.Append(c);
+                }
             }
         }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+            await process.WaitForExitAsync().ConfigureAwait(false);
+            return OperationVeredict.Canceled;
+        }
 
-        await process.WaitForExitAsync();
+        try
+        {
+            await process.WaitForExitAsync(CancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+            await process.WaitForExitAsync().ConfigureAwait(false);
+            return OperationVeredict.Canceled;
+        }
 
         Line($"End Time: \"{DateTime.Now}\"", LineType.VerboseDetails);
         Line(
@@ -182,10 +188,9 @@ public abstract class AbstractProcessOperation : AbstractOperation
             LineType.VerboseDetails
         );
 
-        if (ProcessKilled)
+        if (ProcessKilled || CancellationToken.IsCancellationRequested)
             return OperationVeredict.Canceled;
 
-        // Raw output: redacting here would corrupt the phrases result detection matches on.
         List<string> output = new();
         foreach (var line in GetRawOutput())
         {
@@ -196,6 +201,49 @@ public abstract class AbstractProcessOperation : AbstractOperation
         }
 
         return await GetProcessVeredict(process.ExitCode, output);
+    }
+
+    protected override void OnRunCompleted()
+    {
+        DisposeProcess();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+            DisposeProcess();
+    }
+
+    private void StopProcess()
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                ProcessKilled = true;
+            }
+        }
+        catch (InvalidOperationException) { }
+    }
+
+    private void DisposeProcess()
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                ProcessKilled = true;
+                process.WaitForExit();
+            }
+        }
+        catch (InvalidOperationException) { }
+        finally
+        {
+            process.Dispose();
+        }
     }
 
     protected abstract Task<OperationVeredict> GetProcessVeredict(

--- a/src/UniGetUI.PackageEngine.Operations/DownloadOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/DownloadOperation.cs
@@ -10,11 +10,7 @@ public class DownloadOperation : AbstractOperation
     private readonly IPackage _package;
     public IPackage Package => _package;
     private string downloadLocation;
-    public string DownloadLocation
-    {
-        get => downloadLocation;
-    }
-    private bool canceled;
+    public string DownloadLocation => downloadLocation;
 
     public DownloadOperation(IPackage package, string downloadPath)
         : base(true, null)
@@ -23,10 +19,7 @@ public class DownloadOperation : AbstractOperation
         _package = package;
 
         Metadata.OperationInformation =
-            "Downloading installer for Package="
-            + _package.Id
-            + " with Manager="
-            + _package.Manager.Name;
+            "Downloading installer for Package=" + _package.Id + " with Manager=" + _package.Manager.Name;
         Metadata.Title = CoreTools.Translate(
             "{package} installer download",
             new Dictionary<string, object?> { { "package", _package.Name } }
@@ -45,11 +38,6 @@ public class DownloadOperation : AbstractOperation
             "{package} installer could not be downloaded",
             new Dictionary<string, object?> { { "package", _package.Name } }
         );
-
-        CancelRequested += (_, _) =>
-        {
-            canceled = true;
-        };
     }
 
     public override Task<Uri> GetOperationIcon()
@@ -57,27 +45,26 @@ public class DownloadOperation : AbstractOperation
         return Task.Run(_package.GetIconUrl);
     }
 
-    protected override void ApplyRetryAction(string retryMode)
-    {
-        // Do nothing
-    }
+    protected override void ApplyRetryAction(string retryMode) { }
 
     protected override async Task<OperationVeredict> PerformOperation()
     {
-        canceled = false;
+        bool downloadFileCreated = false;
         try
         {
+            CancellationToken.ThrowIfCancellationRequested();
             Line(
                 $"Fetching download url for package {_package.Name} from {_package.Manager.DisplayName}...",
                 LineType.Information
             );
             await _package.Details.Load();
+            CancellationToken.ThrowIfCancellationRequested();
             Uri? downloadUrl = _package.Details.InstallerUrl;
             if (downloadUrl is null)
             {
                 Line(
                     $"UniGetUI was not able to find any installer for this package. "
-                        + $"Please check that this package has an applicable installer and try again later",
+                        + "Please check that this package has an applicable installer and try again later",
                     LineType.Error
                 );
                 return OperationVeredict.Failure;
@@ -86,6 +73,7 @@ public class DownloadOperation : AbstractOperation
             if (Directory.Exists(downloadLocation))
             {
                 string? fileName = await _package.GetInstallerFileName();
+                CancellationToken.ThrowIfCancellationRequested();
                 if (fileName is null)
                 {
                     Line(
@@ -101,62 +89,64 @@ public class DownloadOperation : AbstractOperation
             using var httpClient = new HttpClient(CoreTools.GenericHttpClientParameters);
             using var response = await httpClient.GetAsync(
                 downloadUrl,
-                HttpCompletionOption.ResponseHeadersRead
+                HttpCompletionOption.ResponseHeadersRead,
+                CancellationToken
             );
-
             response.EnsureSuccessStatusCode();
 
             var totalBytes = response.Content.Headers.ContentLength ?? -1L;
             var canReportProgress = totalBytes > 0;
-
-            using var contentStream = await response.Content.ReadAsStreamAsync();
-            using var fileStream = new FileStream(
+            await using (var contentStream = await response.Content.ReadAsStreamAsync(CancellationToken))
+            await using (var fileStream = new FileStream(
                 downloadLocation,
                 FileMode.Create,
                 FileAccess.Write,
                 FileShare.None,
                 8192,
-                true
-            );
-
-            var buffer = new byte[4 * 1024 * 1024];
-            long totalRead = 0;
-            int bytesRead;
-
-            int oldProgress = -1;
-            while ((bytesRead = await contentStream.ReadAsync(buffer)) > 0)
+                useAsync: true
+            ))
             {
-                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead));
-                totalRead += bytesRead;
-
-                if (canReportProgress)
+                downloadFileCreated = true;
+                var buffer = new byte[4 * 1024 * 1024];
+                long totalRead = 0;
+                int oldProgress = -1;
+                int bytesRead;
+                while (
+                    (bytesRead = await contentStream.ReadAsync(buffer.AsMemory(), CancellationToken)) > 0
+                )
                 {
-                    var progress = (int)((totalRead * 100L) / totalBytes);
-                    if (progress != oldProgress)
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), CancellationToken);
+                    totalRead += bytesRead;
+
+                    if (canReportProgress)
                     {
-                        oldProgress = progress;
-                        Line(
-                            CoreTools.TextProgressGenerator(
-                                30,
-                                progress,
-                                $"{CoreTools.FormatAsSize(totalRead)}/{CoreTools.FormatAsSize(totalBytes)}"
-                            ),
-                            LineType.ProgressIndicator
-                        );
+                        var progress = (int)((totalRead * 100L) / totalBytes);
+                        if (progress != oldProgress)
+                        {
+                            oldProgress = progress;
+                            Line(
+                                CoreTools.TextProgressGenerator(
+                                    30,
+                                    progress,
+                                    $"{CoreTools.FormatAsSize(totalRead)}/{CoreTools.FormatAsSize(totalBytes)}"
+                                ),
+                                LineType.ProgressIndicator
+                            );
+                        }
                     }
-                }
-
-                if (canceled)
-                {
-                    fileStream.Close();
-                    File.Delete(downloadLocation);
-                    Line("User has canceled the operation", LineType.Error);
-                    return OperationVeredict.Canceled;
                 }
             }
 
+            CancellationToken.ThrowIfCancellationRequested();
             Line($"The file was saved to {downloadLocation}", LineType.Information);
             return OperationVeredict.Success;
+        }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+            if (downloadFileCreated)
+                File.Delete(downloadLocation);
+            Line("User has canceled the operation", LineType.Error);
+            return OperationVeredict.Canceled;
         }
         catch (Exception ex)
         {

--- a/src/UniGetUI.PackageEngine.Operations/KillProcessOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/KillProcessOperation.cs
@@ -16,9 +16,9 @@ public class KillProcessOperation : AbstractOperation
         Metadata.Status = $"Closing process(es) {procName}";
         Metadata.Title = $"Closing process(es) {procName}";
         Metadata.OperationInformation = " ";
-        Metadata.SuccessTitle = $"Done!";
-        Metadata.SuccessMessage = $"Done!";
-        Metadata.FailureTitle = $"Failed to close process";
+        Metadata.SuccessTitle = "Done!";
+        Metadata.SuccessMessage = "Done!";
+        Metadata.FailureTitle = "Failed to close process";
         Metadata.FailureMessage = $"The process(es) {procName} could not be closed";
     }
 
@@ -32,38 +32,50 @@ public class KillProcessOperation : AbstractOperation
                 $"Attempting to close all processes with name {ProcessName}...",
                 LineType.Information
             );
-            var procs = Process.GetProcessesByName(ProcessName.Replace(".exe", ""));
-            foreach (var proc in procs)
+            foreach (var proc in Process.GetProcessesByName(ProcessName.Replace(".exe", "")))
             {
-                if (proc.HasExited)
-                    continue;
-                Line(
-                    $"Attempting to close process {ProcessName} with pid={proc.Id}...",
-                    LineType.VerboseDetails
-                );
-                proc.CloseMainWindow();
-                await Task.WhenAny(proc.WaitForExitAsync(), Task.Delay(1000));
-                if (!proc.HasExited)
+                using (proc)
                 {
-                    if (Settings.Get(Settings.K.KillProcessesThatRefuseToDie))
+                    CancellationToken.ThrowIfCancellationRequested();
+                    if (proc.HasExited)
+                        continue;
+                    Line(
+                        $"Attempting to close process {ProcessName} with pid={proc.Id}...",
+                        LineType.VerboseDetails
+                    );
+                    proc.CloseMainWindow();
+                    await Task.WhenAny(
+                        proc.WaitForExitAsync(CancellationToken),
+                        Task.Delay(1000, CancellationToken)
+                    );
+                    CancellationToken.ThrowIfCancellationRequested();
+                    if (!proc.HasExited)
                     {
-                        Line(
-                            $"Timeout for process {ProcessName}, attempting to kill...",
-                            LineType.Information
-                        );
-                        proc.Kill();
-                    }
-                    else
-                    {
-                        Line(
-                            $"{ProcessName} with pid={proc.Id} did not exit and will not be killed. You can change this from UniGetUI settings.",
-                            LineType.Error
-                        );
+                        if (Settings.Get(Settings.K.KillProcessesThatRefuseToDie))
+                        {
+                            Line(
+                                $"Timeout for process {ProcessName}, attempting to kill...",
+                                LineType.Information
+                            );
+                            proc.Kill(entireProcessTree: true);
+                            await proc.WaitForExitAsync(CancellationToken);
+                        }
+                        else
+                        {
+                            Line(
+                                $"{ProcessName} with pid={proc.Id} did not exit and will not be killed. You can change this from UniGetUI settings.",
+                                LineType.Error
+                            );
+                        }
                     }
                 }
             }
 
             return OperationVeredict.Success;
+        }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+            return OperationVeredict.Canceled;
         }
         catch (Exception ex)
         {

--- a/src/UniGetUI.PackageEngine.Operations/PrePostOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PrePostOperation.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageOperations;
 
@@ -6,18 +7,21 @@ namespace UniGetUI.PackageEngine.Operations;
 public class PrePostOperation : AbstractOperation
 {
     private readonly string Payload;
+    private readonly object ProcessLock = new();
+    private Process? ActiveProcess;
 
     public PrePostOperation(string payload)
         : base(true)
     {
         Payload = payload.Replace("\r", "\n").Replace("\n\n", "\n").Replace("\n", "&");
         Metadata.Status = $"Running custom operation {Payload}";
-        Metadata.Title = $"Custom operation";
+        Metadata.Title = "Custom operation";
         Metadata.OperationInformation = " ";
-        Metadata.SuccessTitle = $"Done!";
-        Metadata.SuccessMessage = $"Done!";
-        Metadata.FailureTitle = $"Custom operation failed";
+        Metadata.SuccessTitle = "Done!";
+        Metadata.SuccessMessage = "Done!";
+        Metadata.FailureTitle = "Custom operation failed";
         Metadata.FailureMessage = $"The custom operation {Payload} failed to run";
+        CancelRequested += (_, _) => StopActiveProcess();
     }
 
     protected override void ApplyRetryAction(string retryMode) { }
@@ -25,9 +29,9 @@ public class PrePostOperation : AbstractOperation
     protected override async Task<OperationVeredict> PerformOperation()
     {
         Line($"Running command {Payload}", LineType.Information);
-        var process = new System.Diagnostics.Process
+        using var process = new Process
         {
-            StartInfo = new System.Diagnostics.ProcessStartInfo
+            StartInfo = new ProcessStartInfo
             {
                 FileName = "cmd.exe",
                 Arguments = $"/C {Payload}",
@@ -37,25 +41,87 @@ public class PrePostOperation : AbstractOperation
                 CreateNoWindow = true,
             },
         };
-
-        process.Start();
-        process.BeginErrorReadLine();
-        process.BeginOutputReadLine();
-        process.OutputDataReceived += (s, e) =>
+        DataReceivedEventHandler outputHandler = (_, e) =>
         {
             if (e.Data is not null)
                 Line(e.Data, LineType.Information);
         };
-        process.ErrorDataReceived += (s, e) =>
+        DataReceivedEventHandler errorHandler = (_, e) =>
         {
             if (e.Data is not null)
                 Line(e.Data, LineType.Error);
         };
-        await process.WaitForExitAsync();
+        process.OutputDataReceived += outputHandler;
+        process.ErrorDataReceived += errorHandler;
+        lock (ProcessLock)
+            ActiveProcess = process;
+        bool processStarted = false;
 
-        int exitCode = process.ExitCode;
-        Line($"Exit code is {exitCode}", LineType.Information);
-        return (exitCode == 0 ? OperationVeredict.Success : OperationVeredict.Failure);
+        try
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+            process.Start();
+            processStarted = true;
+            if (CancellationToken.IsCancellationRequested)
+                StopActiveProcess();
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            try
+            {
+                await process.WaitForExitAsync(CancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+            {
+                await process.WaitForExitAsync().ConfigureAwait(false);
+                return OperationVeredict.Canceled;
+            }
+
+            if (CancellationToken.IsCancellationRequested)
+                return OperationVeredict.Canceled;
+
+            int exitCode = process.ExitCode;
+            Line($"Exit code is {exitCode}", LineType.Information);
+            return exitCode == 0 ? OperationVeredict.Success : OperationVeredict.Failure;
+        }
+        finally
+        {
+            if (processStarted && !process.HasExited)
+            {
+                StopActiveProcess();
+                await process.WaitForExitAsync().ConfigureAwait(false);
+            }
+            process.OutputDataReceived -= outputHandler;
+            process.ErrorDataReceived -= errorHandler;
+            lock (ProcessLock)
+            {
+                if (ReferenceEquals(ActiveProcess, process))
+                    ActiveProcess = null;
+            }
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+            StopActiveProcess();
+    }
+
+    private void StopActiveProcess()
+    {
+        Process? process;
+        lock (ProcessLock)
+            process = ActiveProcess;
+        if (process is null)
+            return;
+
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException) { }
     }
 
     public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -362,6 +362,23 @@ public sealed class PackageOperationsTests
         }
     }
 
+    [Fact]
+    public async Task CancelWaitsForTheActiveOperationToCompleteCleanup()
+    {
+        using var operation = new CancellationAwareStubOperation();
+        Task mainThread = operation.MainThread();
+        await operation.PerformStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        operation.Cancel();
+        await operation.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(mainThread.IsCompleted);
+        operation.AllowCleanupToComplete.TrySetResult(true);
+        await mainThread;
+
+        Assert.Equal(OperationStatus.Canceled, operation.Status);
+    }
+
     private static IReadOnlyList<AbstractOperation.InnerOperation> GetInnerOperations(
         AbstractOperation operation,
         string fieldName
@@ -491,6 +508,52 @@ public sealed class PackageOperationsTests
         {
             return Task.FromResult(_veredict);
         }
+    }
+
+    private sealed class CancellationAwareStubOperation : AbstractOperation
+    {
+        public TaskCompletionSource<bool> PerformStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        public TaskCompletionSource<bool> CancellationObserved { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        public TaskCompletionSource<bool> AllowCleanupToComplete { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        public CancellationAwareStubOperation()
+            : base(queue_enabled: false)
+        {
+            Metadata.Status = "Cancelable stub status";
+            Metadata.Title = "Cancelable stub title";
+            Metadata.OperationInformation = "Cancelable stub info";
+            Metadata.SuccessTitle = "Cancelable stub success";
+            Metadata.SuccessMessage = "Cancelable stub success";
+            Metadata.FailureTitle = "Cancelable stub failure";
+            Metadata.FailureMessage = "Cancelable stub failure";
+        }
+
+        protected override void ApplyRetryAction(string retryMode) { }
+
+        protected override async Task<OperationVeredict> PerformOperation()
+        {
+            PerformStarted.TrySetResult(true);
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, CancellationToken);
+            }
+            catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+            {
+                CancellationObserved.TrySetResult(true);
+                await AllowCleanupToComplete.Task;
+                return OperationVeredict.Canceled;
+            }
+
+            return OperationVeredict.Success;
+        }
+
+        public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));
     }
 
     private sealed class LoggingStubOperation : AbstractOperation

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -379,6 +379,144 @@ public sealed class PackageOperationsTests
         Assert.Equal(OperationStatus.Canceled, operation.Status);
     }
 
+    [Fact]
+    public async Task RetryWaitsForCanceledRunCleanupBeforeStartingAgain()
+    {
+        using var operation = new RetryAwareStubOperation();
+        Task firstRun = operation.MainThread();
+        await operation.FirstRunStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        operation.Cancel();
+        await operation.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        operation.Retry(AbstractOperation.RetryMode.Retry);
+
+        await Task.Delay(50);
+        Assert.Equal(1, operation.RunCount);
+        Assert.False(firstRun.IsCompleted);
+
+        operation.AllowCleanupToComplete.TrySetResult(true);
+        await firstRun;
+        await operation.SecondRunStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await WaitForAsync(() => operation.Status is OperationStatus.Succeeded);
+
+        Assert.Equal(2, operation.RunCount);
+        Assert.Equal(1, operation.MaxConcurrentRuns);
+    }
+
+    [Fact]
+    public async Task ConcurrentMainThreadCallsShareTheActiveRun()
+    {
+        using var operation = new CancellationAwareStubOperation();
+
+        Task firstCall = operation.MainThread();
+        Task secondCall = operation.MainThread();
+
+        Assert.Same(firstCall, secondCall);
+        await operation.PerformStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        operation.Cancel();
+        await operation.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        operation.AllowCleanupToComplete.TrySetResult(true);
+        await firstCall;
+    }
+
+    [Fact]
+    public async Task RetryRequestedFromRetriedRunCompletionSchedulesAnotherRun()
+    {
+        using var operation = new RepeatedRetryStubOperation();
+        await operation.MainThread();
+        operation.OperationFailed += (_, _) =>
+        {
+            if (operation.RunCount == 2)
+                operation.Retry(AbstractOperation.RetryMode.Retry);
+        };
+
+        operation.Retry(AbstractOperation.RetryMode.Retry);
+
+        await operation.ThirdRunStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await WaitForAsync(() => operation.Status is OperationStatus.Failed);
+        Assert.Equal(3, operation.RunCount);
+    }
+
+    [Fact]
+    public async Task DisposePreventsADeferredRetryFromStarting()
+    {
+        var operation = new RetryAwareStubOperation();
+        Task firstRun = operation.MainThread();
+        await operation.FirstRunStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        operation.Cancel();
+        await operation.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        operation.Retry(AbstractOperation.RetryMode.Retry);
+
+        operation.Dispose();
+        operation.AllowCleanupToComplete.TrySetResult(true);
+        await firstRun;
+        await Task.Delay(50);
+
+        Assert.Equal(1, operation.RunCount);
+        Assert.Throws<ObjectDisposedException>(() =>
+        {
+            _ = operation.MainThread();
+        });
+    }
+
+    [Fact]
+    public async Task DisposeFromTerminalEventPreservesCompletedStatus()
+    {
+        var operation = new RepeatedRetryStubOperation();
+        operation.OperationFailed += (_, _) => operation.Dispose();
+
+        await operation.MainThread();
+
+        Assert.Equal(OperationStatus.Failed, operation.Status);
+    }
+
+    [Fact]
+    public async Task DisposeFromStartupFailurePreservesFailedStatus()
+    {
+        var operation = new InvalidMetadataStubOperation();
+        operation.OperationFailed += (_, _) => operation.Dispose();
+
+        await operation.MainThread();
+
+        Assert.Equal(OperationStatus.Failed, operation.Status);
+    }
+
+    [Fact]
+    public async Task RetryOptionFailureDoesNotPreventALaterRetry()
+    {
+        using var operation = new ThrowingRetryStubOperation();
+        await operation.MainThread();
+
+        operation.Retry("InvalidRetryMode");
+        operation.Retry(AbstractOperation.RetryMode.Retry);
+
+        await operation.SecondRunStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(2, operation.RunCount);
+    }
+
+    [Fact]
+    public async Task CancellationFromEnqueuedDoesNotRemainOnAFullQueue()
+    {
+        using var firstOperation = new CancellationAwareStubOperation(queueEnabled: true);
+        using var canceledOperation = new CancellationAwareStubOperation(queueEnabled: true);
+        AbstractOperation.OperationQueue.Clear();
+        AbstractOperation.MAX_OPERATIONS = 1;
+
+        Task firstRun = firstOperation.MainThread();
+        await firstOperation.PerformStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        canceledOperation.Enqueued += (_, _) => canceledOperation.Cancel();
+
+        await canceledOperation.MainThread().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(OperationStatus.Canceled, canceledOperation.Status);
+        Assert.DoesNotContain(canceledOperation, AbstractOperation.OperationQueue);
+
+        firstOperation.Cancel();
+        await firstOperation.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        firstOperation.AllowCleanupToComplete.TrySetResult(true);
+        await firstRun;
+    }
+
     private static IReadOnlyList<AbstractOperation.InnerOperation> GetInnerOperations(
         AbstractOperation operation,
         string fieldName
@@ -522,8 +660,8 @@ public sealed class PackageOperationsTests
             TaskCreationOptions.RunContinuationsAsynchronously
         );
 
-        public CancellationAwareStubOperation()
-            : base(queue_enabled: false)
+        public CancellationAwareStubOperation(bool queueEnabled = false)
+            : base(queue_enabled: queueEnabled)
         {
             Metadata.Status = "Cancelable stub status";
             Metadata.Title = "Cancelable stub title";
@@ -551,6 +689,170 @@ public sealed class PackageOperationsTests
             }
 
             return OperationVeredict.Success;
+        }
+
+        public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));
+    }
+
+    private sealed class RetryAwareStubOperation : AbstractOperation
+    {
+        private int _concurrentRuns;
+        private int _maxConcurrentRuns;
+        private int _runCount;
+
+        public TaskCompletionSource<bool> FirstRunStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        public TaskCompletionSource<bool> CancellationObserved { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        public TaskCompletionSource<bool> AllowCleanupToComplete { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        public TaskCompletionSource<bool> SecondRunStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        public int RunCount => Volatile.Read(ref _runCount);
+        public int MaxConcurrentRuns => Volatile.Read(ref _maxConcurrentRuns);
+
+        public RetryAwareStubOperation()
+            : base(queue_enabled: false)
+        {
+            Metadata.Status = "Retryable stub status";
+            Metadata.Title = "Retryable stub title";
+            Metadata.OperationInformation = "Retryable stub info";
+            Metadata.SuccessTitle = "Retryable stub success";
+            Metadata.SuccessMessage = "Retryable stub success";
+            Metadata.FailureTitle = "Retryable stub failure";
+            Metadata.FailureMessage = "Retryable stub failure";
+        }
+
+        protected override void ApplyRetryAction(string retryMode) { }
+
+        protected override async Task<OperationVeredict> PerformOperation()
+        {
+            int concurrentRuns = Interlocked.Increment(ref _concurrentRuns);
+            UpdateMaximum(ref _maxConcurrentRuns, concurrentRuns);
+            int run = Interlocked.Increment(ref _runCount);
+            try
+            {
+                if (run == 1)
+                {
+                    FirstRunStarted.TrySetResult(true);
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, CancellationToken);
+                    }
+                    catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+                    {
+                        CancellationObserved.TrySetResult(true);
+                        await AllowCleanupToComplete.Task;
+                        return OperationVeredict.Canceled;
+                    }
+                }
+
+                SecondRunStarted.TrySetResult(true);
+                return OperationVeredict.Success;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _concurrentRuns);
+            }
+        }
+
+        private static void UpdateMaximum(ref int target, int value)
+        {
+            int current;
+            do
+            {
+                current = Volatile.Read(ref target);
+                if (current >= value)
+                    return;
+            } while (Interlocked.CompareExchange(ref target, value, current) != current);
+        }
+
+        public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));
+    }
+
+    private sealed class RepeatedRetryStubOperation : AbstractOperation
+    {
+        private int _runCount;
+
+        public int RunCount => Volatile.Read(ref _runCount);
+        public TaskCompletionSource<bool> ThirdRunStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        public RepeatedRetryStubOperation()
+            : base(queue_enabled: false)
+        {
+            Metadata.Status = "Repeated retry stub status";
+            Metadata.Title = "Repeated retry stub title";
+            Metadata.OperationInformation = "Repeated retry stub info";
+            Metadata.SuccessTitle = "Repeated retry stub success";
+            Metadata.SuccessMessage = "Repeated retry stub success";
+            Metadata.FailureTitle = "Repeated retry stub failure";
+            Metadata.FailureMessage = "Repeated retry stub failure";
+        }
+
+        protected override void ApplyRetryAction(string retryMode) { }
+
+        protected override Task<OperationVeredict> PerformOperation()
+        {
+            if (Interlocked.Increment(ref _runCount) == 3)
+                ThirdRunStarted.TrySetResult(true);
+            return Task.FromResult(OperationVeredict.Failure);
+        }
+
+        public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));
+    }
+
+    private sealed class InvalidMetadataStubOperation : AbstractOperation
+    {
+        public InvalidMetadataStubOperation()
+            : base(queue_enabled: false) { }
+
+        protected override void ApplyRetryAction(string retryMode) { }
+
+        protected override Task<OperationVeredict> PerformOperation()
+            => Task.FromResult(OperationVeredict.Success);
+
+        public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));
+    }
+
+    private sealed class ThrowingRetryStubOperation : AbstractOperation
+    {
+        private int _runCount;
+
+        public int RunCount => Volatile.Read(ref _runCount);
+        public TaskCompletionSource<bool> SecondRunStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        public ThrowingRetryStubOperation()
+            : base(queue_enabled: false)
+        {
+            Metadata.Status = "Throwing retry stub status";
+            Metadata.Title = "Throwing retry stub title";
+            Metadata.OperationInformation = "Throwing retry stub info";
+            Metadata.SuccessTitle = "Throwing retry stub success";
+            Metadata.SuccessMessage = "Throwing retry stub success";
+            Metadata.FailureTitle = "Throwing retry stub failure";
+            Metadata.FailureMessage = "Throwing retry stub failure";
+        }
+
+        protected override void ApplyRetryAction(string retryMode)
+        {
+            if (retryMode == "InvalidRetryMode")
+                throw new InvalidOperationException("Invalid retry mode");
+        }
+
+        protected override Task<OperationVeredict> PerformOperation()
+        {
+            if (Interlocked.Increment(ref _runCount) == 2)
+                SecondRunStarted.TrySetResult(true);
+            return Task.FromResult(OperationVeredict.Failure);
         }
 
         public override Task<Uri> GetOperationIcon() => Task.FromResult(new Uri("about:blank"));


### PR DESCRIPTION
## Summary
- Remove completed, faulted, and canceled task-recycler entries without retaining captured work.
- Make package-operation cancellation await cleanup and dispose child processes, redirected streams, and retries deterministically.
- Dispose HTTP, image, COM, and manager process resources on all request and error paths.
- Release transient Avalonia view models from static GitHub-auth subscriptions when their controls/pages leave the visual tree.

## Operation lifecycle correctness
A follow-up GPT-5.6 Sol audit traced cancellation, retry, disposal, queueing, and terminal-event interleavings in `AbstractOperation`. It found and fixed races that could:
- start a retry before the canceled run had finished cleanup, allowing the old run to affect the replacement run;
- cancel a `CancellationTokenSource` after concurrent completion disposed it;
- miss cancellation between run publication and CTS creation;
- lose a retry requested from a retried run's terminal callback;
- start a deferred retry after disposal;
- rewrite a completed or startup-failed operation as canceled when disposal occurred in a terminal callback;
- let a retry-option exception poison all later retries;
- retain a canceled operation when cancellation occurred from `Enqueued` while the queue was full.

Runs now publish their task and cancellation owner atomically, concurrent `MainThread()` calls share one active run, retries wait for prior cleanup and retain follow-up requests, and disposal prevents pending or future runs without corrupting terminal state.

## Coverage
- Faulted task recycling no longer poisons a cache key.
- Operation tests cover cancellation cleanup, concurrent `MainThread()` calls, retry serialization, repeated retry callbacks, deferred-retry disposal, terminal/startup-failure disposal, retry-option failure recovery, and cancellation during queue admission.
- Telemetry tests verify response disposal on success and failure.

## Deferred follow-up
Static caches, logs, IPC output, and operation history remain unchanged. Their bounds and eviction policies will be selected only after representative UI/package workloads provide reliable `dotnet-counters` and GC-dump evidence.

## Validation
- `dotnet test UniGetUI.Windows.slnx --no-restore --verbosity q --nologo /p:Platform=x64 -m:1`
- Package-operation lifecycle tests pass on both `net10.0` and `net10.0-windows10.0.26100.0`.