### PR TITLE
Fix duplicate instances on toast click when IPC forward times out

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
@@ -49,9 +49,10 @@ internal static class SingleInstanceRedirector
         {
             while (true)
             {
+                NamedPipeServerStream? pipe = null;
                 try
                 {
-                    var pipe = new NamedPipeServerStream(
+                    pipe = new NamedPipeServerStream(
                         PipeName,
                         PipeDirection.In,
                         maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances,
@@ -63,11 +64,17 @@ internal static class SingleInstanceRedirector
                     // Read off-thread and immediately re-arm: a single slow/stuck client can
                     // never block the next accept nor "busy out" the pipe into timeouts.
                     HandleConnection(pipe, onArgsReceived);
+                    pipe = null; // ownership handed to the read task
                 }
                 catch (Exception ex) when (ex is not ThreadAbortException)
                 {
                     // Keep the listener alive through errors (the pipe breaks on disconnect, etc.)
                     Logger.Warn($"SingleInstanceRedirector listener error: {ex.Message}");
+                }
+                finally
+                {
+                    // Dispose the stream if the handoff never happened, so a broken accept can't leak handles.
+                    pipe?.Dispose();
                 }
             }
         })
@@ -107,32 +114,41 @@ internal static class SingleInstanceRedirector
     /// </summary>
     /// <returns><c>true</c> if the message was delivered successfully.</returns>
     public static bool TryForwardToFirstInstance(string[] args)
+        => ForwardToFirstInstanceAsync(args).GetAwaiter().GetResult();
+
+    private static async Task<bool> ForwardToFirstInstanceAsync(string[] args)
     {
-        var deadline = DateTime.UtcNow + ForwardBudget;
-        Exception? last;
-        do
+        // One token bounds connect, write and flush across retries, so a peer that connects
+        // then stops reading can never block past the budget and skip the fallback.
+        using var cts = new CancellationTokenSource(ForwardBudget);
+        byte[] payload = Encoding.UTF8.GetBytes(string.Join('\n', args)); // newline-delimited args
+        Exception? last = null;
+
+        while (true)
         {
             try
             {
                 using var pipe = new NamedPipeClientStream(
                     serverName: ".",
                     pipeName: PipeName,
-                    direction: PipeDirection.Out);
+                    direction: PipeDirection.Out,
+                    options: PipeOptions.Asynchronous);
 
-                pipe.Connect(500);
-
-                using var writer = new StreamWriter(pipe, Encoding.UTF8);
-                // Newline-delimited args payload.
-                writer.Write(string.Join('\n', args));
-                writer.Flush();
+                await pipe.ConnectAsync(cts.Token).ConfigureAwait(false);
+                await pipe.WriteAsync(payload, cts.Token).ConfigureAwait(false);
+                await pipe.FlushAsync(cts.Token).ConfigureAwait(false);
                 return true;
             }
             catch (Exception ex)
             {
                 last = ex;
-                Thread.Sleep(100);
+                if (cts.IsCancellationRequested)
+                    break;
+
+                try { await Task.Delay(100, cts.Token).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
             }
-        } while (DateTime.UtcNow < deadline);
+        }
 
         Logger.Warn($"Could not forward args to first instance: {last?.Message}");
         return false;

--- a/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
@@ -34,6 +34,11 @@ internal static class SingleInstanceRedirector
 
     private static Thread? _listener;
 
+    // The mutex proves a first instance exists, so keep probing this long before giving up.
+    private static readonly TimeSpan ForwardBudget = TimeSpan.FromSeconds(5);
+    // Bound each read so a client that connects but never sends EOF can't wedge the loop.
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(5);
+
     /// <summary>
     /// Start a background listener thread.  When a second instance forwards its args,
     /// <paramref name="onArgsReceived"/> is invoked on the Avalonia UI thread.
@@ -46,20 +51,18 @@ internal static class SingleInstanceRedirector
             {
                 try
                 {
-                    using var pipe = new NamedPipeServerStream(
+                    var pipe = new NamedPipeServerStream(
                         PipeName,
                         PipeDirection.In,
-                        maxNumberOfServerInstances: 1,
-                        transmissionMode: PipeTransmissionMode.Byte);
+                        maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances,
+                        transmissionMode: PipeTransmissionMode.Byte,
+                        options: PipeOptions.Asynchronous);
 
                     pipe.WaitForConnection();
 
-                    using var reader = new StreamReader(pipe, Encoding.UTF8);
-                    string payload = reader.ReadToEnd();
-
-                    // Args are newline-delimited.
-                    var args = payload.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-                    Dispatcher.UIThread.Post(() => onArgsReceived(args));
+                    // Read off-thread and immediately re-arm: a single slow/stuck client can
+                    // never block the next accept nor "busy out" the pipe into timeouts.
+                    HandleConnection(pipe, onArgsReceived);
                 }
                 catch (Exception ex) when (ex is not ThreadAbortException)
                 {
@@ -76,36 +79,63 @@ internal static class SingleInstanceRedirector
         _listener.Start();
     }
 
+    private static void HandleConnection(NamedPipeServerStream pipe, Action<string[]> onArgsReceived)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using (pipe)
+                using (var reader = new StreamReader(pipe, Encoding.UTF8))
+                using (var cts = new CancellationTokenSource(ReadTimeout))
+                {
+                    string payload = await reader.ReadToEndAsync(cts.Token);
+                    // Args are newline-delimited.
+                    var args = payload.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                    Dispatcher.UIThread.Post(() => onArgsReceived(args));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"SingleInstanceRedirector read error: {ex.Message}");
+            }
+        });
+    }
+
     /// <summary>
     /// Try to forward <paramref name="args"/> to the already-running first instance.
     /// </summary>
     /// <returns><c>true</c> if the message was delivered successfully.</returns>
     public static bool TryForwardToFirstInstance(string[] args)
     {
-        if (args.Length == 0)
-        {
-            // Nothing to forward — still show the window by sending an empty payload.
-        }
+        var deadline = DateTime.UtcNow + ForwardBudget;
+        Exception? last = null;
 
-        try
+        do
         {
-            using var pipe = new NamedPipeClientStream(
-                serverName: ".",
-                pipeName: PipeName,
-                direction: PipeDirection.Out);
+            try
+            {
+                using var pipe = new NamedPipeClientStream(
+                    serverName: ".",
+                    pipeName: PipeName,
+                    direction: PipeDirection.Out);
 
-            pipe.Connect(500);
+                pipe.Connect(500);
 
-            using var writer = new StreamWriter(pipe, Encoding.UTF8);
-            // Newline-delimited args payload.
-            writer.Write(string.Join('\n', args));
-            writer.Flush();
-            return true;
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn($"Could not forward args to first instance: {ex.Message}");
-            return false;
-        }
+                using var writer = new StreamWriter(pipe, Encoding.UTF8);
+                // Newline-delimited args payload.
+                writer.Write(string.Join('\n', args));
+                writer.Flush();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                last = ex;
+                Thread.Sleep(100);
+            }
+        } while (DateTime.UtcNow < deadline);
+
+        Logger.Warn($"Could not forward args to first instance: {last?.Message}");
+        return false;
     }
 }

--- a/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs
@@ -109,8 +109,7 @@ internal static class SingleInstanceRedirector
     public static bool TryForwardToFirstInstance(string[] args)
     {
         var deadline = DateTime.UtcNow + ForwardBudget;
-        Exception? last = null;
-
+        Exception? last;
         do
         {
             try


### PR DESCRIPTION
This pull request refactors and improves the single-instance handling logic in `SingleInstanceRedirector.cs` to make inter-process communication via named pipes more robust and responsive. The main improvements are around error handling, non-blocking connection management, and timeouts for both reading and forwarding arguments between instances.

**Named pipe connection handling improvements:**

* The listener now uses `NamedPipeServerStream.MaxAllowedServerInstances` and asynchronous options, allowing multiple incoming connections to be handled without blocking the main thread. Each client connection is processed off-thread, so a slow or stuck client cannot prevent new connections. (`src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs`)
* Added a new `HandleConnection` method that reads pipe input asynchronously with a timeout (`ReadTimeout`), preventing clients that never send EOF from blocking the server. Errors are logged without crashing the listener. (`src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs`)

**Timeouts and retry logic:**

* Introduced `ForwardBudget` and `ReadTimeout` constants to bound how long the process will attempt to forward arguments to the first instance and how long it will wait for pipe reads, respectively. (`src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs`)
* The `TryForwardToFirstInstance` method now retries connecting and sending arguments to the first instance until the `ForwardBudget` expires, logging the last error if unsuccessful. (`src/UniGetUI.Avalonia/Infrastructure/SingleInstanceRedirector.cs`)