### PR TITLE
Fix NativeAOT WinGet and startup COM paths

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AppShortcutAumidStamper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using UniGetUI.Core.Logging;
 
@@ -30,6 +31,12 @@ internal static class AppShortcutAumidStamper
     {
         if (!OperatingSystem.IsWindows())
             return;
+
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            Logger.Info("Skipping Start Menu shortcut AUMID stamping because NativeAOT does not support legacy COM activation.");
+            return;
+        }
 
         try
         {

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAvaloniaRenderingPolicy.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAvaloniaRenderingPolicy.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Avalonia.Controls;
@@ -63,6 +64,14 @@ internal static class WindowsAvaloniaRenderingPolicy
         Justification = "The DXGI COM interfaces are declared in full and referenced directly here, so their members are preserved by trimming.")]
     private static bool DetectHardwareGpu()
     {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            Logger.Info(
+                "Skipping DXGI hardware GPU detection because NativeAOT does not support legacy COM activation."
+            );
+            return true;
+        }
+
         try
         {
             Guid factoryIid = typeof(IDXGIFactory1).GUID;

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativePackageHandler.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativePackageHandler.cs
@@ -69,7 +69,10 @@ public static class NativePackageHandler
             if (catalogPackage is null)
                 return null;
 
-            var availableVersions = catalogPackage.AvailableVersions?.ToArray() ?? [];
+            var availableVersions =
+                catalogPackage.AvailableVersions is { } versions
+                    ? NativeWinGetCollection.Copy(versions)
+                    : [];
             if (availableVersions.Length > 0)
             {
                 metadata = catalogPackage

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetCollection.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetCollection.cs
@@ -1,0 +1,17 @@
+namespace UniGetUI.PackageEngine.Managers.WingetManager;
+
+internal static class NativeWinGetCollection
+{
+    internal static T[] Copy<T>(IReadOnlyList<T> collection)
+    {
+        ArgumentNullException.ThrowIfNull(collection);
+
+        T[] copy = new T[collection.Count];
+        for (int index = 0; index < copy.Length; index++)
+        {
+            copy[index] = collection[index];
+        }
+
+        return copy;
+    }
+}

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -195,7 +195,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
 
         // Spawn Tasks to find packages on catalogs
         logger.Log("Spawning catalog fetching tasks...");
-        foreach (PackageCatalogReference CatalogReference in AvailableCatalogs.ToArray())
+        foreach (PackageCatalogReference CatalogReference in NativeWinGetCollection.Copy(AvailableCatalogs))
         {
             logger.Log($"Begin search on catalog {CatalogReference.Info.Name}");
             // Connect to catalog
@@ -266,7 +266,9 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
                 );
 
                 FindPackagesResult FoundPackages = CatalogTaskPair.Value.Result;
-                foreach (MatchResult matchResult in FoundPackages.Matches.ToArray())
+                foreach (
+                    MatchResult matchResult in NativeWinGetCollection.Copy(FoundPackages.Matches)
+                )
                 {
                     CatalogPackage nativePackage = matchResult.CatalogPackage;
                     // Create the Package item and add it to the list
@@ -396,7 +398,10 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             try
             {
                 IManagerSource source;
-                var availableVersions = nativePackage.AvailableVersions?.ToArray() ?? [];
+                var availableVersions =
+                    nativePackage.AvailableVersions is { } versions
+                        ? NativeWinGetCollection.Copy(versions)
+                        : [];
                 if (availableVersions.Length > 0)
                 {
                     var installPackage = nativePackage.GetPackageVersionInfo(availableVersions[0]);
@@ -582,7 +587,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             }
 
             List<CatalogPackage> foundPackages = [];
-            foreach (var match in TaskResult.Matches.ToArray())
+            foreach (var match in NativeWinGetCollection.Copy(TaskResult.Matches))
             {
                 foundPackages.Add(match.CatalogPackage);
             }
@@ -601,7 +606,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     )
     {
         return SelectReachableCatalogs(
-            WinGetManager.GetPackageCatalogs().ToArray(),
+            NativeWinGetCollection.Copy(WinGetManager.GetPackageCatalogs()),
             static catalogRef => catalogRef.Info.Name,
             catalogRef => TryConnectLocalCatalog(catalogRef, logger),
             catalogName =>
@@ -688,7 +693,11 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         List<ManagerSource> sources = [];
         INativeTaskLogger logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListSources);
 
-        foreach (PackageCatalogReference catalog in WinGetManager.GetPackageCatalogs().ToList())
+        foreach (
+            PackageCatalogReference catalog in NativeWinGetCollection.Copy(
+                WinGetManager.GetPackageCatalogs()
+            )
+        )
         {
             try
             {
@@ -728,7 +737,12 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
         if (nativePackage is null)
             return [];
 
-        string[] versions = nativePackage.AvailableVersions.Select(x => x.Version).ToArray();
+        var nativeVersions = NativeWinGetCollection.Copy(nativePackage.AvailableVersions);
+        string[] versions = new string[nativeVersions.Length];
+        for (int index = 0; index < nativeVersions.Length; index++)
+        {
+            versions[index] = nativeVersions[index].Version;
+        }
         foreach (string? version in versions)
         {
             logger.Log(version);
@@ -800,7 +814,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             details.ReleaseNotesUrl = new Uri(NativeDetails.ReleaseNotesUrl);
 
         if (NativeDetails.Tags is not null)
-            details.Tags = NativeDetails.Tags.ToArray();
+            details.Tags = NativeWinGetCollection.Copy(NativeDetails.Tags);
 
         bool metadataLoaded = _pingetPackageDetailsProvider.LoadPackageDetails(details, logger);
 

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetIconsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/WinGetIconsHelper.cs
@@ -126,7 +126,7 @@ internal static class WinGetIconsHelper
             return null;
 
         // Get the actual icon and return it
-        foreach (Icon? icon in NativeDetails.Icons.ToArray())
+        foreach (Icon? icon in NativeWinGetCollection.Copy(NativeDetails.Icons))
             if (icon is not null && icon.Url is not null)
                 // Logger.Debug($"Found WinGet native icon for {package.Id} with URL={icon.Url}");
                 return new CacheableIcon(new Uri(icon.Url), icon.Sha256);

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -146,6 +146,18 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void NativeWinGetCollectionCopiesWithoutEnumeratingWinRtCollections()
+    {
+        IReadOnlyList<string> nativeCollection = new EnumeratorThrowingReadOnlyList<string>(
+            ["winget", "msstore"]
+        );
+
+        var collectionCopy = NativeWinGetCollection.Copy(nativeCollection);
+
+        Assert.Equal(["winget", "msstore"], collectionCopy);
+    }
+
+    [Fact]
     public void GetBundledPingetExecutablePathPrefersRootExecutable()
     {
         const string installDir = @"C:\Program Files\UniGetUI";
@@ -1225,6 +1237,19 @@ public sealed class WinGetManagerTests : IDisposable
             handler(details);
             return true;
         }
+    }
+
+    private sealed class EnumeratorThrowingReadOnlyList<T>(IReadOnlyList<T> items) : IReadOnlyList<T>
+    {
+        public int Count => items.Count;
+
+        public T this[int index] => items[index];
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
+            throw new InvalidCastException("Enumeration is not available for this WinRT projection.");
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            throw new InvalidCastException("Enumeration is not available for this WinRT projection.");
     }
 
     private sealed class TestNativeTaskLogger : INativeTaskLogger

--- a/src/WindowsPackageManager.Interop/WindowsPackageManager/WindowsPackageManagerStandardFactory.cs
+++ b/src/WindowsPackageManager.Interop/WindowsPackageManager/WindowsPackageManagerStandardFactory.cs
@@ -49,7 +49,10 @@ public class WindowsPackageManagerStandardFactory : WindowsPackageManagerFactory
         }
         finally
         {
-            Marshal.Release(instance);
+            if (instance != IntPtr.Zero)
+            {
+                Marshal.Release(instance);
+            }
         }
     }
 

--- a/src/WindowsPackageManager.Interop/WindowsPackageManager/WindowsPackageManagerStandardFactory.cs
+++ b/src/WindowsPackageManager.Interop/WindowsPackageManager/WindowsPackageManagerStandardFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Windows.Win32.System.Com;
@@ -18,40 +17,8 @@ public class WindowsPackageManagerStandardFactory : WindowsPackageManagerFactory
     )
         : base(clsidContext, allowLowerTrustRegistration) { }
 
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2072",
-        Justification = "WinGet COM projected activation types come from the Windows Package Manager WinMD and registered COM server; this path does not depend on app-owned trimmed constructors.")]
     protected override T CreateInstance<T>(Guid clsid, Guid iid)
     {
-        if (!_allowLowerTrustRegistration)
-        {
-            Type? projectedType = Type.GetTypeFromCLSID(clsid);
-            if (projectedType is null)
-            {
-                throw new WinGetComActivationException(
-                    clsid,
-                    iid,
-                    unchecked((int)0x80040154),
-                    _allowLowerTrustRegistration
-                );
-            }
-
-            object? activatedInstance = Activator.CreateInstance(projectedType);
-            if (activatedInstance is null)
-            {
-                throw new WinGetComActivationException(
-                    clsid,
-                    iid,
-                    unchecked((int)0x80004003),
-                    _allowLowerTrustRegistration
-                );
-            }
-
-            IntPtr pointer = Marshal.GetIUnknownForObject(activatedInstance);
-            return MarshalGeneric<T>.FromAbi(pointer);
-        }
-
         CLSCTX clsctx = CLSCTX.CLSCTX_LOCAL_SERVER;
         if (_allowLowerTrustRegistration)
         {
@@ -76,7 +43,14 @@ public class WindowsPackageManagerStandardFactory : WindowsPackageManagerFactory
             );
         }
 
-        return MarshalGeneric<T>.FromAbi(instance);
+        try
+        {
+            return MarshalGeneric<T>.FromAbi(instance);
+        }
+        finally
+        {
+            Marshal.Release(instance);
+        }
     }
 
     [DllImport(


### PR DESCRIPTION
## Summary
- enumerate WinGet COM-projected collections by index instead of using unsupported `IReadOnlyList<T>` enumeration
- use raw `CoCreateInstance` plus the CsWinRT projection for standard WinGet activation
- bypass legacy COM GPU detection and shortcut stamping under NativeAOT, preserving their safe fallbacks

Fixes #5083
Fixes #5085

## NativeAOT audit
- The legacy file-picker project is not referenced by the Avalonia publish graph, so it is not a shipped NativeAOT risk.
- Start Menu shortcut AUMID stamping is safely skipped until it can be migrated from legacy COM.
- The DataGrid smooth-scroll reflection hook can be trimmed, falling back to standard scrolling.
- Avalonia DataGrid AOT warnings cover unused automatic-column generation; all app grids use explicit columns and compiled bindings.

## Testing
- `dotnet test UniGetUI.Windows.slnx --verbosity q --nologo /p:Platform=x64`
- Windows x64 NativeAOT publish (`Win-x64-NativeAot`)