### PR TITLE
Fix WinGet updates being hidden by the "already upgraded" cache (#5042)

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -360,20 +360,12 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
                     Manager
                 );
 
-                if (!WinGetPkgOperationHelper.UpdateAlreadyInstalled(UniGetUIPackage))
-                {
-                    NativePackageHandler.AddPackage(UniGetUIPackage, nativePackage);
-                    packages.Add(UniGetUIPackage);
-                    logger.Log(
-                        $"Found package {nativePackage.Name} {nativePackage.Id} on source {source.Name}, from version {version} to version {nativePackage.DefaultInstallVersion.Version}"
-                    );
-                }
-                else
-                {
-                    Logger.Warn(
-                        $"WinGet package {nativePackage.Id} not being shown as an updated as this version has already been marked as installed"
-                    );
-                }
+                // Trust COM IsUpdateAvailable, not the "already upgraded" cache (issue #5042).
+                NativePackageHandler.AddPackage(UniGetUIPackage, nativePackage);
+                packages.Add(UniGetUIPackage);
+                logger.Log(
+                    $"Found package {nativePackage.Name} {nativePackage.Id} on source {source.Name}, from version {version} to version {nativePackage.DefaultInstallVersion.Version}"
+                );
             }
             catch (Exception ex)
             {

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetCliHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/PingetCliHelper.cs
@@ -58,7 +58,7 @@ internal sealed partial class PingetCliHelper : IWinGetManagerHelper
                 Manager
             );
 
-            if (!WinGetPkgOperationHelper.UpdateAlreadyInstalled(package))
+            if (!WinGetPkgOperationHelper.ConsumeAlreadyUpgradedSuppression(package))
             {
                 packages.Add(package);
             }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetCliHelper.cs
@@ -156,7 +156,7 @@ internal sealed class WinGetCliHelper : IWinGetManagerHelper
                 }
 
                 var package = new Package(name, id, version, newVersion, source, Manager);
-                if (!WinGetPkgOperationHelper.UpdateAlreadyInstalled(package))
+                if (!WinGetPkgOperationHelper.ConsumeAlreadyUpgradedSuppression(package))
                 {
                     Packages.Add(package);
                 }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -389,6 +389,25 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             ) == package.NewVersionString;
     }
 
+    public static void ClearUpgradeMark(IPackage package)
+    {
+        Settings.RemoveDictionaryKey<string, string>(
+            Settings.K.WinGetAlreadyUpgradedPackages,
+            package.Id
+        );
+    }
+
+    // One-shot suppression: hide a just-upgraded package once (bridges CLI index lag), then clear
+    // the mark so a still-outdated package reappears next scan instead of forever (issue #5042).
+    public static bool ConsumeAlreadyUpgradedSuppression(IPackage package)
+    {
+        if (!UpdateAlreadyInstalled(package))
+            return false;
+
+        ClearUpgradeMark(package);
+        return true;
+    }
+
     public static string GetLastInstalledVersion(string id)
     {
         var val = Settings.GetDictionaryItem<string, string>(

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -1016,6 +1016,74 @@ public sealed class WinGetManagerTests : IDisposable
         Assert.False(package.OverridenOptions.WinGet_DropArchAndScope);
     }
 
+    [Fact]
+    public void ConsumeAlreadyUpgradedSuppression_HidesOnceThenRevealsOnNextScan()
+    {
+        var manager = new WinGet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.OneShot")
+            .WithVersion("1.0.0")
+            .WithNewVersion("2.0.0")
+            .Build();
+
+        // Simulate a completed upgrade to 2.0.0 (as MarkUpgradeAsDone records it).
+        Settings.SetDictionaryItem<string, string>(
+            Settings.K.WinGetAlreadyUpgradedPackages,
+            package.Id,
+            "2.0.0"
+        );
+
+        // First scan hides the still-listed update once, then consumes the mark...
+        Assert.True(WinGetPkgOperationHelper.ConsumeAlreadyUpgradedSuppression(package));
+        Assert.False(WinGetPkgOperationHelper.UpdateAlreadyInstalled(package));
+
+        // ...so a genuinely-outdated package (no-op upgrade) reappears next scan (issue #5042).
+        Assert.False(WinGetPkgOperationHelper.ConsumeAlreadyUpgradedSuppression(package));
+    }
+
+    [Fact]
+    public void ConsumeAlreadyUpgradedSuppression_DoesNotHideDifferentAvailableVersion()
+    {
+        var manager = new WinGet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.NewerUpdate")
+            .WithVersion("1.0.0")
+            .WithNewVersion("3.0.0")
+            .Build();
+
+        // A mark from a previous upgrade to a different version must never hide a new update.
+        Settings.SetDictionaryItem<string, string>(
+            Settings.K.WinGetAlreadyUpgradedPackages,
+            package.Id,
+            "2.0.0"
+        );
+
+        Assert.False(WinGetPkgOperationHelper.ConsumeAlreadyUpgradedSuppression(package));
+        Assert.Equal(
+            "2.0.0",
+            Settings.GetDictionaryItem<string, string>(
+                Settings.K.WinGetAlreadyUpgradedPackages,
+                package.Id
+            )
+        );
+    }
+
+    [Fact]
+    public void ConsumeAlreadyUpgradedSuppression_NoMarkNeverHides()
+    {
+        var manager = new WinGet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.NoMark")
+            .WithVersion("1.0.0")
+            .WithNewVersion("2.0.0")
+            .Build();
+
+        Assert.False(WinGetPkgOperationHelper.ConsumeAlreadyUpgradedSuppression(package));
+    }
+
     private static void SetCliToolKind(WinGet manager, WinGetCliToolKind kind)
     {
         typeof(WinGet)


### PR DESCRIPTION
This pull request updates how the "already upgraded" cache is handled when listing available package updates, addressing an issue where recently upgraded packages could be hidden from update lists indefinitely. The new logic ensures that such packages are only suppressed from the update list once, then reappear on subsequent scans if still outdated. This improves accuracy and user experience, especially in cases where the CLI index lags behind real package state.

**Improvements to update suppression logic:**

* Added the `ConsumeAlreadyUpgradedSuppression` method to `WinGetPkgOperationHelper`, which hides a just-upgraded package only once and then clears the suppression mark, so outdated packages reappear on the next scan (issue #5042).
* Replaced calls to `UpdateAlreadyInstalled` with `ConsumeAlreadyUpgradedSuppression` in `WinGetCliHelper.cs` and `PingetCliHelper.cs`, ensuring the new one-shot suppression logic is used when listing available updates. 
* In `NativeWinGetHelper.cs`, removed the "already upgraded" cache check entirely and now always trusts the COM `IsUpdateAvailable` property, further preventing packages from being hidden incorrectly.

**Testing and validation:**

* Added comprehensive tests for `ConsumeAlreadyUpgradedSuppression` in `WinGetManagerTests.cs`, covering scenarios where the suppression mark is present, absent, or mismatched with the available version.