### PR TITLE
detect Cask updates parsed with "!=" operator

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
@@ -27,7 +27,7 @@ internal sealed class HomebrewSource : ManagerSource
     }
 }
 
-public class Homebrew : PackageManager
+public partial class Homebrew : PackageManager
 {
     // Standard Homebrew installation paths, in priority order
     private static readonly string[] BREW_PATHS =
@@ -230,8 +230,8 @@ public class Homebrew : PackageManager
     //   Formula: "name (old_version) < new_version"  (versions are comparable)
     //   Cask:    "name (old_version) != new_version" (versions are opaque strings)
     // Both operators must be accepted, otherwise cask updates are silently dropped.
-    private static readonly Regex OutdatedLinePattern =
-        new(@"^(\S+)\s+\(([^)]+)\)\s+(?:<|!=)\s+(.+)$");
+    [GeneratedRegex(@"^(\S+)\s+\(([^)]+)\)\s+(?:<|!=)\s+(.+)$")]
+    private static partial Regex OutdatedLineRegex();
 
     protected override IReadOnlyList<Package> GetAvailableUpdates_UnSafe()
     {
@@ -268,7 +268,7 @@ public class Homebrew : PackageManager
         var packages = new List<Package>();
         foreach (var line in lines)
         {
-            var m = OutdatedLinePattern.Match(line);
+            var m = OutdatedLineRegex().Match(line);
             if (!m.Success) continue;
 
             var id = m.Groups[1].Value.Trim();

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/Homebrew.cs
@@ -226,26 +226,49 @@ public class Homebrew : PackageManager
         return packages;
     }
 
+    // "brew outdated --verbose" prints a different comparison operator per package type:
+    //   Formula: "name (old_version) < new_version"  (versions are comparable)
+    //   Cask:    "name (old_version) != new_version" (versions are opaque strings)
+    // Both operators must be accepted, otherwise cask updates are silently dropped.
+    private static readonly Regex OutdatedLinePattern =
+        new(@"^(\S+)\s+\(([^)]+)\)\s+(?:<|!=)\s+(.+)$");
+
     protected override IReadOnlyList<Package> GetAvailableUpdates_UnSafe()
     {
-        var packages = new List<Package>();
-
-        // Build a lookup of installed packages to retrieve their sources
-        Dictionary<string, IPackage> installed = [];
-        foreach (var pkg in GetInstalledPackages())
-            installed.TryAdd(pkg.Id, pkg);
+        IReadOnlyList<IPackage> installed = GetInstalledPackages();
 
         using var p = new Process { StartInfo = MakeBrewStartInfo("outdated --verbose") };
         IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.ListUpdates, p);
         p.Start();
 
-        // Format: "name (old_version) < new_version"
-        var pattern = new Regex(@"^(\S+)\s+\(([^)]+)\)\s+<\s+(.+)$");
+        var lines = new List<string>();
         string? line;
         while ((line = p.StandardOutput.ReadLine()) is not null)
         {
             logger.AddToStdOut(line);
-            var m = pattern.Match(line);
+            lines.Add(line);
+        }
+
+        logger.AddToStdErr(p.StandardError.ReadToEnd());
+        p.WaitForExit();
+        logger.Close(p.ExitCode);
+
+        return ParseAvailableUpdates(lines, installed);
+    }
+
+    internal IReadOnlyList<Package> ParseAvailableUpdates(
+        IEnumerable<string> lines,
+        IEnumerable<IPackage> installedPackages)
+    {
+        // Build a lookup of installed packages to retrieve their sources (Formula vs Cask)
+        Dictionary<string, IPackage> installed = [];
+        foreach (var pkg in installedPackages)
+            installed.TryAdd(pkg.Id, pkg);
+
+        var packages = new List<Package>();
+        foreach (var line in lines)
+        {
+            var m = OutdatedLinePattern.Match(line);
             if (!m.Success) continue;
 
             var id = m.Groups[1].Value.Trim();
@@ -265,9 +288,6 @@ public class Homebrew : PackageManager
                 this));
         }
 
-        logger.AddToStdErr(p.StandardError.ReadToEnd());
-        p.WaitForExit();
-        logger.Close(p.ExitCode);
         return packages;
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.Homebrew/InternalsVisibleTo.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Homebrew/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UniGetUI.PackageEngine.Tests")]

--- a/src/UniGetUI.PackageEngine.Tests/Fixtures/Homebrew/outdated-verbose.txt
+++ b/src/UniGetUI.PackageEngine.Tests/Fixtures/Homebrew/outdated-verbose.txt
@@ -1,0 +1,5 @@
+fontconfig (2.17.1) < 2.18.2
+shaderc (2026.2) < 2026.3
+python@3.14 (3.14.3_1) < 3.14.6
+firefox (152.0.5) != 152.0.6
+visual-studio-code (1.90.0) != 1.91.0

--- a/src/UniGetUI.PackageEngine.Tests/HomebrewManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/HomebrewManagerTests.cs
@@ -1,0 +1,110 @@
+using UniGetUI.Core.Data;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Managers.HomebrewManager;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Assertions;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Helpers;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+[CollectionDefinition("Homebrew manager tests", DisableParallelization = true)]
+public sealed class HomebrewManagerTestCollection
+{
+    public const string Name = "Homebrew manager tests";
+}
+
+[Collection(HomebrewManagerTestCollection.Name)]
+public sealed class HomebrewManagerTests : IDisposable
+{
+    private readonly string _testRoot = Path.Combine(
+        AppContext.BaseDirectory,
+        nameof(HomebrewManagerTests),
+        Guid.NewGuid().ToString("N")
+    );
+
+    public HomebrewManagerTests()
+    {
+        Directory.CreateDirectory(_testRoot);
+        CoreData.TEST_DataDirectoryOverride = Path.Combine(_testRoot, "Data");
+        Directory.CreateDirectory(CoreData.UniGetUIUserConfigurationDirectory);
+        Settings.ResetSettings();
+    }
+
+    public void Dispose()
+    {
+        Settings.ResetSettings();
+        CoreData.TEST_DataDirectoryOverride = null;
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    // Regression test for issue #5127: "brew outdated --verbose" prints "<" for outdated
+    // Formulae but "!=" for outdated Casks. The parser used to match only "<", so Cask
+    // updates were silently dropped. Both operators must produce update packages.
+    [Fact]
+    public void ParseAvailableUpdatesDetectsBothFormulaAndCaskUpdates()
+    {
+        var manager = new Homebrew();
+        IManagerSource formulaSource = manager.SourcesHelper.Factory.GetSourceOrDefault("Homebrew");
+        IManagerSource caskSource = manager.SourcesHelper.Factory.GetSourceOrDefault("Homebrew Cask");
+
+        // Installed packages carry the source (Formula vs Cask) that updates should inherit.
+        var installed = new List<IPackage>
+        {
+            new Package("Fontconfig", "fontconfig", "2.17.1", formulaSource, manager),
+            new Package("Shaderc", "shaderc", "2026.2", formulaSource, manager),
+            new Package("Python@3.14", "python@3.14", "3.14.3_1", formulaSource, manager),
+            new Package("Firefox", "firefox", "152.0.5", caskSource, manager),
+            new Package("Visual Studio Code", "visual-studio-code", "1.90.0", caskSource, manager),
+        };
+
+        var updates = manager.ParseAvailableUpdates(
+            ReadFixtureLines(Path.Combine("Homebrew", "outdated-verbose.txt")),
+            installed
+        );
+
+        Assert.Collection(
+            updates,
+            package =>
+            {
+                PackageAssert.Matches(package, "Fontconfig", "fontconfig", "2.17.1", "2.18.2");
+                PackageAssert.BelongsTo(package, manager, formulaSource);
+            },
+            package =>
+            {
+                PackageAssert.Matches(package, "Shaderc", "shaderc", "2026.2", "2026.3");
+                PackageAssert.BelongsTo(package, manager, formulaSource);
+            },
+            package =>
+            {
+                PackageAssert.Matches(package, "Python@3.14", "python@3.14", "3.14.3_1", "3.14.6");
+                PackageAssert.BelongsTo(package, manager, formulaSource);
+            },
+            // The two Casks below (matched via "!=") were the ones dropped by the old parser.
+            package =>
+            {
+                PackageAssert.Matches(package, "Firefox", "firefox", "152.0.5", "152.0.6");
+                PackageAssert.BelongsTo(package, manager, caskSource);
+            },
+            package =>
+            {
+                PackageAssert.Matches(
+                    package,
+                    "Visual Studio Code",
+                    "visual-studio-code",
+                    "1.90.0",
+                    "1.91.0"
+                );
+                PackageAssert.BelongsTo(package, manager, caskSource);
+            }
+        );
+    }
+
+    private static string[] ReadFixtureLines(string relativePath)
+    {
+        return PackageEngineFixtureFiles.ReadAllText(relativePath).Replace("\r\n", "\n").Split('\n');
+    }
+}

--- a/src/UniGetUI.PackageEngine.Tests/UniGetUI.PackageEngine.Tests.csproj
+++ b/src/UniGetUI.PackageEngine.Tests/UniGetUI.PackageEngine.Tests.csproj
@@ -31,6 +31,7 @@
         <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Npm\UniGetUI.PackageEngine.Managers.Npm.csproj" />
         <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Snap\UniGetUI.PackageEngine.Managers.Snap.csproj" />
         <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Flatpak\UniGetUI.PackageEngine.Managers.Flatpak.csproj" />
+        <ProjectReference Include="..\UniGetUI.PackageEngine.Managers.Homebrew\UniGetUI.PackageEngine.Managers.Homebrew.csproj" />
         <ProjectReference Include="..\UniGetUI.PackageEngine.Interfaces\UniGetUI.PackageEngine.Interfaces.csproj" />
         <ProjectReference Include="..\UniGetUI.Interface.Enums\UniGetUI.Interface.Enums.csproj" />
         <ProjectReference Include="..\UniGetUI.PackageEngine.Enums\UniGetUI.PackageEngine.Structs.csproj" />


### PR DESCRIPTION
This pull request improves the handling and testing of Homebrew package updates, specifically ensuring that both Formula and Cask updates are detected correctly. The main changes include updating the outdated package parsing logic to support multiple comparison operators, refactoring the parser for testability, and adding regression tests to prevent similar issues in the future.

**Homebrew update detection improvements:**

* Updated the outdated package parsing logic in `Homebrew.cs` to accept both `<` (Formula) and `!=` (Cask) operators, ensuring that updates for both types are detected and processed. Previously, only `<` was accepted, causing Cask updates to be silently dropped.
* Refactored the parsing logic into a new internal method `ParseAvailableUpdates`, making it easier to unit test and maintain.

**Testing and test infrastructure:**

* Added a regression test in `HomebrewManagerTests.cs` to verify that both Formula and Cask updates are detected, preventing future regressions.
* Added a test fixture file `outdated-verbose.txt` containing sample output for both Formula and Cask updates.
* Updated the test project references and added `InternalsVisibleTo` for test access to internal members.
