### PR TITLE
Fix persistence of ForceInversion checkbox user choices

### DIFF
--- a/src/UniGetUI.Avalonia/Views/Controls/Settings/CheckboxCard.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/Settings/CheckboxCard.cs
@@ -36,18 +36,30 @@ public partial class CheckboxCard : SettingsCard
     {
         set
         {
-            _checkbox.IsCheckedChanged -= _checkbox_Toggled;
             setting_name = value;
             IS_INVERTED = CoreSettings.ResolveKey(value).StartsWith("Disable");
-            _checkbox.IsChecked = CoreSettings.Get(setting_name) ^ IS_INVERTED ^ ForceInversion;
-            _textblock.Opacity = (_checkbox.IsChecked ?? false) ? 1 : 0.7;
-            UpdateStateLabel();
-            _checkbox.IsCheckedChanged += _checkbox_Toggled;
-            SyncToggleItemStatus();
+            RefreshCheckedFromSetting();
         }
     }
 
-    public bool ForceInversion { get; set; }
+    private bool _forceInversion;
+    // Recompute on assignment: in XAML this may be set after SettingName, and the load must reflect it.
+    public bool ForceInversion
+    {
+        get => _forceInversion;
+        set { _forceInversion = value; RefreshCheckedFromSetting(); }
+    }
+
+    private void RefreshCheckedFromSetting()
+    {
+        if (setting_name == CoreSettings.K.Unset) return;
+        _checkbox.IsCheckedChanged -= _checkbox_Toggled;
+        _checkbox.IsChecked = CoreSettings.Get(setting_name) ^ IS_INVERTED ^ ForceInversion;
+        _textblock.Opacity = (_checkbox.IsChecked ?? false) ? 1 : 0.7;
+        UpdateStateLabel();
+        _checkbox.IsCheckedChanged += _checkbox_Toggled;
+        SyncToggleItemStatus();
+    }
 
     public bool Checked => _checkbox.IsChecked ?? false;
 


### PR DESCRIPTION
This pull request refactors how the `ForceInversion` property and the checked state are managed in the `CheckboxCard` control. The main improvements ensure that the checked state is always correctly updated when either the setting name or the inversion flag changes, which addresses issues with property assignment order in XAML.

**Improvements to property handling and state synchronization:**

* Refactored the `ForceInversion` property to a full property with a backing field and setter logic that calls `RefreshCheckedFromSetting()` to ensure the checked state is recalculated when `ForceInversion` changes.
* Moved the logic for updating the checked state into a new `RefreshCheckedFromSetting()` method, which is now called whenever `SettingName` or `ForceInversion` is set, ensuring correct state even if properties are assigned in any order.
* Removed the old auto-property implementation of `ForceInversion` and updated event handler management to avoid duplicate event subscriptions.