### PR TITLE
Clear package search queries when closing to the system tray

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -193,6 +193,14 @@ public partial class MainWindowViewModel : ViewModelBase
             UpdateSettingsSuggestions(value);
     }
 
+    public void ClearAllSearchQueries()
+    {
+        DiscoverPage.ViewModel.ClearSearchQuery();
+        UpdatesPage.ViewModel.ClearSearchQuery();
+        InstalledPage.ViewModel.ClearSearchQuery();
+        GlobalSearchText = "";
+    }
+
     // ─── Settings search suggestions ───────────────────────────────────────────
     public ObservableCollection<SettingsSearchResult> SettingsSuggestions { get; } = new();
 

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -500,6 +500,14 @@ public partial class PackagesPageViewModel : ViewModelBase
             FilterPackages();
     }
 
+    public void ClearSearchQuery()
+    {
+        QueryBackup = "";
+        if (string.IsNullOrEmpty(GlobalQueryText)) return;
+        GlobalQueryText = "";
+        if (!MegaQueryBoxEnabled) FilterPackages();
+    }
+
     [RelayCommand]
     public void SubmitSearch()
     {

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -187,6 +187,7 @@ public partial class MainWindow : Window
         if (!_allowClose && (OperatingSystem.IsMacOS() || !Settings.Get(Settings.K.DisableSystemTray)))
         {
             e.Cancel = true;
+            ViewModel.ClearAllSearchQueries();
             Hide();
             return;
         }


### PR DESCRIPTION
This pull request introduces a new feature that allows all search queries across different pages to be cleared at once, and ensures that search queries are reset when the main window is closed (but not fully exited). The main changes involve adding clear methods to the relevant view models and integrating this functionality into the window closing logic.

**New search query clearing feature:**

* Added a `ClearAllSearchQueries` method to `MainWindowViewModel` that clears search queries on `DiscoverPage`, `UpdatesPage`, and `InstalledPage`, and resets the global search text.
* Added a `ClearSearchQuery` method to `PackagesPageViewModel` that resets the search query state and triggers filtering if necessary.

**Integration with window closing behavior:**

* Modified `OnClosing` in `MainWindow.axaml.cs` to call `ViewModel.ClearAllSearchQueries()` when the window is hidden (e.g., minimized to tray), ensuring that search states are reset.
