### PR TITLE
Prevent Alt+Space (and other modified activation keys) from triggering button action

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -28,6 +28,8 @@ public partial class App : Application
     {
         AvaloniaXamlLoader.Load(this);
 
+        ButtonActivationGuard.Install();
+
         // Windows 11 Mica look is opt-in per environment: only merge the translucent
         // surface overrides when Mica is actually usable (Win11 + transparency on).
         // macOS, Linux, Windows 10, and transparency-off all keep the solid Styles.Common look.

--- a/src/UniGetUI.Avalonia/Infrastructure/ButtonActivationGuard.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ButtonActivationGuard.cs
@@ -1,0 +1,26 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal static class ButtonActivationGuard
+{
+    private static bool _installed;
+
+    public static void Install()
+    {
+        if (_installed)
+            return;
+        _installed = true;
+
+        Button.KeyDownEvent.AddClassHandler<Button>(OnButtonKey, RoutingStrategies.Tunnel);
+        Button.KeyUpEvent.AddClassHandler<Button>(OnButtonKey, RoutingStrategies.Tunnel);
+    }
+
+    private static void OnButtonKey(Button button, KeyEventArgs e)
+    {
+        if ((e.Key is Key.Space or Key.Enter) && e.KeyModifiers is not KeyModifiers.None)
+            e.Handled = true;
+    }
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/ButtonActivationGuard.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ButtonActivationGuard.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -8,19 +9,42 @@ internal static class ButtonActivationGuard
 {
     private static bool _installed;
 
+    private static readonly ConditionalWeakTable<Button, object> _suppressedSpacePresses = new();
+    private static readonly object _marker = new();
+
     public static void Install()
     {
         if (_installed)
             return;
         _installed = true;
 
-        Button.KeyDownEvent.AddClassHandler<Button>(OnButtonKey, RoutingStrategies.Tunnel);
-        Button.KeyUpEvent.AddClassHandler<Button>(OnButtonKey, RoutingStrategies.Tunnel);
+        Button.KeyDownEvent.AddClassHandler<Button>(OnButtonKeyDown, RoutingStrategies.Tunnel);
+        Button.KeyUpEvent.AddClassHandler<Button>(OnButtonKeyUp, RoutingStrategies.Tunnel);
     }
 
-    private static void OnButtonKey(Button button, KeyEventArgs e)
+    private static void OnButtonKeyDown(Button button, KeyEventArgs e)
     {
-        if ((e.Key is Key.Space or Key.Enter) && e.KeyModifiers is not KeyModifiers.None)
+        if (e.Key is Key.Space)
+        {
+            if (e.KeyModifiers is not KeyModifiers.None)
+            {
+                _suppressedSpacePresses.AddOrUpdate(button, _marker);
+                e.Handled = true;
+            }
+            else
+            {
+                _suppressedSpacePresses.Remove(button);
+            }
+        }
+        else if (e.Key is Key.Enter && e.KeyModifiers is not KeyModifiers.None)
+        {
+            e.Handled = true;
+        }
+    }
+
+    private static void OnButtonKeyUp(Button button, KeyEventArgs e)
+    {
+        if (e.Key is Key.Space && _suppressedSpacePresses.Remove(button))
             e.Handled = true;
     }
 }


### PR DESCRIPTION
This pull request introduces a new utility, `ButtonActivationGuard`, to improve button input handling in the Avalonia UI application. The main goal is to prevent buttons from being activated by keyboard shortcuts involving modifier keys (like Ctrl, Alt, or Shift), which can help avoid accidental activations and improve accessibility.

The most important changes are:

**Input Handling Improvements:**

* Added a new static class `ButtonActivationGuard` to the `Infrastructure` folder. This class installs a handler that prevents buttons from being activated by the Space or Enter keys when any modifier key is pressed.
* Updated the `Initialize` method in `App.axaml.cs` to call `ButtonActivationGuard.Install()`, ensuring the input guard is set up when the application starts.