### PR TITLE
Add icon for GestureSign V2

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -52527,6 +52527,10 @@
         "https://i.postimg.cc/L8HRGfpc/image.png"
       ]
     },
+    "gesturesignv2": {
+      "icon": "https://raw.githubusercontent.com/Tomclanc/GestureSignv2/main/docs/assets/logo.png",
+      "images": []
+    },
     "websitewatcher": {
       "icon": "https://i.postimg.cc/rsRYp50F/wsw.png",
       "images": [


### PR DESCRIPTION
Adds an icon entry for the WinGet package [`Tomclanc.GestureSignV2`](https://github.com/Tomclanc/GestureSignv2), which currently falls back to the generic package icon in UniGetUI.

- **Normalized icon ID:** `gesturesignv2` (matching UniGetUI's WinGet `GenerateIconId` behavior)
- **Icon:** square 256×256 transparent PNG hosted in the package's official repository
- **Icon URL:** `https://raw.githubusercontent.com/Tomclanc/GestureSignv2/main/docs/assets/logo.png`

Validation performed:
- `screenshot-database-v2.json` parses successfully
- icon URL returns HTTP 200 with `image/png`
- change is limited to the new four-line database entry