### PR TITLE
Add NoRedirectionGuard argument to installer

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -675,7 +675,7 @@ internal static partial class AvaloniaAutoUpdater
             StartInfo = new ProcessStartInfo
             {
                 FileName = installerLocation,
-                Arguments = "/SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NoVCRedist /NoEdgeWebView /NoWinGet",
+                Arguments = "/SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NoVCRedist /NoEdgeWebView /NoWinGet /NoRedirectionGuard",
                 UseShellExecute = true,
                 CreateNoWindow = true,
             },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **Have you confirmed that this issue is caused by UniGetUI itself, and not by the package manager or the package involved?**
If the same issue can be reproduced outside UniGetUI with the relevant package manager or with the package itself, please report it there first. UniGetUI should only be used to track issues that are specific to UniGetUI's behavior or integration.
-----

<!-- optionally, explain here about the committed code -->

After updating UniGetUI, the Junction Redirection Guard process mitigation is enabled which breaks Scoop updates/installs, however restarting the app fixes the issue.

This is caused by Inno Setup: 
https://github.com/jrsoftware/issrc/blob/929fc4e164798bd84fec385a1dc8a899a0d4a100/Projects/Src/Setup.MainFunc.pas#L2458-L2463

Passing the flag [`/NoRedirectionGuard`](https://github.com/jrsoftware/issrc/blob/929fc4e164798bd84fec385a1dc8a899a0d4a100/Projects/Src/Setup.MainFunc.pas#L3215) prevents it from being enabled by default.

-----
Relates to #4607 and #4717 
