### PR TITLE
Restore the desktop-shortcut prompt after installs

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -215,10 +215,7 @@ public partial class App : Application
         if (isDaemonLaunch)
             return;
 
-        if (!mainWindow.IsVisible)
-            mainWindow.Show();
-
-        mainWindow.Activate();
+        mainWindow.ShowFromTray();
     }
 
     public static void ApplyTheme(string value)

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaOperationRegistry.cs
@@ -36,6 +36,8 @@ public static class AvaloniaOperationRegistry
     public static int ErrorsOccurred => _errorsOccurred;
     public static bool RestartRequired { get; set; }
 
+    private static bool _shortcutDialogOpen;
+
     /// <summary>
     /// Register an operation and create its UI view-model.
     /// Must be called before <c>operation.MainThread()</c>.
@@ -294,17 +296,50 @@ public static class AvaloniaOperationRegistry
             await CoreTools.ResetUACForCurrentProcess();
         }
 
-        if (OperatingSystem.IsWindows())
+        if (!anyStillRunning && Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts))
         {
-            var unknownShortcuts = UniGetUI.PackageEngine.Classes.Packages.Classes.DesktopShortcutsDatabase.GetUnknownShortcuts();
+            var unknownShortcuts = DesktopShortcutsDatabase.GetUnknownShortcuts();
             if (unknownShortcuts.Count > 0)
-                WindowsAppNotificationBridge.ShowNewShortcutsNotification(unknownShortcuts);
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    if (Views.MainWindow.IsWindowOnScreen)
+                        Dispatcher.UIThread.Post(() => _ = AutoOpenShortcutsDialogAsync(unknownShortcuts));
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    MacOsNotificationBridge.ShowNewShortcutsNotification(unknownShortcuts);
+                }
+            }
         }
-        else if (OperatingSystem.IsMacOS())
+    }
+
+    public static void PromptPendingShortcutsIfAny()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts)) return;
+        var unknownShortcuts = DesktopShortcutsDatabase.GetUnknownShortcuts();
+        if (unknownShortcuts.Count == 0) return;
+        Dispatcher.UIThread.Post(() => _ = AutoOpenShortcutsDialogAsync(unknownShortcuts));
+    }
+
+    private static async Task AutoOpenShortcutsDialogAsync(IReadOnlyList<string> shortcuts)
+    {
+        if (_shortcutDialogOpen) return;
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime { MainWindow: { } owner })
+            return;
+
+        var pending = shortcuts.ToList();
+        _shortcutDialogOpen = true;
+        try
         {
-            var unknownShortcuts = UniGetUI.PackageEngine.Classes.Packages.Classes.DesktopShortcutsDatabase.GetUnknownShortcuts();
-            if (unknownShortcuts.Count > 0)
-                MacOsNotificationBridge.ShowNewShortcutsNotification(unknownShortcuts);
+            await new Views.ManageDesktopShortcutsWindow(pending).ShowDialog(owner);
+        }
+        finally
+        {
+            _shortcutDialogOpen = false;
+            foreach (var shortcut in pending)
+                DesktopShortcutsDatabase.RemoveFromUnknownShortcuts(shortcut);
         }
     }
 }

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -212,48 +212,6 @@ internal static class WindowsAppNotificationBridge
     }
 
     /// <summary>
-    /// Shows a Windows toast notification after new desktop shortcuts are detected.
-    /// </summary>
-    public static void ShowNewShortcutsNotification(IReadOnlyList<string> shortcuts)
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        if (Settings.AreNotificationsDisabled()) return;
-
-        try
-        {
-            string title;
-            string message;
-
-            if (shortcuts.Count == 1)
-            {
-                title = CoreTools.Translate("Desktop shortcut created");
-                message = CoreTools.Translate(
-                    "UniGetUI has detected a new desktop shortcut that can be deleted automatically.")
-                    + "\n" + shortcuts[0].Split('\\')[^1];
-            }
-            else
-            {
-                string names = string.Join(", ", shortcuts.Select(s => s.Split('\\')[^1]));
-                title = CoreTools.Translate("{0} desktop shortcuts created", shortcuts.Count);
-                message = CoreTools.Translate(
-                    "UniGetUI has detected {0} new desktop shortcuts that can be deleted automatically.",
-                    shortcuts.Count) + "\n" + names;
-            }
-
-            Show(
-                title,
-                message,
-                MainWindow.RuntimeNotificationLevel.Success,
-                launchAction: NotificationArguments.Show);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn("Could not show new shortcuts notification");
-            Logger.Warn(ex);
-        }
-    }
-
-    /// <summary>
     /// Shows a native toast when available, otherwise falls back to the in-app banner.
     /// The <paramref name="launchAction"/> is encoded into the <c>unigetui://</c> launch
     /// argument so the single-instance handler can route the activation when the toast

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1841,6 +1841,8 @@ public partial class MainWindow : Window
         else if (WindowState == WindowState.Minimized)
             WindowState = WindowState.Normal;
         Activate();
+
+        AvaloniaOperationRegistry.PromptPendingShortcutsIfAny();
     }
 
     public bool IsQuitting => Interlocked.CompareExchange(ref _isQuitting, 0, 0) == 1;

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -603,17 +603,18 @@ namespace UniGetUI.PackageEngine.Operations
         protected override async Task HandleSuccess()
         {
             Package.SetTag(PackageTag.AlreadyInstalled);
+
+            if (Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts))
+            {
+                DesktopShortcutsDatabase.HandleNewShortcuts(DesktopShortcutsBeforeStart);
+            }
+
             bool explicitVersionRequested = !string.IsNullOrWhiteSpace(Options.Version);
             var installedPackage = await ResolveInstalledPackageSnapshotAsync(
                 explicitVersionRequested ? Options.Version : Package.VersionString,
                 preferFallbackVersionWhenMissing: explicitVersionRequested
             );
             await InstalledPackagesLoader.Instance.AddForeign(installedPackage);
-
-            if (Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts))
-            {
-                DesktopShortcutsDatabase.HandleNewShortcuts(DesktopShortcutsBeforeStart);
-            }
         }
 
         protected override void Initialize()
@@ -681,6 +682,11 @@ namespace UniGetUI.PackageEngine.Operations
             UpgradablePackagesLoader.Instance.Remove(Package);
             InstalledPackagesLoader.Instance.Remove(Package);
 
+            if (Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts))
+            {
+                DesktopShortcutsDatabase.HandleNewShortcuts(DesktopShortcutsBeforeStart);
+            }
+
             bool explicitVersionRequested = !string.IsNullOrWhiteSpace(Options.Version);
             var installedPackage = await ResolveInstalledPackageSnapshotAsync(
                 explicitVersionRequested
@@ -691,11 +697,6 @@ namespace UniGetUI.PackageEngine.Operations
                 preferFallbackVersionWhenMissing: explicitVersionRequested
             );
             await InstalledPackagesLoader.Instance.AddForeign(installedPackage);
-
-            if (Settings.Get(Settings.K.AskToDeleteNewDesktopShortcuts))
-            {
-                DesktopShortcutsDatabase.HandleNewShortcuts(DesktopShortcutsBeforeStart);
-            }
 
             if (
                 await Package.HasUpdatesIgnoredAsync()

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/DesktopShortcutsDatabase.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/DesktopShortcutsDatabase.cs
@@ -12,7 +12,7 @@ public static class DesktopShortcutsDatabase
         Delete, // The user has allowed the shortcut to be deleted
     }
 
-    private static readonly List<string> UnknownShortcuts = [];
+    private const string PendingShortcutsKey = "PendingDesktopShortcuts";
 
     public static IReadOnlyDictionary<string, bool> GetDatabase()
     {
@@ -173,7 +173,15 @@ public static class DesktopShortcutsDatabase
     /// <returns>True if it was found, false otherwise</returns>
     public static bool RemoveFromUnknownShortcuts(string shortcutPath)
     {
-        return UnknownShortcuts.Remove(shortcutPath);
+        return Settings.RemoveFromList(PendingShortcutsKey, shortcutPath);
+    }
+
+    /// <summary>
+    /// Clears every shortcut awaiting a deletion verdict.
+    /// </summary>
+    public static void ClearUnknownShortcuts()
+    {
+        Settings.ClearList(PendingShortcutsKey);
     }
 
     /// <summary>
@@ -182,7 +190,9 @@ public static class DesktopShortcutsDatabase
     /// <returns>The list of shortcuts awaiting verdicts</returns>
     public static List<string> GetUnknownShortcuts()
     {
-        return UnknownShortcuts;
+        return (Settings.GetList<string>(PendingShortcutsKey) ?? [])
+            .Where(File.Exists)
+            .ToList();
     }
 
     /// <summary>
@@ -228,10 +238,10 @@ public static class DesktopShortcutsDatabase
                 else
                 {
                     // Mark the shortcut as unknown and prompt the user.
-                    if (!UnknownShortcuts.Contains(shortcut))
+                    if (!Settings.ListContains(PendingShortcutsKey, shortcut))
                     {
                         Logger.Info($"Marking the shortcut {shortcut} to be asked to be deleted");
-                        UnknownShortcuts.Add(shortcut);
+                        Settings.AddToList(PendingShortcutsKey, shortcut);
                     }
                 }
             }

--- a/src/UniGetUI.PackageEngine.Tests/DesktopShortcutsDatabaseTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/DesktopShortcutsDatabaseTests.cs
@@ -19,13 +19,13 @@ public sealed class DesktopShortcutsDatabaseTests : IDisposable
         Directory.CreateDirectory(CoreData.UniGetUIUserConfigurationDirectory);
         Settings.ResetSettings();
         DesktopShortcutsDatabase.ResetDatabase();
-        DesktopShortcutsDatabase.GetUnknownShortcuts().Clear();
+        DesktopShortcutsDatabase.ClearUnknownShortcuts();
     }
 
     public void Dispose()
     {
         DesktopShortcutsDatabase.ResetDatabase();
-        DesktopShortcutsDatabase.GetUnknownShortcuts().Clear();
+        DesktopShortcutsDatabase.ClearUnknownShortcuts();
         Settings.ResetSettings();
         CoreData.TEST_DataDirectoryOverride = null;
         if (Directory.Exists(_testRoot))


### PR DESCRIPTION
This pull request refactors how notifications and dialogs for new desktop shortcuts are handled after package operations, shifting from passive toast notifications to an active dialog prompt. It also ensures that the dialog is shown when the main window is restored from the system tray, and centralizes the logic for presenting and tracking the shortcuts dialog. Additionally, some code cleanup and minor logic reordering were performed.

**Desktop shortcut notification and dialog handling:**

* Replaced the Windows toast notification for new desktop shortcuts with an in-app dialog prompt (`AutoOpenShortcutsDialogAsync`) that appears if the user has enabled the relevant setting. The dialog is shown only once at a time and removes handled shortcuts from the database after completion. (`[[1]](diffhunk://#diff-0bf3618786f1fbeff27a5f575b083806e65e872c7d8ab21ca34a246707be051dL297-R345)`, `[[2]](diffhunk://#diff-d67ff391c72f9b5a6f3adb6bfe83e7d8e53b7b58d8395bca47ff3d5ba6138496L214-L255)`)
* Added `PromptPendingShortcutsIfAny` to `AvaloniaOperationRegistry`, which checks for pending shortcuts and triggers the dialog if needed. This method is called when the main window is restored from the tray. (`[[1]](diffhunk://#diff-0bf3618786f1fbeff27a5f575b083806e65e872c7d8ab21ca34a246707be051dL297-R345)`, `[[2]](diffhunk://#diff-133754dff4c1cb9804c5fabcde40f72eb6a6c36bc32e2e3bcd175e50f5f3a963R1844-R1845)`)
* Removed the old `ShowNewShortcutsNotification` method from `WindowsAppNotificationBridge`, as it is no longer used. (`[src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.csL214-L255](diffhunk://#diff-d67ff391c72f9b5a6f3adb6bfe83e7d8e53b7b58d8395bca47ff3d5ba6138496L214-L255)`)

**UI behavior improvements:**

* Modified `MainWindow.ShowFromTray()` to call `PromptPendingShortcutsIfAny`, ensuring users are prompted about new shortcuts when restoring the app from the tray. (`[src/UniGetUI.Avalonia/Views/MainWindow.axaml.csR1844-R1845](diffhunk://#diff-133754dff4c1cb9804c5fabcde40f72eb6a6c36bc32e2e3bcd175e50f5f3a963R1844-R1845)`)
* Changed secondary instance argument handling to use `ShowFromTray()` instead of directly activating the window, ensuring consistent shortcut dialog prompting. (`[src/UniGetUI.Avalonia/App.axaml.csL218-R218](diffhunk://#diff-62e45b2932bd115a1d10c41ef0ac96322b60aa38f2af2714ffc396b8637ca657L218-R218)`)

**Code cleanup and minor logic changes:**

* Refactored the handling of new shortcuts in `PackageOperations.cs` to avoid duplicate code and ensure correct timing of shortcut processing after install/uninstall operations. (`[[1]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cR606-L616)`, `[[2]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cR685-R689)`, `[[3]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cL695-L699)`)
* Introduced a private `_shortcutDialogOpen` flag in `AvaloniaOperationRegistry` to prevent multiple dialogs from opening simultaneously. (`[[1]](diffhunk://#diff-0bf3618786f1fbeff27a5f575b083806e65e872c7d8ab21ca34a246707be051dR39-R40)`, `[[2]](diffhunk://#diff-0bf3618786f1fbeff27a5f575b083806e65e872c7d8ab21ca34a246707be051dL297-R345)`)