### PR TITLE
Fix sorting of installed-packages column under NativeAOT

### DIFF
--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -490,20 +490,28 @@ public sealed class ObservablePackageCollection : AvaloniaList<PackageWrapper>
     public void SetSortDirection(bool ascending) => _ascending = ascending;
 
     /// <summary>Returns <paramref name="items"/> in the current sort order.</summary>
-    public IEnumerable<PackageWrapper> ApplyToList(IEnumerable<PackageWrapper> items) =>
-        _ascending
-            ? items.OrderBy(GetSortKey, StringComparer.OrdinalIgnoreCase)
-            : items.OrderByDescending(GetSortKey, StringComparer.OrdinalIgnoreCase);
+    public IEnumerable<PackageWrapper> ApplyToList(IEnumerable<PackageWrapper> items)
+    {
+        var comparer = Comparer<PackageWrapper>.Create((a, b) => Compare(a, b, CurrentSorter));
+        return _ascending ? items.OrderBy(w => w, comparer) : items.OrderByDescending(w => w, comparer);
+    }
 
-    private string GetSortKey(PackageWrapper w) => GetSortKey(w, CurrentSorter);
+    // Shared by the "Order by" menu (ApplyToList) and the DataGrid's native column sorting
+    // (GetColumnComparer) so both order identically. Versions compare semantically via
+    // CoreTools.Version; a string key can't be used there because that struct has no ToString
+    // override, so its key would be a constant type name that never sorts.
+    private static int Compare(PackageWrapper a, PackageWrapper b, Sorter sorter) => sorter switch
+    {
+        Sorter.Version => a.Package.NormalizedVersion.CompareTo(b.Package.NormalizedVersion),
+        Sorter.NewVersion => a.Package.NormalizedNewVersion.CompareTo(b.Package.NormalizedNewVersion),
+        _ => string.Compare(GetSortKey(a, sorter), GetSortKey(b, sorter), StringComparison.OrdinalIgnoreCase),
+    };
 
     private static string GetSortKey(PackageWrapper w, Sorter sorter) => sorter switch
     {
         Sorter.Checked => w.IsChecked ? "0" : "1",
         Sorter.Name => w.Package.Name,
         Sorter.Id => w.Package.Id,
-        Sorter.Version => w.Package.NormalizedVersion.ToString() ?? string.Empty,
-        Sorter.NewVersion => w.Package.NormalizedNewVersion.ToString() ?? string.Empty,
         Sorter.Source => w.Package.Source.AsString_DisplayName,
         _ => w.Package.Name,
     };
@@ -511,6 +519,5 @@ public sealed class ObservablePackageCollection : AvaloniaList<PackageWrapper>
     // Comparer for the DataGrid's native column sorting. Reflection-free (unlike SortMemberPath),
     // so it keeps working under full-trim NativeAOT release builds — see issue #5103.
     public static IComparer GetColumnComparer(Sorter sorter) =>
-        Comparer<PackageWrapper>.Create((a, b) =>
-            string.Compare(GetSortKey(a, sorter), GetSortKey(b, sorter), StringComparison.OrdinalIgnoreCase));
+        Comparer<PackageWrapper>.Create((a, b) => Compare(a, b, sorter));
 }

--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Net.Http;
@@ -494,7 +495,9 @@ public sealed class ObservablePackageCollection : AvaloniaList<PackageWrapper>
             ? items.OrderBy(GetSortKey, StringComparer.OrdinalIgnoreCase)
             : items.OrderByDescending(GetSortKey, StringComparer.OrdinalIgnoreCase);
 
-    private string GetSortKey(PackageWrapper w) => CurrentSorter switch
+    private string GetSortKey(PackageWrapper w) => GetSortKey(w, CurrentSorter);
+
+    private static string GetSortKey(PackageWrapper w, Sorter sorter) => sorter switch
     {
         Sorter.Checked => w.IsChecked ? "0" : "1",
         Sorter.Name => w.Package.Name,
@@ -504,4 +507,10 @@ public sealed class ObservablePackageCollection : AvaloniaList<PackageWrapper>
         Sorter.Source => w.Package.Source.AsString_DisplayName,
         _ => w.Package.Name,
     };
+
+    // Comparer for the DataGrid's native column sorting. Reflection-free (unlike SortMemberPath),
+    // so it keeps working under full-trim NativeAOT release builds — see issue #5103.
+    public static IComparer GetColumnComparer(Sorter sorter) =>
+        Comparer<PackageWrapper>.Create((a, b) =>
+            string.Compare(GetSortKey(a, sorter), GetSortKey(b, sorter), StringComparison.OrdinalIgnoreCase));
 }

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -84,6 +84,26 @@ public abstract partial class AbstractPackagesPage : UserControl,
         // Double-click a list row → show details
         PackageList.DoubleTapped += (_, _) => _ = ShowDetailsForPackage(SelectedItem);
 
+        // Native DataGrid column sorting. The default SortMemberPath path resolves the property by
+        // reflection, which full-trim NativeAOT release builds strip away — so CanUserSort reports
+        // false and header clicks are silently dropped (issue #5103). A strongly-typed
+        // CustomSortComparer plus an explicit CanUserSort keeps Avalonia's built-in sort AOT-safe.
+        foreach (var col in PackageList.Columns)
+        {
+            ObservablePackageCollection.Sorter? sorter = (col.Tag as string) switch
+            {
+                "Name" => ObservablePackageCollection.Sorter.Name,
+                "Id" => ObservablePackageCollection.Sorter.Id,
+                "Version" => ObservablePackageCollection.Sorter.Version,
+                "NewVersion" => ObservablePackageCollection.Sorter.NewVersion,
+                "Source" => ObservablePackageCollection.Sorter.Source,
+                _ => null,
+            };
+            if (sorter is null) continue;
+            col.CanUserSort = true;
+            col.CustomSortComparer = ObservablePackageCollection.GetColumnComparer(sorter.Value);
+        }
+
         // Keyboard shortcuts on the package list. Handled on the tunnel route (and even when
         // already handled) because the DataGrid swallows Enter on the bubble route otherwise.
         PackageList.AddHandler(KeyDownEvent, PackageList_KeyDown, RoutingStrategies.Tunnel, handledEventsToo: true);


### PR DESCRIPTION
This pull request improves sorting functionality for package lists, particularly to ensure compatibility with NativeAOT release builds by avoiding reflection-based sorting. The changes introduce a strongly-typed comparer for both manual and DataGrid column sorting, ensuring consistent and reliable sorting behavior across the UI.

**Sorting improvements for package lists:**

* Refactored the `ApplyToList` method in `PackageCollections.cs` to use a strongly-typed comparer, ensuring that sorting is consistent and supports semantic version comparison for package versions. This replaces the previous string-based key sorting for version fields.
* Added a static `Compare` method and updated `GetSortKey` to be static and accept a sorter parameter, supporting more flexible and accurate sorting logic.
* Introduced the `GetColumnComparer` method to provide a reflection-free comparer for DataGrid's native column sorting, supporting AOT-safe builds.

**UI integration for AOT-safe DataGrid sorting:**

* Updated `AbstractPackagesPage.axaml.cs` to assign a strongly-typed `CustomSortComparer` to each sortable DataGrid column, and explicitly set `CanUserSort` to true, ensuring column header clicks trigger sorting even in NativeAOT builds.

**General code maintenance:**

* Added a missing `using System.Collections;` directive in `PackageCollections.cs` to support the new comparer implementation.