### PR TITLE
Refresh tray icon on system theme change

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1091,6 +1091,11 @@ public partial class MainWindow : Window
             borderOwner.ApplyWindowBorderColor(hWnd);
         }
 
+        if (msg == WM_SETTINGCHANGE && Instance is { } trayOwner)
+        {
+            trayOwner.UpdateSystemTrayStatus();
+        }
+
         // ── Snap Layouts: report HTMAXBUTTON over the custom maximize button so Win11 shows the
         // layout flyout, and emulate hover/press/click since input now arrives as NC messages. ──
         if (Instance is { } self && self.WindowButtons.IsVisible)


### PR DESCRIPTION
This pull request introduces a small but important change to the `MainWindow.axaml.cs` file to enhance system tray integration. Now, when the `WM_SETTINGCHANGE` message is received, the system tray status is updated accordingly. This ensures the application's tray icon reflects any changes in system settings in real time.

System tray integration:

* Added a handler in `OnWindowsWndProc` to call `UpdateSystemTrayStatus()` when a `WM_SETTINGCHANGE` message is received, ensuring the tray icon stays in sync with system settings.