### PR TITLE
export installed packages and updates to CSV

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -887,5 +887,11 @@
   "{package} installer and manifest download": "{package} installer and manifest download",
   "{0} installer and manifest are being downloaded": "{0} installer and manifest are being downloaded",
   "{package} installer and manifest were downloaded successfully": "{package} installer and manifest were downloaded successfully",
-  "{package} installer and manifest could not be downloaded": "{package} installer and manifest could not be downloaded"
+  "{package} installer and manifest could not be downloaded": "{package} installer and manifest could not be downloaded",
+  "Export to CSV": "Export to CSV",
+  "Nothing to export": "Nothing to export",
+  "There are no packages to export.": "There are no packages to export.",
+  "CSV file": "CSV file",
+  "The file was saved to {0}": "The file was saved to {0}",
+  "The file could not be saved:": "The file could not be saved:"
 }

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using System.Text;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
@@ -12,8 +14,6 @@ using Avalonia.Media;
 using Avalonia.Media.Transformation;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
-using System.IO;
-using System.Text;
 using UniGetUI.Avalonia.Extensions;
 using UniGetUI.Avalonia.ViewModels.Pages;
 using UniGetUI.Avalonia.Views.Controls;

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -641,6 +641,12 @@ public abstract partial class AbstractPackagesPage : UserControl,
     private static string CsvEscape(string? field)
     {
         field ??= "";
+
+        // Guard against spreadsheet formula injection (CWE-1236): package metadata is
+        // external, and a value starting with one of these executes as a formula in Excel/Sheets.
+        if (field.Length > 0 && "=+-@\t\r".IndexOf(field[0]) >= 0)
+            field = "'" + field;
+
         if (field.IndexOfAny(['"', ',', '\n', '\r']) >= 0)
             return "\"" + field.Replace("\"", "\"\"") + "\"";
         return field;

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -10,10 +10,14 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Transformation;
+using Avalonia.Platform.Storage;
 using Avalonia.Threading;
+using System.IO;
+using System.Text;
 using UniGetUI.Avalonia.Extensions;
 using UniGetUI.Avalonia.ViewModels.Pages;
 using UniGetUI.Avalonia.Views.Controls;
+using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Interfaces;
@@ -559,4 +563,86 @@ public abstract partial class AbstractPackagesPage : UserControl,
     protected static MainWindow? GetMainWindow()
         => Application.Current?.ApplicationLifetime
             is IClassicDesktopStyleApplicationLifetime { MainWindow: MainWindow w } ? w : null;
+
+    // ─── CSV export ───────────────────────────────────────────────────────────
+    // Exports the checked packages, or the whole filtered list when nothing is checked.
+    protected async Task ExportPackagesToCsvAsync()
+    {
+        if (GetMainWindow() is not { } win) return;
+
+        var vm = ViewModel;
+        var packages = vm.FilteredPackages.GetCheckedPackages();
+        if (packages.Count == 0) packages = vm.FilteredPackages.GetPackages();
+
+        if (packages.Count == 0)
+        {
+            MainWindow.Instance?.ShowBanner(
+                CoreTools.Translate("Nothing to export"),
+                CoreTools.Translate("There are no packages to export."),
+                MainWindow.RuntimeNotificationLevel.Error);
+            return;
+        }
+
+        var file = await win.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            SuggestedFileName = CoreTools.MakeValidFileName(vm.PageTitle) + ".csv",
+            FileTypeChoices =
+            [
+                new FilePickerFileType(CoreTools.Translate("CSV file")) { Patterns = ["*.csv"] },
+            ],
+        });
+
+        var path = file?.TryGetLocalPath();
+        if (path is null) return;
+
+        try
+        {
+            // UTF-8 BOM so Excel renders accented package names correctly
+            await File.WriteAllTextAsync(path, BuildCsv(packages, vm.RoleIsUpdateLike), new UTF8Encoding(true));
+
+            MainWindow.Instance?.ShowBanner(
+                CoreTools.Translate("Success!"),
+                CoreTools.Translate("The file was saved to {0}", path),
+                MainWindow.RuntimeNotificationLevel.Success);
+
+            await CoreTools.ShowFileOnExplorer(path);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("An error occurred while exporting packages to CSV");
+            Logger.Error(ex);
+            MainWindow.Instance?.ShowBanner(
+                CoreTools.Translate("An error occurred"),
+                CoreTools.Translate("The file could not be saved:") + " " + ex.Message,
+                MainWindow.RuntimeNotificationLevel.Error);
+        }
+    }
+
+    private static string BuildCsv(IReadOnlyList<IPackage> packages, bool includeNewVersion)
+    {
+        var sb = new StringBuilder();
+
+        var header = new List<string> { CoreTools.Translate("Package Name"), CoreTools.Translate("Package ID"), CoreTools.Translate("Version") };
+        if (includeNewVersion) header.Add(CoreTools.Translate("New version"));
+        header.Add(CoreTools.Translate("Source"));
+        sb.AppendLine(string.Join(",", header.Select(CsvEscape)));
+
+        foreach (var p in packages)
+        {
+            var row = new List<string> { p.Name, p.Id, p.VersionString };
+            if (includeNewVersion) row.Add(p.NewVersionString);
+            row.Add(p.Source.AsString_DisplayName);
+            sb.AppendLine(string.Join(",", row.Select(CsvEscape)));
+        }
+
+        return sb.ToString();
+    }
+
+    private static string CsvEscape(string? field)
+    {
+        field ??= "";
+        if (field.IndexOfAny(['"', ',', '\n', '\r']) >= 0)
+            return "\"" + field.Replace("\"", "\"\"") + "\"";
+        return field;
+    }
 }

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
@@ -129,6 +129,8 @@ public class InstalledPackagesPage : AbstractPackagesPage
         ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("add_to", CoreTools.Translate("Add selection to bundle"),
             () => _ = ExportSelectionToBundleAsync(vm));
+        ViewModel.AddToolbarButton("save_as", CoreTools.Translate("Export to CSV"),
+            () => _ = ExportPackagesToCsvAsync());
     }
 
     // ─── Context menu ─────────────────────────────────────────────────────────

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -106,6 +106,9 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         });
         ViewModel.AddToolbarButton("clipboard_list", CoreTools.Translate("Manage ignored updates"),
             () => vm.RequestManageIgnoredCommand.Execute(null));
+        ViewModel.AddToolbarSeparator();
+        ViewModel.AddToolbarButton("save_as", CoreTools.Translate("Export to CSV"),
+            () => _ = ExportPackagesToCsvAsync());
     }
 
     // ─── Context menu ─────────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request adds a feature to export the list of packages to a CSV file from both the Installed Packages and Software Updates pages. It introduces a new toolbar button for this action and handles the export process, including CSV formatting and error handling.

**CSV Export Feature:**

* Added an `Export to CSV` toolbar button to both the Installed Packages (`InstalledPackagesPage.cs`) and Software Updates (`SoftwareUpdatesPage.cs`) pages, allowing users to export the current package list or selection. 
* Implemented the `ExportPackagesToCsvAsync` method in `AbstractPackagesPage.axaml.cs` to handle CSV export, including file selection, CSV building, and user notifications.
* Added CSV formatting helpers (`BuildCsv` and `CsvEscape`) to ensure proper CSV output, including UTF-8 BOM for compatibility with Excel and correct escaping of special characters.

**Dependency and Import Updates:**

* Added necessary imports for file handling, encoding, and Avalonia file picker support in `AbstractPackagesPage.axaml.cs`.