### PR TITLE
Fix installation scope not being respected (#5098)

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
@@ -301,8 +301,8 @@ public partial class InstallOptionsViewModel : ObservableObject
             string globalName = CoreTools.Translate(CommonTranslations.ScopeNames[PackageScope.Global]);
             ScopeOptions.Add(localName);
             ScopeOptions.Add(globalName);
-            if (options.InstallationScope == "Local") SelectedScope = localName;
-            if (options.InstallationScope == "Global") SelectedScope = globalName;
+            if (options.InstallationScope == PackageScope.Local) SelectedScope = localName;
+            if (options.InstallationScope == PackageScope.Global) SelectedScope = globalName;
         }
         ScopeEnabled = caps.SupportsCustomScopes;
 
@@ -575,8 +575,8 @@ public partial class InstallOptionsViewModel : ObservableObject
 
     private static string ScopeToString(string? selected)
     {
-        if (selected == CoreTools.Translate(CommonTranslations.ScopeNames[PackageScope.Local])) return "Local";
-        if (selected == CoreTools.Translate(CommonTranslations.ScopeNames[PackageScope.Global])) return "Global";
+        if (selected == CoreTools.Translate(CommonTranslations.ScopeNames[PackageScope.Local])) return PackageScope.Local;
+        if (selected == CoreTools.Translate(CommonTranslations.ScopeNames[PackageScope.Global])) return PackageScope.Global;
         return "";
     }
 


### PR DESCRIPTION
This pull request makes a small but important improvement to how installation scopes are handled in the `InstallOptionsViewModel`. The changes ensure that scope comparisons and assignments use the `PackageScope` constants instead of hardcoded string values, which improves code consistency and reduces the risk of errors.

- **Refactoring for consistency and maintainability:**
  * Updated assignments and comparisons in `InstallOptionsViewModel` to use `PackageScope.Local` and `PackageScope.Global` constants instead of the string literals `"Local"` and `"Global"`. This applies to both the constructor logic and the `ScopeToString` method. 
  
  fix issue #5098