### PR TITLE
Implement WinUI-style immersive overlays and migrate existing pop-ups; tweak context menus to better match WinUI styling; implement sliding pill animation

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -67,6 +67,15 @@
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#ECECEC"/>
                     <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#F6F6F6"/>
+                    <!-- WinUI dropdown controls use the same control/card fill as settings actions. -->
+                    <StaticResource x:Key="ComboBoxBackground" ResourceKey="SettingsCardBackground"/>
+                    <StaticResource x:Key="ComboBoxBackgroundUnfocused" ResourceKey="SettingsCardBackground"/>
+                    <StaticResource x:Key="ComboBoxBackgroundPointerOver" ResourceKey="SettingsCardHoverBackground"/>
+                    <StaticResource x:Key="ComboBoxBackgroundPressed" ResourceKey="SettingsCardHoverBackground"/>
+                    <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="Transparent"/>
+                    <SolidColorBrush x:Key="ComboBoxBackgroundBorderBrushUnfocused" Color="Transparent"/>
+                    <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="Transparent"/>
+                    <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="Transparent"/>
                     <!-- Package list container; near-transparent over Mica (see Styles.WindowsMica) -->
                     <SolidColorBrush x:Key="PackageListBackground"       Color="#FBFBFB"/>
                     <!-- Column header: WinUI default button (ControlFillColorDefault fill + ControlStrokeColorDefault border) -->
@@ -176,6 +185,15 @@
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#0DFFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#393939"/>
                     <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#323232"/>
+                    <!-- WinUI dropdown controls use the same control/card fill as settings actions. -->
+                    <StaticResource x:Key="ComboBoxBackground" ResourceKey="SettingsCardBackground"/>
+                    <StaticResource x:Key="ComboBoxBackgroundUnfocused" ResourceKey="SettingsCardBackground"/>
+                    <StaticResource x:Key="ComboBoxBackgroundPointerOver" ResourceKey="SettingsCardHoverBackground"/>
+                    <StaticResource x:Key="ComboBoxBackgroundPressed" ResourceKey="SettingsCardHoverBackground"/>
+                    <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="Transparent"/>
+                    <SolidColorBrush x:Key="ComboBoxBackgroundBorderBrushUnfocused" Color="Transparent"/>
+                    <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="Transparent"/>
+                    <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="Transparent"/>
                     <!-- Package list container; near-transparent over Mica (see Styles.WindowsMica) -->
                     <SolidColorBrush x:Key="PackageListBackground"       Color="#2D2D2D"/>
                     <!-- Column header: WinUI default button (ControlFillColorDefault fill + ControlStrokeColorDefault border) -->

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -31,6 +31,8 @@
                          gets a lighter light-theme value to read as the same weight as the compact title-bar field. -->
                     <SolidColorBrush x:Key="SearchBoxPlaceholderForeground"   Color="#72000000"/>
                     <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#52000000"/>
+                    <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#B3FFFFFF"/>
+                    <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#0F000000"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5C000000"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#FFFFFFFF"/>
                     <!-- Opaque WinUI menu surface and low-contrast divider. -->
@@ -119,6 +121,8 @@
                          share it since thick-stroke heaviness only reads as darker on light backgrounds. -->
                     <SolidColorBrush x:Key="SearchBoxPlaceholderForeground"   Color="#C5FFFFFF"/>
                     <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#C5FFFFFF"/>
+                    <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#0FFFFFFF"/>
+                    <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#12FFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5DFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#E4000000"/>
                     <!-- WinUI's dark flyout surface is an opaque #2C2C2C. -->

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -32,6 +32,7 @@
                     <SolidColorBrush x:Key="SearchBoxPlaceholderForeground"   Color="#72000000"/>
                     <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#52000000"/>
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#B3FFFFFF"/>
+                    <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#0F000000"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5C000000"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#FFFFFFFF"/>
@@ -131,6 +132,7 @@
                     <SolidColorBrush x:Key="SearchBoxPlaceholderForeground"   Color="#C5FFFFFF"/>
                     <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#C5FFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#0FFFFFFF"/>
+                    <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#B31E1E1E"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#12FFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5DFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#E4000000"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -33,6 +33,10 @@
                     <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#52000000"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5C000000"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#FFFFFFFF"/>
+                    <!-- Opaque WinUI menu surface and low-contrast divider. -->
+                    <SolidColorBrush x:Key="MenuSurfaceBrush"            Color="#FFFFFFFF"/>
+                    <SolidColorBrush x:Key="MenuSurfaceBorderBrush"      Color="#0F000000"/>
+                    <SolidColorBrush x:Key="MenuDividerBrush"            Color="#0F000000"/>
                     <!-- Text on accent -->
                     <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush"      Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush"    Color="#B3FFFFFF"/>
@@ -64,6 +68,8 @@
                     <SolidColorBrush x:Key="AppDialogPanelBackground"    Color="#F9F9F9"/>
                     <SolidColorBrush x:Key="AppDialogSubtleBackground"   Color="#EEEEEE"/>
                     <SolidColorBrush x:Key="AppDialogDarkBackground"     Color="#EEEEEE"/>
+                    <SolidColorBrush x:Key="ScreenshotLetterboxBackground" Color="#202020"/>
+                    <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="#4D000000"/>
                     <!-- Warning banner -->
                     <SolidColorBrush x:Key="WarningBannerBackground"     Color="#FFF4CE"/>
                     <SolidColorBrush x:Key="WarningBannerBorderBrush"    Color="#9D5D00"/>
@@ -76,7 +82,7 @@
                     <SolidColorBrush x:Key="StatusErrorBackground"       Color="#FDE7E9"/>
                     <SolidColorBrush x:Key="StatusErrorBorderBrush"      Color="#C42B1C"/>
                     <SolidColorBrush x:Key="StatusInfoBackground"        Color="#E5F1FA"/>
-                    <SolidColorBrush x:Key="StatusInfoBorderBrush"       Color="#005FB8"/>
+                    <SolidColorBrush x:Key="StatusInfoBorderBrush"       Color="{DynamicResource SystemAccentColor}"/>
                     <!-- Status badge foreground -->
                     <SolidColorBrush x:Key="StatusSuccessForeground"     Color="#0F7B0F"/>
                     <SolidColorBrush x:Key="StatusWarningForeground"     Color="#9D5D00"/>
@@ -115,6 +121,10 @@
                     <SolidColorBrush x:Key="MegaQueryPlaceholderForeground"   Color="#C5FFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5DFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#E4000000"/>
+                    <!-- WinUI's dark flyout surface is an opaque #2C2C2C. -->
+                    <SolidColorBrush x:Key="MenuSurfaceBrush"            Color="#FF2C2C2C"/>
+                    <SolidColorBrush x:Key="MenuSurfaceBorderBrush"      Color="#26FFFFFF"/>
+                    <SolidColorBrush x:Key="MenuDividerBrush"            Color="#15FFFFFF"/>
                     <!-- Text on accent -->
                     <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush"      Color="#000000"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush"    Color="#80000000"/>
@@ -146,6 +156,8 @@
                     <SolidColorBrush x:Key="AppDialogPanelBackground"    Color="#2C2C2C"/>
                     <SolidColorBrush x:Key="AppDialogSubtleBackground"   Color="#393939"/>
                     <SolidColorBrush x:Key="AppDialogDarkBackground"     Color="#1A1A1A"/>
+                    <SolidColorBrush x:Key="ScreenshotLetterboxBackground" Color="#202020"/>
+                    <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="#4D000000"/>
                     <!-- Warning banner -->
                     <SolidColorBrush x:Key="WarningBannerBackground"     Color="#433519"/>
                     <SolidColorBrush x:Key="WarningBannerBorderBrush"    Color="#A07208"/>
@@ -186,6 +198,44 @@
     <!-- Column headers default to Avalonia's 12px bare-TextBlock size; WinUI renders them at 14px. -->
     <Style Selector="DataGridColumnHeader">
         <Setter Property="FontSize" Value="14"/>
+    </Style>
+
+    <!-- WinUI-style menu geometry. Insetting each item keeps its hover fill away from the
+         flyout edge, while separators deliberately span the presenter's usable width. -->
+    <Style Selector="MenuFlyoutPresenter">
+        <Setter Property="Background" Value="{DynamicResource MenuSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource MenuSurfaceBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="0,4"/>
+    </Style>
+    <Style Selector="MenuFlyoutPresenter MenuItem">
+        <Setter Property="Margin" Value="4,0"/>
+        <Setter Property="Padding" Value="8,4,8,5"/>
+        <Setter Property="MinHeight" Value="32"/>
+        <Setter Property="CornerRadius" Value="4"/>
+    </Style>
+    <Style Selector="MenuFlyoutPresenter Separator">
+        <Setter Property="Margin" Value="0,4"/>
+        <Setter Property="Background" Value="{DynamicResource MenuDividerBrush}"/>
+    </Style>
+    <Style Selector="ContextMenu">
+        <Setter Property="Background" Value="{DynamicResource MenuSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource MenuSurfaceBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="0,4"/>
+    </Style>
+    <Style Selector="ContextMenu MenuItem">
+        <Setter Property="Margin" Value="4,0"/>
+        <Setter Property="Padding" Value="8,4,8,5"/>
+        <Setter Property="MinHeight" Value="32"/>
+        <Setter Property="CornerRadius" Value="4"/>
+    </Style>
+    <Style Selector="ContextMenu MenuItem /template/ ContentPresenter#PART_HeaderPresenter">
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+    </Style>
+    <Style Selector="ContextMenu Separator">
+        <Setter Property="Margin" Value="0,4"/>
+        <Setter Property="Background" Value="{DynamicResource MenuDividerBrush}"/>
     </Style>
     <Style Selector="DataGridRow:selected">
         <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -248,34 +248,23 @@
     </Style>
 
     <!-- Sidebar navigation items: WinUI NavigationViewItem-style selection.
-         Fluent's default fills the selected item with the accent colour; instead use a subtle
-         neutral fill plus a vertical accent pill on the left edge. The content presenter is named
-         ContentHost (not PART_ContentPresenter) so the base theme's accent-fill setters don't apply. -->
+         The accent pill is a single moving overlay owned by SidebarView. The content presenter is
+         named ContentHost (not PART_ContentPresenter) so the base theme's accent-fill setters don't
+         apply. -->
     <Style Selector="ListBoxItem.nav-item">
         <Setter Property="Margin" Value="0,2"/>
         <Setter Property="Template">
             <ControlTemplate>
-                <Panel>
-                    <ContentPresenter Name="ContentHost"
-                                      Background="{TemplateBinding Background}"
-                                      BorderBrush="{TemplateBinding BorderBrush}"
-                                      BorderThickness="{TemplateBinding BorderThickness}"
-                                      CornerRadius="{TemplateBinding CornerRadius}"
-                                      ContentTemplate="{TemplateBinding ContentTemplate}"
-                                      Content="{TemplateBinding Content}"
-                                      Padding="{TemplateBinding Padding}"
-                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
-                    <Border Name="SelectionPill"
-                            Width="3" Height="16" CornerRadius="1.5"
-                            Background="{DynamicResource AccentFillColorDefaultBrush}"
-                            HorizontalAlignment="Left" VerticalAlignment="Center"
-                            Opacity="0">
-                        <Border.Transitions>
-                            <Transitions><DoubleTransition Property="Opacity" Duration="0:0:0.1"/></Transitions>
-                        </Border.Transitions>
-                    </Border>
-                </Panel>
+                <ContentPresenter Name="ContentHost"
+                                  Background="{TemplateBinding Background}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  CornerRadius="{TemplateBinding CornerRadius}"
+                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                  Content="{TemplateBinding Content}"
+                                  Padding="{TemplateBinding Padding}"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
             </ControlTemplate>
         </Setter>
     </Style>
@@ -291,10 +280,6 @@
     <Style Selector="ListBoxItem.nav-item:selected:pointerover /template/ ContentPresenter#ContentHost">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}"/>
     </Style>
-    <Style Selector="ListBoxItem.nav-item:selected /template/ Border#SelectionPill">
-        <Setter Property="Opacity" Value="1"/>
-    </Style>
-
     <!-- View-mode segmented selector (List / Grid / Icons): WinUI Segmented-style selection — subtle
          fill plus an accent underline under the selected segment, not Fluent's full-accent fill. -->
     <Style Selector="ListBoxItem.segment-item">

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -152,7 +152,7 @@
                     <SolidColorBrush x:Key="AppBorderBrush"              Color="#353535"/>
                     <SolidColorBrush x:Key="AppBadgeBackground"          Color="#3C3C3C"/>
                     <!-- Dialogs -->
-                    <SolidColorBrush x:Key="AppDialogBackground"         Color="#202020"/>
+                    <SolidColorBrush x:Key="AppDialogBackground"         Color="#2C2C2C"/>
                     <SolidColorBrush x:Key="AppDialogPanelBackground"    Color="#2C2C2C"/>
                     <SolidColorBrush x:Key="AppDialogSubtleBackground"   Color="#393939"/>
                     <SolidColorBrush x:Key="AppDialogDarkBackground"     Color="#1A1A1A"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -13,6 +13,25 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColorDark2}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#37000000"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <!-- Avalonia's Fluent controls still map these states to the raw system accent.
+                         Route them through WinUI's theme-adjusted accent fill instead. -->
+                    <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlBorderBrushFocused" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlSelectionHighlightColor" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlButtonBackgroundPressed" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlButtonForegroundPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundFillChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundFillIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CalendarViewSelectedBorderBrush" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedStroke" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedFill" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SliderTrackValueFill" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SliderTrackValueFillPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SliderTrackValueFillPressed" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="ToggleSwitchFillOn" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SplitButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#09000000"/>
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#06000000"/>
@@ -104,6 +123,25 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColor}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#28FFFFFF"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <!-- Avalonia's Fluent controls still map these states to the raw system accent.
+                         Route them through WinUI's lighter dark-theme accent fill instead. -->
+                    <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlBorderBrushFocused" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlSelectionHighlightColor" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlButtonBackgroundPressed" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="TextControlButtonForegroundPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundFillChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CheckBoxCheckBackgroundFillIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="CalendarViewSelectedBorderBrush" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedStroke" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedFill" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SliderTrackValueFill" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SliderTrackValueFillPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SliderTrackValueFillPressed" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="ToggleSwitchFillOn" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="SplitButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#0FFFFFFF"/>
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#0AFFFFFF"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -301,10 +301,10 @@
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
                     <Border Name="SelectionPill"
-                            Height="2" CornerRadius="1"
+                            Width="16" Height="3" CornerRadius="1.5"
                             Background="{DynamicResource AccentFillColorDefaultBrush}"
-                            HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
-                            Margin="5,0,5,2"
+                            HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                            Margin="0,0,0,2"
                             Opacity="0">
                         <Border.Transitions>
                             <Transitions><DoubleTransition Property="Opacity" Duration="0:0:0.1"/></Transitions>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -43,7 +43,7 @@
                     <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush"     Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="#FFFFFFFF"/>
                     <!-- Settings cards -->
-                    <SolidColorBrush x:Key="SettingsCardBackground"      Color="#FBFBFB"/>
+                    <SolidColorBrush x:Key="SettingsCardBackground"      Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#ECECEC"/>
                     <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#F6F6F6"/>
                     <!-- Package list container; near-transparent over Mica (see Styles.WindowsMica) -->
@@ -131,7 +131,7 @@
                     <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush"     Color="#87FFFFFF"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="#FFFFFFFF"/>
                     <!-- Settings cards -->
-                    <SolidColorBrush x:Key="SettingsCardBackground"      Color="#2D2D2D"/>
+                    <SolidColorBrush x:Key="SettingsCardBackground"      Color="#0DFFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#393939"/>
                     <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#323232"/>
                     <!-- Package list container; near-transparent over Mica (see Styles.WindowsMica) -->

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -13,25 +13,6 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColorDark2}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#37000000"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
-                    <!-- Avalonia's Fluent controls still map these states to the raw system accent.
-                         Route them through WinUI's theme-adjusted accent fill instead. -->
-                    <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlBorderBrushFocused" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlSelectionHighlightColor" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlButtonBackgroundPressed" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlButtonForegroundPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeChecked" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundFillChecked" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundFillIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CalendarViewSelectedBorderBrush" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedStroke" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedFill" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SliderTrackValueFill" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SliderTrackValueFillPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SliderTrackValueFillPressed" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="ToggleSwitchFillOn" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SplitButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#09000000"/>
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#06000000"/>
@@ -132,25 +113,6 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColor}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#28FFFFFF"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
-                    <!-- Avalonia's Fluent controls still map these states to the raw system accent.
-                         Route them through WinUI's lighter dark-theme accent fill instead. -->
-                    <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlBorderBrushFocused" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlSelectionHighlightColor" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlButtonBackgroundPressed" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="TextControlButtonForegroundPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeChecked" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundStrokeIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundFillChecked" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CheckBoxCheckBackgroundFillIndeterminate" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="CalendarViewSelectedBorderBrush" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedStroke" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="RadioButtonOuterEllipseCheckedFill" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SliderTrackValueFill" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SliderTrackValueFillPointerOver" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SliderTrackValueFillPressed" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="ToggleSwitchFillOn" ResourceKey="AccentFillColorDefaultBrush"/>
-                    <StaticResource x:Key="SplitButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#0FFFFFFF"/>
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#0AFFFFFF"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
@@ -30,7 +30,7 @@
             <SolidColorBrush x:Key="AppDialogDarkBackground"     Color="#80FFFFFF"/>
             <!-- Flyouts / menus / dropdowns / tooltips: DWM acrylic backdrop with the card tint over it -->
             <SolidColorBrush x:Key="FlyoutPresenterBackground"     Color="#80FFFFFF"/>
-            <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="#80FFFFFF"/>
+            <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="#FFFFFFFF"/>
             <SolidColorBrush x:Key="ComboBoxDropDownBackground"    Color="#80FFFFFF"/>
             <SolidColorBrush x:Key="ToolTipBackground"             Color="#80FFFFFF"/>
             <!-- Expander chrome -->
@@ -71,7 +71,7 @@
                  stays readably dark even when the popup floats over bright content (e.g. the release-notes
                  WebView) — a lighter tint let the white page wash the menu out (#5007) -->
             <SolidColorBrush x:Key="FlyoutPresenterBackground"     Color="#BF2D2D2D"/>
-            <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="#BF2D2D2D"/>
+            <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="#FF2C2C2C"/>
             <SolidColorBrush x:Key="ComboBoxDropDownBackground"    Color="#BF2D2D2D"/>
             <SolidColorBrush x:Key="ToolTipBackground"             Color="#BF2D2D2D"/>
             <!-- Expander chrome -->

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
@@ -16,7 +16,7 @@
             <!-- Window/page surface goes transparent so Mica shows behind chrome + page -->
             <SolidColorBrush x:Key="MicaPageBackground"          Color="Transparent"/>
             <!-- Cards / panels: translucent white layers over the (light) Mica -->
-            <SolidColorBrush x:Key="SettingsCardBackground"      Color="#80FFFFFF"/>
+            <SolidColorBrush x:Key="SettingsCardBackground"      Color="#B3FFFFFF"/>
             <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#14000000"/>
             <!-- Package list: near-transparent so Mica shows through, matching WinUI's SystemFillColorNeutralBackground -->
             <SolidColorBrush x:Key="PackageListBackground"       Color="#06000000"/>
@@ -53,8 +53,8 @@
 
         <ResourceDictionary x:Key="Dark">
             <SolidColorBrush x:Key="MicaPageBackground"          Color="Transparent"/>
-            <!-- Cards / panels: translucent dark layers; ~40% so the wallpaper-tinted Mica bleeds through -->
-            <SolidColorBrush x:Key="SettingsCardBackground"      Color="#662D2D2D"/>
+            <!-- Cards / panels: WinUI's translucent card layer over the Mica backdrop -->
+            <SolidColorBrush x:Key="SettingsCardBackground"      Color="#0DFFFFFF"/>
             <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#26FFFFFF"/>
             <!-- Package list: near-transparent so Mica shows through, matching WinUI's SystemFillColorNeutralBackground -->
             <SolidColorBrush x:Key="PackageListBackground"       Color="#08FFFFFF"/>

--- a/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MicaWindowHelper.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.VisualTree;
 using UniGetUI.Avalonia.Assets.Styles;
 
 namespace UniGetUI.Avalonia.Infrastructure;
@@ -48,22 +49,22 @@ internal static class MicaWindowHelper
         };
     }
 
-    // Gives flyouts / menus / combo dropdowns / tooltips a native Win11 acrylic backdrop:
-    // the popup window is made transparent and DWM paints the (blurred, theme-adaptive)
-    // acrylic material behind it. Registered once at startup when Mica is enabled.
+    // Applies the Windows 11 transient-surface treatment to popup hosts. Menus use an
+    // opaque WinUI surface; combo dropdowns, tooltips, and ordinary flyouts use acrylic.
+    // Registered once at startup when Mica is enabled.
     public static void EnableAcrylicPopups()
     {
         if (!IsMicaEnabled() || _acrylicPopupsHooked)
             return;
         _acrylicPopupsHooked = true;
 
-        // In-app flyouts/menus/tooltips/combo popups are hosted in a PopupRoot; style each as it loads.
+        // In-app menus, flyouts, tooltips, and combo popups are hosted in a PopupRoot.
         Control.LoadedEvent.AddClassHandler<PopupRoot>((root, _) => ApplyAcrylicToPopup(root));
 
         // The system-tray context menu is NOT a PopupRoot — Avalonia hosts it in its own Window
         // (Avalonia.Win32.TrayIconImpl.TrayPopupRoot), so it misses the handler above and would
-        // render with no backdrop (transparent over the desktop). Catch it by type name and apply
-        // the same acrylic treatment. The other Windows (MainWindow/dialogs) are handled via Apply().
+        // render with no surface over the desktop. Catch it by type name and apply the opaque
+        // menu treatment. The other Windows (MainWindow/dialogs) are handled via Apply().
         Control.LoadedEvent.AddClassHandler<Window>((win, _) =>
         {
             if (win.GetType().Name == "TrayPopupRoot")
@@ -76,10 +77,28 @@ internal static class MicaWindowHelper
         if (!IsMicaEnabled())
             return;
 
+        // Menus use WinUI's opaque flyout surface. Other transient controls (combo boxes,
+        // tooltips and ordinary flyouts) retain acrylic.
+        bool isMenu = root.GetType().Name == "TrayPopupRoot"
+                      || root.GetVisualDescendants()
+                          .Any(control => control is MenuFlyoutPresenter or ContextMenu);
+        if (isMenu)
+        {
+            root.TransparencyLevelHint = new[] { WindowTransparencyLevel.None };
+            if (root.TryFindResource("MenuSurfaceBrush", root.ActualThemeVariant, out object? resource)
+                && resource is IBrush brush)
+            {
+                root.Background = brush;
+            }
+
+            ApplyRoundedCorners(root);
+            return;
+        }
+
         // Request acrylic (not Transparent): the Transparent level makes a layered window, and DWM
         // system backdrops never paint on those — so the popup ended up fully see-through with only
-        // the presenter tint, unreadable when shown over the desktop (e.g. the tray menu). AcrylicBlur
-        // gives a composited window DWM can actually fill. This path only runs when Mica is enabled
+        // the presenter tint and make its contents unreadable. AcrylicBlur gives a composited window
+        // DWM can actually fill. This path only runs when Mica is enabled
         // (Win11 + transparency effects), so acrylic is always available here.
         root.TransparencyLevelHint = new[] { WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Blur };
         root.Background = Brushes.Transparent;
@@ -91,6 +110,15 @@ internal static class MicaWindowHelper
         NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
         int backdrop = DWMSBT_TRANSIENTWINDOW;
         NativeMethods.DwmSetWindowAttribute(handle, DWMWA_SYSTEMBACKDROP_TYPE, ref backdrop, sizeof(int));
+    }
+
+    private static void ApplyRoundedCorners(TopLevel root)
+    {
+        if (root.TryGetPlatformHandle()?.Handle is not { } handle || handle == 0)
+            return;
+
+        int corner = DWMWCP_ROUND;
+        NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
     }
 
     /// <summary>

--- a/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
@@ -136,7 +136,7 @@ internal sealed class TrayService : IDisposable
         menu.Add(new NativeMenuItemSeparator());
 
         menu.Add(new NativeMenuItem(
-            CoreTools.Translate("UniGetUI Version {0}", CoreData.VersionName))
+            CoreTools.Translate("UniGetUI Version {0} by Devolutions", CoreData.VersionName))
         {
             IsEnabled = false,
         });

--- a/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
@@ -135,8 +135,12 @@ internal sealed class TrayService : IDisposable
         menu.Add(installed);
         menu.Add(new NativeMenuItemSeparator());
 
+        menu.Add(new NativeMenuItem(CoreTools.Translate("UniGetUI by Devolutions"))
+        {
+            IsEnabled = false,
+        });
         menu.Add(new NativeMenuItem(
-            CoreTools.Translate("UniGetUI Version {0} by Devolutions", CoreData.VersionName))
+            $"{CoreTools.Translate("Version")} {CoreData.VersionName}")
         {
             IsEnabled = false,
         });

--- a/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
@@ -136,7 +136,7 @@ internal sealed class TrayService : IDisposable
         menu.Add(new NativeMenuItemSeparator());
 
         menu.Add(new NativeMenuItem(
-            CoreTools.Translate("UniGetUI Version {0} by Devolutions", CoreData.VersionName))
+            CoreTools.Translate("UniGetUI Version {0}", CoreData.VersionName))
         {
             IsEnabled = false,
         });

--- a/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/TrayService.cs
@@ -135,12 +135,8 @@ internal sealed class TrayService : IDisposable
         menu.Add(installed);
         menu.Add(new NativeMenuItemSeparator());
 
-        menu.Add(new NativeMenuItem(CoreTools.Translate("UniGetUI by Devolutions"))
-        {
-            IsEnabled = false,
-        });
         menu.Add(new NativeMenuItem(
-            $"{CoreTools.Translate("Version")} {CoreData.VersionName}")
+            CoreTools.Translate("UniGetUI Version {0} by Devolutions", CoreData.VersionName))
         {
             IsEnabled = false,
         });

--- a/src/UniGetUI.Avalonia/Infrastructure/UninstallConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/UninstallConfirmationDialog.cs
@@ -22,15 +22,10 @@ internal static class UninstallConfirmationDialog
         }
 
         bool isConfirmed = false;
-        var dialog = new Window
+        var dialog = new UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
         {
-            Width = packages.Count == 1 ? 520 : 560,
-            Height = packages.Count == 1 ? 220 : 380,
-            MinWidth = 420,
-            MinHeight = packages.Count == 1 ? 220 : 300,
-            CanResize = packages.Count > 1,
-            ShowInTaskbar = false,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            MaxWidth = packages.Count == 1 ? 520 : 560,
+            MaxHeight = packages.Count == 1 ? 220 : 380,
             Title = CoreTools.Translate("Are you sure?"),
         };
 

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/ManageIgnoredUpdatesViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/ManageIgnoredUpdatesViewModel.cs
@@ -11,8 +11,6 @@ namespace UniGetUI.Avalonia.ViewModels;
 
 public partial class ManageIgnoredUpdatesViewModel : ObservableObject
 {
-    public event EventHandler? CloseRequested;
-
     public string Title { get; } = CoreTools.Translate("Manage ignored updates");
     public string Description { get; } = CoreTools.Translate("The packages listed here won't be taken in account when checking for updates. Double-click them or click the button on their right to stop ignoring their updates.");
     public string ResetLabel { get; } = CoreTools.Translate("Reset list");

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/BackupViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/BackupViewModel.cs
@@ -347,13 +347,11 @@ public partial class BackupViewModel : ViewModelBase, IDisposable
             Width = 360,
         };
 
-        var dialog = new Window
+        var dialog = new UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
         {
             Title = CoreTools.Translate("Select backup"),
-            Width = 440,
-            Height = 160,
-            CanResize = false,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            MaxWidth = 440,
+            MaxHeight = 160,
             Content = new StackPanel
             {
                 Margin = new Thickness(20),

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -122,7 +122,7 @@ public partial class SidebarViewModel : ViewModelBase
     public event EventHandler<PageType>? NavigationRequested;
 
     public string VersionLabel { get; } =
-        CoreTools.Translate("UniGetUI Version {0} by Devolutions", CoreData.VersionName);
+        CoreTools.Translate("UniGetUI Version {0}", CoreData.VersionName);
 
     [RelayCommand]
     public void RequestNavigation(string? pageName)

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -122,7 +122,7 @@ public partial class SidebarViewModel : ViewModelBase
     public event EventHandler<PageType>? NavigationRequested;
 
     public string VersionLabel { get; } =
-        CoreTools.Translate("UniGetUI Version {0}", CoreData.VersionName);
+        CoreTools.Translate("UniGetUI Version {0} by Devolutions", CoreData.VersionName);
 
     [RelayCommand]
     public void RequestNavigation(string? pageName)

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -366,13 +366,10 @@ public partial class PackagesPageViewModel : ViewModelBase
     {
         object? bgResource = null;
         Application.Current?.Resources.TryGetResource("AppWindowBackground", Application.Current.ActualThemeVariant, out bgResource);
-        var dialog = new Window
+        var dialog = new UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
         {
-            Width = 460,
-            Height = 180,
-            CanResize = false,
-            ShowInTaskbar = false,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            MaxWidth = 460,
+            MaxHeight = 180,
             Title = title,
             Background = bgResource as IBrush,
         };

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
@@ -26,6 +26,8 @@ public partial class InfoBar : UserControl
     }
 
     private InfoBarViewModel? _vm;
+    private IDisposable? _severityStripBinding;
+    private IDisposable? _severityIconBinding;
 
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
@@ -53,17 +55,19 @@ public partial class InfoBar : UserControl
         BodyBorder.Classes.Set("severity-warning", severity == InfoBarSeverity.Warning);
         BodyBorder.Classes.Set("severity-info", severity == InfoBarSeverity.Informational);
 
-        // Strip colour (solid, not theme-sensitive)
-        var stripColor = severity switch
+        _severityStripBinding?.Dispose();
+        _severityIconBinding?.Dispose();
+        _severityStripBinding = null;
+        _severityIconBinding = null;
+
+        Color? stripColor = severity switch
         {
             InfoBarSeverity.Warning => Color.Parse("#F7A800"),
             InfoBarSeverity.Error => Color.Parse("#C42B1C"),
             InfoBarSeverity.Success => Color.Parse("#107C10"),
-            _ => Color.Parse("#0078D4"),
+            _ => null,
         };
-        SeverityStrip.Background = new SolidColorBrush(stripColor);
 
-        // Icon (shared SVG asset, tinted with the severity colour)
         SeverityIcon.Path = severity switch
         {
             InfoBarSeverity.Warning => WarningIcon,
@@ -71,6 +75,23 @@ public partial class InfoBar : UserControl
             InfoBarSeverity.Success => SuccessIcon,
             _ => InfoIcon,
         };
-        SeverityIcon.Foreground = new SolidColorBrush(stripColor);
+
+        if (stripColor is { } color)
+        {
+            var brush = new SolidColorBrush(color);
+            SeverityStrip.Background = brush;
+            SeverityIcon.Foreground = brush;
+        }
+        else
+        {
+            SeverityStrip.ClearValue(Border.BackgroundProperty);
+            SeverityIcon.ClearValue(ForegroundProperty);
+            _severityStripBinding = SeverityStrip.Bind(
+                Border.BackgroundProperty,
+                this.GetResourceObservable("SystemAccentColor"));
+            _severityIconBinding = SeverityIcon.Bind(
+                ForegroundProperty,
+                this.GetResourceObservable("SystemAccentColor"));
+        }
     }
 }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/AboutWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/AboutWindow.axaml
@@ -1,15 +1,15 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         xmlns:about="using:UniGetUI.Avalonia.Views.Pages.AboutPages"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.AboutWindow"
         Title="{t:Translate About UniGetUI}"
-        Width="700" MinWidth="500"
-        Height="600" MinHeight="400"
-        CanResize="True"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+        MaxWidth="700"
+        MinWidth="500"
+        MaxHeight="600"
+        MinHeight="400"
+        Background="{DynamicResource AppDialogBackground}">
 
     <TabControl x:Name="MainTabControl" Margin="8">
 
@@ -31,4 +31,4 @@
 
     </TabControl>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/AboutWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/AboutWindow.axaml.cs
@@ -3,12 +3,11 @@ using Avalonia.Threading;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class AboutWindow : Window
+public partial class AboutWindow : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public AboutWindow()
     {
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
     }
 
     protected override void OnOpened(EventArgs e)

--- a/src/UniGetUI.Avalonia/Views/DialogPages/BundleSecurityReportDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/BundleSecurityReportDialog.axaml
@@ -1,17 +1,15 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.BundleSecurityReportDialog"
         Title="{t:Translate Bundle security report}"
-        Width="580"
-        Height="420"
+        MaxWidth="580"
         MinWidth="400"
+        MaxHeight="420"
         MinHeight="300"
-        CanResize="True"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid Margin="20"
           RowDefinitions="Auto,*,Auto"
@@ -42,4 +40,4 @@
 
     </Grid>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/BundleSecurityReportDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/BundleSecurityReportDialog.axaml.cs
@@ -4,12 +4,11 @@ using UniGetUI.Interface.Enums;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class BundleSecurityReportDialog : Window
+public partial class BundleSecurityReportDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public BundleSecurityReportDialog(BundleReport report)
     {
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
         var sb = new System.Text.StringBuilder();
         foreach (var (pkgId, entries) in report.Contents)

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml
@@ -1,14 +1,14 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.CrashReportWindow"
         Title="{t:Translate UniGetUI – Crash Report}"
-        Width="800" MinWidth="500"
-        Height="580" MinHeight="380"
-        CanResize="True"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+        MaxWidth="800"
+        MinWidth="500"
+        MaxHeight="580"
+        MinHeight="380"
+        Background="{DynamicResource AppDialogBackground}">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="24,20,24,24" Spacing="16">
@@ -66,4 +66,4 @@
         </StackPanel>
     </ScrollViewer>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/CrashReportWindow.axaml.cs
@@ -8,7 +8,7 @@ using UniGetUI.Core.Tools;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-internal sealed partial class CrashReportWindow : Window
+internal sealed partial class CrashReportWindow : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     private readonly string _crashReport;
 
@@ -16,7 +16,6 @@ internal sealed partial class CrashReportWindow : Window
     {
         _crashReport = crashReport;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         CrashReportText.Text = crashReport;
         DontSendButton.Content = CoreTools.Translate("Don't Send");
         SendButton.Content = CoreTools.Translate("Send Report");

--- a/src/UniGetUI.Avalonia/Views/DialogPages/DiscardBundleChangesDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/DiscardBundleChangesDialog.axaml
@@ -1,33 +1,25 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.DiscardBundleChangesDialog"
         Title="{t:Translate Unsaved changes}"
-        Width="460"
-        SizeToContent="Height"
+        MaxWidth="460"
         MinHeight="160"
-        CanResize="False"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid Margin="20"
-          RowDefinitions="Auto,Auto,Auto"
+          RowDefinitions="Auto,Auto"
           RowSpacing="12">
 
         <TextBlock Grid.Row="0"
-                   Text="{t:Translate Unsaved changes}"
-                   FontSize="16"
-                   FontWeight="SemiBold"
-                   automation:AutomationProperties.HeadingLevel="1"/>
-
-        <TextBlock Grid.Row="1"
                    Text="{t:Translate You have unsaved changes in the current bundle. Do you want to discard them?}"
                    TextWrapping="Wrap"
                    Opacity="0.85"/>
 
-        <StackPanel Grid.Row="2"
+        <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Spacing="8">
@@ -44,4 +36,4 @@
 
     </Grid>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/DiscardBundleChangesDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/DiscardBundleChangesDialog.axaml.cs
@@ -3,14 +3,13 @@ using Avalonia.Threading;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class DiscardBundleChangesDialog : Window
+public partial class DiscardBundleChangesDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public bool Confirmed { get; private set; }
 
     public DiscardBundleChangesDialog()
     {
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         CancelButton.Click += (_, _) => Close();
         DiscardButton.Click += (_, _) => { Confirmed = true; Close(); };
     }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ImmersiveDialog.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ImmersiveDialog.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using UniGetUI.Core.Logging;
+
+namespace UniGetUI.Avalonia.Views.DialogPages;
+
+/// <summary>
+/// Base class for modal content hosted inside <see cref="MainWindow"/>.
+/// It exposes dialog-oriented show and close operations while the host owns presentation,
+/// focus, animation, and stacking.
+/// </summary>
+public class ImmersiveDialog : ContentControl
+{
+    public static readonly StyledProperty<string?> TitleProperty =
+        AvaloniaProperty.Register<ImmersiveDialog, string?>(nameof(Title));
+    public static readonly StyledProperty<bool> IsCloseButtonVisibleProperty =
+        AvaloniaProperty.Register<ImmersiveDialog, bool>(nameof(IsCloseButtonVisible), true);
+
+    internal event EventHandler? CloseRequested;
+    public event EventHandler<CancelEventArgs>? Closing;
+
+    public string? Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public bool IsCloseButtonVisible
+    {
+        get => GetValue(IsCloseButtonVisibleProperty);
+        set => SetValue(IsCloseButtonVisibleProperty, value);
+    }
+
+    public Task ShowDialog(Window owner)
+    {
+        MainWindow host = owner as MainWindow
+            ?? throw new ArgumentException(
+                "An immersive dialog must be owned by the main window.",
+                nameof(owner));
+        return host.ShowImmersiveDialogAsync(this);
+    }
+
+    public void Show(Window owner) => _ = ShowAndLogFailureAsync(owner);
+
+    private async Task ShowAndLogFailureAsync(Window owner)
+    {
+        try
+        {
+            await ShowDialog(owner);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+        }
+    }
+
+    public void Close()
+    {
+        var args = new CancelEventArgs();
+        Closing?.Invoke(this, args);
+        if (!args.Cancel)
+            CloseRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    internal void NotifyOpened() => OnOpened(EventArgs.Empty);
+    internal void NotifyClosed() => OnClosed(EventArgs.Empty);
+
+    protected virtual void OnOpened(EventArgs e) { }
+    protected virtual void OnClosed(EventArgs e) { }
+}

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml
@@ -1,39 +1,22 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
         xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
-        xmlns:chrome="using:Avalonia.Controls.Chrome"
         x:Class="UniGetUI.Avalonia.Views.InstallOptionsWindow"
         x:DataType="vm:InstallOptionsViewModel"
-        Width="680" MinWidth="500"
-        SizeToContent="Height"
-        CanResize="False"
+        MaxWidth="680"
+        MinWidth="500"
         Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner"
-        Title="">
+        Title="{Binding DialogTitle}">
 
-    <Window.KeyBindings>
+    <dialogs:ImmersiveDialog.KeyBindings>
         <KeyBinding Gesture="Ctrl+S" Command="{Binding SaveCommand}"/>
         <KeyBinding Gesture="Meta+S" Command="{Binding SaveCommand}"/>
-    </Window.KeyBindings>
+    </dialogs:ImmersiveDialog.KeyBindings>
 
-    <Window.Styles>
-        <!-- Extended client area adds a full-screen caption button; hide it so only the
-             standard window buttons remain (matches the Manage-ignored-updates window). -->
-        <Style Selector=":is(Control)[(chrome|WindowDecorationProperties.ElementRole)=FullScreenButton]">
-            <Setter Property="IsVisible" Value="False"/>
-        </Style>
-    </Window.Styles>
-
-    <Grid RowDefinitions="Auto,Auto">
-
-        <!-- Draggable title-bar strip: the client area is extended over the OS title bar,
-             so this restores window dragging (the ScrollViewer below would otherwise eat it). -->
-        <Border Grid.Row="0" Height="32" Background="Transparent"
-                PointerPressed="TitleBar_PointerPressed"/>
-
-        <ScrollViewer Grid.Row="1"
+    <Grid>
+        <ScrollViewer
                       MaxHeight="820"
                       VerticalScrollBarVisibility="Auto"
                       HorizontalScrollBarVisibility="Disabled">
@@ -59,4 +42,4 @@
             </StackPanel>
         </ScrollViewer>
     </Grid>
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsWindow.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.PackageEngine.Enums;
@@ -8,7 +7,7 @@ using UniGetUI.PackageEngine.Serializable;
 
 namespace UniGetUI.Avalonia.Views;
 
-public partial class InstallOptionsWindow : Window
+public partial class InstallOptionsWindow : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public bool ShouldProceedWithOperation =>
         ((InstallOptionsViewModel)DataContext!).ShouldProceedWithOperation;
@@ -19,11 +18,6 @@ public partial class InstallOptionsWindow : Window
         DataContext = vm;
         InitializeComponent();
 
-        // Drop the OS title-bar strip but keep the system min/close buttons, extending the
-        // client area into the title-bar region (matches the Manage-ignored-updates window).
-        ExtendClientAreaToDecorationsHint = true;
-        ExtendClientAreaTitleBarHeightHint = -1;
-
         vm.CloseRequested += (_, _) => Close();
     }
 
@@ -33,11 +27,4 @@ public partial class InstallOptionsWindow : Window
         Dispatcher.UIThread.Post(OptionsControl.FocusProfileSelector, DispatcherPriority.Background);
     }
 
-    // The client area is extended over the title bar, so provide window dragging from the
-    // transparent strip at the top.
-    private void TitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
-            BeginMoveDrag(e);
-    }
 }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/IntegrityViolationDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/IntegrityViolationDialog.axaml
@@ -1,28 +1,20 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.IntegrityViolationDialog"
         Title="{t:Translate Integrity violation}"
-        Width="520"
-        SizeToContent="Height"
+        MaxWidth="520"
         MinHeight="200"
-        CanResize="False"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid Margin="20"
-          RowDefinitions="Auto,Auto,Auto"
+          RowDefinitions="Auto,Auto"
           RowSpacing="12">
 
-        <TextBlock Grid.Row="0"
-                   Text="{t:Translate Integrity violation}"
-                   FontSize="16"
-                   FontWeight="SemiBold"
-                   automation:AutomationProperties.HeadingLevel="1"/>
-
-        <StackPanel Grid.Row="1" Spacing="8">
+        <StackPanel Grid.Row="0" Spacing="8">
             <TextBlock Text="{t:Translate UniGetUI or some of its components are missing or corrupt. It is strongly recommended to reinstall UniGetUI to adress the situation.}"
                        TextWrapping="Wrap"
                        FontWeight="SemiBold"
@@ -36,7 +28,7 @@
         </StackPanel>
 
         <Button x:Name="CloseButton"
-                Grid.Row="2"
+                Grid.Row="1"
                 Content="{t:Translate Close}"
                 MinWidth="90"
                 HorizontalAlignment="Right"
@@ -45,4 +37,4 @@
 
     </Grid>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/IntegrityViolationDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/IntegrityViolationDialog.axaml.cs
@@ -3,12 +3,11 @@ using Avalonia.Threading;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class IntegrityViolationDialog : Window
+public partial class IntegrityViolationDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public IntegrityViolationDialog()
     {
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         CloseButton.Click += (_, _) => Close();
     }
 

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageDesktopShortcutsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageDesktopShortcutsWindow.axaml
@@ -1,42 +1,34 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
     xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
         xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.ManageDesktopShortcutsWindow"
         x:DataType="vm:ManageDesktopShortcutsViewModel"
-        Width="950" MinWidth="560"
-        Height="520" MinHeight="300"
-        CanResize="True"
-        ShowInTaskbar="False"
+        MaxWidth="950"
+        MinWidth="560"
+        MaxHeight="520"
+        MinHeight="300"
         Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner"
         Title="{t:Translate Text='Manage shortcuts'}">
 
-    <Window.Styles>
+    <dialogs:ImmersiveDialog.Styles>
         <Style Selector="DataGridCell:current /template/ Grid#FocusVisual">
             <Setter Property="IsVisible" Value="False"/>
         </Style>
         <Style Selector="DataGridCell:current">
             <Setter Property="BorderBrush" Value="Transparent"/>
         </Style>
-    </Window.Styles>
+    </dialogs:ImmersiveDialog.Styles>
 
-    <Grid RowDefinitions="Auto,Auto,*,Auto"
+    <Grid RowDefinitions="Auto,*,Auto"
           Margin="16"
           RowSpacing="8">
 
-        <!-- ── Title ── -->
-        <TextBlock Grid.Row="0"
-                   Text="{t:Translate Text='Manage shortcuts'}"
-                   FontSize="20"
-                   FontWeight="SemiBold"
-                   Margin="0,0,0,4"
-                   automation:AutomationProperties.HeadingLevel="1"/>
-
         <!-- ── Header: description + Reset list button ── -->
-        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="8">
 
             <StackPanel Orientation="Vertical" Spacing="2">
                 <TextBlock Text="{t:Translate Text='UniGetUI has detected the following desktop shortcuts which can be removed automatically on future upgrades'}"
@@ -92,7 +84,7 @@
         </Grid>
 
         <!-- ── Shortcut list ── -->
-        <Border Grid.Row="2"
+        <Border Grid.Row="1"
                 CornerRadius="8"
                 BorderThickness="1"
                 BorderBrush="{DynamicResource AppBorderBrush}"
@@ -196,7 +188,7 @@
         </Border>
 
         <!-- ── Footer: auto-delete toggle + save button ── -->
-        <Grid Grid.Row="3" ColumnDefinitions="*,Auto" ColumnSpacing="8" Margin="0,4,0,0">
+        <Grid Grid.Row="2" ColumnDefinitions="*,Auto" ColumnSpacing="8" Margin="0,4,0,0">
 
             <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                 <ToggleSwitch IsChecked="{Binding AutoDelete}"
@@ -220,4 +212,4 @@
         </Grid>
 
     </Grid>
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageDesktopShortcutsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageDesktopShortcutsWindow.axaml.cs
@@ -5,14 +5,13 @@ using UniGetUI.Avalonia.ViewModels;
 
 namespace UniGetUI.Avalonia.Views;
 
-public partial class ManageDesktopShortcutsWindow : Window
+public partial class ManageDesktopShortcutsWindow : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public ManageDesktopShortcutsWindow(System.Collections.Generic.IReadOnlyList<string>? shortcuts = null)
     {
         var vm = new ManageDesktopShortcutsViewModel(shortcuts);
         DataContext = vm;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         vm.CloseRequested += (_, _) => Close();
     }
 

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml
@@ -78,10 +78,9 @@
         </Grid>
 
         <!-- ── Package list (mirrors the WinUI ItemsView: flat rows, no header) ── -->
-        <Border Grid.Row="1" CornerRadius="8"
-                BorderThickness="1"
-                BorderBrush="{DynamicResource AppBorderBrush}"
-                Background="{DynamicResource AppDialogPanelBackground}">
+        <Border Grid.Row="1"
+                CornerRadius="8"
+                Background="{DynamicResource AppDialogDarkBackground}">
           <Panel>
 
             <!-- Empty state -->

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml
@@ -1,20 +1,21 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
+        xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
         xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.ManageIgnoredUpdatesWindow"
         x:DataType="vm:ManageIgnoredUpdatesViewModel"
-        Width="850" MinWidth="520"
-        Height="500" MinHeight="280"
-        CanResize="True"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner"
-        Title="{Binding Title}">
+        Title="{Binding Title}"
+        MaxWidth="850"
+        MinWidth="520"
+        MaxHeight="500"
+        MinHeight="280"
+        HorizontalContentAlignment="Stretch"
+        VerticalContentAlignment="Stretch">
 
-    <Window.Styles>
+    <dialogs:ImmersiveDialog.Styles>
         <!-- WinUI-style row hover highlight. The base Background must be set via a style
              (not a local value) so the :pointerover setter can override it. -->
         <Style Selector="Border.row">
@@ -23,15 +24,14 @@
         <Style Selector="Border.row:pointerover">
             <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
         </Style>
-    </Window.Styles>
+    </dialogs:ImmersiveDialog.Styles>
 
     <Grid RowDefinitions="Auto,*"
-          Margin="16"
-          RowSpacing="8">
+          Margin="20"
+          RowSpacing="12">
 
-        <!-- ── Header: description + Reset list button (title is carried by the window caption) ── -->
+        <!-- ── Description + Reset list button ── -->
         <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="8">
-
             <TextBlock Text="{Binding Description}"
                        TextWrapping="Wrap"
                        VerticalAlignment="Center"
@@ -78,7 +78,7 @@
         </Grid>
 
         <!-- ── Package list (mirrors the WinUI ItemsView: flat rows, no header) ── -->
-        <Border Grid.Row="1" Margin="0,4,0,0" CornerRadius="8"
+        <Border Grid.Row="1" CornerRadius="8"
                 BorderThickness="1"
                 BorderBrush="{DynamicResource AppBorderBrush}"
                 Background="{DynamicResource AppDialogPanelBackground}">
@@ -170,4 +170,4 @@
         </Border>
 
     </Grid>
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageIgnoredUpdatesWindow.axaml.cs
@@ -1,76 +1,39 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using UniGetUI.Avalonia.ViewModels;
-using UniGetUI.Core.Logging;
-using UniGetUI.Core.SettingsEngine;
 
 namespace UniGetUI.Avalonia.Views;
 
-public partial class ManageIgnoredUpdatesWindow : Window
+public partial class ManageIgnoredUpdatesWindow : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
-    public ManageIgnoredUpdatesWindow(Window? owner = null)
+    public ManageIgnoredUpdatesWindow()
     {
         var vm = new ManageIgnoredUpdatesViewModel();
         DataContext = vm;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
-        // Set the size before the window opens so CenterOwner positions it correctly.
-        ApplyInitialSize(owner);
-
-        vm.CloseRequested += (_, _) => Close();
+        KeyDown += OnDialogKeyDown;
+        AttachedToVisualTree += (_, _) => Dispatcher.UIThread.Post(FocusInitialControl,
+            DispatcherPriority.Background);
     }
 
-    // Restore the user's last size, falling back to the XAML default, and never open larger
-    // than the owner window (recovers the adaptive sizing of the pre-Avalonia overlay).
-    private void ApplyInitialSize(Window? owner)
+    private void FocusInitialControl()
     {
-        double width = Width;
-        double height = Height;
-
-        string saved = Settings.GetValue(Settings.K.IgnoredUpdatesWindowSize);
-        if (!string.IsNullOrEmpty(saved))
-        {
-            string[] parts = saved.Split(',');
-            if (parts.Length == 2 && int.TryParse(parts[0], out int w) && int.TryParse(parts[1], out int h))
-            {
-                width = w;
-                height = h;
-            }
-        }
-
-        if (owner is not null)
-        {
-            width = Math.Min(width, owner.Width - 40);
-            height = Math.Min(height, owner.Height - 40);
-        }
-
-        Width = Math.Max(MinWidth, width);
-        Height = Math.Max(MinHeight, height);
+        if (((ManageIgnoredUpdatesViewModel)DataContext!).HasEntries)
+            IgnoredUpdatesGrid.Focus();
+        else
+            ResetButton.Focus();
     }
 
-    protected override void OnClosing(WindowClosingEventArgs e)
+    private void OnDialogKeyDown(object? sender, KeyEventArgs e)
     {
-        // Persist only the normal (non-maximized) size so the dialog reopens as the user left it.
-        if (WindowState == WindowState.Normal)
+        if (e.Key == Key.Escape)
         {
-            try { Settings.SetValue(Settings.K.IgnoredUpdatesWindowSize, $"{(int)Width},{(int)Height}"); }
-            catch (Exception ex) { Logger.Error(ex); }
+            Close();
+            e.Handled = true;
         }
-        base.OnClosing(e);
-    }
-
-    protected override void OnOpened(EventArgs e)
-    {
-        base.OnOpened(e);
-        Dispatcher.UIThread.Post(() =>
-        {
-            if (((ManageIgnoredUpdatesViewModel)DataContext!).HasEntries)
-                IgnoredUpdatesGrid.Focus();
-            else
-                ResetButton.Focus();
-        }, DispatcherPriority.Background);
     }
 
     private void ResetYes_Click(object? sender, RoutedEventArgs e)

--- a/src/UniGetUI.Avalonia/Views/DialogPages/MissingDependencyDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/MissingDependencyDialog.axaml
@@ -1,28 +1,19 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.MissingDependencyDialog"
-        Width="560"
-        SizeToContent="Height"
+        MaxWidth="560"
         MinHeight="230"
-        CanResize="False"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid Margin="20"
-          RowDefinitions="Auto,Auto,Auto"
+          RowDefinitions="Auto,Auto"
           RowSpacing="12">
 
-        <TextBlock x:Name="TitleBlock"
-                   Grid.Row="0"
-                   FontSize="16"
-                   FontWeight="SemiBold"
-                   TextWrapping="Wrap"
-                   automation:AutomationProperties.HeadingLevel="1"/>
-
-        <StackPanel Grid.Row="1" Spacing="8">
+        <StackPanel Grid.Row="0" Spacing="8">
             <TextBlock x:Name="DescBlock"
                        TextWrapping="Wrap"
                        Margin="0,0,0,5"/>
@@ -47,7 +38,7 @@
                          IsVisible="False"/>
         </StackPanel>
 
-        <StackPanel Grid.Row="2"
+        <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Spacing="8">
@@ -61,4 +52,4 @@
 
     </Grid>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/MissingDependencyDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/MissingDependencyDialog.axaml.cs
@@ -10,7 +10,7 @@ using UniGetUI.PackageEngine.Classes.Manager.Classes;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class MissingDependencyDialog : Window
+public partial class MissingDependencyDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     private readonly ManagerDependency _dep;
     private readonly int _current;
@@ -26,7 +26,6 @@ public partial class MissingDependencyDialog : Window
         _total = total;
 
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
         bool notFirstTime =
             Settings.GetDictionaryItem<string, string>(Settings.K.DependencyManagement, dep.Name)
@@ -36,7 +35,6 @@ public partial class MissingDependencyDialog : Window
         Title = CoreTools.Translate("Missing dependency")
             + (total > 1 ? $" ({current}/{total})" : "");
 
-        TitleBlock.Text = Title;
         DescBlock.Text = CoreTools.Translate(
             "UniGetUI requires {0} to operate, but it was not found on your system.", dep.Name);
         InfoBlock.Text = CoreTools.Translate(

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml
@@ -1,14 +1,14 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.OperationFailedDialog"
-        Width="800" MinWidth="500"
-        Height="550" MinHeight="300"
-        CanResize="True"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+        MaxWidth="800"
+        MinWidth="500"
+        MaxHeight="550"
+        MinHeight="300"
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid RowDefinitions="Auto,*,Auto">
 
@@ -43,4 +43,4 @@
         </Border>
 
     </Grid>
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -12,7 +12,7 @@ using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class OperationFailedDialog : Window
+public partial class OperationFailedDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     private readonly AbstractOperation _operation;
 
@@ -20,7 +20,6 @@ public partial class OperationFailedDialog : Window
     {
         _operation = operation;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         Title = operation.Metadata.FailureMessage;
 
         HeaderContent.Text =

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml
@@ -1,16 +1,16 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels.DialogPages"
         xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.OperationOutputWindow"
         x:DataType="vm:OperationOutputViewModel"
-        Width="700" MinWidth="400"
-        Height="500" MinHeight="300"
-        CanResize="True"
-        ShowInTaskbar="False"
+        MaxWidth="700"
+        MinWidth="400"
+        MaxHeight="500"
+        MinHeight="300"
         Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner"
         Title="{Binding Title}">
 
     <Border Margin="8"
@@ -22,4 +22,4 @@
                                 automation:AutomationProperties.AccessibilityView="Raw"/>
     </Border>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationOutputWindow.axaml.cs
@@ -7,14 +7,13 @@ using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class OperationOutputWindow : Window
+public partial class OperationOutputWindow : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public OperationOutputWindow(AbstractOperation operation)
     {
         var vm = new OperationOutputViewModel(operation);
         DataContext = vm;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
         OutputText.SetLines(vm.OutputLines);
         vm.OutputLines.CollectionChanged += OnOutputLinesChanged;

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -1,20 +1,20 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:vm="using:UniGetUI.Avalonia.ViewModels"
         xmlns:controls="using:UniGetUI.Avalonia.Views.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.PackageDetailsWindow"
         x:DataType="vm:PackageDetailsViewModel"
-        Width="1000" MinWidth="640"
-        Height="720" MinHeight="420"
-        CanResize="True"
-        ShowInTaskbar="False"
+        MaxWidth="1000"
+        MinWidth="640"
+        MaxHeight="720"
+        MinHeight="420"
         Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner"
-        Title="{Binding PackageName}">
+        Title="{t:Translate Package details}">
 
-    <Window.Styles>
+    <dialogs:ImmersiveDialog.Styles>
         <Style Selector="Expander /template/ ToggleButton#ExpanderHeader">
             <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
         </Style>
@@ -97,7 +97,7 @@
         <Style Selector="Border#ScreenshotsBorder:pointerover Button.carousel-nav">
             <Setter Property="Opacity" Value="0.9"/>
         </Style>
-    </Window.Styles>
+    </dialogs:ImmersiveDialog.Styles>
 
     <Grid>
         <!-- Loading indicator across the very top -->
@@ -255,9 +255,10 @@
                                 x:Name="ScreenshotsBorder"
                                 Height="320">
                             <Panel>
-                                <!-- Black letterbox only behind actual screenshots; the empty-state
+                                <!-- Neutral WinUI fallback only behind actual screenshots; the empty-state
                                      banner below composites over the themed window background instead. -->
-                                <Border Background="#000000" IsVisible="{Binding HasScreenshots}"/>
+                                <Border Background="{DynamicResource ScreenshotLetterboxBackground}"
+                                        IsVisible="{Binding HasScreenshots}"/>
                                 <Carousel x:Name="ScreenshotsCarousel"
                                           IsVisible="{Binding HasScreenshots}"
                                           ItemsSource="{Binding Screenshots}"
@@ -337,4 +338,4 @@
             </Grid>
         </ScrollViewer>
     </Grid>
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
@@ -24,7 +24,7 @@ using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.Views;
 
-public partial class PackageDetailsWindow : Window
+public partial class PackageDetailsWindow : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     private const double WideThreshold = 950;
     private const string ContributeUrl = "https://github.com/Devolutions/UniGetUI";
@@ -44,7 +44,6 @@ public partial class PackageDetailsWindow : Window
         _vm = new PackageDetailsViewModel(package, operation);
         DataContext = _vm;
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
         // Honor the OS "reduce motion" preference: drop the screenshot slide animation.
         if (MotionPreference.ReducedMotion)

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml
@@ -1,33 +1,25 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.ResetSettingsDialog"
         Title="{t:Translate Reset UniGetUI}"
-        Width="460"
-        SizeToContent="Height"
+        MaxWidth="460"
         MinHeight="160"
-        CanResize="False"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid Margin="20"
-          RowDefinitions="Auto,Auto,Auto"
+          RowDefinitions="Auto,Auto"
           RowSpacing="12">
 
         <TextBlock Grid.Row="0"
-                   Text="{t:Translate Reset UniGetUI}"
-                   FontSize="16"
-                   FontWeight="SemiBold"
-                   automation:AutomationProperties.HeadingLevel="1"/>
-
-        <TextBlock Grid.Row="1"
                    Text="{t:Translate Do you really want to reset UniGetUI to its default settings? This action cannot be undone.}"
                    TextWrapping="Wrap"
                    Opacity="0.85"/>
 
-        <StackPanel Grid.Row="2"
+        <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Spacing="8">
@@ -44,4 +36,4 @@
 
     </Grid>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ResetSettingsDialog.axaml.cs
@@ -3,14 +3,13 @@ using Avalonia.Threading;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class ResetSettingsDialog : Window
+public partial class ResetSettingsDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public bool Confirmed { get; private set; }
 
     public ResetSettingsDialog()
     {
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         CancelButton.Click += (_, _) => Close();
         ResetButton.Click += (_, _) => { Confirmed = true; Close(); };
     }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/SimpleErrorDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/SimpleErrorDialog.axaml
@@ -1,34 +1,25 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
         xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.SimpleErrorDialog"
-        Width="480"
-        SizeToContent="Height"
+        MaxWidth="480"
         MinHeight="160"
-        CanResize="False"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid Margin="20"
-          RowDefinitions="Auto,Auto,Auto"
+          RowDefinitions="Auto,Auto"
           RowSpacing="12">
 
-        <TextBlock x:Name="TitleBlock"
-                   Grid.Row="0"
-                   FontSize="16"
-                   FontWeight="SemiBold"
-                   TextWrapping="Wrap"
-                   automation:AutomationProperties.HeadingLevel="1"/>
-
         <TextBlock x:Name="MessageBlock"
-                   Grid.Row="1"
+                   Grid.Row="0"
                    TextWrapping="Wrap"
                    Opacity="0.85"/>
 
         <Button x:Name="OkButton"
-                Grid.Row="2"
+                Grid.Row="1"
                 Content="{t:Translate OK}"
                 MinWidth="80"
                 HorizontalAlignment="Right"
@@ -37,4 +28,4 @@
 
     </Grid>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/SimpleErrorDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/SimpleErrorDialog.axaml.cs
@@ -3,14 +3,12 @@ using Avalonia.Threading;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class SimpleErrorDialog : Window
+public partial class SimpleErrorDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public SimpleErrorDialog(string title, string message)
     {
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
         Title = title;
-        TitleBlock.Text = title;
         MessageBlock.Text = message;
         OkButton.Click += (_, _) => Close();
     }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml
@@ -1,30 +1,23 @@
-<Window xmlns="https://github.com/avaloniaui"
+<dialogs:ImmersiveDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:UniGetUI.Avalonia.Views.DialogPages"
     xmlns:automation="clr-namespace:Avalonia.Automation;assembly=Avalonia.Controls"
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.TelemetryDialog"
         Title="{t:Translate Share anonymous usage data}"
-        Width="520" MinWidth="420"
-        SizeToContent="Height"
+        IsCloseButtonVisible="False"
+        MaxWidth="520"
+        MinWidth="420"
         MinHeight="250"
-        CanResize="False"
-        ShowInTaskbar="False"
-        Background="{DynamicResource AppDialogBackground}"
-        WindowStartupLocation="CenterOwner">
+
+        Background="{DynamicResource AppDialogBackground}">
 
     <Grid Margin="20"
-          RowDefinitions="Auto,Auto,Auto"
+          RowDefinitions="Auto,Auto"
           RowSpacing="12">
 
-        <!-- Title -->
-        <TextBlock Grid.Row="0"
-                   Text="{t:Translate Share anonymous usage data}"
-                   FontSize="18"
-                   FontWeight="SemiBold"
-                   automation:AutomationProperties.HeadingLevel="1"/>
-
         <!-- Body -->
-        <StackPanel Grid.Row="1" Spacing="8">
+        <StackPanel Grid.Row="0" Spacing="8">
             <TextBlock Text="{t:Translate UniGetUI collects anonymous usage data with the sole purpose of understanding and improving the user experience.}"
                        TextWrapping="Wrap" Opacity="0.85"/>
             <TextBlock x:Name="Body2" TextWrapping="Wrap" Opacity="0.85"/>
@@ -40,7 +33,7 @@
         </StackPanel>
 
         <!-- Buttons -->
-        <StackPanel Grid.Row="2"
+        <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Spacing="8"
@@ -53,4 +46,4 @@
 
     </Grid>
 
-</Window>
+</dialogs:ImmersiveDialog>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml.cs
@@ -4,14 +4,13 @@ using UniGetUI.Core.Tools;
 
 namespace UniGetUI.Avalonia.Views.DialogPages;
 
-public partial class TelemetryDialog : Window
+public partial class TelemetryDialog : UniGetUI.Avalonia.Views.DialogPages.ImmersiveDialog
 {
     public bool? Result { get; private set; }
 
     public TelemetryDialog()
     {
         InitializeComponent();
-        UniGetUI.Avalonia.Infrastructure.MicaWindowHelper.Apply(this);
 
         Body2.Text = CoreTools.Translate("No personal information is collected nor sent, and the collected data is anonimized, so it can't be back-tracked to you.");
 

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -50,6 +50,33 @@
         <Style Selector="Border#NavFlyout.open">
             <Setter Property="Opacity" Value="1"/>
         </Style>
+        <!-- Shared WinUI caption-button states for the main window and immersive dialogs. -->
+        <Style Selector="Button.caption">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+        </Style>
+        <Style Selector="Button.caption:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
+            <Setter Property="CornerRadius" Value="0"/>
+        </Style>
+        <Style Selector="Button.caption:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}"/>
+            <Setter Property="CornerRadius" Value="0"/>
+        </Style>
+        <Style Selector="Button.caption-close:pointerover">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="Button.caption-close:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#C42B1C"/>
+        </Style>
+        <Style Selector="Button.caption-close:pressed">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="Button.caption-close:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="#A4262C"/>
+        </Style>
     </Window.Styles>
     <Panel>
         <!-- Solid inactive-state fallback, using the same theme resource as the #5111 Mica failure path. -->
@@ -611,64 +638,113 @@
                 </Border>
             </Popup>
 
-            <!-- Right column: Linux window buttons on the far right -->
+            <!-- Right column: custom Windows/Linux caption buttons -->
             <Panel Grid.Column="2">
 
                 <!-- Custom min / max / close (shown on Windows, and Linux without native decorations; IsVisible set in code-behind) -->
                 <StackPanel x:Name="WindowButtons"
                             Orientation="Horizontal"
                             HorizontalAlignment="Right"
-                            VerticalAlignment="Center"
-                            Margin="0,0,4,0"
+                            VerticalAlignment="Top"
                             Spacing="0"
                             IsVisible="False">
                     <!-- Minimize: horizontal line -->
-                    <Button Width="46" Height="32" Padding="0"
-                            Background="Transparent" BorderThickness="0" CornerRadius="0"
+                    <Button Width="46" Height="44"
+                            Classes="caption"
                                                         automation:AutomationProperties.Name="{t:Translate Minimize}"
                             ToolTip.Tip="{t:Translate Minimize}"
                             Click="MinimizeButton_Click">
-                        <Path Stroke="{DynamicResource SystemBaseHighColor}"
-                              StrokeThickness="1.5"
+                        <Path Stroke="{Binding $parent[Button].Foreground}"
+                              StrokeThickness="1"
                               StrokeLineCap="Round"
                                                             automation:AutomationProperties.AccessibilityView="Raw"
-                              Data="M2,0 H10"
-                              Width="12" Height="2"
+                              Data="M1,1 H9"
+                              Width="10" Height="2"
                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Button>
                     <!-- Maximize / Restore: square outline, geometry swapped in code-behind -->
                     <Button x:Name="MaximizeButton"
-                            Width="46" Height="32" Padding="0"
-                            Background="Transparent" BorderThickness="0" CornerRadius="0"
+                            Width="46" Height="44"
+                            Classes="caption"
                                                         automation:AutomationProperties.Name="{t:Translate Maximize}"
                             ToolTip.Tip="{t:Translate Maximize}"
                             Click="MaximizeButton_Click">
                         <Path x:Name="MaximizeIcon"
-                              Stroke="{DynamicResource SystemBaseHighColor}"
-                              StrokeThickness="1.5"
+                              Stroke="{Binding $parent[Button].Foreground}"
+                              StrokeThickness="1"
                               StrokeLineCap="Round"
                                                             automation:AutomationProperties.AccessibilityView="Raw"
 
                               Data="M0,0 H10 V10 H0 Z"
-                              Width="12" Height="12"
+                              Width="10" Height="10"
                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Button>
                     <!-- Close: X -->
-                    <Button Width="46" Height="32" Padding="0"
-                            Background="Transparent" BorderThickness="0" CornerRadius="0"
+                    <Button Width="46" Height="44"
+                            Classes="caption caption-close"
                                                         automation:AutomationProperties.Name="{t:Translate Close}"
                             ToolTip.Tip="{t:Translate Close}"
                             Click="CloseButton_Click">
-                        <Path Stroke="{DynamicResource SystemBaseHighColor}"
-                              StrokeThickness="1.5"
-                              StrokeLineCap="Round"
-                                                            automation:AutomationProperties.AccessibilityView="Raw"
-                              Data="M0,0 L10,10 M10,0 L0,10"
-                              Width="12" Height="12"
-                              HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/cross.svg"
+                                          Width="14"
+                                          Height="14"
+                                          automation:AutomationProperties.AccessibilityView="Raw"/>
                     </Button>
                 </StackPanel>
             </Panel>
+        </Grid>
+
+        <!-- Immersive same-window modal layer, inset from and attached to its owner. -->
+        <Grid x:Name="ModalLayer"
+              IsVisible="False"
+              Opacity="0"
+              Background="{DynamicResource SmokeFillColorDefaultBrush}"
+              Margin="{Binding $parent[Window].WindowDecorationMargin}"
+              ZIndex="2000"
+              automation:AutomationProperties.AccessibilityView="Control">
+            <Border x:Name="ModalSurface"
+                    Margin="48"
+                    MaxWidth="1100"
+                    MaxHeight="900"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Background="{DynamicResource AppDialogBackground}"
+                    BorderBrush="{DynamicResource AppBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    ClipToBounds="True"
+                    KeyboardNavigation.TabNavigation="Cycle"
+                    BoxShadow="0 8 32 0 #59000000">
+                <Grid RowDefinitions="Auto,*">
+                    <Grid Grid.Row="0"
+                          Height="48"
+                          Margin="20,0,0,0"
+                          ColumnDefinitions="*,Auto">
+                        <TextBlock x:Name="ModalTitle"
+                                   VerticalAlignment="Center"
+                                   FontSize="20"
+                                   FontWeight="SemiBold"
+                                   TextTrimming="CharacterEllipsis"/>
+                        <Button x:Name="ModalCloseButton"
+                                Grid.Column="1"
+                                Width="46"
+                                Height="28"
+                                Classes="caption caption-close"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Click="ModalCloseButton_Click"
+                                automation:AutomationProperties.Name="{t:Translate Close}">
+                            <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/cross.svg"
+                                              Width="12"
+                                              Height="12"/>
+                        </Button>
+                    </Grid>
+                    <ContentControl x:Name="ModalContent"
+                                    Grid.Row="1"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"/>
+                </Grid>
+            </Border>
         </Grid>
 
         <!-- ── Toast notifications: floating overlay, stacked bottom-right ──

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -17,6 +17,9 @@
         MinWidth="700"
         MinHeight="500">
     <Window.Styles>
+        <Style Selector="Border#GlobalSearchContainer">
+            <Setter Property="Background" Value="{DynamicResource SearchBoxInactiveBackground}"/>
+        </Style>
         <!-- Global search box focus: a WinUI-style accent underline that spans the whole box
              (field + button) along the bottom, instead of recoloring the entire border. Toggled
              via styles (opacity) so the .focus-within setter wins over the base. -->
@@ -40,6 +43,7 @@
             <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
         </Style>
         <Style Selector="Border#GlobalSearchContainer:focus-within">
+            <Setter Property="Background" Value="{DynamicResource SearchBoxFocusedBackground}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SearchBoxFocusedBorderBrush}"/>
         </Style>
         <!-- Nav flyout cross-fade. The flyout's icons sit exactly over the static rail's icons, so
@@ -522,7 +526,6 @@
                     Height="32"
                     CornerRadius="5"
                     BorderThickness="1"
-                    Background="{DynamicResource SearchBoxInactiveBackground}"
                     ClipToBounds="True"
                     automation:AutomationProperties.AccessibilityView="Control">
                 <Panel>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -690,7 +690,7 @@
                         <Path Stroke="{Binding $parent[Button].Foreground}"
                               StrokeThickness="1.25"
                               StrokeLineCap="Round"
-                              Data="M0,0 L10,10 M10,0 L0,10"
+                              Data="M0.75,0.75 L9.25,9.25 M9.25,0.75 L0.75,9.25"
                               Width="10"
                               Height="10"
                               HorizontalAlignment="Center"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -688,10 +688,15 @@
                                                         automation:AutomationProperties.Name="{t:Translate Close}"
                             ToolTip.Tip="{t:Translate Close}"
                             Click="CloseButton_Click">
-                        <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/cross.svg"
-                                          Width="14"
-                                          Height="14"
-                                          automation:AutomationProperties.AccessibilityView="Raw"/>
+                        <Path Stroke="{Binding $parent[Button].Foreground}"
+                              StrokeThickness="1.25"
+                              StrokeLineCap="Round"
+                              Data="M0,0 L10,10 M10,0 L0,10"
+                              Width="10"
+                              Height="10"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              automation:AutomationProperties.AccessibilityView="Raw"/>
                     </Button>
                 </StackPanel>
             </Panel>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -521,7 +521,6 @@
                     Margin="0,0,40,0"
                     Height="32"
                     CornerRadius="5"
-                    BorderBrush="Transparent"
                     BorderThickness="1"
                     Background="{DynamicResource SearchBoxInactiveBackground}"
                     ClipToBounds="True"

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -39,6 +39,9 @@
             <Setter Property="Opacity" Value="1"/>
             <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
         </Style>
+        <Style Selector="Border#GlobalSearchContainer:focus-within">
+            <Setter Property="BorderBrush" Value="{DynamicResource SearchBoxFocusedBorderBrush}"/>
+        </Style>
         <!-- Nav flyout cross-fade. The flyout's icons sit exactly over the static rail's icons, so
              fading (rather than sliding) keeps the icons perfectly aligned — only the labels fade
              in/out, reading as a clean expand/collapse with no second nav appearing and no gap.
@@ -518,9 +521,9 @@
                     Margin="0,0,40,0"
                     Height="32"
                     CornerRadius="5"
-                    BorderBrush="{DynamicResource AppBorderBrush}"
+                    BorderBrush="Transparent"
                     BorderThickness="1"
-                    Background="{DynamicResource AppBadgeBackground}"
+                    Background="{DynamicResource SearchBoxInactiveBackground}"
                     ClipToBounds="True"
                     automation:AutomationProperties.AccessibilityView="Control">
                 <Panel>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia;
@@ -15,6 +16,8 @@ using Avalonia.VisualTree;
 using UniGetUI.Avalonia.Extensions;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels;
+using UniGetUI.Avalonia.Views.Controls;
+using UniGetUI.Avalonia.Views.DialogPages;
 using UniGetUI.Avalonia.Views.Pages;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
@@ -109,6 +112,12 @@ public partial class MainWindow : Window
     private double _operationsPanelHeight = 240;
     private bool _userResizedPanel;
     private readonly HashSet<OperationViewModel> _badgeSubscriptions = new();
+    private readonly SemaphoreSlim _modalTransitionSemaphore = new(1, 1);
+    private readonly List<ImmersiveDialog> _modalStack = new();
+    private readonly Dictionary<ImmersiveDialog, Control?> _modalFocusHistory = new();
+    private readonly List<UniGetUiWebView> _webViewsHiddenForModal = new();
+    private IDisposable? _modalTitleSubscription;
+    private Control? _focusBeforeModal;
 
     public enum RuntimeNotificationLevel
     {
@@ -149,6 +158,7 @@ public partial class MainWindow : Window
         UpdateOperationsPanelRow();
 
         Resized += (_, _) => _ = SaveGeometryAsync();
+        ModalLayer.SizeChanged += (_, _) => UpdateModalSurfaceSize();
         PositionChanged += (_, _) => _ = SaveGeometryAsync();
         this.GetObservable(WindowStateProperty).SubscribeValue(state => { UpdateOnScreenState(); _ = SaveGeometryAsync(); });
         this.GetObservable(IsVisibleProperty).SubscribeValue(_ => UpdateOnScreenState());
@@ -237,6 +247,16 @@ public partial class MainWindow : Window
 
     private void Window_KeyDown(object? sender, KeyEventArgs e)
     {
+        // A WinUI ContentDialog is a true modal scope: background navigation and package-page
+        // shortcuts must not run while keyboard focus is inside the dialog.
+        if (ModalLayer.IsVisible)
+        {
+            if (e.Key == Key.Escape)
+                (ModalContent.Content as ImmersiveDialog)?.Close();
+            e.Handled = true;
+            return;
+        }
+
         bool isCtrl = e.KeyModifiers.HasFlag(KeyModifiers.Control);
         bool isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
 
@@ -450,25 +470,12 @@ public partial class MainWindow : Window
             HamburgerPanel.Opacity = active ? 1.0 : 0.6;
             WindowButtons.Opacity = active ? 1.0 : 0.55;
 
-            // Match WinUI's inactive Mica appearance without invoking the permanent, global
-            // NotifyMicaUnavailable() fallback used when composition actually fails (#5111).
-            // A partial (not full) overlay so the inactive window still keeps some of the Mica
-            // tint instead of flattening to solid grey. Skip it while a modal dialog is open: the
-            // window deactivates but shouldn't grey out behind its own dialog. Modeless owned
-            // windows (operation output/failure) don't count — the main window should still grey
-            // when the user switches to another application.
+            // WinUI replaces inactive Mica with SolidBackgroundFillColorBase rather than leaving
+            // a partially wallpaper-tinted backdrop. AppWindowBackground is that token
+            // (#F3F3F3 light / #202020 dark), so make the fallback fully opaque while inactive.
             InactiveMicaFallback.Opacity =
-                MicaWindowHelper.IsMicaEnabled() && !active && !HasOpenModalDialog() ? 0.4 : 0.0;
+                MicaWindowHelper.IsMicaEnabled() && !active ? 1.0 : 0.0;
         });
-
-    // True when a window opened modally (ShowDialog) over this one is currently open.
-    private bool HasOpenModalDialog()
-    {
-        foreach (var owned in OwnedWindows)
-            if (owned.IsDialog)
-                return true;
-        return false;
-    }
 
     private void SetupTitleBar()
     {
@@ -892,7 +899,7 @@ public partial class MainWindow : Window
     {
         MaximizeIcon.Data = Geometry.Parse(
             isMaximized
-                ? "M2,0 H10 V8 H2 Z M0,2 H8 V10 H0 Z"
+                ? "M3,0 H10 V7 H8 V2 H3 Z M0,3 H7 V10 H0 Z"
                 : "M0,0 H10 V10 H0 Z");
         ToolTip.SetTip(
             MaximizeButton,
@@ -903,7 +910,7 @@ public partial class MainWindow : Window
     // button's bounds — the area for which we claim HTMAXBUTTON so Snap Layouts can attach.
     private bool HitTestMaximizeButton(nint lParam)
     {
-        if (!MaximizeButton.IsVisible)
+        if (!MaximizeButton.IsVisible || !MaximizeButton.IsEnabled)
             return false;
         try
         {
@@ -931,7 +938,7 @@ public partial class MainWindow : Window
         if (key is not null && this.TryFindResource(key, ActualThemeVariant, out var res) && res is IBrush brush)
             MaximizeButton.Background = brush;
         else
-            MaximizeButton.Background = Brushes.Transparent;
+            MaximizeButton.ClearValue(BackgroundProperty);
     }
 
     private static void TrackNonClientMouseLeave(nint hWnd)
@@ -1445,6 +1452,259 @@ public partial class MainWindow : Window
     public void OpenManagerSettings(IPackageManager? manager = null) =>
         ViewModel.OpenManagerSettings(manager);
     public void ShowHelp(string uriAttachment = "") => ViewModel.ShowHelp(uriAttachment);
+
+    /// <summary>
+    /// Shows the ignored-updates editor as a modal surface inside this window. Keeping the
+    /// surface in the owner's visual tree makes it resize with the app and avoids a second
+    /// task-switcher/window-management target.
+    /// </summary>
+    public async Task ShowManageIgnoredUpdatesAsync()
+    {
+        var dialog = new ManageIgnoredUpdatesWindow();
+        await ShowImmersiveDialogAsync(dialog);
+    }
+
+    public async Task ShowImmersiveDialogAsync(ImmersiveDialog dialog)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void CloseDialog(object? sender, EventArgs args) => completion.TrySetResult();
+        bool opened = false;
+        bool added = false;
+        dialog.CloseRequested += CloseDialog;
+
+        try
+        {
+            await _modalTransitionSemaphore.WaitAsync();
+            try
+            {
+                if (_modalStack.Contains(dialog))
+                    throw new InvalidOperationException("The immersive dialog is already open.");
+
+                if (_modalStack.Count == 0)
+                {
+                    _focusBeforeModal = FocusManager?.GetFocusedElement() as Control;
+                    HideNativeWebViewsForModal();
+                    // Block pointer input without putting every underlying control into Avalonia's
+                    // disabled visual state. The modal layer owns focus while it is visible.
+                    MainContentRoot.IsHitTestVisible = false;
+                    TitleBarGrid.IsHitTestVisible = false;
+                }
+                else
+                {
+                    _modalFocusHistory[_modalStack[^1]] =
+                        FocusManager?.GetFocusedElement() as Control;
+                }
+
+                ModalContent.Content = null;
+                _modalStack.Add(dialog);
+                added = true;
+                PresentModal(dialog);
+                dialog.NotifyOpened();
+                opened = true;
+                await AnimateModalAsync(opening: true);
+                FocusModalIfNeeded(dialog);
+            }
+            finally
+            {
+                _modalTransitionSemaphore.Release();
+            }
+
+            await completion.Task;
+        }
+        finally
+        {
+            dialog.CloseRequested -= CloseDialog;
+            await _modalTransitionSemaphore.WaitAsync();
+            try
+            {
+                int index = added ? _modalStack.IndexOf(dialog) : -1;
+                bool isTopmost = index >= 0 && index == _modalStack.Count - 1;
+                if (isTopmost)
+                {
+                    try
+                    {
+                        await AnimateModalAsync(opening: false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex);
+                    }
+                    ModalContent.Content = null;
+                }
+
+                if (index >= 0)
+                    _modalStack.RemoveAt(index);
+                _modalFocusHistory.Remove(dialog);
+
+                if (opened)
+                {
+                    try
+                    {
+                        dialog.NotifyClosed();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex);
+                    }
+                }
+
+                if (_modalStack.Count > 0)
+                {
+                    PresentModal(_modalStack[^1]);
+                    ModalLayer.Opacity = 1;
+                    ModalSurface.Opacity = 1;
+                    ModalSurface.RenderTransform = null;
+                    RestoreModalFocus(_modalStack[^1]);
+                }
+                else
+                {
+                    _modalTitleSubscription?.Dispose();
+                    _modalTitleSubscription = null;
+                    ModalLayer.IsVisible = false;
+                    ModalContent.Content = null;
+                    ModalTitle.Text = "";
+                    MainContentRoot.IsHitTestVisible = true;
+                    TitleBarGrid.IsHitTestVisible = true;
+                    RestoreNativeWebViewsAfterModal();
+                    Dispatcher.UIThread.Post(
+                        () => _focusBeforeModal?.Focus(),
+                        DispatcherPriority.Background);
+                    _focusBeforeModal = null;
+                }
+            }
+            finally
+            {
+                _modalTransitionSemaphore.Release();
+            }
+        }
+    }
+
+    private void PresentModal(ImmersiveDialog dialog)
+    {
+        _modalTitleSubscription?.Dispose();
+        _modalTitleSubscription = dialog.GetObservable(ImmersiveDialog.TitleProperty)
+            .SubscribeValue(title => ModalTitle.Text = title ?? "");
+        ModalCloseButton.IsVisible = dialog.IsCloseButtonVisible;
+        ModalContent.Content = dialog;
+        ModalLayer.IsVisible = true;
+        UpdateModalSurfaceSize();
+    }
+
+    private void HideNativeWebViewsForModal()
+    {
+        _webViewsHiddenForModal.Clear();
+        foreach (UniGetUiWebView webView in MainContentRoot.GetVisualDescendants().OfType<UniGetUiWebView>())
+        {
+            if (!webView.IsVisible)
+                continue;
+
+            _webViewsHiddenForModal.Add(webView);
+            webView.IsVisible = false;
+        }
+    }
+
+    private void RestoreNativeWebViewsAfterModal()
+    {
+        foreach (UniGetUiWebView webView in _webViewsHiddenForModal)
+            webView.IsVisible = true;
+        _webViewsHiddenForModal.Clear();
+    }
+
+    private void FocusModalIfNeeded(ImmersiveDialog dialog)
+    {
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                if (ReferenceEquals(ModalContent.Content, dialog) && !dialog.IsKeyboardFocusWithin)
+                    ModalCloseButton.Focus();
+            },
+            DispatcherPriority.Background);
+    }
+
+    private void RestoreModalFocus(ImmersiveDialog dialog)
+    {
+        _modalFocusHistory.Remove(dialog, out Control? previousFocus);
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                if (!ReferenceEquals(ModalContent.Content, dialog))
+                    return;
+                if (previousFocus?.Focus() != true && !dialog.IsKeyboardFocusWithin)
+                    ModalCloseButton.Focus();
+            },
+            DispatcherPriority.Background);
+    }
+
+    private void ModalCloseButton_Click(object? sender, RoutedEventArgs e) =>
+        (ModalContent.Content as ImmersiveDialog)?.Close();
+
+    private void UpdateModalSurfaceSize()
+    {
+        if (ModalContent.Content is not ImmersiveDialog dialog)
+            return;
+
+        const double maximumSurfaceWidth = 1100;
+        const double maximumSurfaceHeight = 900;
+        double layerWidth = ModalLayer.Bounds.Width > 0 ? ModalLayer.Bounds.Width : Bounds.Width;
+        double layerHeight = ModalLayer.Bounds.Height > 0 ? ModalLayer.Bounds.Height : Bounds.Height;
+        double availableWidth = Math.Max(0, layerWidth - 96);
+        double availableHeight = Math.Max(0, layerHeight - 96);
+
+        ModalSurface.MaxWidth = Math.Min(maximumSurfaceWidth, availableWidth);
+        ModalSurface.MaxHeight = Math.Min(maximumSurfaceHeight, availableHeight);
+        ModalSurface.Width = double.IsFinite(dialog.MaxWidth)
+            ? Math.Min(dialog.MaxWidth, ModalSurface.MaxWidth)
+            : double.NaN;
+        ModalSurface.Height = double.IsFinite(dialog.MaxHeight)
+            ? Math.Min(dialog.MaxHeight, ModalSurface.MaxHeight)
+            : double.NaN;
+    }
+
+    private async Task AnimateModalAsync(bool opening)
+    {
+        if (MotionPreference.ReducedMotion)
+        {
+            ModalLayer.Opacity = opening ? 1 : 0;
+            ModalSurface.Opacity = opening ? 1 : 0;
+            ModalSurface.RenderTransform = null;
+            return;
+        }
+
+        var scale = new ScaleTransform();
+        ModalSurface.RenderTransformOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative);
+        ModalSurface.RenderTransform = scale;
+
+        double fromOpacity = opening ? 0 : 1;
+        double toOpacity = opening ? 1 : 0;
+        double fromScale = opening ? 1.06 : 1;
+        double toScale = opening ? 1 : 1.06;
+        var duration = TimeSpan.FromMilliseconds(opening ? 180 : 120);
+        long started = Stopwatch.GetTimestamp();
+        while (true)
+        {
+            double progress = Math.Clamp(
+                Stopwatch.GetElapsedTime(started).TotalMilliseconds / duration.TotalMilliseconds,
+                0,
+                1);
+            double eased = 1 - Math.Pow(1 - progress, 3);
+            double opacity = fromOpacity + ((toOpacity - fromOpacity) * eased);
+            double currentScale = fromScale + ((toScale - fromScale) * eased);
+
+            ModalLayer.Opacity = opacity;
+            ModalSurface.Opacity = opacity;
+            scale.ScaleX = currentScale;
+            scale.ScaleY = currentScale;
+
+            if (progress >= 1)
+                break;
+            await Task.Delay(16);
+        }
+
+        ModalLayer.Opacity = toOpacity;
+        ModalSurface.Opacity = toOpacity;
+        scale.ScaleX = toScale;
+        scale.ScaleY = toScale;
+    }
 
     /// <summary>
     /// Focuses the global search box and optionally pre-fills a character typed

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
@@ -67,7 +67,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
                 StrokeThickness = 1.5,
                 StrokeLineCap = PenLineCap.Round,
                 StrokeJoin = PenLineJoin.Round,
-                Stretch = Stretch.Uniform,
+                Stretch = Stretch.None,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
             };
@@ -101,6 +101,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             {
                 OnContent = "",
                 OffContent = "",
+                HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
             };
             AutomationProperties.SetName(toggle, manager.DisplayName);
@@ -170,26 +171,28 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
         TextBlock text)
     {
         string bgKey, fgKey, label;
+        glyph.RenderTransform = null;
         if (!manager.IsEnabled())
         {
             bgKey = "WarningBannerBackground";
             fgKey = "StatusWarningForeground";
             label = CoreTools.Translate("Disabled");
-            glyph.Data = Geometry.Parse("M3.5,1 V4.2 M3.5,6 V6.1");
+            glyph.Data = Geometry.Parse("M2.5,0.9 L2.5,2.6 M2.5,3.9 L2.5,4");
         }
         else if (manager.Status.Found)
         {
             bgKey = "StatusSuccessBackground";
             fgKey = "StatusSuccessForeground";
             label = CoreTools.Translate("Ready");
-            glyph.Data = Geometry.Parse("M1,3.6 L2.8,5.4 L6,1.5");
+            glyph.Data = Geometry.Parse("M0.5,2.6 L2,4.1 L4.5,0.9");
+            glyph.RenderTransform = new TranslateTransform(0, 2);
         }
         else
         {
             bgKey = "StatusErrorBackground";
             fgKey = "StatusErrorForeground";
             label = CoreTools.Translate("Not found");
-            glyph.Data = Geometry.Parse("M1.4,1.4 L5.6,5.6 M5.6,1.4 L1.4,5.6");
+            glyph.Data = Geometry.Parse("M0.75,0.75 L4.25,4.25 M4.25,0.75 L0.75,4.25");
         }
         IBrush background = LookupBrush(bgKey);
         badge.Background = background;

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
@@ -10,8 +10,8 @@ using UniGetUI.Avalonia.Views.Controls.Settings;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Interfaces;
-using CoreSettings = UniGetUI.Core.SettingsEngine.Settings;
 using AvaloniaPath = Avalonia.Controls.Shapes.Path;
+using CoreSettings = UniGetUI.Core.SettingsEngine.Settings;
 
 namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
 

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
@@ -52,7 +52,6 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
                 FontSize = 12,
                 FontWeight = FontWeight.SemiBold,
                 VerticalAlignment = VerticalAlignment.Center,
-                Foreground = LookupBrush("TextFillColorPrimaryBrush"),
             };
             AutomationProperties.SetAccessibilityView(badgeText, AccessibilityView.Raw);
 
@@ -194,6 +193,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
         badge.Background = background;
         icon.Fill = LookupBrush(fgKey);
         glyph.Stroke = background;
+        text.Foreground = LookupBrush("TextFillColorPrimaryBrush");
         text.Text = label;
         // Bake state into Name so VoiceOver always announces it on macOS
         AutomationProperties.SetName(toggle, $"{manager.DisplayName}, {label}");

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
@@ -177,7 +177,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             bgKey = "WarningBannerBackground";
             fgKey = "StatusWarningForeground";
             label = CoreTools.Translate("Disabled");
-            glyph.Data = Geometry.Parse("M2.5,0.9 L2.5,2.6 M2.5,3.9 L2.5,4");
+            glyph.Data = Geometry.Parse("M2.5,0.4 L2.5,2.1 M2.1,4 L2.9,4");
         }
         else if (manager.Status.Found)
         {
@@ -185,7 +185,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             fgKey = "StatusSuccessForeground";
             label = CoreTools.Translate("Ready");
             glyph.Data = Geometry.Parse("M0.5,2.6 L2,4.1 L4.5,0.9");
-            glyph.RenderTransform = new TranslateTransform(0, 2);
+            glyph.RenderTransform = new TranslateTransform(0, 1);
         }
         else
         {

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
@@ -177,7 +177,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             bgKey = "WarningBannerBackground";
             fgKey = "StatusWarningForeground";
             label = CoreTools.Translate("Disabled");
-            glyph.Data = Geometry.Parse("M2.5,0.4 L2.5,2.1 M2.1,4 L2.9,4");
+            glyph.Data = Geometry.Parse("M2.5,0.4 L2.5,2.1 M2.1,4.5 L2.9,4.5");
         }
         else if (manager.Status.Found)
         {
@@ -185,7 +185,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             fgKey = "StatusSuccessForeground";
             label = CoreTools.Translate("Ready");
             glyph.Data = Geometry.Parse("M0.5,2.6 L2,4.1 L4.5,0.9");
-            glyph.RenderTransform = new TranslateTransform(0, 1);
+            glyph.RenderTransform = new TranslateTransform(0, 0.5);
         }
         else
         {

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Layout;
 using Avalonia.Media;
 using UniGetUI.Avalonia.Infrastructure;
@@ -10,6 +11,7 @@ using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Interfaces;
 using CoreSettings = UniGetUI.Core.SettingsEngine.Settings;
+using AvaloniaPath = Avalonia.Controls.Shapes.Path;
 
 namespace UniGetUI.Avalonia.Views.Pages.SettingsPages;
 
@@ -22,7 +24,8 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
     public event EventHandler<Type>? NavigationRequested { add { } remove { } }
     public event EventHandler<IPackageManager>? ManagerNavigationRequested;
 
-    private readonly List<(ToggleSwitch Toggle, IPackageManager Manager, Border Badge, TextBlock BadgeText)> _rows = [];
+    private readonly List<(ToggleSwitch Toggle, IPackageManager Manager, Border Badge,
+        Ellipse BadgeIcon, AvaloniaPath BadgeGlyph, TextBlock BadgeText)> _rows = [];
     private bool _isLoadingToggles;
 
     public ManagersHomepage()
@@ -49,13 +52,46 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
                 FontSize = 12,
                 FontWeight = FontWeight.SemiBold,
                 VerticalAlignment = VerticalAlignment.Center,
+                Foreground = LookupBrush("TextFillColorPrimaryBrush"),
             };
             AutomationProperties.SetAccessibilityView(badgeText, AccessibilityView.Raw);
+
+            var badgeIcon = new Ellipse
+            {
+                Width = 12,
+                Height = 12,
+            };
+            var badgeGlyph = new AvaloniaPath
+            {
+                Width = 7,
+                Height = 7,
+                StrokeThickness = 1.5,
+                StrokeLineCap = PenLineCap.Round,
+                StrokeJoin = PenLineJoin.Round,
+                Stretch = Stretch.Uniform,
+            };
+            var iconHost = new Grid
+            {
+                Width = 12,
+                Height = 12,
+                VerticalAlignment = VerticalAlignment.Center,
+                Children = { badgeIcon, badgeGlyph },
+            };
+            AutomationProperties.SetAccessibilityView(iconHost, AccessibilityView.Raw);
+
+            var badgeContent = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 5,
+                VerticalAlignment = VerticalAlignment.Center,
+                Children = { iconHost, badgeText },
+            };
             var badge = new Border
             {
                 CornerRadius = new CornerRadius(4),
                 Padding = new Thickness(6, 3, 6, 3),
-                Child = badgeText,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Child = badgeContent,
             };
             AutomationProperties.SetAccessibilityView(badge, AccessibilityView.Raw);
 
@@ -72,14 +108,14 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
                 _isLoadingToggles = true;
                 toggle.IsChecked = manager.IsEnabled();
                 _isLoadingToggles = false;
-                ApplyStatusBadge(manager, toggle, badge, badgeText);
+                ApplyStatusBadge(manager, toggle, badge, badgeIcon, badgeGlyph, badgeText);
             };
             toggle.IsCheckedChanged += async (_, _) =>
             {
                 if (_isLoadingToggles) return;
                 CoreSettings.SetDictionaryItem(CoreSettings.K.DisabledManagers, manager.Name, toggle.IsChecked != true);
                 await Task.Run(manager.Initialize);
-                ApplyStatusBadge(manager, toggle, badge, badgeText);
+                ApplyStatusBadge(manager, toggle, badge, badgeIcon, badgeGlyph, badgeText);
                 AccessibilityAnnouncementService.AnnounceToggle(manager.DisplayName, toggle.IsChecked == true);
             };
 
@@ -108,7 +144,7 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             btn.Click += (_, _) => ManagerNavigationRequested?.Invoke(this, capturedManager);
 
             ManagersPanel.Children.Add(btn);
-            _rows.Add((toggle, manager, badge, badgeText));
+            _rows.Add((toggle, manager, badge, badgeIcon, badgeGlyph, badgeText));
         }
     }
 
@@ -116,15 +152,21 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
     public void RefreshToggles()
     {
         _isLoadingToggles = true;
-        foreach (var (toggle, manager, badge, badgeText) in _rows)
+        foreach (var (toggle, manager, badge, badgeIcon, badgeGlyph, badgeText) in _rows)
         {
             toggle.IsChecked = manager.IsEnabled();
-            ApplyStatusBadge(manager, toggle, badge, badgeText);
+            ApplyStatusBadge(manager, toggle, badge, badgeIcon, badgeGlyph, badgeText);
         }
         _isLoadingToggles = false;
     }
 
-    private void ApplyStatusBadge(IPackageManager manager, ToggleSwitch toggle, Border badge, TextBlock text)
+    private void ApplyStatusBadge(
+        IPackageManager manager,
+        ToggleSwitch toggle,
+        Border badge,
+        Ellipse icon,
+        AvaloniaPath glyph,
+        TextBlock text)
     {
         string bgKey, fgKey, label;
         if (!manager.IsEnabled())
@@ -132,21 +174,26 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             bgKey = "WarningBannerBackground";
             fgKey = "StatusWarningForeground";
             label = CoreTools.Translate("Disabled");
+            glyph.Data = Geometry.Parse("M3.5,1 V4.2 M3.5,6 V6.1");
         }
         else if (manager.Status.Found)
         {
             bgKey = "StatusSuccessBackground";
             fgKey = "StatusSuccessForeground";
             label = CoreTools.Translate("Ready");
+            glyph.Data = Geometry.Parse("M1,3.6 L2.8,5.4 L6,1.5");
         }
         else
         {
             bgKey = "StatusErrorBackground";
             fgKey = "StatusErrorForeground";
             label = CoreTools.Translate("Not found");
+            glyph.Data = Geometry.Parse("M1.4,1.4 L5.6,5.6 M5.6,1.4 L1.4,5.6");
         }
-        badge.Background = LookupBrush(bgKey);
-        text.Foreground = LookupBrush(fgKey);
+        IBrush background = LookupBrush(bgKey);
+        badge.Background = background;
+        icon.Fill = LookupBrush(fgKey);
+        glyph.Stroke = background;
         text.Text = label;
         // Bake state into Name so VoiceOver always announces it on macOS
         AutomationProperties.SetName(toggle, $"{manager.DisplayName}, {label}");

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/ManagersHomepage.axaml.cs
@@ -62,12 +62,14 @@ public sealed partial class ManagersHomepage : UserControl, ISettingsPage
             };
             var badgeGlyph = new AvaloniaPath
             {
-                Width = 7,
-                Height = 7,
+                Width = 5,
+                Height = 5,
                 StrokeThickness = 1.5,
                 StrokeLineCap = PenLineCap.Round,
                 StrokeJoin = PenLineJoin.Round,
                 Stretch = Stretch.Uniform,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             var iconHost = new Grid
             {

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -184,8 +184,7 @@
                     </StackPanel>
                 </ListBoxItem>
 
-                <!-- More: a nav item visually, but it opens a menu instead of selecting a page,
-                     so code-behind shows its flyout and re-syncs selection rather than highlighting it. -->
+                <!-- More is kept selected while its flyout is open so its navigation pill remains visible. -->
                 <ListBoxItem x:Name="MoreNavBtn" Tag="More" Classes="nav-item" Padding="4,2" CornerRadius="6"
                              automation:AutomationProperties.Name="{t:Translate More}"
                              ToolTip.Tip="{t:Translate More}">

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -13,7 +13,7 @@
              x:DataType="vm:SidebarViewModel"
              MinWidth="64">
 
-    <Grid RowDefinitions="*,Auto">
+    <Grid x:Name="SidebarLayout" RowDefinitions="*,Auto">
 
         <!-- Main nav items -->
         <ListBox x:Name="NavListBox"
@@ -233,5 +233,16 @@
             </ListBox>
 
         </StackPanel>
+
+        <!-- One shared indicator moves between items so selection changes use WinUI's
+             leading/trailing-edge stretch instead of fading separate item indicators. -->
+        <Canvas Grid.RowSpan="2" IsHitTestVisible="False">
+            <Border x:Name="NavigationSelectionPill"
+                    Width="3"
+                    Height="16"
+                    CornerRadius="1.5"
+                    Background="{DynamicResource AccentFillColorDefaultBrush}"
+                    IsVisible="False"/>
+        </Canvas>
     </Grid>
 </UserControl>

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -21,6 +21,7 @@ public partial class SidebarView : BaseView<SidebarViewModel>
     private int _pillAnimationVersion;
 
     private const double PillHeight = 16d;
+    private const double MaxPillStretch = PillHeight * 5d;
     private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(300);
 
     /// <summary>
@@ -227,6 +228,14 @@ public partial class SidebarView : BaseView<SidebarViewModel>
             double bottomProgress = movingDown ? lead : trail;
             double top = Lerp(startTop, targetTop, topProgress);
             double bottom = Lerp(startBottom, targetBottom, bottomProgress);
+
+            if (bottom - top > MaxPillStretch)
+            {
+                if (movingDown)
+                    top = bottom - MaxPillStretch;
+                else
+                    bottom = top + MaxPillStretch;
+            }
 
             animation.Children.Add(new KeyFrame
             {

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -4,8 +4,11 @@ using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
+using Avalonia.Threading;
+using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels;
 
 namespace UniGetUI.Avalonia.Views;
@@ -14,6 +17,11 @@ public partial class SidebarView : BaseView<SidebarViewModel>
 {
     private bool _lastNavItemSelectionWasAuto;
     private bool _isMoreFlyoutOpen;
+    private CancellationTokenSource? _pillAnimationCancellation;
+    private int _pillAnimationVersion;
+
+    private const double PillHeight = 16d;
+    private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(300);
 
     /// <summary>
     /// Whether the nav item text labels are shown. False renders an icon-only rail; true renders the
@@ -80,6 +88,7 @@ public partial class SidebarView : BaseView<SidebarViewModel>
             _ => null,
         };
         _lastNavItemSelectionWasAuto = false;
+        QueueSelectionPillUpdate(animate: NavigationSelectionPill.IsVisible);
     }
 
     private void NavListBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -97,6 +106,7 @@ public partial class SidebarView : BaseView<SidebarViewModel>
         {
             // Keep the item selected until the menu closes so its accent pill remains anchored.
             _isMoreFlyoutOpen = true;
+            QueueSelectionPillUpdate(animate: true, item);
             FlyoutBase.ShowAttachedFlyout(item);
             return;
         }
@@ -127,5 +137,153 @@ public partial class SidebarView : BaseView<SidebarViewModel>
             item.Focus();
         else
             NavListBox.Focus();
+    }
+
+    private void QueueSelectionPillUpdate(bool animate, ListBoxItem? targetItem = null)
+    {
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                if ((targetItem ?? NavListBox.SelectedItem ?? FooterNavListBox.SelectedItem) is ListBoxItem item)
+                {
+                    MoveSelectionPill(item, animate);
+                }
+                else
+                {
+                    _pillAnimationCancellation?.Cancel();
+                    NavigationSelectionPill.IsVisible = false;
+                }
+            },
+            DispatcherPriority.Render);
+    }
+
+    private void MoveSelectionPill(ListBoxItem item, bool animate)
+    {
+        Point? itemPosition = item.TranslatePoint(default, SidebarLayout);
+        if (itemPosition is null || item.Bounds.Height <= 0)
+            return;
+
+        double targetTop = itemPosition.Value.Y + ((item.Bounds.Height - PillHeight) / 2d);
+        double targetLeft = itemPosition.Value.X;
+
+        _pillAnimationCancellation?.Cancel();
+        _pillAnimationCancellation?.Dispose();
+        _pillAnimationCancellation = null;
+
+        Canvas.SetLeft(NavigationSelectionPill, targetLeft);
+
+        if (!NavigationSelectionPill.IsVisible || !animate || MotionPreference.ReducedMotion)
+        {
+            Canvas.SetTop(NavigationSelectionPill, targetTop);
+            NavigationSelectionPill.Height = PillHeight;
+            NavigationSelectionPill.IsVisible = true;
+            return;
+        }
+
+        double currentTop = Canvas.GetTop(NavigationSelectionPill);
+        if (double.IsNaN(currentTop))
+            currentTop = targetTop;
+
+        double currentBottom = currentTop + NavigationSelectionPill.Height;
+        double targetBottom = targetTop + PillHeight;
+        if (Math.Abs(currentTop - targetTop) < 0.5)
+            return;
+
+        bool movingDown = targetTop > currentTop;
+        _pillAnimationCancellation = new CancellationTokenSource();
+        int version = ++_pillAnimationVersion;
+        _ = AnimatePillEdgesAsync(
+            currentTop,
+            currentBottom,
+            targetTop,
+            targetBottom,
+            movingDown,
+            version,
+            _pillAnimationCancellation.Token);
+    }
+
+    private async Task AnimatePillEdgesAsync(
+        double startTop,
+        double startBottom,
+        double targetTop,
+        double targetBottom,
+        bool movingDown,
+        int version,
+        CancellationToken cancellationToken)
+    {
+        var animation = new Animation
+        {
+            Duration = PillAnimationDuration,
+            FillMode = FillMode.Forward,
+        };
+
+        const int sampleCount = 20;
+        for (int sample = 0; sample <= sampleCount; sample++)
+        {
+            double progress = (double)sample / sampleCount;
+            double lead = EvaluateBezier(progress, 0d, 0d, 0d, 1d);
+            double trail = EvaluateBezier(progress, 0.5d, 0d, 0.2d, 1d);
+            double topProgress = movingDown ? trail : lead;
+            double bottomProgress = movingDown ? lead : trail;
+            double top = Lerp(startTop, targetTop, topProgress);
+            double bottom = Lerp(startBottom, targetBottom, bottomProgress);
+
+            animation.Children.Add(new KeyFrame
+            {
+                Cue = new Cue(progress),
+                Setters =
+                {
+                    new Setter(Canvas.TopProperty, top),
+                    new Setter(Layoutable.HeightProperty, Math.Max(1d, bottom - top)),
+                },
+            });
+        }
+
+        try
+        {
+            await animation.RunAsync(NavigationSelectionPill, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (version != _pillAnimationVersion || cancellationToken.IsCancellationRequested)
+            return;
+
+        Canvas.SetTop(NavigationSelectionPill, targetTop);
+        NavigationSelectionPill.Height = PillHeight;
+    }
+
+    private static double Lerp(double start, double end, double progress)
+        => start + ((end - start) * progress);
+
+    private static double EvaluateBezier(
+        double progress,
+        double control1X,
+        double control1Y,
+        double control2X,
+        double control2Y)
+    {
+        double low = 0d;
+        double high = 1d;
+        for (int i = 0; i < 12; i++)
+        {
+            double parameter = (low + high) / 2d;
+            if (BezierCoordinate(parameter, control1X, control2X) < progress)
+                low = parameter;
+            else
+                high = parameter;
+        }
+
+        return BezierCoordinate((low + high) / 2d, control1Y, control2Y);
+    }
+
+    private static double BezierCoordinate(double parameter, double control1, double control2)
+    {
+        double inverse = 1d - parameter;
+        return (3d * inverse * inverse * parameter * control1)
+               + (3d * inverse * parameter * parameter * control2)
+               + (parameter * parameter * parameter);
     }
 }

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -21,7 +21,7 @@ public partial class SidebarView : BaseView<SidebarViewModel>
     private int _pillAnimationVersion;
 
     private const double PillHeight = 16d;
-    private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(600);
+    private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(400);
 
     /// <summary>
     /// Whether the nav item text labels are shown. False renders an icon-only rail; true renders the

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -21,8 +21,7 @@ public partial class SidebarView : BaseView<SidebarViewModel>
     private int _pillAnimationVersion;
 
     private const double PillHeight = 16d;
-    private const double MaxPillStretch = PillHeight * 5d;
-    private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(600);
 
     /// <summary>
     /// Whether the nav item text labels are shown. False renders an icon-only rail; true renders the
@@ -228,14 +227,6 @@ public partial class SidebarView : BaseView<SidebarViewModel>
             double bottomProgress = movingDown ? lead : trail;
             double top = Lerp(startTop, targetTop, topProgress);
             double bottom = Lerp(startBottom, targetBottom, bottomProgress);
-
-            if (bottom - top > MaxPillStretch)
-            {
-                if (movingDown)
-                    top = bottom - MaxPillStretch;
-                else
-                    bottom = top + MaxPillStretch;
-            }
 
             animation.Children.Add(new KeyFrame
             {

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -13,6 +13,7 @@ namespace UniGetUI.Avalonia.Views;
 public partial class SidebarView : BaseView<SidebarViewModel>
 {
     private bool _lastNavItemSelectionWasAuto;
+    private bool _isMoreFlyoutOpen;
 
     /// <summary>
     /// Whether the nav item text labels are shown. False renders an icon-only rail; true renders the
@@ -31,6 +32,15 @@ public partial class SidebarView : BaseView<SidebarViewModel>
     public SidebarView()
     {
         InitializeComponent();
+        if (FlyoutBase.GetAttachedFlyout(MoreNavBtn) is { } moreFlyout)
+        {
+            moreFlyout.Opened += (_, _) => _isMoreFlyoutOpen = true;
+            moreFlyout.Closed += (_, _) =>
+            {
+                _isMoreFlyoutOpen = false;
+                SyncListBoxSelection(ViewModel?.SelectedPageType ?? PageType.Null);
+            };
+        }
     }
 
     protected override void OnDataContextChanged(EventArgs e)
@@ -50,6 +60,9 @@ public partial class SidebarView : BaseView<SidebarViewModel>
 
     private void SyncListBoxSelection(PageType page)
     {
+        if (_isMoreFlyoutOpen)
+            return;
+
         // Selection lives in two ListBoxes (main + footer); only one may hold a selection at a time.
         _lastNavItemSelectionWasAuto = true;
         NavListBox.SelectedItem = page switch
@@ -82,8 +95,8 @@ public partial class SidebarView : BaseView<SidebarViewModel>
 
         if (tag == "More")
         {
-            // Not a page: re-sync selection so "More" doesn't stay highlighted, then open its menu.
-            SyncListBoxSelection(ViewModel?.SelectedPageType ?? PageType.Null);
+            // Keep the item selected until the menu closes so its accent pill remains anchored.
+            _isMoreFlyoutOpen = true;
             FlyoutBase.ShowAttachedFlyout(item);
             return;
         }

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -29,6 +29,7 @@
       <!-- Header as one inset, rounded bar (WinUI-style): rounded + inset ends, no borders/separators -->
       <Style Selector="DataGridColumnHeader">
          <Setter Property="Background" Value="{DynamicResource PackageListHeaderBackground}"/>
+         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
          <Setter Property="HorizontalContentAlignment" Value="Center"/>
          <Setter Property="AreSeparatorsVisible" Value="False"/>
          <Setter Property="SeparatorBrush" Value="Transparent"/>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -922,9 +922,9 @@
                 <Button x:Name="OrderByButton"
                         Padding="10,6"
                         CornerRadius="4"
-                        Background="Transparent"
+                        Background="{DynamicResource SettingsCardBackground}"
                         BorderThickness="1"
-                        BorderBrush="{DynamicResource AppBorderBrush}"
+                        BorderBrush="Transparent"
                         automation:AutomationProperties.LabeledBy="{Binding #OrderByLabel}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <TextBlock Text="{Binding SortFieldName}" VerticalAlignment="Center" FontSize="14"/>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -15,6 +15,9 @@
              Name="ABSTRACT_PAGE">
 
     <UserControl.Styles>
+      <Style Selector="Border#MegaQueryContainer">
+         <Setter Property="Background" Value="{DynamicResource SearchBoxInactiveBackground}"/>
+      </Style>
       <!-- Suppress per-cell focus highlight so the whole row appears selected -->
       <Style Selector="DataGridCell:current /template/ Grid#FocusVisual">
          <Setter Property="IsVisible" Value="False"/>
@@ -92,6 +95,7 @@
          <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
       </Style>
       <Style Selector="Border#MegaQueryContainer:focus-within">
+         <Setter Property="Background" Value="{DynamicResource SearchBoxFocusedBackground}"/>
          <Setter Property="BorderBrush" Value="{DynamicResource SearchBoxFocusedBorderBrush}"/>
       </Style>
    </UserControl.Styles>
@@ -852,7 +856,6 @@
                             Grid.ColumnSpan="2"
                             CornerRadius="8"
                             BorderThickness="1"
-                            Background="{DynamicResource SearchBoxInactiveBackground}"
                             ClipToBounds="True">
                         <Panel>
                             <Grid ColumnDefinitions="*,64">

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -851,7 +851,6 @@
                             Grid.Column="1"
                             Grid.ColumnSpan="2"
                             CornerRadius="8"
-                            BorderBrush="Transparent"
                             BorderThickness="1"
                             Background="{DynamicResource SearchBoxInactiveBackground}"
                             ClipToBounds="True">

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -91,6 +91,9 @@
          <Setter Property="Opacity" Value="1"/>
          <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
       </Style>
+      <Style Selector="Border#MegaQueryContainer:focus-within">
+         <Setter Property="BorderBrush" Value="{DynamicResource SearchBoxFocusedBorderBrush}"/>
+      </Style>
    </UserControl.Styles>
 
    <UserControl.Resources>
@@ -848,9 +851,9 @@
                             Grid.Column="1"
                             Grid.ColumnSpan="2"
                             CornerRadius="8"
-                            BorderBrush="{DynamicResource AppBorderBrush}"
+                            BorderBrush="Transparent"
                             BorderThickness="1"
-                            Background="{DynamicResource MicaPageBackground}"
+                            Background="{DynamicResource SearchBoxInactiveBackground}"
                             ClipToBounds="True">
                         <Panel>
                             <Grid ColumnDefinitions="*,64">

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -49,7 +49,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
         ViewModel.ManageIgnoredRequested += async () =>
         {
             if (GetMainWindow() is { } win)
-                await new ManageIgnoredUpdatesWindow(win).ShowDialog(win);
+                await win.ShowManageIgnoredUpdatesAsync();
         };
 
         // "New version" sort option is only relevant on the updates page


### PR DESCRIPTION
Replaces pop-up windows with same-window immersive dialogs styled after WinUI. 
The PR also:
- improves caption button styling (minimize, maximize, close with changed glyphs, taller Windows11-style designs, and proper colors) 
- adjusts context menus (right-click, tray and main menu overflow menu) to be more similar to WinUI
- introduces small refinements for the UI interface in various places (glitchy pill with expansion menu open, new darker WinUI-accurate dark mode fallback color, etc.). 

<img width="1916" height="1294" alt="image" src="https://github.com/user-attachments/assets/27229b0e-998e-4916-93b1-6e0d0b10a32b" />

<img width="778" height="884" alt="image" src="https://github.com/user-attachments/assets/c30be87a-7474-4876-bc88-54af22388f1b" />

<img width="557" height="715" alt="image" src="https://github.com/user-attachments/assets/3b4298d2-209a-4ec5-809f-6219270819d2" />

Closes: #5189, #5191, #5177