### PR TITLE
Add clear (x) button to title bar search box

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -386,6 +386,7 @@
   "Toggle navigation panel": "Toggle navigation panel",
   "Minimize": "Minimize",
   "Maximize": "Maximize",
+  "Clear search": "Clear search",
   "UniGetUI by Devolutions": "UniGetUI by Devolutions",
   "UniGetUI is an application that makes managing your software easier, by providing an all-in-one graphical interface for your command-line package managers.": "UniGetUI is an application that makes managing your software easier, by providing an all-in-one graphical interface for your command-line package managers.",
   "Useful links": "Useful links",

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -505,7 +505,7 @@
                                  CornerRadius="0"
                                  BorderThickness="0"
                                  VerticalContentAlignment="Center"
-                                 Padding="12,0,4,0"
+                                 Padding="12,0,30,0"
                                  Background="Transparent"
                                  PlaceholderForeground="{DynamicResource SearchBoxPlaceholderForeground}"
                                  PlaceholderText="{Binding GlobalSearchPlaceholder}"
@@ -527,6 +527,27 @@
                                 <x:Double x:Key="TextControlPlaceholderOpacity">1</x:Double>
                             </TextBox.Resources>
                         </TextBox>
+                        <!-- Clear (✕): overlays the right edge of the text column, shown only when
+                             the box has text; the TextBox's right padding reserves room for it. -->
+                        <Button Grid.Column="0"
+                                x:Name="ClearSearchButton"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                Width="24"
+                                Height="24"
+                                Margin="0,0,3,3"
+                                Padding="0"
+                                CornerRadius="4"
+                                BorderThickness="0"
+                                Background="Transparent"
+                                IsVisible="{Binding GlobalSearchText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                automation:AutomationProperties.Name="{t:Translate Clear search}"
+                                ToolTip.Tip="{t:Translate Clear search}"
+                                Click="ClearSearchBox_Click">
+                            <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/cross.svg"
+                                              Width="12"
+                                              Height="12"/>
+                        </Button>
                         <Button Grid.Column="1"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1412,6 +1412,12 @@ public partial class MainWindow : Window
         }
     }
 
+    private void ClearSearchBox_Click(object? sender, RoutedEventArgs e)
+    {
+        ViewModel.GlobalSearchText = "";
+        GlobalSearchBox.Focus();
+    }
+
     private void SuggestionsList_Tapped(object? sender, TappedEventArgs e)
     {
         if (SuggestionsList.SelectedItem is SettingsSearchResult result)


### PR DESCRIPTION
This pull request improves the search box in `MainWindow` by adding a clear ("✕") button, making it easier for users to clear their search input. The button only appears when there is text in the search box, and clicking it clears the input and refocuses the search box. The padding of the search box was also adjusted to accommodate the new button.

**Search box usability improvements:**

* Added a clear ("✕") button (`ClearSearchButton`) to the search box in `MainWindow.axaml`, which appears only when the search box contains text and allows users to quickly clear the input.
* Implemented the `ClearSearchBox_Click` event handler in `MainWindow.axaml.cs` to clear the search text and refocus the search box when the clear button is clicked.
* Increased the right padding of the search box to ensure space for the clear button and prevent text overlap.