### PR TITLE
Make the whole operation card open the live log on tap

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -260,7 +260,13 @@
                                         CornerRadius="6"
                                         Padding="10,6"
                                         Margin="0,3,0,3">
-                                    <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Grid ColumnDefinitions="*,Auto">
+
+                                        <Border Grid.Column="0"
+                                                Background="Transparent"
+                                                Cursor="Hand"
+                                                Tapped="OperationCard_Tapped">
+                                        <Grid ColumnDefinitions="Auto,*">
 
                                         <!-- Package icon -->
                                         <Image Grid.Column="0"
@@ -349,9 +355,11 @@
                                             </ItemsControl>
 
                                         </StackPanel>
+                                        </Grid>
+                                        </Border>
 
                                         <!-- Split-button: Cancel/Close + "…" menu -->
-                                        <Border Grid.Column="2"
+                                        <Border Grid.Column="1"
                                                 CornerRadius="6"
                                                 ClipToBounds="True"
                                                 VerticalAlignment="Center">

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1509,6 +1509,15 @@ public partial class MainWindow : Window
             ViewModel.SelectSuggestion(result);
     }
 
+    private void OperationCard_Tapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Source is Visual source && source.FindAncestorOfType<Button>(includeSelf: true) is not null)
+            return;
+
+        if ((sender as Control)?.DataContext is OperationViewModel op)
+            op.ShowDetailsCommand.Execute(null);
+    }
+
     // ─── Public navigation API ────────────────────────────────────────────────
     public void Navigate(PageType type) => ViewModel.NavigateTo(type);
     public void OpenManagerLogs(IPackageManager? manager = null) => ViewModel.OpenManagerLogs(manager);


### PR DESCRIPTION
This pull request enhances the user interaction for operation cards in the `MainWindow` by making the entire card clickable to show operation details, except when clicking on buttons inside the card. The changes involve updating the layout in `MainWindow.axaml` and adding a new event handler in the code-behind.

**User interaction improvements:**

* Made the entire operation card clickable by wrapping it in a `Border` with a `Tapped` event handler (`OperationCard_Tapped`), allowing users to open operation details by clicking anywhere on the card except on buttons. (`[[1]](diffhunk://#diff-012586c62dd3805ea5ba53cc80e12374143d98ca79a5ea88c7e39296f7c028a4L263-R269)`, `[[2]](diffhunk://#diff-012586c62dd3805ea5ba53cc80e12374143d98ca79a5ea88c7e39296f7c028a4R358-R362)`)
* Added the `OperationCard_Tapped` method in `MainWindow.axaml.cs`, which checks if the tap originated from a button and, if not, executes the `ShowDetailsCommand` for the corresponding operation. (`[src/UniGetUI.Avalonia/Views/MainWindow.axaml.csR1512-R1520](diffhunk://#diff-133754dff4c1cb9804c5fabcde40f72eb6a6c36bc32e2e3bcd175e50f5f3a963R1512-R1520)`)
