### PR TITLE
auto-size the operations panel to its rows, capped at 3

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -65,11 +65,15 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowFailedOperationBadge))]
+    [NotifyPropertyChangedFor(nameof(OperationsSplitterVisible))]
     private bool _operationsPanelVisible;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowFailedOperationBadge))]
+    [NotifyPropertyChangedFor(nameof(OperationsSplitterVisible))]
     private bool _operationsPanelExpanded = true;
+
+    public bool OperationsSplitterVisible => OperationsPanelVisible && OperationsPanelExpanded;
 
     private readonly List<AbstractOperation> _operationBatch = new();
     private bool _batchSummaryShown;

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -123,7 +123,7 @@
                           Grid.Row="1"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
-                          IsVisible="{Binding OperationsPanelVisible}"
+                          IsVisible="{Binding OperationsSplitterVisible}"
                           automation:AutomationProperties.AccessibilityView="Raw"
                           Background="{DynamicResource AppSplitterBackground}"
                           Opacity="0.8"/>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -119,7 +119,8 @@
             </TransitioningContentControl>
 
             <!-- ── GridSplitter (only visible when operations are present) ── -->
-            <GridSplitter Grid.Row="1"
+            <GridSplitter x:Name="OperationsSplitter"
+                          Grid.Row="1"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           IsVisible="{Binding OperationsPanelVisible}"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -105,6 +106,7 @@ public partial class MainWindow : Window
     // Last user-chosen height (px) of the operations panel; restored when re-expanded.
     private double _operationsPanelHeight = 240;
     private bool _userResizedPanel;
+    private readonly HashSet<OperationViewModel> _badgeSubscriptions = new();
 
     public enum RuntimeNotificationLevel
     {
@@ -136,6 +138,7 @@ public partial class MainWindow : Window
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         ViewModel.Operations.CollectionChanged += OnOperationsCollectionChanged;
         OperationsSplitter.DragCompleted += OnOperationsSplitterDragCompleted;
+        SyncBadgeSubscriptions();
         UpdateOperationsPanelRow();
 
         Resized += (_, _) => _ = SaveGeometryAsync();
@@ -372,11 +375,33 @@ public partial class MainWindow : Window
     {
         if (ViewModel.Operations.Count == 0)
             _userResizedPanel = false;
+        SyncBadgeSubscriptions();
         ScheduleOperationsAutoSize();
     }
 
+    private void SyncBadgeSubscriptions()
+    {
+        _badgeSubscriptions.RemoveWhere(vm =>
+        {
+            if (ViewModel.Operations.Contains(vm))
+                return false;
+            vm.Badges.CollectionChanged -= OnOperationBadgesChanged;
+            return true;
+        });
+
+        foreach (OperationViewModel vm in ViewModel.Operations)
+            if (_badgeSubscriptions.Add(vm))
+                vm.Badges.CollectionChanged += OnOperationBadgesChanged;
+    }
+
+    private void OnOperationBadgesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        => ScheduleOperationsAutoSize();
+
     private void OnOperationsSplitterDragCompleted(object? sender, VectorEventArgs e)
     {
+        if (!ViewModel.OperationsPanelVisible || !ViewModel.OperationsPanelExpanded)
+            return;
+
         if (ContentRoot.RowDefinitions.Count >= 3)
         {
             RowDefinition row = ContentRoot.RowDefinitions[2];

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Specialized;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia;
@@ -103,6 +104,7 @@ public partial class MainWindow : Window
 
     // Last user-chosen height (px) of the operations panel; restored when re-expanded.
     private double _operationsPanelHeight = 240;
+    private bool _userResizedPanel;
 
     public enum RuntimeNotificationLevel
     {
@@ -132,6 +134,8 @@ public partial class MainWindow : Window
         // Title-bar back button: visible whenever there's somewhere to go back to (mirrors WinUI's TitleBar.IsBackButtonVisible).
         ViewModel.CanGoBackChanged += (_, canGoBack) => BackButton.IsVisible = canGoBack;
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        ViewModel.Operations.CollectionChanged += OnOperationsCollectionChanged;
+        OperationsSplitter.DragCompleted += OnOperationsSplitterDragCompleted;
         UpdateOperationsPanelRow();
 
         Resized += (_, _) => _ = SaveGeometryAsync();
@@ -292,7 +296,10 @@ public partial class MainWindow : Window
     {
         if (e.PropertyName is nameof(MainWindowViewModel.OperationsPanelExpanded)
                            or nameof(MainWindowViewModel.OperationsPanelVisible))
+        {
             UpdateOperationsPanelRow();
+            ScheduleOperationsAutoSize();
+        }
 
         // Expanding the panel while an operation has failed jumps to that op (the failure
         // badge on the chevron is what drew the user here).
@@ -314,10 +321,6 @@ public partial class MainWindow : Window
         }, DispatcherPriority.Background);
     }
 
-    // Drive the operations-panel grid row: a resizable pixel height while the panel is
-    // open, Auto otherwise so it collapses to just the toolbar (or vanishes when empty).
-    // The GridSplitter writes the row height directly, so we read it back to preserve the
-    // user's chosen size across collapse/expand.
     private void UpdateOperationsPanelRow()
     {
         if (ContentRoot.RowDefinitions.Count < 3)
@@ -326,16 +329,61 @@ public partial class MainWindow : Window
         RowDefinition row = ContentRoot.RowDefinitions[2];
         if (ViewModel.OperationsPanelVisible && ViewModel.OperationsPanelExpanded)
         {
-            row.MinHeight = 80;
-            row.Height = new GridLength(_operationsPanelHeight, GridUnitType.Pixel);
+            row.MinHeight = 48;
+            double height = _userResizedPanel ? _operationsPanelHeight : ComputeOperationsAutoHeight();
+            if (height <= 0)
+                height = _operationsPanelHeight;
+            row.Height = new GridLength(height, GridUnitType.Pixel);
         }
         else
         {
-            if (row.Height.IsAbsolute && row.Height.Value > 0)
+            if (_userResizedPanel && row.Height.IsAbsolute && row.Height.Value > 0)
                 _operationsPanelHeight = row.Height.Value;
             row.MinHeight = 0;
             row.Height = GridLength.Auto;
         }
+    }
+
+    private double ComputeOperationsAutoHeight()
+    {
+        int count = ViewModel.Operations.Count;
+        if (count == 0)
+            return 0;
+
+        const double chrome = 42;
+        const double fallbackRow = 68;
+
+        double rows = 0;
+        int visible = Math.Min(count, 3);
+        for (int i = 0; i < visible; i++)
+            rows += (OperationsList.ContainerFromIndex(i) as Control)?.Bounds.Height ?? fallbackRow;
+
+        return chrome + rows;
+    }
+
+    private void ScheduleOperationsAutoSize()
+    {
+        if (_userResizedPanel)
+            return;
+        Dispatcher.UIThread.Post(UpdateOperationsPanelRow, DispatcherPriority.Loaded);
+    }
+
+    private void OnOperationsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (ViewModel.Operations.Count == 0)
+            _userResizedPanel = false;
+        ScheduleOperationsAutoSize();
+    }
+
+    private void OnOperationsSplitterDragCompleted(object? sender, VectorEventArgs e)
+    {
+        if (ContentRoot.RowDefinitions.Count >= 3)
+        {
+            RowDefinition row = ContentRoot.RowDefinitions[2];
+            if (row.Height.IsAbsolute && row.Height.Value > 0)
+                _operationsPanelHeight = row.Height.Value;
+        }
+        _userResizedPanel = true;
     }
 
     // ─── Navigation rail / docked pane (responsive) ────────────────────────────


### PR DESCRIPTION
This pull request improves the behavior and user experience of the operations panel in the main window by making its size more responsive and preserving user adjustments. The main changes include tracking when the user resizes the panel, automatically sizing the panel based on its content, and updating the UI more reliably when operations change.

**Operations panel resizing and auto-sizing improvements:**

* The panel now tracks whether the user has manually resized it (`_userResizedPanel`), and only auto-sizes if the user hasn't adjusted it.
* Introduced a method to automatically compute the panel's height based on the number and size of operation items, for a better default experience.
* The minimum height for the operations panel was reduced from 80px to 48px for improved layout flexibility.

**UI event handling and state management:**

* The code now listens for changes in the operations collection and splitter drag events to update the panel size and track user interaction, ensuring the panel responds correctly to content and user actions. 
* The grid splitter is now named (`OperationsSplitter`) for event hookup, and relevant event handlers are added to manage resizing logic. 
