### PR TITLE
Fix app auto-navigating to Updates when a toast is shown

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -275,11 +275,9 @@ internal static class WindowsAppNotificationBridge
             string launchArg = BuildLaunchArgument(launchAction);
             if (Win32ToastNotifier.Show(title, message, launchArg))
             {
-                // When the app is already running, raise activation immediately so the
-                // in-process handler fires; a subsequent toast click routes through the
-                // single-instance redirector on launch via TryParseToastLaunchArgument.
-                if (MainWindow.Instance is not null)
-                    RaiseActivation(launchAction);
+                // Show-only: the launch action fires only when the user clicks the toast, routed via
+                // the unigetui:// deep-link through the single-instance handler. Raising it on show
+                // would navigate the app on its own (e.g. yank to Updates the moment updates load).
                 return true;
             }
         }


### PR DESCRIPTION
This pull request makes a small but important change to the toast notification activation logic. The code no longer immediately raises the activation event when showing a notification; instead, activation is now only triggered when the user clicks the toast, preventing unintended navigation within the app.

- Notification activation logic update:
  * In `WindowsAppNotificationBridge.cs`, removed the immediate call to `RaiseActivation` when displaying a toast. Activation now occurs only on user interaction (toast click), avoiding automatic navigation when a notification is shown.
  
  fix issue #5102