### PR TITLE
only show OS notifications when the app is hidden

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
@@ -35,7 +35,7 @@ internal static partial class MacOsNotificationBridge
             string message = operation.Metadata.Status.Length > 0
                 ? operation.Metadata.Status
                 : CoreTools.Translate("Please wait...");
-            DeliverNotification(title, message);
+            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Progress, allowInAppFallback: false);
             return true;
         }
         catch (Exception ex)
@@ -57,7 +57,7 @@ internal static partial class MacOsNotificationBridge
             string message = operation.Metadata.SuccessMessage.Length > 0
                 ? operation.Metadata.SuccessMessage
                 : CoreTools.Translate("Success!");
-            DeliverNotification(title, message);
+            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Success, allowInAppFallback: false);
             return true;
         }
         catch (Exception ex)
@@ -79,7 +79,7 @@ internal static partial class MacOsNotificationBridge
             string message = operation.Metadata.FailureMessage.Length > 0
                 ? operation.Metadata.FailureMessage
                 : CoreTools.Translate("An error occurred while processing this package");
-            DeliverNotification(title, message);
+            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Error, allowInAppFallback: false);
             return true;
         }
         catch (Exception ex)
@@ -109,7 +109,7 @@ internal static partial class MacOsNotificationBridge
                 title = CoreTools.Translate("Updates found!");
                 message = CoreTools.Translate("{0} packages can be updated", upgradable.Count);
             }
-            DeliverNotification(title, message);
+            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Success);
         }
         catch (Exception ex)
         {
@@ -135,7 +135,7 @@ internal static partial class MacOsNotificationBridge
                 title = CoreTools.Translate("{0} packages are being updated", upgradable.Count);
                 message = string.Join(", ", upgradable.Select(p => p.Name));
             }
-            DeliverNotification(title, message);
+            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Progress);
         }
         catch (Exception ex)
         {
@@ -150,7 +150,8 @@ internal static partial class MacOsNotificationBridge
         {
             DeliverNotification(
                 CoreTools.Translate("{0} can be updated to version {1}", "UniGetUI", newVersion),
-                CoreTools.Translate("You have currently version {0} installed", CoreData.VersionName));
+                CoreTools.Translate("You have currently version {0} installed", CoreData.VersionName),
+                MainWindow.RuntimeNotificationLevel.Success);
         }
         catch (Exception ex)
         {
@@ -179,7 +180,7 @@ internal static partial class MacOsNotificationBridge
                     "UniGetUI has detected {0} new desktop shortcuts that can be deleted automatically.",
                     shortcuts.Count);
             }
-            DeliverNotification(title, message);
+            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Success);
         }
         catch (Exception ex)
         {
@@ -190,8 +191,20 @@ internal static partial class MacOsNotificationBridge
 
     // ── Core delivery ──────────────────────────────────────────────────────
 
-    private static void DeliverNotification(string title, string message)
+    private static void DeliverNotification(
+        string title,
+        string message,
+        MainWindow.RuntimeNotificationLevel level,
+        bool allowInAppFallback = true)
     {
+        if (MainWindow.IsWindowOnScreen)
+        {
+            if (allowInAppFallback)
+                Dispatcher.UIThread.Post(() =>
+                    MainWindow.Instance?.ShowRuntimeNotification(title, message, level));
+            return;
+        }
+
         if (!EnsureInitialized())
             throw new InvalidOperationException("The macOS notification bridge is unavailable.");
 

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -270,7 +270,10 @@ internal static class WindowsAppNotificationBridge
         bool allowInAppFallback = true)
     {
 #if WINDOWS
-        if (OperatingSystem.IsWindows() && Win32ToastNotifier.IsAvailable())
+        // Only fire an OS toast when the app is out of sight (minimized or hidden to the tray).
+        // While the window is on screen the user can already see the operations panel / in-app
+        // toast, so a native toast would just be noise; fall through to the in-app path instead.
+        if (OperatingSystem.IsWindows() && !MainWindow.IsWindowOnScreen && Win32ToastNotifier.IsAvailable())
         {
             string launchArg = BuildLaunchArgument(launchAction);
             if (Win32ToastNotifier.Show(title, message, launchArg))

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -113,6 +113,11 @@ public partial class MainWindow : Window
 
     public static MainWindow? Instance { get; private set; }
 
+    // True while the window is on screen (visible and not minimized). Read from any thread by
+    // the notification bridge to suppress OS toasts while the user is looking at the app.
+    private static volatile bool _isOnScreen;
+    public static bool IsWindowOnScreen => _isOnScreen;
+
     private MainWindowViewModel ViewModel => (MainWindowViewModel)DataContext!;
     public PageType CurrentPage => ViewModel.CurrentPage_t;
 
@@ -136,7 +141,8 @@ public partial class MainWindow : Window
 
         Resized += (_, _) => _ = SaveGeometryAsync();
         PositionChanged += (_, _) => _ = SaveGeometryAsync();
-        this.GetObservable(WindowStateProperty).SubscribeValue(state => { _ = SaveGeometryAsync(); });
+        this.GetObservable(WindowStateProperty).SubscribeValue(state => { UpdateOnScreenState(); _ = SaveGeometryAsync(); });
+        this.GetObservable(IsVisibleProperty).SubscribeValue(_ => UpdateOnScreenState());
 
         _trayService = new TrayService(this);
         _trayService.UpdateStatus();
@@ -1361,6 +1367,9 @@ public partial class MainWindow : Window
     }
 
     public void UpdateSystemTrayStatus() => _trayService?.UpdateStatus();
+
+    private void UpdateOnScreenState()
+        => _isOnScreen = IsVisible && WindowState != WindowState.Minimized;
 
     public void ShowRuntimeNotification(string title, string message, RuntimeNotificationLevel level) =>
         ShowBanner(title, message, level);


### PR DESCRIPTION
This pull request improves the notification system for both macOS and Windows by making notifications more context-aware and reducing redundant OS toasts when the application window is visible. It introduces a new mechanism to suppress native notifications while the user is actively viewing the app, ensuring that only in-app notifications are shown in this case. The changes also add support for specifying notification levels and controlling in-app fallback behavior.

**Notification delivery improvements:**

* Updated `DeliverNotification` in `MacOsNotificationBridge.cs` to accept a `RuntimeNotificationLevel` and an `allowInAppFallback` flag, allowing finer control over notification type and delivery method. Now, if the main window is visible, notifications are shown in-app instead of as OS toasts.
* All notification methods in `MacOsNotificationBridge.cs` (`ShowProgress`, `ShowSuccess`, `ShowError`, `ShowUpdatesAvailableNotification`, `ShowUpgradingPackagesNotification`, `ShowSelfUpdateAvailableNotification`, `ShowNewShortcutsNotification`) now specify the notification level and, where appropriate, disable in-app fallback to ensure consistent behavior.

**Windows notification logic:**

* Modified `Show` in `WindowsAppNotificationBridge.cs` to only show native OS toasts if the main window is not on screen, preventing duplicate notifications when the user is already looking at the app.

**Main window state tracking:**

* Added a static, thread-safe `_isOnScreen` property to `MainWindow.axaml.cs` to track whether the window is visible and not minimized, and exposed it via `IsWindowOnScreen` for use by notification bridges.
* Hooked into window visibility and state changes to keep `_isOnScreen` up to date, ensuring notification logic always reflects the current UI state.