### PR TITLE
surface UAC consent prompt in the foreground

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -14,6 +14,7 @@ using UniGetUI.Avalonia.Extensions;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.Avalonia.Views.Pages;
+using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -140,6 +141,12 @@ public partial class MainWindow : Window
 
         _trayService = new TrayService(this);
         _trayService.UpdateStatus();
+
+        // Let the elevation code activate us right before a UAC prompt, so we own the foreground
+        // and can delegate it to the consent UI (#5146). Only activate when we're already on screen;
+        // don't yank a tray-hidden window forward during silent/background elevation.
+        CoreData.BringMainWindowToForegroundAsync = () =>
+            Dispatcher.UIThread.InvokeAsync(() => { if (IsVisible) ShowFromTray(); }).GetTask();
     }
 
     protected override void OnOpened(EventArgs e)

--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -428,6 +428,14 @@ namespace UniGetUI.Core.Data
         public static string ElevatorArgs = "";
 
         /// <summary>
+        /// Set by the UI layer to bring the main window to the foreground and wait until it is.
+        /// Called right before a UAC prompt is triggered so the app owns the foreground and can
+        /// delegate it to the consent UI (fixes prompts hiding behind the window with secure desktop off).
+        /// Null in headless mode, where no window exists to activate.
+        /// </summary>
+        public static Func<Task>? BringMainWindowToForegroundAsync;
+
+        /// <summary>
         /// This method will return the most appropriate data directory.
         /// If the new directory exists, it will be used.
         /// If the new directory does not exist, but the old directory does, it will be moved to the new location, and the new location will be used.

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -603,6 +603,14 @@ namespace UniGetUI.Core.Tools
             return new Uri(url);
         }
 
+        // Grants every process the right to set the foreground window, bypassing the
+        // foreground lock so a UAC consent prompt can surface in front. ASFW_ANY = -1.
+        private const int ASFW_ANY = -1;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool AllowSetForegroundWindow(int dwProcessId);
+
         /// <summary>
         /// Enables GSudo cache for the current process
         /// </summary>
@@ -656,6 +664,19 @@ namespace UniGetUI.Core.Tools
                         StandardOutputEncoding = Encoding.UTF8,
                     },
                 };
+
+                // This is the one spot where a UAC consent prompt is raised. With secure desktop
+                // off, Windows won't let the prompt steal focus from a background console child,
+                // so it just flashes the taskbar (#5146). Bring our own window to the foreground
+                // first, then delegate that foreground right so the consent UI can come forward.
+                if (OperatingSystem.IsWindows())
+                {
+                    var bringToFront = CoreData.BringMainWindowToForegroundAsync;
+                    if (bringToFront is not null)
+                        await bringToFront();
+                    AllowSetForegroundWindow(ASFW_ANY);
+                }
+
                 p.Start();
                 await p.WaitForExitAsync();
                 _isCaching = false;

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -612,6 +612,23 @@ namespace UniGetUI.Core.Tools
         private static extern bool AllowSetForegroundWindow(int dwProcessId);
 
         /// <summary>
+        /// Windows: bring UniGetUI to the foreground and grant foreground rights so an imminent
+        /// UAC consent prompt surfaces in front instead of only flashing the taskbar (#5146).
+        /// No-op elsewhere, and when the app owns no visible foreground window to delegate.
+        /// Must be called immediately before launching the elevator.
+        /// </summary>
+        public static async Task PrepareForegroundForElevationAsync()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            var bringToFront = CoreData.BringMainWindowToForegroundAsync;
+            if (bringToFront is not null)
+                await bringToFront();
+            AllowSetForegroundWindow(ASFW_ANY);
+        }
+
+        /// <summary>
         /// Enables GSudo cache for the current process
         /// </summary>
         private static bool _isCaching;
@@ -665,17 +682,9 @@ namespace UniGetUI.Core.Tools
                     },
                 };
 
-                // This is the one spot where a UAC consent prompt is raised. With secure desktop
-                // off, Windows won't let the prompt steal focus from a background console child,
-                // so it just flashes the taskbar (#5146). Bring our own window to the foreground
-                // first, then delegate that foreground right so the consent UI can come forward.
-                if (OperatingSystem.IsWindows())
-                {
-                    var bringToFront = CoreData.BringMainWindowToForegroundAsync;
-                    if (bringToFront is not null)
-                        await bringToFront();
-                    AllowSetForegroundWindow(ASFW_ANY);
-                }
+                // When admin-rights caching is enabled, the UAC consent prompt is raised here.
+                // Surface it in front instead of letting it flash unnoticed in the taskbar (#5146).
+                await PrepareForegroundForElevationAsync();
 
                 p.Start();
                 await p.WaitForExitAsync();

--- a/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -106,6 +107,13 @@ public abstract class AbstractProcessOperation : AbstractOperation
         }
 
         CancellationToken.ThrowIfCancellationRequested();
+
+        // When admin-rights caching is disabled (or a cache miss), the elevator is launched
+        // directly here and the UAC prompt is raised at this Start() — bring it to the
+        // foreground too, not just on the cached path (#5146).
+        if (process.StartInfo.FileName == CoreData.ElevatorPath)
+            await CoreTools.PrepareForegroundForElevationAsync();
+
         process.Start();
         if (CancellationToken.IsCancellationRequested)
         {


### PR DESCRIPTION
This pull request improves how the application handles User Account Control (UAC) consent prompts on Windows, ensuring that the consent dialog appears in the foreground and is not hidden behind other windows. The main changes introduce a mechanism for the UI layer to bring the main window forward before a UAC prompt is shown, and update the elevation logic to support this behavior.

**Foreground window activation for UAC prompts:**

* Added a `BringMainWindowToForegroundAsync` delegate to `CoreData`, allowing the UI layer to expose a method for bringing the main window to the foreground before a UAC prompt is triggered. This ensures the consent prompt is not hidden behind other windows, especially when secure desktop is off.
* In `MainWindow.axaml.cs`, set `CoreData.BringMainWindowToForegroundAsync` to a method that brings the window forward only if it is currently visible, preventing the window from being shown unexpectedly if it's hidden in the tray.
* Updated the UAC elevation logic in `Tools.cs` to call `BringMainWindowToForegroundAsync` (if set) and then invoke the Windows API `AllowSetForegroundWindow`, ensuring the consent dialog can take focus.
* Added P/Invoke definitions for `AllowSetForegroundWindow` and related constants to support the above logic.

**Code organization:**

* Added a missing import for `UniGetUI.Core.Data` in `MainWindow.axaml.cs` to support the new delegate.