### PR TITLE
Stop self-update from recreating the desktop shortcut

### DIFF
--- a/UniGetUI.iss
+++ b/UniGetUI.iss
@@ -332,7 +332,7 @@ Source: "InstallerExtras\ForceUniGetUIPortable"; DestDir: "{app}"; Tasks: portab
 
 [Icons]
 Name: "{autostartmenu}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; AppUserModelID: "Devolutions.UniGetUI"; Tasks: regularinstall\startmenuicon
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: regularinstall\desktopicon
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: regularinstall\desktopicon; Check: not CmdLineParamExists('/NoDesktopShortcut')
 
 [Run]
 ; Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File -NonInteractive ""{tmp}\EnsureWinGet.ps1"""; StatusMsg: "Ensuring WinGet is properly installed... (this may take a while)"; WorkingDir: {app}; Check: not CmdLineParamExists('/NoWinGet'); Flags: runhidden

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAutoUpdater.cs
@@ -675,7 +675,7 @@ internal static partial class AvaloniaAutoUpdater
             StartInfo = new ProcessStartInfo
             {
                 FileName = installerLocation,
-                Arguments = "/SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NoVCRedist /NoEdgeWebView /NoWinGet /NoRedirectionGuard",
+                Arguments = "/SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NoVCRedist /NoEdgeWebView /NoWinGet /NoRedirectionGuard /NoDesktopShortcut",
                 UseShellExecute = true,
                 CreateNoWindow = true,
             },


### PR DESCRIPTION
This pull request introduces an improvement to the installer’s behavior regarding desktop shortcut creation. The main change ensures that, during automated or silent installations, a desktop shortcut is not created unless explicitly requested.

**Installer behavior improvements:**

* The installer now checks for the `/NoDesktopShortcut` command-line parameter and will skip creating a desktop shortcut if this parameter is present. (`UniGetUI.iss`)
* The auto-updater process now always passes the `/NoDesktopShortcut` flag when launching the installer, preventing unwanted desktop shortcuts during automated updates. (`AvaloniaAutoUpdater.cs`)