### PR TITLE
Fix "Uninstall package, then update it" failing on WinGet packages

### DIFF
--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
@@ -381,7 +381,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
         reinstallOp.OperationFailed += (_, _) => TelemetryHandler.InstallPackage(package, TEL_OP_RESULT.FAILED, TEL_InstallReferral.ALREADY_INSTALLED);
         AvaloniaOperationRegistry.Add(uninstallOp);
         AvaloniaOperationRegistry.Add(reinstallOp);
-        _ = uninstallOp.MainThread();
+        // uninstallOp runs as reinstallOp's prerequisite; launching it directly too would execute it twice concurrently
         _ = reinstallOp.MainThread();
     }
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -368,7 +368,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         updateOp.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(package, TEL_OP_RESULT.FAILED);
         AvaloniaOperationRegistry.Add(uninstallOp);
         AvaloniaOperationRegistry.Add(updateOp);
-        _ = uninstallOp.MainThread();
+        // uninstallOp runs as updateOp's prerequisite; launching it directly too would execute it twice concurrently
         _ = updateOp.MainThread();
     }
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -363,7 +363,8 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         var uninstallOp = new UninstallPackageOperation(package, uninstallOpts);
         uninstallOp.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.SUCCESS);
         uninstallOp.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.FAILED);
-        var updateOp = new UpdatePackageOperation(package, updateOpts, req: uninstallOp);
+        // Once uninstalled the package is gone, so the second step must install the new version fresh; a plain update would fail with "no installed package found".
+        var updateOp = new InstallPackageOperation(package, updateOpts, req: uninstallOp);
         updateOp.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(package, TEL_OP_RESULT.SUCCESS);
         updateOp.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(package, TEL_OP_RESULT.FAILED);
         AvaloniaOperationRegistry.Add(uninstallOp);


### PR DESCRIPTION
This pull request makes important corrections to the uninstall-then-reinstall and uninstall-then-update workflows for package management, ensuring operations are not executed twice and that updates after uninstall are handled correctly.

**Bug fixes and workflow corrections:**

* In `InstalledPackagesPage.cs`, removed the direct launch of `uninstallOp` in `LaunchUninstallThenReinstall` to prevent running the uninstall operation twice concurrently, since it's already a prerequisite for the reinstall operation.
* In `SoftwareUpdatesPage.cs`, changed the second step of `LaunchUninstallThenUpdate` from an update to a fresh install operation, because after uninstalling, the package must be installed anew rather than updated. Also removed the direct launch of `uninstallOp` to avoid concurrent execution, as it's now a prerequisite for the install operation.