### PR TITLE
Fix installer runtime error and update installation process

### DIFF
--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -82,6 +82,8 @@ AppModifyPath="{app}\UniGetUI.Installer.exe" /silent /NoDeployInstaller
 [Code]
 var
   PreserveAutostartDisabled: Boolean;
+  // Set once the marker is written (which happens only after {app} is initialized).
+  MarkerWritten: Boolean;
 
 // StartupApproved stores the on/off state in the first byte's low bit (03 = off).
 function IsAutostartDisabledByUser: Boolean;
@@ -147,11 +149,17 @@ begin
     ForceDirectories(ExpandConstant('{app}'));
     Pid := GetCurrentProcessId;
     SaveStringToFile(UpdateMarkerPath(), IntToStr(Pid), False);
+    MarkerWritten := True;
 end;
 
 procedure RemoveUpdateMarker;
 begin
+    // Guard against DeinitializeSetup expanding {app} on an abort before the
+    // directory page is confirmed — {app} isn't initialized yet and would throw.
+    if not MarkerWritten then
+        Exit;
     DeleteFile(UpdateMarkerPath());
+    MarkerWritten := False;
 end;
 
 // Runs before any file is copied: shut everything down, then mark the copy window.

--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -148,8 +148,8 @@ var
 begin
     ForceDirectories(ExpandConstant('{app}'));
     Pid := GetCurrentProcessId;
-    SaveStringToFile(UpdateMarkerPath(), IntToStr(Pid), False);
-    MarkerWritten := True;
+    // Track reality: only guard removal if the marker was actually written.
+    MarkerWritten := SaveStringToFile(UpdateMarkerPath(), IntToStr(Pid), False);
 end;
 
 procedure RemoveUpdateMarker;
@@ -158,8 +158,9 @@ begin
     // directory page is confirmed — {app} isn't initialized yet and would throw.
     if not MarkerWritten then
         Exit;
-    DeleteFile(UpdateMarkerPath());
-    MarkerWritten := False;
+    // Keep the flag set if deletion fails, so DeinitializeSetup retries it.
+    if DeleteFile(UpdateMarkerPath()) then
+        MarkerWritten := False;
 end;
 
 // Runs before any file is copied: shut everything down, then mark the copy window.

--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -302,16 +302,20 @@ Root: HKA; Subkey: "Software\Classes\UniGetUI.PackageBundle\DefaultIcon"; ValueT
 Root: HKA; Subkey: "Software\Classes\UniGetUI.PackageBundle\shell\open\command"; ValueType: string; ValueData: """{app}\{#MyAppExeName}"" ""%1"""; Flags: uninsdeletekey; Tasks: regularinstall;
 
 
+; This section deletes ONLY files the current build never ships (leftovers from the old
+; WinUI install). The live set — Assets\, *.dll, *.pdb, *.json (incl. runtimeconfig.json) —
+; is deliberately NOT listed: [Files] overwrites those in place (ignoreversion, atomic
+; temp-then-rename), so a cancelled/interrupted update can't leave the running app missing
+; files (which the crash handler would report as "Missing Files"). Deleting the live set up
+; front, as this used to, guaranteed a broken install if the copy was cut short.
+; WARNING: only add patterns here that the current build does NOT produce — matches are
+; deleted before the copy, so a live match would blank the install on an interrupted update.
 [InstallDelete]
 Type: filesandordirs; Name: "{app}\Avalonia"
-Type: filesandordirs; Name: "{app}\Assets"
 Type: files; Name: "{app}\WingetUI.exe"
 Type: files; Name: "{app}\UniGetUI.Avalonia.exe"
-Type: files; Name: "{app}\*.dll"
-Type: files; Name: "{app}\*.pdb"
 Type: files; Name: "{app}\*.pri"
 Type: files; Name: "{app}\*.xbf"
-Type: files; Name: "{app}\*.json"
 
 [Files]
 ; Deploy installer for autorepair jobs (unless disabled)


### PR DESCRIPTION
This pull request makes several improvements to the installer script (`UniGetUI.iss`) to ensure safer update behavior and improve reliability during installation and uninstallation. The key changes focus on preventing accidental deletion of live files during updates, and on tracking the state of marker file operations to avoid errors if installation is aborted.

**Reliability and Safety Improvements:**

* Added a `MarkerWritten` flag to track if the update marker file has been written, preventing errors if cleanup is attempted before initialization. 
* Updated the `RemoveUpdateMarker` procedure to check the `MarkerWritten` flag before attempting to delete the marker file, avoiding exceptions if the installation is aborted early.

**Install/Uninstall File Management:**

* Modified the `[InstallDelete]` section to only delete files and directories that are no longer produced by the current build, preventing accidental deletion of live files during interrupted or cancelled updates. The live set of files is now preserved to ensure the app is not left in a broken state.
