### PR TITLE
Fix window content layout and restore behavior from system tray

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -935,25 +935,19 @@ public partial class MainWindow : Window
         // the top inset, leaving the WS_THICKFRAME left/right/bottom resize border as glass.
         if (msg == WM_NCCALCSIZE && wParam.ToInt64() != 0)
         {
-            // When maximized, Windows places the window so its resize border sits offscreen
-            // (top-left near (-frame, -frame)). Claiming the whole window rect as client then
-            // pushes the title bar's top few pixels off the monitor, clipping the search box
-            // so it hugs the top edge (#5013). While maximized, inset the client rect by the
-            // frame thickness so it fills exactly the visible monitor; keep the full-rect
-            // (borderless, extended) client otherwise.
+            // Maximized: client = work area (the window already equals it), not a phantom frame inset (#5117/#5013).
             if (NativeMethods.IsZoomed(hWnd))
             {
-                uint dpi = NativeMethods.GetDpiForWindow(hWnd);
-                if (dpi == 0) dpi = 96;
-                var border = default(NativeMethods.RECT);
-                if (NativeMethods.AdjustWindowRectExForDpi(ref border, WS_THICKFRAME, false, 0, dpi))
+                nint monitor = NativeMethods.MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+                if (monitor != 0)
                 {
-                    var p = Marshal.PtrToStructure<NativeMethods.NCCALCSIZE_PARAMS>(lParam);
-                    p.rgrc0.Left -= border.Left;
-                    p.rgrc0.Top -= border.Top;
-                    p.rgrc0.Right -= border.Right;
-                    p.rgrc0.Bottom -= border.Bottom;
-                    Marshal.StructureToPtr(p, lParam, false);
+                    var mi = new NativeMethods.MONITORINFO { cbSize = Marshal.SizeOf<NativeMethods.MONITORINFO>() };
+                    if (NativeMethods.GetMonitorInfo(monitor, ref mi))
+                    {
+                        var p = Marshal.PtrToStructure<NativeMethods.NCCALCSIZE_PARAMS>(lParam);
+                        p.rgrc0 = mi.rcWork;
+                        Marshal.StructureToPtr(p, lParam, false);
+                    }
                 }
             }
             handled = true;

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1343,9 +1343,14 @@ public partial class MainWindow : Window
     // ─── BackgroundAPI integration ────────────────────────────────────────────
     public void ShowFromTray()
     {
+        // Show() restores a hidden window to its pre-maximize size, so re-apply Maximized if it was:
+        // a native maximize (Snap Layouts / Win+Up) never updates Avalonia's _showWindowState.
+        bool restoreMaximized = !IsVisible && WindowState == WindowState.Maximized;
         if (!IsVisible)
             Show();
-        if (WindowState == WindowState.Minimized)
+        if (restoreMaximized)
+            WindowState = WindowState.Maximized;
+        else if (WindowState == WindowState.Minimized)
             WindowState = WindowState.Normal;
         Activate();
     }


### PR DESCRIPTION
This pull request makes targeted improvements to how the application window behaves on Windows, especially regarding maximizing and restoring from the system tray. The changes ensure the window is correctly sized and positioned when maximized and that restoring from the tray maintains the expected window state.

**Window Management Improvements:**

* When the window is maximized, the client area now matches the monitor's work area exactly, preventing UI elements from being clipped or positioned offscreen. This replaces the previous logic that applied a phantom frame inset.
* When restoring the window from the system tray, the code now checks if the window was maximized before being hidden and reapplies the maximized state if needed. This ensures consistent behavior, especially when the maximize state wasn't tracked by the UI framework.
