### PR TITLE
Rework nav selection pill animation for lower GPU cost

### DIFF
--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -205,7 +205,11 @@ public partial class SidebarView : BaseView<SidebarViewModel>
 
         double currentCenter = _pillTranslate.Y + ((PillHeight / 2d) * _pillScale.ScaleY);
         if (Math.Abs(currentCenter - targetCenter) < 0.5)
+        {
+            _pillScale.ScaleY = 1d;
+            _pillTranslate.Y = targetTop;
             return;
+        }
 
         _pillAnimationCancellation = new CancellationTokenSource();
         int version = ++_pillAnimationVersion;

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml.cs
@@ -1,10 +1,10 @@
+using System.Diagnostics;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
-using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
@@ -20,8 +20,15 @@ public partial class SidebarView : BaseView<SidebarViewModel>
     private CancellationTokenSource? _pillAnimationCancellation;
     private int _pillAnimationVersion;
 
+    private readonly ScaleTransform _pillScale = new() { ScaleX = 1d, ScaleY = 1d };
+    private readonly TranslateTransform _pillTranslate = new();
+    private ListBoxItem? _pendingPillItem;
+    private bool _pendingPillAnimate;
+
     private const double PillHeight = 16d;
-    private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(400);
+    private const double MaxPillStretch = 1.0d;
+    private const double PillStretchReferenceDistance = 120d;
+    private static readonly TimeSpan PillAnimationDuration = TimeSpan.FromMilliseconds(180);
 
     /// <summary>
     /// Whether the nav item text labels are shown. False renders an icon-only rail; true renders the
@@ -40,6 +47,13 @@ public partial class SidebarView : BaseView<SidebarViewModel>
     public SidebarView()
     {
         InitializeComponent();
+
+        NavigationSelectionPill.RenderTransformOrigin = new RelativePoint(0d, 0d, RelativeUnit.Relative);
+        NavigationSelectionPill.RenderTransform = new TransformGroup
+        {
+            Children = { _pillScale, _pillTranslate },
+        };
+
         if (FlyoutBase.GetAttachedFlyout(MoreNavBtn) is { } moreFlyout)
         {
             moreFlyout.Opened += (_, _) => _isMoreFlyoutOpen = true;
@@ -150,6 +164,7 @@ public partial class SidebarView : BaseView<SidebarViewModel>
                 }
                 else
                 {
+                    ClearPendingPillLayout();
                     _pillAnimationCancellation?.Cancel();
                     NavigationSelectionPill.IsVisible = false;
                 }
@@ -159,12 +174,20 @@ public partial class SidebarView : BaseView<SidebarViewModel>
 
     private void MoveSelectionPill(ListBoxItem item, bool animate)
     {
+        ClearPendingPillLayout();
+
         Point? itemPosition = item.TranslatePoint(default, SidebarLayout);
         if (itemPosition is null || item.Bounds.Height <= 0)
+        {
+            _pendingPillItem = item;
+            _pendingPillAnimate = animate;
+            item.LayoutUpdated += OnPendingPillLayoutUpdated;
             return;
+        }
 
         double targetTop = itemPosition.Value.Y + ((item.Bounds.Height - PillHeight) / 2d);
         double targetLeft = itemPosition.Value.X;
+        double targetCenter = targetTop + (PillHeight / 2d);
 
         _pillAnimationCancellation?.Cancel();
         _pillAnimationCancellation?.Dispose();
@@ -174,85 +197,82 @@ public partial class SidebarView : BaseView<SidebarViewModel>
 
         if (!NavigationSelectionPill.IsVisible || !animate || MotionPreference.ReducedMotion)
         {
-            Canvas.SetTop(NavigationSelectionPill, targetTop);
-            NavigationSelectionPill.Height = PillHeight;
+            _pillScale.ScaleY = 1d;
+            _pillTranslate.Y = targetTop;
             NavigationSelectionPill.IsVisible = true;
             return;
         }
 
-        double currentTop = Canvas.GetTop(NavigationSelectionPill);
-        if (double.IsNaN(currentTop))
-            currentTop = targetTop;
-
-        double currentBottom = currentTop + NavigationSelectionPill.Height;
-        double targetBottom = targetTop + PillHeight;
-        if (Math.Abs(currentTop - targetTop) < 0.5)
+        double currentCenter = _pillTranslate.Y + ((PillHeight / 2d) * _pillScale.ScaleY);
+        if (Math.Abs(currentCenter - targetCenter) < 0.5)
             return;
 
-        bool movingDown = targetTop > currentTop;
         _pillAnimationCancellation = new CancellationTokenSource();
         int version = ++_pillAnimationVersion;
-        _ = AnimatePillEdgesAsync(
-            currentTop,
-            currentBottom,
-            targetTop,
-            targetBottom,
-            movingDown,
-            version,
-            _pillAnimationCancellation.Token);
+        _ = AnimatePillAsync(currentCenter, targetCenter, version, _pillAnimationCancellation.Token);
     }
 
-    private async Task AnimatePillEdgesAsync(
-        double startTop,
-        double startBottom,
-        double targetTop,
-        double targetBottom,
-        bool movingDown,
+    private void ClearPendingPillLayout()
+    {
+        if (_pendingPillItem is { } pending)
+        {
+            pending.LayoutUpdated -= OnPendingPillLayoutUpdated;
+            _pendingPillItem = null;
+        }
+    }
+
+    private void OnPendingPillLayoutUpdated(object? sender, EventArgs e)
+    {
+        if (_pendingPillItem is { } item)
+            MoveSelectionPill(item, _pendingPillAnimate);
+    }
+
+    private async Task AnimatePillAsync(
+        double startCenter,
+        double targetCenter,
         int version,
         CancellationToken cancellationToken)
     {
-        var animation = new Animation
-        {
-            Duration = PillAnimationDuration,
-            FillMode = FillMode.Forward,
-        };
+        double distance = Math.Abs(targetCenter - startCenter);
+        double stretch = MaxPillStretch * Math.Clamp(distance / PillStretchReferenceDistance, 0d, 1d);
+        long started = Stopwatch.GetTimestamp();
+        double durationMs = PillAnimationDuration.TotalMilliseconds;
 
-        const int sampleCount = 20;
-        for (int sample = 0; sample <= sampleCount; sample++)
+        while (true)
         {
-            double progress = (double)sample / sampleCount;
-            double lead = EvaluateBezier(progress, 0d, 0d, 0d, 1d);
-            double trail = EvaluateBezier(progress, 0.5d, 0d, 0.2d, 1d);
-            double topProgress = movingDown ? trail : lead;
-            double bottomProgress = movingDown ? lead : trail;
-            double top = Lerp(startTop, targetTop, topProgress);
-            double bottom = Lerp(startBottom, targetBottom, bottomProgress);
+            if (cancellationToken.IsCancellationRequested)
+                return;
 
-            animation.Children.Add(new KeyFrame
+            double progress = Math.Clamp(
+                Stopwatch.GetElapsedTime(started).TotalMilliseconds / durationMs,
+                0d,
+                1d);
+
+            double eased = EvaluateBezier(progress, 0.33d, 0d, 0.1d, 1d);
+            double center = Lerp(startCenter, targetCenter, eased);
+            double scaleY = 1d + (stretch * Math.Sin(Math.PI * progress));
+
+            _pillScale.ScaleY = scaleY;
+            _pillTranslate.Y = center - ((PillHeight / 2d) * scaleY);
+
+            if (progress >= 1d)
+                break;
+
+            try
             {
-                Cue = new Cue(progress),
-                Setters =
-                {
-                    new Setter(Canvas.TopProperty, top),
-                    new Setter(Layoutable.HeightProperty, Math.Max(1d, bottom - top)),
-                },
-            });
-        }
-
-        try
-        {
-            await animation.RunAsync(NavigationSelectionPill, cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
+                await Task.Delay(16, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
         }
 
         if (version != _pillAnimationVersion || cancellationToken.IsCancellationRequested)
             return;
 
-        Canvas.SetTop(NavigationSelectionPill, targetTop);
-        NavigationSelectionPill.Height = PillHeight;
+        _pillScale.ScaleY = 1d;
+        _pillTranslate.Y = targetCenter - (PillHeight / 2d);
     }
 
     private static double Lerp(double start, double end, double progress)


### PR DESCRIPTION
The sliding selection pill added in #5194 was expensive on the GPU and could balloon or fail to follow the page. This reworks how the pill moves — same WinUI-style effect, far cheaper, and correct during startup.

###  Problem                                                                                                                                                                                          
                                                                                                                                                                                                   
The pill animation drove Canvas.Top and Height, both layout-affecting properties. Every animation frame forced a full measure/arrange pass plus re-rasterization, and on a Mica window that re-presents the entire translucent surface each frame. Measured ~13% GPU while a single pill slide was on screen — disproportionate for a 3×16 px bar, and rough on low-end machines.                                                                                                                                                                         
                                                                                                                                                                                                   
  Two secondary issues surfaced while fixing it:                                                                                                                                                   
  - The edge-stretch was proportional to travel distance and unbounded, so the long Discover→Settings jump (which crosses the empty gap to the footer group) ballooned the pill to ~5× its height — it read as a rubber band, not the subtle WinUI elastic.                                                                                                                                          
  - A startup race: if the pill's position update fired before the target nav item had a layout, it was silently dropped and never retried — so switching pages while the app was still opening left the pill behind.
  
### Changes                                                                                                                                                                                          
                                                                                                                                                                                                   
  - Transform-driven motion. The pill now animates via RenderTransform (TranslateTransform.Y + ScaleTransform.ScaleY) instead of layout properties. The compositor moves a cached layer with no per-frame layout pass, and there's no per-move Animation/KeyFrame allocation (less GC).                                                                                                          
  - Shorter duration (400 ms → 180 ms). On Mica the cost is presents × window-area; shortening at a steady 60 fps cuts presents ~55% while staying smooth. Net effect: GPU spike drops from ~13% to the ~5–6% range, for ~0.18 s per navigation.                                                                                                                                                     
  - Capped, distance-aware stretch. The pill's center slides while ScaleY bumps via 1 + stretch·sin, with stretch clamped so the peak is 2× regardless of distance (short hops stretch proportionally less). Keeps the Fluent elastic feel without the balloon.                                                                                                                         
  - Startup layout-race fix. When the target item isn't laid out yet, defer via its LayoutUpdated and retry (it fires every layout pass, so it self-heals across the several passes at startup). Any newer selection — or hiding the pill — clears the pending retry so the latest selection always wins.