### PR TITLE
Fail package operations when agent broker is unavailable instead of falling back, update package broker libs

### DIFF
--- a/src/UniGetUI.Avalonia.slnx
+++ b/src/UniGetUI.Avalonia.slnx
@@ -213,36 +213,6 @@
       <Platform Solution="*|x64" Project="x64" />
     </Project>
   </Folder>
-  <Folder Name="/UniGetUI.PackageEngine.Managers.Chocolatey/">
-    <Project Path="UniGetUI.PackageEngine.Managers.Chocolatey/UniGetUI.PackageEngine.Managers.Chocolatey.csproj">
-      <Platform Solution="*|arm64" Project="arm64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-  </Folder>
-  <Folder Name="/UniGetUI.PackageEngine.Managers.PowerShell/">
-    <Project Path="UniGetUI.PackageEngine.Managers.PowerShell/UniGetUI.PackageEngine.Managers.PowerShell.csproj">
-      <Platform Solution="*|arm64" Project="arm64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-  </Folder>
-  <Folder Name="/UniGetUI.PackageEngine.Managers.Scoop/">
-    <Project Path="UniGetUI.PackageEngine.Managers.Scoop/UniGetUI.PackageEngine.Managers.Scoop.csproj">
-      <Platform Solution="*|arm64" Project="arm64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-  </Folder>
-  <Folder Name="/UniGetUI.PackageEngine.Managers.WinGet/">
-    <Project Path="UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj">
-      <Platform Solution="*|arm64" Project="arm64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-  </Folder>
-  <Folder Name="/WindowsPackageManager.Interop/">
-    <Project Path="WindowsPackageManager.Interop/ExternalLibraries.WindowsPackageManager.Interop.csproj">
-      <Platform Solution="*|arm64" Project="arm64" />
-      <Platform Solution="*|x64" Project="x64" />
-    </Project>
-  </Folder>
   <Folder Name="/UniGetUI.PackageEngine.AgentBroker/">
     <Project Path="UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj">
       <Platform Solution="*|arm64" Project="arm64" />

--- a/src/UniGetUI.Avalonia.slnx
+++ b/src/UniGetUI.Avalonia.slnx
@@ -195,6 +195,60 @@
       <Platform Solution="*|x64" Project="x64" />
     </Project>
   </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.Managers.Apt/">
+    <Project Path="UniGetUI.PackageEngine.Managers.Apt/UniGetUI.PackageEngine.Managers.Apt.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.Managers.Dnf/">
+    <Project Path="UniGetUI.PackageEngine.Managers.Dnf/UniGetUI.PackageEngine.Managers.Dnf.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.Managers.Pacman/">
+    <Project Path="UniGetUI.PackageEngine.Managers.Pacman/UniGetUI.PackageEngine.Managers.Pacman.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.Managers.Chocolatey/">
+    <Project Path="UniGetUI.PackageEngine.Managers.Chocolatey/UniGetUI.PackageEngine.Managers.Chocolatey.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.Managers.PowerShell/">
+    <Project Path="UniGetUI.PackageEngine.Managers.PowerShell/UniGetUI.PackageEngine.Managers.PowerShell.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.Managers.Scoop/">
+    <Project Path="UniGetUI.PackageEngine.Managers.Scoop/UniGetUI.PackageEngine.Managers.Scoop.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.Managers.WinGet/">
+    <Project Path="UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/WindowsPackageManager.Interop/">
+    <Project Path="WindowsPackageManager.Interop/ExternalLibraries.WindowsPackageManager.Interop.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
+  <Folder Name="/UniGetUI.PackageEngine.AgentBroker/">
+    <Project Path="UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj">
+      <Platform Solution="*|arm64" Project="arm64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
   <Folder Name="/UniGetUI.PackageEngine.Operations/">
     <Project Path="UniGetUI.PackageEngine.Operations/UniGetUI.PackageEngine.Operations.csproj">
       <Platform Solution="*|arm64" Project="arm64" />

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -14,6 +14,7 @@ using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Classes.Manager.Classes;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Operations;
 using UniGetUI.PackageOperations;
 
 namespace UniGetUI.Avalonia.Infrastructure;
@@ -116,6 +117,14 @@ internal static class AvaloniaBootstrapper
             Secrets.GetOpenSearchUsername(),
             Secrets.GetOpenSearchPassword());
         AbstractOperation.QueueDrained += (_, _) => _ = TelemetryHandler.FlushPackageEventsAsync();
+        PackageOperation.BrokerUnavailable += (_, message) =>
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (MainWindow.Instance is not { } owner) return;
+                _ = new SimpleErrorDialog(
+                    CoreTools.Translate("Agent broker unavailable"),
+                    message).ShowDialog(owner);
+            });
         _ = TelemetryHandler.InitializeAsync()
             .ContinueWith(
                 t => Logger.Error(t.Exception!),

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -22,6 +22,10 @@ namespace UniGetUI.Avalonia.Infrastructure;
 internal static class AvaloniaBootstrapper
 {
     private static bool _hasStarted;
+
+    // Coalesces broker-unavailable notifications: during bulk operations every failed
+    // package raises the event, but only one dialog should be visible at a time.
+    private static bool _brokerUnavailableDialogActive;
     private static IpcServer? _ipcApi;
 
     public static async Task InitializeAsync()
@@ -118,12 +122,25 @@ internal static class AvaloniaBootstrapper
             Secrets.GetOpenSearchPassword());
         AbstractOperation.QueueDrained += (_, _) => _ = TelemetryHandler.FlushPackageEventsAsync();
         PackageOperation.BrokerUnavailable += (_, message) =>
-            Dispatcher.UIThread.Post(() =>
+            Dispatcher.UIThread.Post(async void () =>
             {
-                if (MainWindow.Instance is not { } owner) return;
-                _ = new SimpleErrorDialog(
-                    CoreTools.Translate("Agent broker unavailable"),
-                    message).ShowDialog(owner);
+                // Runs on the UI thread, so the flag needs no synchronization.
+                if (_brokerUnavailableDialogActive || MainWindow.Instance is not { } owner) return;
+                _brokerUnavailableDialogActive = true;
+                try
+                {
+                    await new SimpleErrorDialog(
+                        CoreTools.Translate("Agent broker unavailable"),
+                        message).ShowDialog(owner);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex);
+                }
+                finally
+                {
+                    _brokerUnavailableDialogActive = false;
+                }
             });
         _ = TelemetryHandler.InitializeAsync()
             .ContinueWith(

--- a/src/UniGetUI.PackageEngine.AgentBroker/BrokerRequestBuilder.cs
+++ b/src/UniGetUI.PackageEngine.AgentBroker/BrokerRequestBuilder.cs
@@ -83,28 +83,47 @@ public static class BrokerRequestBuilder
     };
 
     /// <summary>
+    /// Whether a UniGetUI manager name can be mapped to a broker protocol manager,
+    /// and therefore whether operations for it can be routed through the broker.
+    /// </summary>
+    public static bool SupportsManager(string managerName) =>
+        TryMapManagerName(managerName, out _);
+
+    /// <summary>
     /// Maps UniGetUI manager names to the broker protocol canonical managers.
     /// PowerShell 5 and PowerShell 7 are modeled as separate managers.
     /// </summary>
-    private static ManagerName MapManagerName(string managerName)
+    private static ManagerName MapManagerName(string managerName) =>
+        TryMapManagerName(managerName, out var mapped)
+            ? mapped
+            : throw new ArgumentException($"Unsupported manager for the broker: {managerName}");
+
+    private static bool TryMapManagerName(string managerName, out ManagerName mapped)
     {
-        if (managerName.Equals("Winget", StringComparison.OrdinalIgnoreCase))
+        ManagerName? result = managerName.ToLowerInvariant() switch
         {
-            return ManagerName.Winget;
-        }
+            "winget" => ManagerName.Winget,
+            "powershell" => ManagerName.PowerShell,
+            "powershell7" or "pwsh" => ManagerName.PowerShell7,
+            "apt" => ManagerName.Apt,
+            "bun" => ManagerName.Bun,
+            "cargo" => ManagerName.Cargo,
+            "chocolatey" => ManagerName.Chocolatey,
+            "dnf" => ManagerName.Dnf,
+            ".net tool" or "dotnet" => ManagerName.Dotnet,
+            "flatpak" => ManagerName.Flatpak,
+            "homebrew" => ManagerName.Homebrew,
+            "npm" => ManagerName.Npm,
+            "pacman" => ManagerName.Pacman,
+            "pip" => ManagerName.Pip,
+            "scoop" => ManagerName.Scoop,
+            "snap" => ManagerName.Snap,
+            "vcpkg" => ManagerName.Vcpkg,
+            _ => null,
+        };
 
-        if (managerName.Equals("PowerShell", StringComparison.OrdinalIgnoreCase))
-        {
-            return ManagerName.PowerShell;
-        }
-
-        if (managerName.Equals("PowerShell7", StringComparison.OrdinalIgnoreCase) ||
-            managerName.Equals("pwsh", StringComparison.OrdinalIgnoreCase))
-        {
-            return ManagerName.PowerShell7;
-        }
-
-        throw new ArgumentException($"Unsupported manager for the broker: {managerName}");
+        mapped = result ?? default;
+        return result is not null;
     }
 
     private static Scope? MapScope(string? scope)

--- a/src/UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj
+++ b/src/UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Now.Policy.Api" Version="2026.7.27" />
-        <PackageReference Include="Devolutions.Now.Policy.Client" Version="2026.7.27" />
+        <PackageReference Include="Devolutions.Now.Policy.Api" Version="2026.7.28" />
+        <PackageReference Include="Devolutions.Now.Policy.Client" Version="2026.7.28" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj
+++ b/src/UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Now.Policy.Api" Version="2026.7.13" />
-        <PackageReference Include="Devolutions.Now.Policy.Client" Version="2026.7.13" />
+        <PackageReference Include="Devolutions.Now.Policy.Api" Version="2026.7.27" />
+        <PackageReference Include="Devolutions.Now.Policy.Client" Version="2026.7.27" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.PackageEngine.Operations/InternalsVisibleTo.cs
+++ b/src/UniGetUI.PackageEngine.Operations/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UniGetUI.PackageEngine.Tests")]

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -27,6 +27,13 @@ namespace UniGetUI.PackageEngine.Operations
 {
     public abstract class PackageOperation : AbstractProcessOperation
     {
+        /// <summary>
+        /// Raised when an operation that must be routed through the Devolutions Agent broker
+        /// cannot proceed because the broker is not available. The payload is a user-facing
+        /// error message. The UI layer subscribes to this to show an error message box.
+        /// </summary>
+        public static event EventHandler<string>? BrokerUnavailable;
+
         protected List<string> DesktopShortcutsBeforeStart = [];
 
         public readonly IPackage Package;
@@ -206,13 +213,18 @@ namespace UniGetUI.PackageEngine.Operations
 
             using var client = CreateBrokerClient(RequiresAdminRights());
 
-            // Check broker availability.
+            // Check broker availability. Brokered operations must not fall back to local
+            // execution: policy evaluation and kill/pre/post actions are owned by the broker.
             if (!await client.IsAvailable(CancellationToken))
             {
-                Line("Agent broker is not available, falling back to local execution.", LineType.Information);
-                Line("Note: kill/pre/post operation actions were delegated to the broker and will not run for this fallback execution.", LineType.Information);
-                Logger.Warn("[AgentBroker] Broker not available, falling back to process execution");
-                return await base.PerformOperation();
+                Line("Agent broker is not available. The operation cannot continue.", LineType.Error);
+                Logger.Error("[AgentBroker] Broker not available, aborting operation");
+                string message = CoreTools.Translate(
+                    "The Devolutions Agent broker is not available. The operation cannot be performed. Please ensure the Devolutions Agent is installed and running.");
+                Metadata.FailureTitle = CoreTools.Translate("Agent broker unavailable");
+                Metadata.FailureMessage = message;
+                BrokerUnavailable?.Invoke(this, message);
+                return OperationVeredict.Failure;
             }
 
             // Resolve the install location the same way the local WinGet path does, so the

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -34,6 +34,12 @@ namespace UniGetUI.PackageEngine.Operations
         /// </summary>
         public static event EventHandler<string>? BrokerUnavailable;
 
+        /// <summary>
+        /// Test seam: substitutes the transport used to reach the agent broker so tests can
+        /// simulate broker outages without a real named pipe. Always null in production.
+        /// </summary>
+        internal static Func<Devolutions.Now.Policy.Client.IBrokerTransport>? BrokerTransportFactory;
+
         protected List<string> DesktopShortcutsBeforeStart = [];
 
         public readonly IPackage Package;
@@ -217,14 +223,7 @@ namespace UniGetUI.PackageEngine.Operations
             // execution: policy evaluation and kill/pre/post actions are owned by the broker.
             if (!await client.IsAvailable(CancellationToken))
             {
-                Line("Agent broker is not available. The operation cannot continue.", LineType.Error);
-                Logger.Error("[AgentBroker] Broker not available, aborting operation");
-                string message = CoreTools.Translate(
-                    "The Devolutions Agent broker is not available. The operation cannot be performed. Please ensure the Devolutions Agent is installed and running.");
-                Metadata.FailureTitle = CoreTools.Translate("Agent broker unavailable");
-                Metadata.FailureMessage = message;
-                BrokerUnavailable?.Invoke(this, message);
-                return OperationVeredict.Failure;
+                return HandleBrokerUnavailable();
             }
 
             // Resolve the install location the same way the local WinGet path does, so the
@@ -279,6 +278,13 @@ namespace UniGetUI.PackageEngine.Operations
                 Line("Broker operation was canceled.", LineType.Error);
                 return OperationVeredict.Canceled;
             }
+            catch (BrokerClientException ex) when (ex.Kind is BrokerClientErrorKind.BrokerUnavailable)
+            {
+                // The broker can stop between the availability probe and the request itself;
+                // route this through the same unavailable handling as a failed probe.
+                Logger.Error($"[AgentBroker] Broker became unavailable during the operation: {ex}");
+                return HandleBrokerUnavailable();
+            }
             catch (BrokerClientException ex)
             {
                 Line($"Broker operation failed: {ex.Message}", LineType.Error);
@@ -287,6 +293,24 @@ namespace UniGetUI.PackageEngine.Operations
                 Metadata.FailureMessage = ex.Message;
                 return OperationVeredict.Failure;
             }
+        }
+
+        /// <summary>
+        /// Fails the operation because the agent broker is unreachable: brokered operations
+        /// must not fall back to local execution, since policy evaluation and kill/pre/post
+        /// actions are owned by the broker. Sets the failure metadata and raises
+        /// <see cref="BrokerUnavailable"/> so the UI can notify the user.
+        /// </summary>
+        private OperationVeredict HandleBrokerUnavailable()
+        {
+            Line("Agent broker is not available. The operation cannot continue.", LineType.Error);
+            Logger.Error("[AgentBroker] Broker not available, aborting operation");
+            string message = CoreTools.Translate(
+                "The Devolutions Agent broker is not available. The operation cannot be performed. Please ensure the Devolutions Agent is installed and running.");
+            Metadata.FailureTitle = CoreTools.Translate("Agent broker unavailable");
+            Metadata.FailureMessage = message;
+            BrokerUnavailable?.Invoke(this, message);
+            return OperationVeredict.Failure;
         }
 
         private List<string> DisplayBrokerOutput(string? encodedStdout)
@@ -327,6 +351,7 @@ namespace UniGetUI.PackageEngine.Operations
             new(
                 new BrokerClientOptions
                 {
+                    Transport = BrokerTransportFactory?.Invoke(),
                     RequestedElevation = requestedElevation
                         ? BrokerElevation.Elevated
                         : BrokerElevation.Standard,
@@ -356,7 +381,7 @@ namespace UniGetUI.PackageEngine.Operations
             {
                 BrokerClientErrorKind.PolicyDenied => "Operation denied by policy",
                 BrokerClientErrorKind.UnsupportedCapability => "Operation unsupported by broker",
-                BrokerClientErrorKind.BrokerUnavailable or BrokerClientErrorKind.Timeout => "Broker communication error",
+                BrokerClientErrorKind.Timeout => "Broker communication error",
                 _ => "Operation failed via broker",
             };
 

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -167,8 +167,8 @@ namespace UniGetUI.PackageEngine.Operations
 
         /// <summary>
         /// Override to intercept operations and route through the Devolutions Agent broker
-        /// when the UseAgentBroker setting is enabled and the manager supports it (WinGet only for now).
-        /// Falls back to process-based execution otherwise.
+        /// when the UseAgentBroker setting is enabled and the manager is supported by the
+        /// broker protocol. Falls back to process-based execution otherwise.
         /// </summary>
         protected override async Task<OperationVeredict> PerformOperation()
         {
@@ -193,14 +193,14 @@ namespace UniGetUI.PackageEngine.Operations
         }
 
         /// <summary>
-        /// Whether a package operation is eligible for broker routing. Only WinGet is
-        /// supported in this iteration, and virtual/local sources are excluded: the agent
-        /// command builder always emits --source from the request, while the local WinGet
+        /// Whether a package operation is eligible for broker routing. The manager must be
+        /// mappable to a broker protocol manager, and virtual/local sources are excluded:
+        /// the agent command builder always emits --source from the request, while the local
         /// path deliberately omits it for virtual sources (e.g. the Local PC source).
         /// </summary>
         private static bool IsBrokerEligible(IPackage package) =>
             Settings.Get(Settings.K.UseAgentBroker)
-            && IsWinGetManager(package.Manager)
+            && BrokerRequestBuilder.SupportsManager(package.Manager.Name)
             && !package.Source.IsVirtualManager;
 
         /// <summary>
@@ -381,9 +381,10 @@ namespace UniGetUI.PackageEngine.Operations
 
         /// <summary>
         /// Resolves the install location to send in a broker request, matching the local
-        /// execution path: for updates this uses the WinGet portable-install safeguard
+        /// execution path: for WinGet updates this uses the portable-install safeguard
         /// (registry-detected location, saved value only under WinGetForceLocationOnUpdate);
-        /// for installs the configured custom location; for uninstalls nothing.
+        /// for installs (and non-WinGet updates) the configured custom location; for
+        /// uninstalls nothing.
         /// </summary>
         private string? GetBrokerEffectiveInstallLocation()
         {
@@ -391,10 +392,12 @@ namespace UniGetUI.PackageEngine.Operations
             {
                 case OperationType.Update:
 #if WINDOWS
-                    return WinGetPkgOperationHelper.GetEffectiveUpdateLocation(Package, Options);
-#else
-                    return null;
+                    if (IsWinGetManager(Package.Manager))
+                    {
+                        return WinGetPkgOperationHelper.GetEffectiveUpdateLocation(Package, Options);
+                    }
 #endif
+                    goto case OperationType.Install;
                 case OperationType.Install:
                     return string.IsNullOrWhiteSpace(Options.CustomInstallLocation)
                         ? null

--- a/src/UniGetUI.PackageEngine.Tests/BrokerRequestBuilderTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/BrokerRequestBuilderTests.cs
@@ -30,6 +30,20 @@ public class BrokerRequestBuilderTests
     [InlineData("Winget", ManagerName.Winget)]
     [InlineData("PowerShell", ManagerName.PowerShell)]
     [InlineData("PowerShell7", ManagerName.PowerShell7)]
+    [InlineData("Apt", ManagerName.Apt)]
+    [InlineData("Bun", ManagerName.Bun)]
+    [InlineData("Cargo", ManagerName.Cargo)]
+    [InlineData("Chocolatey", ManagerName.Chocolatey)]
+    [InlineData("Dnf", ManagerName.Dnf)]
+    [InlineData(".NET Tool", ManagerName.Dotnet)]
+    [InlineData("Flatpak", ManagerName.Flatpak)]
+    [InlineData("Homebrew", ManagerName.Homebrew)]
+    [InlineData("Npm", ManagerName.Npm)]
+    [InlineData("Pacman", ManagerName.Pacman)]
+    [InlineData("Pip", ManagerName.Pip)]
+    [InlineData("Scoop", ManagerName.Scoop)]
+    [InlineData("Snap", ManagerName.Snap)]
+    [InlineData("vcpkg", ManagerName.Vcpkg)]
     public void Build_MapsSupportedManagers(string managerName, ManagerName expected)
     {
         var package = new PackageBuilder()
@@ -44,11 +58,21 @@ public class BrokerRequestBuilderTests
     public void Build_ThrowsForUnsupportedManager()
     {
         var package = new PackageBuilder()
-            .WithManager(new PackageManagerBuilder().WithName("Scoop").Build())
+            .WithManager(new PackageManagerBuilder().WithName("NotARealManager").Build())
             .Build();
 
         Assert.Throws<ArgumentException>(
             () => BrokerRequestBuilder.Build(package, new InstallOptions(), OperationType.Install));
+    }
+
+    [Theory]
+    [InlineData("Winget", true)]
+    [InlineData("Chocolatey", true)]
+    [InlineData("Scoop", true)]
+    [InlineData("NotARealManager", false)]
+    public void SupportsManager_MatchesMapping(string managerName, bool expected)
+    {
+        Assert.Equal(expected, BrokerRequestBuilder.SupportsManager(managerName));
     }
 
     [Fact]

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Reflection;
 using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Enums;
@@ -13,6 +14,12 @@ using UniGetUI.PackageEngine.Structs;
 using UniGetUI.PackageEngine.Tests.Infrastructure.Builders;
 using UniGetUI.PackageEngine.Tests.Infrastructure.Fakes;
 using UniGetUI.PackageOperations;
+using BrokerClientErrorKind = Devolutions.Now.Policy.Client.BrokerClientErrorKind;
+using BrokerClientException = Devolutions.Now.Policy.Client.BrokerClientException;
+using BrokerTransportKind = Devolutions.Now.Policy.Api.Transport;
+using BrokerTransportRequest = Devolutions.Now.Policy.Client.BrokerTransportRequest;
+using BrokerTransportResponse = Devolutions.Now.Policy.Client.BrokerTransportResponse;
+using IBrokerTransport = Devolutions.Now.Policy.Client.IBrokerTransport;
 
 namespace UniGetUI.PackageEngine.Tests;
 
@@ -517,6 +524,77 @@ public sealed class PackageOperationsTests
         await firstRun;
     }
 
+    [Fact]
+    public async Task BrokerOperationFailsWithoutLocalFallbackWhenProbeFails()
+    {
+        var transport = new FakeBrokerTransport(healthy: false);
+
+        await AssertBrokerUnavailableFailure(transport);
+    }
+
+    [Fact]
+    public async Task BrokerOperationFailsWithoutLocalFallbackWhenBrokerDropsAfterProbe()
+    {
+        var transport = new FakeBrokerTransport(healthy: true);
+
+        await AssertBrokerUnavailableFailure(transport);
+
+        // The availability probe succeeded; the outage happened on the actual request.
+        Assert.Contains("/v1/health", transport.RequestedPaths);
+        Assert.Contains(transport.RequestedPaths, path => path != "/v1/health");
+    }
+
+    /// <summary>
+    /// Runs an install operation against a broker whose transport simulates an outage and
+    /// asserts the policy-enforcement contract: the operation fails with the
+    /// broker-unavailable metadata, raises <see cref="PackageOperation.BrokerUnavailable"/>,
+    /// and never falls back to local process execution.
+    /// </summary>
+    private static async Task AssertBrokerUnavailableFailure(FakeBrokerTransport transport)
+    {
+        bool originalSetting = Settings.Get(Settings.K.UseAgentBroker);
+        bool localExecutionPrepared = false;
+        var manager = new PackageManagerBuilder()
+            .WithName("Chocolatey")
+            .ConfigureManager(m =>
+            {
+                m.ExecutablePath = "C:\\test-tools\\choco.exe";
+                m.ExecutableArguments = "--test";
+            })
+            .ConfigureOperation(helper =>
+                helper.ParametersFactory = (package, _, operation) =>
+                {
+                    localExecutionPrepared = true;
+                    return [operation.ToString().ToLowerInvariant(), package.Id];
+                })
+            .Build();
+        var package = new PackageBuilder().WithManager(manager).Build();
+        string? notifiedMessage = null;
+        EventHandler<string> onBrokerUnavailable = (_, message) => notifiedMessage = message;
+        PackageOperation.BrokerUnavailable += onBrokerUnavailable;
+        PackageOperation.BrokerTransportFactory = () => transport;
+        Settings.Set(Settings.K.UseAgentBroker, true);
+        try
+        {
+            using var operation = new BrokerProbingInstallPackageOperation(package, new InstallOptions());
+            var veredict = await operation.InvokePerformOperationForTests();
+
+            Assert.Equal(OperationVeredict.Failure, veredict);
+            Assert.Equal(
+                CoreTools.Translate("Agent broker unavailable"),
+                operation.Metadata.FailureTitle);
+            Assert.False(string.IsNullOrWhiteSpace(operation.Metadata.FailureMessage));
+            Assert.Equal(operation.Metadata.FailureMessage, notifiedMessage);
+            Assert.False(localExecutionPrepared);
+        }
+        finally
+        {
+            Settings.Set(Settings.K.UseAgentBroker, originalSetting);
+            PackageOperation.BrokerTransportFactory = null;
+            PackageOperation.BrokerUnavailable -= onBrokerUnavailable;
+        }
+    }
+
     private static IReadOnlyList<AbstractOperation.InnerOperation> GetInnerOperations(
         AbstractOperation operation,
         string fieldName
@@ -571,6 +649,40 @@ public sealed class PackageOperationsTests
 
             await Task.Delay(25);
         }
+    }
+
+    private sealed class BrokerProbingInstallPackageOperation : InstallPackageOperation
+    {
+        public BrokerProbingInstallPackageOperation(IPackage package, InstallOptions options)
+            : base(package, options, IgnoreParallelInstalls: true) { }
+
+        public Task<OperationVeredict> InvokePerformOperationForTests() => PerformOperation();
+    }
+
+    private sealed class FakeBrokerTransport(bool healthy) : IBrokerTransport
+    {
+        public List<string> RequestedPaths { get; } = [];
+
+        public BrokerTransportKind Kind => BrokerTransportKind.HttpNamedPipe;
+
+        public Task<BrokerTransportResponse> Send(
+            BrokerTransportRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            RequestedPaths.Add(request.Path);
+            if (healthy && request.Path == "/v1/health")
+            {
+                return Task.FromResult(new BrokerTransportResponse { StatusCode = 200, Body = "{}" });
+            }
+
+            throw new BrokerClientException(
+                BrokerClientErrorKind.BrokerUnavailable,
+                "Simulated broker outage",
+                request.Path);
+        }
+
+        public void Dispose() { }
     }
 
     private class InspectableInstallPackageOperation : InstallPackageOperation


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **Have you confirmed that this issue is caused by UniGetUI itself, and not by the package manager or the package involved?**
If the same issue can be reproduced outside UniGetUI with the relevant package manager or with the package itself, please report it there first. UniGetUI should only be used to track issues that are specific to UniGetUI's behavior or integration.
-----

When broker mode (`UseAgentBroker`) is active, package operations previously fell back silently to local process execution if the Devolutions Agent broker was not reachable, and only WinGet operations were routed through the broker at all.

**1. Remove the non-brokered fallback**

- `PackageOperation.PerformBrokerOperation` now aborts with `OperationVeredict.Failure` when the broker is unreachable, setting a clear failure title ("Agent broker unavailable") and message. The fallback was unsafe: it bypassed policy evaluation and skipped the kill/pre/post actions delegated to the broker.
- A new static `PackageOperation.BrokerUnavailable` event is raised at that point. `AvaloniaBootstrapper` subscribes to it and shows a `SimpleErrorDialog` message box on the UI thread telling the user to ensure the Devolutions Agent is installed and running.

**2. Route all protocol-supported managers through the broker**

- Bumps `Devolutions.Now.Policy.Api`/`.Client` to 2026.7.28, which extends the protocol `ManagerName` enum beyond WinGet/PowerShell.
- Broker eligibility is now driven by `BrokerRequestBuilder.SupportsManager` instead of a WinGet-only check, covering all UniGetUI managers (Chocolatey, Scoop, Pip, Npm, .NET Tool, Cargo, vcpkg, and the Unix managers).
- The WinGet portable-install location safeguard now applies only to WinGet updates; other managers use the configured custom install location.

**3. Solution/CI housekeeping**

- Adds the cross-platform AgentBroker, Apt, Dnf and Pacman projects to `UniGetUI.Avalonia.slnx` so VS builds of the Avalonia solution resolve all project references (Windows-only projects stay in `UniGetUI.Windows.slnx`, since Linux CI restores the Avalonia solution).
