### PR TITLE
Release Help/Release Notes WebView when leaving the page

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -577,6 +577,13 @@ public partial class MainWindowViewModel : ViewModelBase
         NavigateTo(type);
     }
 
+    private void ReleaseWebViewPage(Control? leftPage)
+    {
+        if (leftPage is null) return;
+        if (ReferenceEquals(leftPage, HelpPage)) { HelpPage?.Dispose(); HelpPage = null; }
+        else if (ReferenceEquals(leftPage, ReleaseNotesPage)) { ReleaseNotesPage?.Dispose(); ReleaseNotesPage = null; }
+    }
+
     private Control GetPageForType(PageType type) =>
         type switch
         {
@@ -643,6 +650,10 @@ public partial class MainWindowViewModel : ViewModelBase
         CurrentPageContent = newPage;
         _oldPage = _currentPage;
         _currentPage = newPage_t;
+
+        // #5129: Help/ReleaseNotes each host a WebView2 that the control never releases on
+        // detach. Drop the page when leaving so its WebView2 process cluster gets freed.
+        ReleaseWebViewPage(oldPage);
 
         if (toHistory && _oldPage is not PageType.Null)
         {

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml.cs
@@ -4,11 +4,12 @@ using UniGetUI.Avalonia.ViewModels.Pages;
 
 namespace UniGetUI.Avalonia.Views.Pages;
 
-public partial class HelpPage : UserControl, IEnterLeaveListener
+public partial class HelpPage : UserControl, IEnterLeaveListener, IDisposable
 {
     private readonly HelpPageViewModel _viewModel;
     private string _pendingNavigation = HelpPageViewModel.HelpBaseUrl;
     private bool _adapterReady;
+    private bool _disposed;
 
     public HelpPage()
     {
@@ -77,4 +78,15 @@ public partial class HelpPage : UserControl, IEnterLeaveListener
 
     private void ReloadButton_Click(object? sender, RoutedEventArgs e) =>
         WebViewControl.Refresh();
+
+    // Detach the WebView so its WebView2 host/controller is released; the page is
+    // rebuilt fresh on next visit (MainWindowViewModel drops the cached instance).
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (!OperatingSystem.IsLinux())
+            WebViewControl.Stop();
+        WebViewBorder.Child = null;
+    }
 }

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml.cs
@@ -3,11 +3,12 @@ using UniGetUI.Avalonia.ViewModels.Pages;
 
 namespace UniGetUI.Avalonia.Views.Pages;
 
-public partial class ReleaseNotesPage : UserControl, IEnterLeaveListener
+public partial class ReleaseNotesPage : UserControl, IEnterLeaveListener, IDisposable
 {
     private readonly ReleaseNotesPageViewModel _viewModel;
     private bool _loaded;
     private bool _adapterReady;
+    private bool _disposed;
 
     public ReleaseNotesPage()
     {
@@ -52,4 +53,15 @@ public partial class ReleaseNotesPage : UserControl, IEnterLeaveListener
     }
 
     public void OnLeave() { }
+
+    // Detach the WebView so its WebView2 host/controller is released; the page is
+    // rebuilt fresh on next visit (MainWindowViewModel drops the cached instance).
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (!OperatingSystem.IsLinux())
+            WebViewControl.Stop();
+        WebViewBorder.Child = null;
+    }
 }


### PR DESCRIPTION
This pull request improves resource management for pages hosting WebView2 controls by ensuring that the associated processes are properly released when navigating away from the Help or Release Notes pages. This change prevents unnecessary resource usage and potential memory leaks by disposing of these pages and their WebView2 instances when they are no longer in use.

**Resource management improvements for WebView2 pages:**

* Added the `IDisposable` interface and a `Dispose` method to both `HelpPage` and `ReleaseNotesPage`, which stops the WebView2 control and detaches it from the UI when the page is disposed. 
* Introduced the `ReleaseWebViewPage` method in `MainWindowViewModel` to dispose of and release cached instances of `HelpPage` and `ReleaseNotesPage` when navigating away from them, ensuring their WebView2 process clusters are freed.
* Updated the navigation logic in `MainWindowViewModel.NavigateTo` to call `ReleaseWebViewPage` when switching pages, further ensuring proper cleanup of WebView2 resources.
