### PR TITLE
Fix release publish 422 from duplicate asset names

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -767,9 +767,10 @@ jobs:
           $Repository = $Env:GITHUB_REPOSITORY
           $DraftArg = if ($DraftRelease) { '--draft' } else { $null }
 
+          # De-duplicate by basename: release asset names must be unique (e.g. two sizes.md would 422).
           $Files = Get-ChildItem -Path . -Recurse -File | Where-Object {
             $_.Name -eq 'checksums.txt' -or $_.Name -notmatch '^checksums\..+\.txt$'
-          }
+          } | Group-Object Name | ForEach-Object { $_.Group[0] }
 
           if ($DryRun) {
             Write-Host "Dry Run: skipping GitHub release creation!"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to ensure that release asset names are unique when uploading files during the release process. The main change is a de-duplication step that prevents multiple files with the same basename from being included, which could cause errors during release creation.

Release process improvements:

* [`.github/workflows/build-release.yml`](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84R770-R773): Added a step to de-duplicate files by basename when collecting release assets, ensuring that each asset name is unique and preventing upload errors (e.g., two files named `sizes.md` would cause a 422 error).
