### PR TITLE
Honor explicit per-package install location on WinGet update

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -124,7 +124,13 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
                 }
                 else if (
                     options.CustomInstallLocation != ""
-                    && Settings.Get(Settings.K.WinGetForceLocationOnUpdate)
+                    // A location set explicitly for this package is honored on update (issue #5164).
+                    // A location inherited from the manager-wide default stays opt-in behind the
+                    // setting, so updates don't relocate existing installs wholesale (issue #4210).
+                    && (
+                        options.CustomInstallLocationIsExplicit
+                        || Settings.Get(Settings.K.WinGetForceLocationOnUpdate)
+                    )
                 )
                 {
                     parameters.AddRange(["--location", $"\"{options.CustomInstallLocation}\""]);

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallOptionsFactory.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallOptionsFactory.cs
@@ -72,6 +72,12 @@ namespace UniGetUI.PackageEngine.PackageClasses
         )
         {
             var instance = overridePackageOptions ?? LoadForPackage(package);
+
+            // A location typed into this package's own options is an explicit, per-package choice;
+            // one inherited from the manager default below is not. Consumers (e.g. WinGet updates)
+            // use this to honor explicit locations while keeping manager-wide defaults opt-in.
+            bool locationIsExplicit = instance.OverridesNextLevelOpts;
+
             if (!instance.OverridesNextLevelOpts)
             {
                 Logger.Debug(
@@ -85,6 +91,8 @@ namespace UniGetUI.PackageEngine.PackageClasses
                     legalizedId
                 );
             }
+
+            instance.CustomInstallLocationIsExplicit = locationIsExplicit;
 
             if (elevated is not null)
                 instance.RunAsAdministrator = (bool)elevated;

--- a/src/UniGetUI.PackageEngine.Serializable/InstallOptions.cs
+++ b/src/UniGetUI.PackageEngine.Serializable/InstallOptions.cs
@@ -220,6 +220,10 @@ namespace UniGetUI.PackageEngine.Serializable
 
         public bool OverridesNextLevelOpts { get; set; }
 
+        // True when CustomInstallLocation was set explicitly for this package rather than inherited
+        // from the manager-wide default. Transient (not serialized): set by InstallOptionsFactory.
+        public bool CustomInstallLocationIsExplicit { get; set; }
+
         public override InstallOptions Copy()
         {
             var copy = new InstallOptions();
@@ -233,8 +237,9 @@ namespace UniGetUI.PackageEngine.Serializable
             foreach (var listKey in _listKeys)
                 copy._listVal[listKey] = this._listVal[listKey].ToList();
 
-            // Handle non-automated OverridesNextLevelOpts
+            // Handle non-automated properties
             copy.OverridesNextLevelOpts = OverridesNextLevelOpts;
+            copy.CustomInstallLocationIsExplicit = CustomInstallLocationIsExplicit;
             return copy;
         }
 

--- a/src/UniGetUI.PackageEngine.Tests/InstallOptionsFactoryTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/InstallOptionsFactoryTests.cs
@@ -70,6 +70,26 @@ public sealed class InstallOptionsFactoryTests : IDisposable
             resolved.CustomInstallLocation
         );
         Assert.True(resolved.InteractiveInstallation);
+        Assert.False(resolved.CustomInstallLocationIsExplicit);
+    }
+
+    [Fact]
+    public void LoadApplicable_MarksLocationExplicitOnlyForPerPackageOverrides()
+    {
+        var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();
+
+        var explicitPackage = new PackageBuilder().WithManager(manager).WithId($"Pkg{Guid.NewGuid():N}").Build();
+        InstallOptionsFactory.SaveForPackage(
+            new InstallOptions { OverridesNextLevelOpts = true, CustomInstallLocation = @"D:\dev\app" },
+            explicitPackage
+        );
+
+        var inheritedPackage = new PackageBuilder().WithManager(manager).WithId($"Pkg{Guid.NewGuid():N}").Build();
+        InstallOptionsFactory.SaveForManager(new InstallOptions { CustomInstallLocation = @"D:\Apps\%PACKAGE%" }, manager);
+        InstallOptionsFactory.SaveForPackage(new InstallOptions(), inheritedPackage);
+
+        Assert.True(InstallOptionsFactory.LoadApplicable(explicitPackage).CustomInstallLocationIsExplicit);
+        Assert.False(InstallOptionsFactory.LoadApplicable(inheritedPackage).CustomInstallLocationIsExplicit);
     }
 
     [Fact]

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -859,6 +859,106 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void WinGetUpdateEmitsExplicitLocationEvenWhenForceSettingIsOff()
+    {
+        // #5164: a location set explicitly for this package is honored on update on its own.
+        Settings.Set(Settings.K.WinGetForceLocationOnUpdate, false);
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.ExplicitLocation")
+            .WithVersion("1.0.0")
+            .WithNewVersion("2.0.0")
+            .Build();
+        var options = new InstallOptions
+        {
+            CustomInstallLocation = @"D:\dev\contoso",
+            CustomInstallLocationIsExplicit = true,
+        };
+
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.Contains("--location", parameters);
+        Assert.Contains("\"D:\\dev\\contoso\"", parameters);
+    }
+
+    [Fact]
+    public void WinGetUpdateOmitsInheritedLocationWhenForceSettingIsOff()
+    {
+        // #4210: a location inherited from the manager-wide default must not relocate installs
+        // on update unless the user opts in.
+        Settings.Set(Settings.K.WinGetForceLocationOnUpdate, false);
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.InheritedLocation")
+            .WithVersion("1.0.0")
+            .WithNewVersion("2.0.0")
+            .Build();
+        var options = new InstallOptions
+        {
+            CustomInstallLocation = @"D:\Apps\Contoso.InheritedLocation",
+            CustomInstallLocationIsExplicit = false,
+        };
+
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.DoesNotContain("--location", parameters);
+    }
+
+    [Fact]
+    public void WinGetUpdateEmitsInheritedLocationWhenForceSettingIsOn()
+    {
+        // #4210: the manager-wide default is still applied on update when the user opts in.
+        Settings.Set(Settings.K.WinGetForceLocationOnUpdate, true);
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.InheritedForced")
+            .WithVersion("1.0.0")
+            .WithNewVersion("2.0.0")
+            .Build();
+        var options = new InstallOptions
+        {
+            CustomInstallLocation = @"D:\Apps\Contoso.InheritedForced",
+            CustomInstallLocationIsExplicit = false,
+        };
+
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.Contains("--location", parameters);
+        Assert.Contains("\"D:\\Apps\\Contoso.InheritedForced\"", parameters);
+    }
+
+    [Fact]
+    public void WinGetUpdateOmitsExplicitLocationForPingetUpgrade()
+    {
+        // Pinget upgrade rejects --location, so #5164's explicit-location behavior is scoped to
+        // system WinGet: even an explicit location (with the setting on) must not be emitted.
+        Settings.Set(Settings.K.WinGetForceLocationOnUpdate, true);
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.BundledPinget);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.PingetExplicit")
+            .WithVersion("1.0.0")
+            .WithNewVersion("2.0.0")
+            .Build();
+        var options = new InstallOptions
+        {
+            CustomInstallLocation = @"D:\dev\contoso",
+            CustomInstallLocationIsExplicit = true,
+        };
+
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.DoesNotContain("--location", parameters);
+    }
+
+    [Fact]
     public void WinGetOperationHelperSkipsUnsupportedFlagsForPingetUninstall()
     {
         var manager = new WinGet();


### PR DESCRIPTION
This pull request improves how custom install locations are handled for package installations and updates, ensuring that only explicitly set per-package locations are always honored, while manager-wide defaults remain opt-in for updates. The main changes introduce a new property to track whether a custom location was set explicitly for a package, and update the logic and tests accordingly.

**Custom Install Location Handling:**

* Added a `CustomInstallLocationIsExplicit` property to the `InstallOptions` class to indicate if a location was set explicitly for a package rather than inherited from a manager-wide default. This property is transient and not serialized.
* Updated the `InstallOptions.Copy()` method to ensure the new `CustomInstallLocationIsExplicit` property is copied correctly.

**Install Options Factory Logic:**

* Modified `InstallOptionsFactory.LoadApplicable` to set `CustomInstallLocationIsExplicit` based on whether the location was explicitly set for the package (`OverridesNextLevelOpts`).

**WinGet Package Operation Logic:**

* Updated the logic in `WinGetPkgOperationHelper.cs` so that on updates, only explicit per-package install locations are always honored; inherited manager-wide defaults require the opt-in setting as before. This prevents unintended relocation of existing installs.

**Testing:**

* Added a new test to `InstallOptionsFactoryTests` to verify that `CustomInstallLocationIsExplicit` is correctly set for explicit per-package overrides and not for inherited manager defaults.
