### PR TITLE
Persist typed-but-uncommitted Close Apps process name

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
@@ -556,6 +556,7 @@ public partial class InstallOptionsViewModel : ObservableObject
 
     private void ApplyToOptions()
     {
+        AddKillProcess(); // flush any process name typed but not yet committed to a chip
         var s = SnapshotOptions();
         _options.RunAsAdministrator = s.RunAsAdministrator;
         _options.InteractiveInstallation = s.InteractiveInstallation;


### PR DESCRIPTION
This pull request makes a minor improvement to the `InstallOptionsViewModel` by ensuring that any process name entered by the user, but not yet committed, is added before applying installation options. This helps prevent potential loss of user input when applying options.

* Ensured that `AddKillProcess()` is called before taking a snapshot of options in `ApplyToOptions()`, so any uncommitted process name is flushed and included in the options.