### PR TITLE
Suppress WinGet COM phantom updates on 'no newer version' verdict

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -300,6 +300,9 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
                 }
             }
 
+            if (operation is OperationType.Update)
+                SuppressPhantomUpgrade(package);
+
             Logger.Warn(
                 $"Update for {package.Id} is not applicable to this system, even without scope/architecture constraints"
             );
@@ -403,6 +406,17 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             Settings.K.WinGetUpgradeAttempts,
             id,
             $"{count}{AttemptSeparator}{version}"
+        );
+    }
+
+    public static void SuppressPhantomUpgrade(IPackage package)
+    {
+        if (IsUnknownVersion(package.NewVersionString))
+            return;
+        Settings.SetDictionaryItem<string, string>(
+            Settings.K.WinGetUpgradeAttempts,
+            package.Id,
+            $"{StuckUpgradeThreshold}{AttemptSeparator}{package.NewVersionString}"
         );
     }
 

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -1093,6 +1093,38 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void WinGetUpdateNotApplicableSuppressesPhantomUpdate()
+    {
+        var manager = new WinGet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Hugin.Hugin")
+            .WithVersion("20.25.0")
+            .WithNewVersion("2025.0.1")
+            .Build();
+
+        Assert.False(WinGetPkgOperationHelper.IsStuckUpgradeLoop(package));
+
+        var veredict = manager.OperationHelper.GetResult(
+            package,
+            OperationType.Update,
+            [],
+            unchecked((int)0x8A15002B)
+        );
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.True(WinGetPkgOperationHelper.IsStuckUpgradeLoop(package));
+
+        var newerUpdate = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Hugin.Hugin")
+            .WithVersion("20.25.0")
+            .WithNewVersion("2026.0.0")
+            .Build();
+        Assert.False(WinGetPkgOperationHelper.IsStuckUpgradeLoop(newerUpdate));
+    }
+
+    [Fact]
     public void WinGetUpdateNotApplicableViaPingetRetriesWithoutScopeAndArchitecture()
     {
         // Bundled pinget signals "not applicable" with a non-zero exit code and a


### PR DESCRIPTION
This pull request addresses an issue where "phantom" WinGet updates (updates that are continually offered but cannot be applied) are not properly suppressed, which can lead to stuck upgrade loops. The main changes add logic to record and suppress these phantom upgrades, and introduce a new test to verify the behavior. 
Bugfix: Suppression of phantom WinGet upgrades (#5188)

* Added a call to `SuppressPhantomUpgrade` in `WinGetPkgOperationHelper.GetResult` when an update operation is not applicable, ensuring that repeated, non-applicable updates are not continually offered.
* Implemented the `SuppressPhantomUpgrade` method in `WinGetPkgOperationHelper`, which records the attempted upgrade in settings to prevent stuck upgrade loops.

Testing

* Added a new test, `WinGetUpdateNotApplicableSuppressesPhantomUpdate`, to verify that phantom updates are properly suppressed and that newer updates are not affected by the suppression.