### PR TITLE
Confirm before resetting settings to defaults

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -84,6 +84,7 @@
   "Show UniGetUI": "Show UniGetUI",
   "Quit": "Quit",
   "Are you sure?": "Are you sure?",
+  "Do you really want to reset UniGetUI to its default settings? This action cannot be undone.": "Do you really want to reset UniGetUI to its default settings? This action cannot be undone.",
   "Do you really want to uninstall {0}?": "Do you really want to uninstall {0}?",
   "Do you really want to uninstall the following {0} packages?": "Do you really want to uninstall the following {0} packages?",
   "No": "No",

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/GeneralViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/GeneralViewModel.cs
@@ -69,8 +69,13 @@ public partial class GeneralViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void ResetSettings(Visual? _)
+    private async Task ResetSettings(Visual? visual)
     {
+        if (visual is null || TopLevel.GetTopLevel(visual) is not Window owner) return;
+        var dialog = new ResetSettingsDialog();
+        await dialog.ShowDialog(owner);
+        if (!dialog.Confirmed) return;
+
         try { CoreSettings.ResetSettings(); }
         catch (Exception ex) { Logger.Error(ex); }
         AccessibilityAnnouncementService.Announce(

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml
@@ -1,0 +1,47 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
+        xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
+        x:Class="UniGetUI.Avalonia.Views.DialogPages.ResetSettingsDialog"
+        Title="{t:Translate Reset UniGetUI}"
+        Width="460"
+        SizeToContent="Height"
+        MinHeight="160"
+        CanResize="False"
+        ShowInTaskbar="False"
+        Background="{DynamicResource AppDialogBackground}"
+        WindowStartupLocation="CenterOwner">
+
+    <Grid Margin="20"
+          RowDefinitions="Auto,Auto,Auto"
+          RowSpacing="12">
+
+        <TextBlock Grid.Row="0"
+                   Text="{t:Translate Reset UniGetUI}"
+                   FontSize="16"
+                   FontWeight="SemiBold"
+                   automation:AutomationProperties.HeadingLevel="1"/>
+
+        <TextBlock Grid.Row="1"
+                   Text="{t:Translate Do you really want to reset UniGetUI to its default settings? This action cannot be undone.}"
+                   TextWrapping="Wrap"
+                   Opacity="0.85"/>
+
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8">
+            <Button x:Name="CancelButton"
+                    Content="{t:Translate Cancel}"
+                    MinWidth="80"
+                    automation:AutomationProperties.Name="{t:Translate Cancel}"/>
+            <Button x:Name="ResetButton"
+                    Content="{t:Translate Reset UniGetUI}"
+                    MinWidth="140"
+                    Classes="accent"
+                    automation:AutomationProperties.Name="{t:Translate Reset UniGetUI}"/>
+        </StackPanel>
+
+    </Grid>
+
+</Window>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+
+namespace UniGetUI.Avalonia.Views.DialogPages;
+
+public partial class ResetSettingsDialog : Window
+{
+    public bool Confirmed { get; private set; }
+
+    public ResetSettingsDialog()
+    {
+        InitializeComponent();
+        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
+        CancelButton.Click += (_, _) => Close();
+        ResetButton.Click += (_, _) => { Confirmed = true; Close(); };
+    }
+
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+        Dispatcher.UIThread.Post(() => CancelButton.Focus(), DispatcherPriority.Background);
+    }
+}


### PR DESCRIPTION
This pull request adds a confirmation dialog before resetting UniGetUI to its default settings, improving user experience and preventing accidental resets. The main changes include implementing a new dialog window, updating the reset logic to show the confirmation dialog, and adding the necessary translation string.

**Reset Settings Confirmation Dialog:**

* Added a new dialog window `ResetSettingsDialog` with UI and logic to confirm resetting UniGetUI to default settings. The dialog presents a warning message and "Cancel" and "Reset UniGetUI" buttons. (`src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml``src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml.cs` 
* Updated the `ResetSettings` command in `GeneralViewModel.cs` to show the confirmation dialog and only proceed with the reset if the user confirms. (`src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/GeneralViewModel.cs` 

**Localization:**

* Added a new translation string to `lang_en.json` for the dialog's warning message. (`src/Languages/lang_en.json` [src/Languages/lang_en.jsonR87](diffhunk://#diff-f8d36a381022aa27a72a2569e4660c301689d5490e8a2ad5c8d755f701331fafR87))
