### PR TITLE
Fix PowerShell modules always updating in CurrentUser scope

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
@@ -9,6 +9,7 @@ using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.ManagerClasses.Classes;
 using UniGetUI.PackageEngine.ManagerClasses.Manager;
 using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.Structs;
 
 namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 {
@@ -234,6 +235,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                         packageVers.Append(package.VersionString + "|");
                         packageIdVersion[package.Id.ToLower()] = package.VersionString;
                     }
+                    var packageIdScope = BuildInstalledScopeMap(pair.Value);
 
                     var SearchUrl =
                         $"{pair.Key.Url.ToString().Trim('/')}/GetUpdates()"
@@ -260,41 +262,16 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                             .Content.ReadAsStringAsync()
                             .GetAwaiter()
                             .GetResult();
-                        MatchCollection matches = Regex.Matches(
-                            SearchResults,
-                            "<entry>([\\s\\S]*?)<\\/entry>"
-                        );
-
-                        foreach (Match match in matches)
-                        {
-                            if (!match.Success)
-                                continue;
-
-                            string id = Regex
-                                .Match(match.Value, "<d:Id>([^<]+)</d:Id>")
-                                .Groups[1]
-                                .Value;
-                            string new_version = Regex
-                                .Match(match.Value, "<d:Version>([^<]+)</d:Version>")
-                                .Groups[1]
-                                .Value;
-                            // Match title = Regex.Match(match.Value, "<title[ \\\"\\=A-Za-z0-9]+>([^<>]+)<\\/title>");
-
-                            logger.Log(
-                                $"Found package {id} version {new_version} on source {pair.Key.Name}"
-                            );
-
-                            var nativePackage = new Package(
-                                CoreTools.FormatAsName(id),
-                                id,
-                                packageIdVersion[id.ToLower()],
-                                new_version,
+                        Packages.AddRange(
+                            ParseUpdatesResponse(
+                                SearchResults,
+                                packageIdVersion,
+                                packageIdScope,
                                 pair.Key,
-                                this
-                            );
-                            Packages.Add(nativePackage);
-                            Manifests[nativePackage.GetHash()] = match.Value;
-                        }
+                                this,
+                                logger
+                            )
+                        );
                     }
                 }
                 catch (Exception ex)
@@ -320,6 +297,75 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             return Packages
                 .Where(p => maxVersions[p.Id.ToLower()] < p.NormalizedNewVersion)
                 .ToArray();
+        }
+
+        /// <summary>
+        /// Maps each installed package id (lowercased) to the scope its update should target.
+        /// When a package is installed in both scopes, the system-wide (Machine) scope wins so
+        /// the AllUsers copy never stays stale (regression guard for issue #5163).
+        /// </summary>
+        internal static Dictionary<string, string?> BuildInstalledScopeMap(
+            IEnumerable<IPackage> installedPackages
+        )
+        {
+            var scopeMap = new Dictionary<string, string?>();
+            foreach (var package in installedPackages)
+            {
+                string key = package.Id.ToLower();
+                string? scope = package.OverridenOptions.Scope;
+                if (scope == PackageScope.Machine || !scopeMap.ContainsKey(key))
+                    scopeMap[key] = scope;
+            }
+            return scopeMap;
+        }
+
+        /// <summary>
+        /// Parses a NuGet OData GetUpdates() response into update packages, carrying each
+        /// installed package's scope onto its update so operations (e.g. Update-PSResource
+        /// -Scope) don't silently fall back to CurrentUser (regression guard for issue #5163).
+        /// </summary>
+        internal static List<Package> ParseUpdatesResponse(
+            string searchResults,
+            IReadOnlyDictionary<string, string> packageIdVersion,
+            IReadOnlyDictionary<string, string?> packageIdScope,
+            IManagerSource source,
+            BaseNuGet manager,
+            INativeTaskLogger? logger = null
+        )
+        {
+            var packages = new List<Package>();
+            MatchCollection matches = Regex.Matches(searchResults, "<entry>([\\s\\S]*?)<\\/entry>");
+
+            foreach (Match match in matches)
+            {
+                if (!match.Success)
+                    continue;
+
+                string id = Regex.Match(match.Value, "<d:Id>([^<]+)</d:Id>").Groups[1].Value;
+                string new_version = Regex
+                    .Match(match.Value, "<d:Version>([^<]+)</d:Version>")
+                    .Groups[1]
+                    .Value;
+
+                if (!packageIdVersion.TryGetValue(id.ToLower(), out string? installedVersion))
+                    continue;
+
+                logger?.Log($"Found package {id} version {new_version} on source {source.Name}");
+
+                var nativePackage = new Package(
+                    CoreTools.FormatAsName(id),
+                    id,
+                    installedVersion,
+                    new_version,
+                    source,
+                    manager,
+                    new OverridenInstallationOptions(packageIdScope.GetValueOrDefault(id.ToLower()))
+                );
+                packages.Add(nativePackage);
+                Manifests[nativePackage.GetHash()] = match.Value;
+            }
+
+            return packages;
         }
 
         protected sealed override IReadOnlyList<Package> GetInstalledPackages_UnSafe() =>

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
@@ -301,8 +301,12 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
         /// <summary>
         /// Maps each installed package id (lowercased) to the scope its update should target.
-        /// When a package is installed in both scopes, the system-wide (Machine) scope wins so
-        /// the AllUsers copy never stays stale (regression guard for issue #5163).
+        /// Mirrors the last-wins keying of the version map so the scope and the installed
+        /// version always come from the same enumerated package (issue #5163). A module
+        /// installed in a single scope updates in that scope; a module installed in both
+        /// resolves to whichever scope is enumerated last (as its version does) — surfacing
+        /// an independent update per scope would require scope-aware package identity, which
+        /// the upgrade loader does not currently support.
         /// </summary>
         internal static Dictionary<string, string?> BuildInstalledScopeMap(
             IEnumerable<IPackage> installedPackages
@@ -310,12 +314,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
         {
             var scopeMap = new Dictionary<string, string?>();
             foreach (var package in installedPackages)
-            {
-                string key = package.Id.ToLower();
-                string? scope = package.OverridenOptions.Scope;
-                if (scope == PackageScope.Machine || !scopeMap.ContainsKey(key))
-                    scopeMap[key] = scope;
-            }
+                scopeMap[package.Id.ToLower()] = package.OverridenOptions.Scope;
             return scopeMap;
         }
 

--- a/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
@@ -159,21 +159,25 @@ public sealed class PowerShell7ManagerTests
         Assert.DoesNotContain("AllUsers", parameters);
     }
 
-    // A module installed in both scopes must update its system-wide (AllUsers) copy so it
-    // never stays stale, regardless of the order the scopes are reported in.
+    // For a module installed in both scopes, the resolved update scope must track the same
+    // enumerated package as the installed version (last-wins), so the two never disagree.
+    // Independent per-scope updates aren't representable in the scope-blind upgrade loader.
     [Fact]
-    public void BuildInstalledScopeMap_PrefersMachineWhenInstalledInBothScopes()
+    public void BuildInstalledScopeMap_TracksSameEnumeratedPackageAsVersion()
     {
         var manager = new PowerShell7();
         var installed = PowerShell7.ParseInstalledPackages(
             [
                 "##SCOPE:AllUsers##", "Devolutions.PowerShell\t2025.1.0\tPSGallery",
-                "##SCOPE:CurrentUser##", "Devolutions.PowerShell\t2025.1.0\tPSGallery",
+                "##SCOPE:CurrentUser##", "Devolutions.PowerShell\t2025.2.0\tPSGallery",
             ], manager);
 
         var idScope = BaseNuGet.BuildInstalledScopeMap(installed);
 
-        Assert.Equal(PackageScope.Machine, idScope["devolutions.powershell"]);
+        // CurrentUser is enumerated last, so both the version (2025.2.0) and the scope resolve to it
+        Assert.Equal(PackageScope.User, idScope["devolutions.powershell"]);
+        Assert.Equal("2025.2.0", installed[^1].VersionString);
+        Assert.Equal(PackageScope.User, installed[^1].OverridenOptions.Scope);
     }
 
     // Regression for https://github.com/Devolutions/UniGetUI/issues/4781:

--- a/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PowerShell7ManagerTests.cs
@@ -1,6 +1,7 @@
 #if WINDOWS
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Managers.PowerShell7Manager;
+using UniGetUI.PackageEngine.Managers.PowerShellManager;
 using UniGetUI.PackageEngine.Serializable;
 
 namespace UniGetUI.PackageEngine.Tests;
@@ -108,6 +109,71 @@ public sealed class PowerShell7ManagerTests
 
         Assert.Contains("AllUsers", parameters);
         Assert.DoesNotContain("CurrentUser", parameters);
+    }
+
+    // Regression for https://github.com/Devolutions/UniGetUI/issues/5163:
+    // the update-list package produced from the GetUpdates() response must carry the
+    // installed scope, otherwise Update-PSResource silently defaults to CurrentUser and
+    // the AllUsers copy never updates.
+    [Fact]
+    public void ParseUpdatesResponse_CarriesAllUsersScopeOntoUpdate()
+    {
+        var manager = new PowerShell7();
+        var installed = PowerShell7.ParseInstalledPackages(
+            ["##SCOPE:AllUsers##", "Devolutions.PowerShell\t2025.1.0\tPSGallery"], manager);
+        var source = installed[0].Source;
+        var idVersion = new Dictionary<string, string> { ["devolutions.powershell"] = "2025.1.0" };
+        var idScope = BaseNuGet.BuildInstalledScopeMap(installed);
+
+        var xml = "<entry><d:Id>Devolutions.PowerShell</d:Id><d:Version>2025.2.0</d:Version></entry>";
+        var update = Assert.Single(
+            BaseNuGet.ParseUpdatesResponse(xml, idVersion, idScope, source, manager));
+
+        Assert.Equal("2025.1.0", update.VersionString);
+        Assert.Equal("2025.2.0", update.NewVersionString);
+        Assert.Equal(PackageScope.Machine, update.OverridenOptions.Scope);
+
+        var parameters = manager.OperationHelper.GetParameters(update, new InstallOptions(), OperationType.Update);
+        Assert.Contains("AllUsers", parameters);
+        Assert.DoesNotContain("CurrentUser", parameters);
+    }
+
+    [Fact]
+    public void ParseUpdatesResponse_CurrentUserModuleStaysCurrentUser()
+    {
+        var manager = new PowerShell7();
+        var installed = PowerShell7.ParseInstalledPackages(
+            ["##SCOPE:CurrentUser##", "Devolutions.PowerShell\t2025.1.0\tPSGallery"], manager);
+        var source = installed[0].Source;
+        var idVersion = new Dictionary<string, string> { ["devolutions.powershell"] = "2025.1.0" };
+        var idScope = BaseNuGet.BuildInstalledScopeMap(installed);
+
+        var xml = "<entry><d:Id>Devolutions.PowerShell</d:Id><d:Version>2025.2.0</d:Version></entry>";
+        var update = Assert.Single(
+            BaseNuGet.ParseUpdatesResponse(xml, idVersion, idScope, source, manager));
+
+        Assert.Equal(PackageScope.User, update.OverridenOptions.Scope);
+
+        var parameters = manager.OperationHelper.GetParameters(update, new InstallOptions(), OperationType.Update);
+        Assert.Contains("CurrentUser", parameters);
+        Assert.DoesNotContain("AllUsers", parameters);
+    }
+
+    // A module installed in both scopes must update its system-wide (AllUsers) copy so it
+    // never stays stale, regardless of the order the scopes are reported in.
+    [Fact]
+    public void BuildInstalledScopeMap_PrefersMachineWhenInstalledInBothScopes()
+    {
+        var manager = new PowerShell7();
+        var installed = PowerShell7.ParseInstalledPackages(
+            [
+                "##SCOPE:AllUsers##", "Devolutions.PowerShell\t2025.1.0\tPSGallery",
+                "##SCOPE:CurrentUser##", "Devolutions.PowerShell\t2025.1.0\tPSGallery",
+            ], manager);
+
+        var idScope = BaseNuGet.BuildInstalledScopeMap(installed);
+
+        Assert.Equal(PackageScope.Machine, idScope["devolutions.powershell"]);
     }
 
     // Regression for https://github.com/Devolutions/UniGetUI/issues/4781:


### PR DESCRIPTION
This pull request improves how NuGet-based package managers handle update detection and scope assignment, specifically addressing issues where PowerShell modules installed for "AllUsers" were not being updated correctly. The changes ensure that updates inherit the correct installation scope, preventing regressions where updates defaulted to the wrong user context. The update logic is now more robust and thoroughly tested.

Key improvements and fixes:

**Update Detection and Scope Handling:**
* Refactored the update detection logic in `BaseNuGet.cs` to parse update responses using a new `ParseUpdatesResponse` method, which ensures each update package carries the correct installed scope. This prevents updates from incorrectly defaulting to "CurrentUser" when the package was installed for "AllUsers". 
* Introduced the `BuildInstalledScopeMap` utility to map installed package IDs to their scopes, mirroring the version selection logic so that both version and scope are consistently determined. 

**Testing and Regression Coverage:**
* Added comprehensive unit tests in `PowerShell7ManagerTests.cs` to verify that update packages inherit the correct scope, including scenarios for "AllUsers", "CurrentUser", and packages installed in both scopes. These tests specifically guard against regressions.
* Updated test imports to include the new utilities and ensure test coverage for the refactored logic.

**Code Maintenance:**
* Added missing namespace imports in `BaseNuGet.cs` for consistency and to support the new logic.