### PR TITLE
Fix text entry in immersive dialogs blocked while a modal is open

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -271,8 +271,10 @@ public partial class MainWindow : Window
         if (ModalLayer.IsVisible)
         {
             if (e.Key == Key.Escape)
+            {
                 (ModalContent.Content as ImmersiveDialog)?.Close();
-            e.Handled = true;
+                e.Handled = true;
+            }
             return;
         }
 


### PR DESCRIPTION
This pull request makes a small change to the `Window_KeyDown` event handler to improve code clarity and maintainability. The change wraps the logic for handling the Escape key in a block, making it easier to read and extend in the future.

- Code style improvement:
  * [`src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs`](diffhunk://#diff-133754dff4c1cb9804c5fabcde40f72eb6a6c36bc32e2e3bcd175e50f5f3a963R274-R277): Wrapped the Escape key handling logic in braces within the `Window_KeyDown` event handler for better readability and maintainability.