### PR TITLE
Fix dark theme rendering as pure black when Mica can't paint

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using Avalonia.Platform;
+using UniGetUI.Avalonia.Assets.Styles;
 
 namespace UniGetUI.Avalonia.Infrastructure;
 
@@ -24,6 +25,7 @@ internal static class MicaWindowHelper
     private const int DWMSBT_TRANSIENTWINDOW = 3; // Acrylic — for transient surfaces (menus/flyouts); Mica won't paint on these
 
     private static bool _acrylicPopupsHooked;
+    private static bool _micaConfirmedUnavailable;
 
     public static void Apply(Window window)
     {
@@ -71,6 +73,9 @@ internal static class MicaWindowHelper
 
     private static void ApplyAcrylicToPopup(TopLevel root)
     {
+        if (!IsMicaEnabled())
+            return;
+
         // Request acrylic (not Transparent): the Transparent level makes a layered window, and DWM
         // system backdrops never paint on those — so the popup ended up fully see-through with only
         // the presenter tint, unreadable when shown over the desktop (e.g. the tray menu). AcrylicBlur
@@ -89,14 +94,36 @@ internal static class MicaWindowHelper
     }
 
     /// <summary>
-    /// True when the native Mica look should be used: Windows 11+ AND the user has
-    /// "Transparency effects" enabled. When transparency is off we keep the solid look,
-    /// since the Mica backdrop otherwise lingers (DWM keeps painting it).
+    /// True when the native Mica look should be used: Windows 11+, "Transparency effects" on,
+    /// GPU-accelerated (software rendering can't be transparent, so Mica shows as black — #5111),
+    /// and no window has since found the backdrop didn't engage. Otherwise keep the solid look.
     /// </summary>
     public static bool IsMicaEnabled()
         => OperatingSystem.IsWindows()
            && Environment.OSVersion.Version.Build >= 22000
+           && !_micaConfirmedUnavailable
+           && !WindowsAvaloniaRenderingPolicy.ShouldUseSoftwareRendering
            && IsOsTransparencyEnabled();
+
+    /// <summary>
+    /// Latch Mica off for the session and drop the translucent surface overrides so every surface
+    /// falls back to the solid look, once a window confirms the backdrop never engaged (#5111).
+    /// </summary>
+    public static void NotifyMicaUnavailable()
+    {
+        if (_micaConfirmedUnavailable)
+            return;
+        _micaConfirmedUnavailable = true;
+
+        if (Application.Current is { } app)
+        {
+            for (int i = app.Resources.MergedDictionaries.Count - 1; i >= 0; i--)
+            {
+                if (app.Resources.MergedDictionaries[i] is WindowsMicaStyles)
+                    app.Resources.MergedDictionaries.RemoveAt(i);
+            }
+        }
+    }
 
     private static bool IsOsTransparencyEnabled()
     {

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -851,6 +851,16 @@ public partial class MainWindow : Window
             return;
         }
 
+        // Mica was requested; None means DWM granted no backdrop, so the transparent window would
+        // render pure black (#5111). Latch Mica off and keep a solid background instead.
+        if (ActualTransparencyLevel == WindowTransparencyLevel.None)
+        {
+            MicaWindowHelper.NotifyMicaUnavailable();
+            if (this.TryFindResource("AppWindowBackground", ActualThemeVariant, out var solidBg) && solidBg is IBrush solidBrush)
+                Background = solidBrush;
+            return;
+        }
+
         // The custom NCCALCSIZE frame keeps WS_THICKFRAME, so DWM still has a frame to round.
         int corner = DWMWCP_ROUND;
         NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));


### PR DESCRIPTION
This pull request improves the reliability and user experience of the Mica visual effect on Windows 11 by adding a fallback mechanism for situations where Mica is unavailable. If the system or hardware cannot provide the Mica effect, the application will now automatically revert to a solid background, preventing rendering issues like pure black windows. The changes also ensure that all surfaces consistently use the fallback style once Mica is confirmed unavailable.

**Mica fallback and reliability improvements:**

* Added a `_micaConfirmedUnavailable` flag and a `NotifyMicaUnavailable()` method in `MicaWindowHelper` to globally disable Mica and remove related styles if the effect is confirmed unavailable. 
* Updated the `IsMicaEnabled()` logic to check for hardware acceleration and the new `_micaConfirmedUnavailable` flag, ensuring Mica is only used when supported.
* Modified `ApplyAcrylicToPopup` to skip applying acrylic if Mica is not enabled, preventing visual glitches on unsupported systems.

**Main window handling:**

* In `MainWindow.axaml.cs`, added logic to detect when Mica is unavailable (`WindowTransparencyLevel.None`), call `NotifyMicaUnavailable()`, and set a solid background brush as a fallback.

**Code organization:**

* Added a missing using directive for `UniGetUI.Avalonia.Assets.Styles` to support style removal in `MicaWindowHelper`.