### PR TITLE
Fix Italian installer message formatting

### DIFF
--- a/InstallerExtras/CustomMessages.iss
+++ b/InstallerExtras/CustomMessages.iss
@@ -154,7 +154,7 @@ Italian.RegInst=Esegui installazione normale
 Italian.RegStartMmenuIcon=Crea collegamento nel menu Start
 Italian.RegDesktopIcon=Crea collegamento sul desktop
 Italian.PackageBundleName=Raccolta pacchetti UniGetUI
-Italian.InvalidInstallPath=Il percorso di installazione selezionato contiene un carattere non valido.%nIl percorso di installazione non può contenere caratteri speciali.%ner continuare inserisci un percorso valido, ad esempio %1.
+Italian.InvalidInstallPath=Il percorso di installazione selezionato contiene un carattere non valido. Il percorso di installazione non può contenere caratteri speciali. Per continuare inserisci un percorso valido, ad esempio %1.
 Italian.RemovingOldIcons=Rimozione icone precedenti...
 Italian.LaunchProgram=Esegui %1
 


### PR DESCRIPTION
Remove line breaks from Italian InvalidInstallPath message and fix grammar (er → Per). Reformats the installer dialog text to display on a single line with proper spacing.
