### PR TITLE
handle installation scope for PowerShell modules

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
@@ -436,6 +436,12 @@ public partial class InstallOptionsViewModel : ObservableObject
         SkipHashEnabled = op is not OperationType.Uninstall && caps.CanSkipIntegrityChecks;
         ArchEnabled = op is not OperationType.Uninstall && caps.SupportsCustomArchitectures;
         VersionEnabled = op is OperationType.Install && (caps.SupportsCustomVersions || caps.SupportsPreRelease);
+        ScopeEnabled = caps.SupportsCustomScopes && op switch
+        {
+            OperationType.Update => caps.SupportsCustomScopesOnUpdate,
+            OperationType.Uninstall => caps.SupportsCustomScopesOnUninstall,
+            _ => true,
+        };
     }
 
     // ── Live command preview ──────────────────────────────────────────────────

--- a/src/UniGetUI.PackageEngine.Enums/ManagerCapabilities.cs
+++ b/src/UniGetUI.PackageEngine.Enums/ManagerCapabilities.cs
@@ -37,6 +37,10 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         public bool SupportsCustomArchitectures = false;
         public string[] SupportedCustomArchitectures = [];
         public bool SupportsCustomScopes = false;
+        // Whether a custom scope can be applied to update/uninstall too, not just install
+        // (e.g. Windows PowerShell 5.x's Update-Module has no -Scope parameter)
+        public bool SupportsCustomScopesOnUpdate = true;
+        public bool SupportsCustomScopesOnUninstall = true;
         public bool SupportsPreRelease = false;
         public bool SupportsCustomLocations = false;
         public bool SupportsCustomSources = false;

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell/Helpers/PowerShellPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell/Helpers/PowerShellPkgOperationHelper.cs
@@ -36,16 +36,11 @@ internal sealed class PowerShellPkgOperationHelper : BasePkgOperationHelper
             // Update-Module (PowerShellGet) has no -Scope parameter; only Install-Module accepts it
             if (operation is OperationType.Install && !package.OverridenOptions.PowerShell_DoNotSetScopeParameter)
             {
-                if (
-                    package.OverridenOptions.Scope == PackageScope.Global
-                    || (
-                        package.OverridenOptions.Scope is null
-                        && options.InstallationScope == PackageScope.Global
-                    )
-                )
-                    parameters.AddRange(["-Scope", "AllUsers"]);
-                else
-                    parameters.AddRange(["-Scope", "CurrentUser"]);
+                // The scope chosen in the options dialog wins; fall back to the auto-detected install scope
+                string scope = options.InstallationScope.Length > 0
+                    ? options.InstallationScope
+                    : package.OverridenOptions.Scope ?? "";
+                parameters.AddRange(["-Scope", scope == PackageScope.Global ? "AllUsers" : "CurrentUser"]);
             }
         }
 

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell/PowerShell.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell/PowerShell.cs
@@ -25,6 +25,9 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                 SupportsCustomVersions = true,
                 CanDownloadInstaller = true,
                 SupportsCustomScopes = true,
+                // Update-Module/Uninstall-Module (PowerShellGet) take no -Scope; only Install-Module does
+                SupportsCustomScopesOnUpdate = false,
+                SupportsCustomScopesOnUninstall = false,
                 CanListDependencies = true,
                 SupportsCustomSources = true,
                 SupportsPreRelease = true,

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell7/Helpers/PowerShell7PkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell7/Helpers/PowerShell7PkgOperationHelper.cs
@@ -49,16 +49,11 @@ internal sealed class PowerShell7PkgOperationHelper : BasePkgOperationHelper
             if (options.PreRelease)
                 parameters.Add("-Prerelease");
 
-            if (
-                package.OverridenOptions.Scope is PackageScope.Global
-                || (
-                    package.OverridenOptions.Scope is null
-                    && options.InstallationScope is PackageScope.Global
-                )
-            )
-                parameters.AddRange(["-Scope", "AllUsers"]);
-            else
-                parameters.AddRange(["-Scope", "CurrentUser"]);
+            // The scope chosen in the options dialog wins; fall back to the auto-detected install scope
+            string scope = options.InstallationScope.Length > 0
+                ? options.InstallationScope
+                : package.OverridenOptions.Scope ?? "";
+            parameters.AddRange(["-Scope", scope == PackageScope.Global ? "AllUsers" : "CurrentUser"]);
         }
 
         parameters.AddRange(

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
@@ -23,6 +23,8 @@ namespace UniGetUI.PackageEngine.Managers.PowerShell7Manager
                 CanRunAsAdmin = true,
                 SupportsCustomVersions = true,
                 SupportsCustomScopes = true,
+                // Uninstall-PSResource is invoked without a scope, so the selector is a no-op there
+                SupportsCustomScopesOnUninstall = false,
                 SupportsCustomSources = true,
                 SupportsPreRelease = true,
                 CanDownloadInstaller = true,

--- a/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
@@ -1,6 +1,7 @@
 #if WINDOWS
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Managers.PowerShell7Manager;
+using UniGetUI.PackageEngine.Serializable;
 
 namespace UniGetUI.PackageEngine.Tests;
 
@@ -60,6 +61,53 @@ public sealed class PowerShell7ManagerTests
         );
 
         Assert.Equal("Pester", package.Id);
+    }
+
+    // Regression for https://github.com/Devolutions/UniGetUI/issues/5110:
+    // a scope explicitly chosen in the options dialog must override the auto-detected
+    // install scope, otherwise the command never changes for an installed module.
+    [Fact]
+    public void GetParameters_ExplicitScopeOverridesDetectedScope()
+    {
+        var manager = new PowerShell7();
+        var package = Assert.Single(PowerShell7.ParseInstalledPackages(
+            ["##SCOPE:AllUsers##", "Devolutions.PowerShell\t2025.1.0\tPSGallery"], manager));
+        Assert.Equal(PackageScope.Machine, package.OverridenOptions.Scope);
+
+        var options = new InstallOptions { InstallationScope = PackageScope.User };
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.Contains("CurrentUser", parameters);
+        Assert.DoesNotContain("AllUsers", parameters);
+    }
+
+    [Fact]
+    public void GetParameters_ExplicitGlobalOverridesDetectedUserScope()
+    {
+        var manager = new PowerShell7();
+        var package = Assert.Single(PowerShell7.ParseInstalledPackages(
+            ["##SCOPE:CurrentUser##", "Devolutions.PowerShell\t2025.1.0\tPSGallery"], manager));
+        Assert.Equal(PackageScope.User, package.OverridenOptions.Scope);
+
+        var options = new InstallOptions { InstallationScope = PackageScope.Machine };
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.Contains("AllUsers", parameters);
+        Assert.DoesNotContain("CurrentUser", parameters);
+    }
+
+    [Fact]
+    public void GetParameters_DefaultScopeFallsBackToDetectedScope()
+    {
+        var manager = new PowerShell7();
+        var package = Assert.Single(PowerShell7.ParseInstalledPackages(
+            ["##SCOPE:AllUsers##", "Devolutions.PowerShell\t2025.1.0\tPSGallery"], manager));
+
+        var options = new InstallOptions();
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.Contains("AllUsers", parameters);
+        Assert.DoesNotContain("CurrentUser", parameters);
     }
 
     // Regression for https://github.com/Devolutions/UniGetUI/issues/4781:

--- a/src/UniGetUI.PackageEngine.Tests/PowerShellManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PowerShellManagerTests.cs
@@ -1,5 +1,7 @@
 #if WINDOWS
+using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Managers.PowerShellManager;
+using UniGetUI.PackageEngine.Serializable;
 
 namespace UniGetUI.PackageEngine.Tests;
 
@@ -54,6 +56,52 @@ public sealed class PowerShellManagerTests
         );
 
         Assert.Equal("Pester", package.Id);
+    }
+
+    private static UniGetUI.PackageEngine.Interfaces.IPackage BuildInstalledPackage(PowerShell manager)
+        => Assert.Single(PowerShell.ParseInstalledPackages(
+            [
+                "Version Name Repository Description",
+                "------- ---- ---------- -----------",
+                "1.0.0 Devolutions.PowerShell PSGallery x",
+            ],
+            manager));
+
+    [Fact]
+    public void GetParameters_InstallRespectsExplicitScope()
+    {
+        var manager = new PowerShell();
+        var package = BuildInstalledPackage(manager);
+
+        var options = new InstallOptions { InstallationScope = PackageScope.Machine };
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Install);
+
+        Assert.Contains("-Scope", parameters);
+        Assert.Contains("AllUsers", parameters);
+    }
+
+    // Regression for https://github.com/Devolutions/UniGetUI/issues/5110:
+    // Update-Module (Windows PowerShell 5.x / PowerShellGet 1.0.0.1) has no -Scope parameter,
+    // so no scope must be emitted for an update regardless of the selected scope.
+    [Fact]
+    public void GetParameters_UpdateOmitsScope()
+    {
+        var manager = new PowerShell();
+        var package = BuildInstalledPackage(manager);
+
+        var options = new InstallOptions { InstallationScope = PackageScope.Machine };
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.DoesNotContain("-Scope", parameters);
+    }
+
+    [Fact]
+    public void Capabilities_ScopeAppliesToInstallOnly()
+    {
+        var manager = new PowerShell();
+        Assert.True(manager.Capabilities.SupportsCustomScopes);
+        Assert.False(manager.Capabilities.SupportsCustomScopesOnUpdate);
+        Assert.False(manager.Capabilities.SupportsCustomScopesOnUninstall);
     }
 }
 #endif


### PR DESCRIPTION
This pull request refines how custom installation scopes are handled for PowerShell and PowerShell 7 package managers, ensuring that scope selection is correctly applied only when supported and that user-selected scopes override auto-detected ones. It also adds comprehensive regression tests to prevent future issues related to scope handling.

**Improvements to scope handling logic:**

* Updated `ManagerCapabilities` to introduce `SupportsCustomScopesOnUpdate` and `SupportsCustomScopesOnUninstall`, allowing more granular control over when custom scopes are available for different operations (`Install`, `Update`, `Uninstall`).
* Modified PowerShell and PowerShell 7 manager capability definitions to correctly set these new flags, reflecting that only install operations support custom scopes for PowerShell, and only install/uninstall as appropriate for PowerShell 7. 
* Refined logic in `ApplyProfileEnableState` to enable or disable scope selection based on these new capability flags and the current operation type.

**Command parameter generation fixes:**

* Changed parameter generation in both PowerShell and PowerShell 7 helpers so that an explicitly chosen scope in the options dialog always overrides the detected scope, and scope parameters are only emitted when supported by the operation type. 
**Regression and behavior tests:**

* Added targeted tests to ensure scope selection logic works as intended, including cases where explicit scopes override detected scopes, and that scope parameters are omitted when not supported. Also verifies the new capability flags. 
These changes ensure more predictable and correct behavior for package installation, update, and uninstall operations across supported PowerShell environments.