### PR TITLE
Translate environment-variable syntax labels into all locales

### DIFF
--- a/src/Languages/lang_af.json
+++ b/src/Languages/lang_af.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Daar is geen pakkette om uit te voer nie.",
   "CSV file": "CSV-lêer",
   "The file was saved to {0}": "Die lêer is gestoor na {0}",
-  "The file could not be saved:": "Die lêer kon nie gestoor word nie:"
+  "The file could not be saved:": "Die lêer kon nie gestoor word nie:",
+  "Environment variables use %VARIABLE% syntax.": "Omgewingsveranderlikes gebruik %VARIABLE%-sintaksis.",
+  "Environment variables use <VARIABLE> syntax.": "Omgewingsveranderlikes gebruik <VARIABLE>-sintaksis.",
+  "Change environment variable syntax": "Verander omgewingsveranderlike-sintaksis"
 }

--- a/src/Languages/lang_ar.json
+++ b/src/Languages/lang_ar.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "لا توجد حزم للتصدير.",
   "CSV file": "ملف CSV",
   "The file was saved to {0}": "تم حفظ الملف في {0}",
-  "The file could not be saved:": "تعذّر حفظ الملف:"
+  "The file could not be saved:": "تعذّر حفظ الملف:",
+  "Environment variables use %VARIABLE% syntax.": "متغيرات البيئة تستخدم صيغة %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "متغيرات البيئة تستخدم صيغة <VARIABLE>.",
+  "Change environment variable syntax": "تغيير صيغة متغيرات البيئة"
 }

--- a/src/Languages/lang_be.json
+++ b/src/Languages/lang_be.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Няма пакетаў для экспарту.",
   "CSV file": "Файл CSV",
   "The file was saved to {0}": "Файл захаваны ў {0}",
-  "The file could not be saved:": "Не ўдалося захаваць файл:"
+  "The file could not be saved:": "Не ўдалося захаваць файл:",
+  "Environment variables use %VARIABLE% syntax.": "Зменныя асяроддзя выкарыстоўваюць сінтаксіс %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Зменныя асяроддзя выкарыстоўваюць сінтаксіс <VARIABLE>.",
+  "Change environment variable syntax": "Змяніць сінтаксіс зменных асяроддзя"
 }

--- a/src/Languages/lang_bg.json
+++ b/src/Languages/lang_bg.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Няма пакети за експортиране.",
   "CSV file": "CSV файл",
   "The file was saved to {0}": "Файлът беше запазен в {0}",
-  "The file could not be saved:": "Файлът не можа да бъде запазен:"
+  "The file could not be saved:": "Файлът не можа да бъде запазен:",
+  "Environment variables use %VARIABLE% syntax.": "Променливите на средата използват синтаксис %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Променливите на средата използват синтаксис <VARIABLE>.",
+  "Change environment variable syntax": "Промяна на синтаксиса на променливите на средата"
 }

--- a/src/Languages/lang_bn.json
+++ b/src/Languages/lang_bn.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "রপ্তানি করার জন্য কোনো প্যাকেজ নেই।",
   "CSV file": "CSV ফাইল",
   "The file was saved to {0}": "ফাইলটি {0}-এ সংরক্ষণ করা হয়েছে",
-  "The file could not be saved:": "ফাইলটি সংরক্ষণ করা যায়নি:"
+  "The file could not be saved:": "ফাইলটি সংরক্ষণ করা যায়নি:",
+  "Environment variables use %VARIABLE% syntax.": "এনভায়রনমেন্ট ভেরিয়েবল %VARIABLE% সিনট্যাক্স ব্যবহার করে।",
+  "Environment variables use <VARIABLE> syntax.": "এনভায়রনমেন্ট ভেরিয়েবল <VARIABLE> সিনট্যাক্স ব্যবহার করে।",
+  "Change environment variable syntax": "এনভায়রনমেন্ট ভেরিয়েবল সিনট্যাক্স পরিবর্তন করুন"
 }

--- a/src/Languages/lang_ca.json
+++ b/src/Languages/lang_ca.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "No hi ha paquets per exportar.",
   "CSV file": "Fitxer CSV",
   "The file was saved to {0}": "El fitxer s'ha desat a {0}",
-  "The file could not be saved:": "No s'ha pogut desar el fitxer:"
+  "The file could not be saved:": "No s'ha pogut desar el fitxer:",
+  "Environment variables use %VARIABLE% syntax.": "Les variables d'entorn utilitzen la sintaxi %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Les variables d'entorn utilitzen la sintaxi <VARIABLE>.",
+  "Change environment variable syntax": "Canvia la sintaxi de les variables d'entorn"
 }

--- a/src/Languages/lang_cs.json
+++ b/src/Languages/lang_cs.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Nejsou žádné balíčky k exportu.",
   "CSV file": "Soubor CSV",
   "The file was saved to {0}": "Soubor byl uložen do {0}",
-  "The file could not be saved:": "Soubor se nepodařilo uložit:"
+  "The file could not be saved:": "Soubor se nepodařilo uložit:",
+  "Environment variables use %VARIABLE% syntax.": "Proměnné prostředí používají syntaxi %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Proměnné prostředí používají syntaxi <VARIABLE>.",
+  "Change environment variable syntax": "Změnit syntaxi proměnných prostředí"
 }

--- a/src/Languages/lang_da.json
+++ b/src/Languages/lang_da.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Der er ingen pakker at eksportere.",
   "CSV file": "CSV-fil",
   "The file was saved to {0}": "Filen blev gemt i {0}",
-  "The file could not be saved:": "Filen kunne ikke gemmes:"
+  "The file could not be saved:": "Filen kunne ikke gemmes:",
+  "Environment variables use %VARIABLE% syntax.": "Miljøvariabler bruger syntaksen %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Miljøvariabler bruger syntaksen <VARIABLE>.",
+  "Change environment variable syntax": "Skift syntaks for miljøvariabler"
 }

--- a/src/Languages/lang_de.json
+++ b/src/Languages/lang_de.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Es gibt keine Pakete zum Exportieren.",
   "CSV file": "CSV-Datei",
   "The file was saved to {0}": "Die Datei wurde unter {0} gespeichert",
-  "The file could not be saved:": "Die Datei konnte nicht gespeichert werden:"
+  "The file could not be saved:": "Die Datei konnte nicht gespeichert werden:",
+  "Environment variables use %VARIABLE% syntax.": "Umgebungsvariablen verwenden die Syntax %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Umgebungsvariablen verwenden die Syntax <VARIABLE>.",
+  "Change environment variable syntax": "Syntax für Umgebungsvariablen ändern"
 }

--- a/src/Languages/lang_el.json
+++ b/src/Languages/lang_el.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Δεν υπάρχουν πακέτα για εξαγωγή.",
   "CSV file": "Αρχείο CSV",
   "The file was saved to {0}": "Το αρχείο αποθηκεύτηκε στο {0}",
-  "The file could not be saved:": "Το αρχείο δεν ήταν δυνατό να αποθηκευτεί:"
+  "The file could not be saved:": "Το αρχείο δεν ήταν δυνατό να αποθηκευτεί:",
+  "Environment variables use %VARIABLE% syntax.": "Οι μεταβλητές περιβάλλοντος χρησιμοποιούν σύνταξη %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Οι μεταβλητές περιβάλλοντος χρησιμοποιούν σύνταξη <VARIABLE>.",
+  "Change environment variable syntax": "Αλλαγή σύνταξης μεταβλητών περιβάλλοντος"
 }

--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -943,5 +943,8 @@
   "Running custom operation {0}": "Running custom operation {0}",
   "Custom operation": "Custom operation",
   "Custom operation failed": "Custom operation failed",
-  "The custom operation {0} failed to run": "The custom operation {0} failed to run"
+  "The custom operation {0} failed to run": "The custom operation {0} failed to run",
+  "Environment variables use %VARIABLE% syntax.": "Environment variables use %VARIABLE% syntax.",
+  "Environment variables use <VARIABLE> syntax.": "Environment variables use <VARIABLE> syntax.",
+  "Change environment variable syntax": "Change environment variable syntax"
 }

--- a/src/Languages/lang_eo.json
+++ b/src/Languages/lang_eo.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Ne estas pakaĵoj por eksporti.",
   "CSV file": "CSV-dosiero",
   "The file was saved to {0}": "La dosiero estis konservita al {0}",
-  "The file could not be saved:": "La dosiero ne povis esti konservita:"
+  "The file could not be saved:": "La dosiero ne povis esti konservita:",
+  "Environment variables use %VARIABLE% syntax.": "Mediovariabloj uzas la sintakson %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Mediovariabloj uzas la sintakson <VARIABLE>.",
+  "Change environment variable syntax": "Ŝanĝi sintakson de mediovariabloj"
 }

--- a/src/Languages/lang_es-MX.json
+++ b/src/Languages/lang_es-MX.json
@@ -944,5 +944,8 @@
   "There are no packages to export.": "No hay paquetes para exportar.",
   "CSV file": "Archivo CSV",
   "The file was saved to {0}": "El archivo se guardó en {0}",
-  "The file could not be saved:": "No se pudo guardar el archivo:"
+  "The file could not be saved:": "No se pudo guardar el archivo:",
+  "Environment variables use %VARIABLE% syntax.": "Las variables de entorno usan la sintaxis %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Las variables de entorno usan la sintaxis <VARIABLE>.",
+  "Change environment variable syntax": "Cambiar la sintaxis de las variables de entorno"
 }

--- a/src/Languages/lang_es.json
+++ b/src/Languages/lang_es.json
@@ -944,5 +944,8 @@
   "There are no packages to export.": "No hay paquetes para exportar.",
   "CSV file": "Archivo CSV",
   "The file was saved to {0}": "El archivo se guardó en {0}",
-  "The file could not be saved:": "No se pudo guardar el archivo:"
+  "The file could not be saved:": "No se pudo guardar el archivo:",
+  "Environment variables use %VARIABLE% syntax.": "Las variables de entorno usan la sintaxis %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Las variables de entorno usan la sintaxis <VARIABLE>.",
+  "Change environment variable syntax": "Cambiar la sintaxis de las variables de entorno"
 }

--- a/src/Languages/lang_et.json
+++ b/src/Languages/lang_et.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Eksportimiseks pole pakette.",
   "CSV file": "CSV-fail",
   "The file was saved to {0}": "Fail salvestati asukohta {0}",
-  "The file could not be saved:": "Faili ei õnnestunud salvestada:"
+  "The file could not be saved:": "Faili ei õnnestunud salvestada:",
+  "Environment variables use %VARIABLE% syntax.": "Keskkonnamuutujad kasutavad süntaksit %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Keskkonnamuutujad kasutavad süntaksit <VARIABLE>.",
+  "Change environment variable syntax": "Muuda keskkonnamuutujate süntaksit"
 }

--- a/src/Languages/lang_fa.json
+++ b/src/Languages/lang_fa.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "هیچ بسته‌ای برای استخراج وجود ندارد.",
   "CSV file": "فایل CSV",
   "The file was saved to {0}": "فایل در {0} ذخیره شد",
-  "The file could not be saved:": "فایل ذخیره نشد:"
+  "The file could not be saved:": "فایل ذخیره نشد:",
+  "Environment variables use %VARIABLE% syntax.": "متغیرهای محیطی از نحو %VARIABLE% استفاده می‌کنند.",
+  "Environment variables use <VARIABLE> syntax.": "متغیرهای محیطی از نحو <VARIABLE> استفاده می‌کنند.",
+  "Change environment variable syntax": "تغییر نحو متغیرهای محیطی"
 }

--- a/src/Languages/lang_fi.json
+++ b/src/Languages/lang_fi.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Vietäviä paketteja ei ole.",
   "CSV file": "CSV-tiedosto",
   "The file was saved to {0}": "Tiedosto tallennettiin kohteeseen {0}",
-  "The file could not be saved:": "Tiedostoa ei voitu tallentaa:"
+  "The file could not be saved:": "Tiedostoa ei voitu tallentaa:",
+  "Environment variables use %VARIABLE% syntax.": "Ympäristömuuttujat käyttävät %VARIABLE%-syntaksia.",
+  "Environment variables use <VARIABLE> syntax.": "Ympäristömuuttujat käyttävät <VARIABLE>-syntaksia.",
+  "Change environment variable syntax": "Muuta ympäristömuuttujien syntaksia"
 }

--- a/src/Languages/lang_fil.json
+++ b/src/Languages/lang_fil.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Walang mga package na i-export.",
   "CSV file": "CSV file",
   "The file was saved to {0}": "Na-save ang file sa {0}",
-  "The file could not be saved:": "Hindi ma-save ang file:"
+  "The file could not be saved:": "Hindi ma-save ang file:",
+  "Environment variables use %VARIABLE% syntax.": "Gumagamit ang mga environment variable ng %VARIABLE% na syntax.",
+  "Environment variables use <VARIABLE> syntax.": "Gumagamit ang mga environment variable ng <VARIABLE> na syntax.",
+  "Change environment variable syntax": "Baguhin ang syntax ng environment variable"
 }

--- a/src/Languages/lang_fr.json
+++ b/src/Languages/lang_fr.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Il n'y a aucun paquet à exporter.",
   "CSV file": "Fichier CSV",
   "The file was saved to {0}": "Le fichier a été enregistré dans {0}",
-  "The file could not be saved:": "Le fichier n'a pas pu être enregistré :"
+  "The file could not be saved:": "Le fichier n'a pas pu être enregistré :",
+  "Environment variables use %VARIABLE% syntax.": "Les variables d'environnement utilisent la syntaxe %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Les variables d'environnement utilisent la syntaxe <VARIABLE>.",
+  "Change environment variable syntax": "Modifier la syntaxe des variables d'environnement"
 }

--- a/src/Languages/lang_gl.json
+++ b/src/Languages/lang_gl.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Non hai paquetes que exportar.",
   "CSV file": "Ficheiro CSV",
   "The file was saved to {0}": "O ficheiro gardouse en {0}",
-  "The file could not be saved:": "Non se puido gardar o ficheiro:"
+  "The file could not be saved:": "Non se puido gardar o ficheiro:",
+  "Environment variables use %VARIABLE% syntax.": "As variables de contorno usan a sintaxe %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "As variables de contorno usan a sintaxe <VARIABLE>.",
+  "Change environment variable syntax": "Cambiar a sintaxe das variables de contorno"
 }

--- a/src/Languages/lang_gu.json
+++ b/src/Languages/lang_gu.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "નિકાસ કરવા માટે કોઈ packages નથી.",
   "CSV file": "CSV ફાઇલ",
   "The file was saved to {0}": "ફાઇલ {0} માં સાચવાઈ",
-  "The file could not be saved:": "ફાઇલ સાચવી શકાઈ નહીં:"
+  "The file could not be saved:": "ફાઇલ સાચવી શકાઈ નહીં:",
+  "Environment variables use %VARIABLE% syntax.": "એન્વાયર્નમેન્ટ વેરિયેબલ %VARIABLE% સિન્ટેક્સ વાપરે છે.",
+  "Environment variables use <VARIABLE> syntax.": "એન્વાયર્નમેન્ટ વેરિયેબલ <VARIABLE> સિન્ટેક્સ વાપરે છે.",
+  "Change environment variable syntax": "એન્વાયર્નમેન્ટ વેરિયેબલ સિન્ટેક્સ બદલો"
 }

--- a/src/Languages/lang_he.json
+++ b/src/Languages/lang_he.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "אין חבילות לייצוא.",
   "CSV file": "קובץ CSV",
   "The file was saved to {0}": "הקובץ נשמר אל {0}",
-  "The file could not be saved:": "לא ניתן היה לשמור את הקובץ:"
+  "The file could not be saved:": "לא ניתן היה לשמור את הקובץ:",
+  "Environment variables use %VARIABLE% syntax.": "משתני סביבה משתמשים בתחביר %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "משתני סביבה משתמשים בתחביר <VARIABLE>.",
+  "Change environment variable syntax": "שינוי תחביר משתני הסביבה"
 }

--- a/src/Languages/lang_hi.json
+++ b/src/Languages/lang_hi.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "निर्यात करने के लिए कोई पैकेज नहीं है।",
   "CSV file": "CSV फ़ाइल",
   "The file was saved to {0}": "फ़ाइल {0} में सहेजी गई",
-  "The file could not be saved:": "फ़ाइल सहेजी नहीं जा सकी:"
+  "The file could not be saved:": "फ़ाइल सहेजी नहीं जा सकी:",
+  "Environment variables use %VARIABLE% syntax.": "एनवायरनमेंट वेरिएबल %VARIABLE% सिंटैक्स का उपयोग करते हैं।",
+  "Environment variables use <VARIABLE> syntax.": "एनवायरनमेंट वेरिएबल <VARIABLE> सिंटैक्स का उपयोग करते हैं।",
+  "Change environment variable syntax": "एनवायरनमेंट वेरिएबल सिंटैक्स बदलें"
 }

--- a/src/Languages/lang_hr.json
+++ b/src/Languages/lang_hr.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Nema paketa za izvoz.",
   "CSV file": "CSV datoteka",
   "The file was saved to {0}": "Datoteka je spremljena u {0}",
-  "The file could not be saved:": "Datoteka se nije mogla spremiti:"
+  "The file could not be saved:": "Datoteka se nije mogla spremiti:",
+  "Environment variables use %VARIABLE% syntax.": "Varijable okruženja koriste sintaksu %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Varijable okruženja koriste sintaksu <VARIABLE>.",
+  "Change environment variable syntax": "Promijeni sintaksu varijabli okruženja"
 }

--- a/src/Languages/lang_hu.json
+++ b/src/Languages/lang_hu.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Nincsenek exportálható csomagok.",
   "CSV file": "CSV fájl",
   "The file was saved to {0}": "A fájl ide lett mentve: {0}",
-  "The file could not be saved:": "A fájlt nem sikerült menteni:"
+  "The file could not be saved:": "A fájlt nem sikerült menteni:",
+  "Environment variables use %VARIABLE% syntax.": "A környezeti változók a(z) %VARIABLE% szintaxist használják.",
+  "Environment variables use <VARIABLE> syntax.": "A környezeti változók a(z) <VARIABLE> szintaxist használják.",
+  "Change environment variable syntax": "Környezeti változók szintaxisának módosítása"
 }

--- a/src/Languages/lang_id.json
+++ b/src/Languages/lang_id.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Tidak ada paket untuk diekspor.",
   "CSV file": "File CSV",
   "The file was saved to {0}": "File disimpan ke {0}",
-  "The file could not be saved:": "File tidak dapat disimpan:"
+  "The file could not be saved:": "File tidak dapat disimpan:",
+  "Environment variables use %VARIABLE% syntax.": "Variabel lingkungan menggunakan sintaks %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Variabel lingkungan menggunakan sintaks <VARIABLE>.",
+  "Change environment variable syntax": "Ubah sintaks variabel lingkungan"
 }

--- a/src/Languages/lang_it.json
+++ b/src/Languages/lang_it.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Non ci sono pacchetti da esportare.",
   "CSV file": "File CSV",
   "The file was saved to {0}": "Il file è stato salvato in {0}",
-  "The file could not be saved:": "Non è stato possibile salvare il file:"
+  "The file could not be saved:": "Non è stato possibile salvare il file:",
+  "Environment variables use %VARIABLE% syntax.": "Le variabili d'ambiente usano la sintassi %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Le variabili d'ambiente usano la sintassi <VARIABLE>.",
+  "Change environment variable syntax": "Cambia la sintassi delle variabili d'ambiente"
 }

--- a/src/Languages/lang_ja.json
+++ b/src/Languages/lang_ja.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "エクスポートするパッケージがありません。",
   "CSV file": "CSVファイル",
   "The file was saved to {0}": "ファイルを{0}に保存しました",
-  "The file could not be saved:": "ファイルを保存できませんでした："
+  "The file could not be saved:": "ファイルを保存できませんでした：",
+  "Environment variables use %VARIABLE% syntax.": "環境変数は %VARIABLE% 構文を使用します。",
+  "Environment variables use <VARIABLE> syntax.": "環境変数は <VARIABLE> 構文を使用します。",
+  "Change environment variable syntax": "環境変数の構文を変更"
 }

--- a/src/Languages/lang_ka.json
+++ b/src/Languages/lang_ka.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "ექსპორტისთვის პაკეტები არ არის.",
   "CSV file": "CSV ფაილი",
   "The file was saved to {0}": "ფაილი შენახულია {0}-ში",
-  "The file could not be saved:": "ფაილის შენახვა ვერ მოხერხდა:"
+  "The file could not be saved:": "ფაილის შენახვა ვერ მოხერხდა:",
+  "Environment variables use %VARIABLE% syntax.": "გარემოს ცვლადები იყენებს %VARIABLE% სინტაქსს.",
+  "Environment variables use <VARIABLE> syntax.": "გარემოს ცვლადები იყენებს <VARIABLE> სინტაქსს.",
+  "Change environment variable syntax": "გარემოს ცვლადების სინტაქსის შეცვლა"
 }

--- a/src/Languages/lang_kn.json
+++ b/src/Languages/lang_kn.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "ರಫ್ತು ಮಾಡಲು ಯಾವುದೇ packages ಇಲ್ಲ.",
   "CSV file": "CSV ಫೈಲ್",
   "The file was saved to {0}": "ಫೈಲ್ ಅನ್ನು {0} ಗೆ ಉಳಿಸಲಾಗಿದೆ",
-  "The file could not be saved:": "ಫೈಲ್ ಅನ್ನು ಉಳಿಸಲಾಗಲಿಲ್ಲ:"
+  "The file could not be saved:": "ಫೈಲ್ ಅನ್ನು ಉಳಿಸಲಾಗಲಿಲ್ಲ:",
+  "Environment variables use %VARIABLE% syntax.": "ಪರಿಸರ ವೇರಿಯೇಬಲ್‌ಗಳು %VARIABLE% ಸಿಂಟ್ಯಾಕ್ಸ್ ಬಳಸುತ್ತವೆ.",
+  "Environment variables use <VARIABLE> syntax.": "ಪರಿಸರ ವೇರಿಯೇಬಲ್‌ಗಳು <VARIABLE> ಸಿಂಟ್ಯಾಕ್ಸ್ ಬಳಸುತ್ತವೆ.",
+  "Change environment variable syntax": "ಪರಿಸರ ವೇರಿಯೇಬಲ್ ಸಿಂಟ್ಯಾಕ್ಸ್ ಬದಲಾಯಿಸಿ"
 }

--- a/src/Languages/lang_ko.json
+++ b/src/Languages/lang_ko.json
@@ -944,5 +944,8 @@
   "There are no packages to export.": "내보낼 패키지가 없습니다.",
   "CSV file": "CSV 파일",
   "The file was saved to {0}": "파일이 {0}에 저장되었습니다",
-  "The file could not be saved:": "파일을 저장할 수 없습니다:"
+  "The file could not be saved:": "파일을 저장할 수 없습니다:",
+  "Environment variables use %VARIABLE% syntax.": "환경 변수는 %VARIABLE% 구문을 사용합니다.",
+  "Environment variables use <VARIABLE> syntax.": "환경 변수는 <VARIABLE> 구문을 사용합니다.",
+  "Change environment variable syntax": "환경 변수 구문 변경"
 }

--- a/src/Languages/lang_ku.json
+++ b/src/Languages/lang_ku.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Ti paket tune ku bên derxistin.",
   "CSV file": "Pelê CSV",
   "The file was saved to {0}": "Pel li {0} hate tomarkirin",
-  "The file could not be saved:": "Pel nehat tomarkirin:"
+  "The file could not be saved:": "Pel nehat tomarkirin:",
+  "Environment variables use %VARIABLE% syntax.": "Guhêrbarên jîngehê hevoksaziya %VARIABLE% bikar tînin.",
+  "Environment variables use <VARIABLE> syntax.": "Guhêrbarên jîngehê hevoksaziya <VARIABLE> bikar tînin.",
+  "Change environment variable syntax": "Hevoksaziya guhêrbarên jîngehê biguhêre"
 }

--- a/src/Languages/lang_lt.json
+++ b/src/Languages/lang_lt.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Nėra paketų, kuriuos būtų galima eksportuoti.",
   "CSV file": "CSV failas",
   "The file was saved to {0}": "Failas išsaugotas į {0}",
-  "The file could not be saved:": "Nepavyko išsaugoti failo:"
+  "The file could not be saved:": "Nepavyko išsaugoti failo:",
+  "Environment variables use %VARIABLE% syntax.": "Aplinkos kintamieji naudoja %VARIABLE% sintaksę.",
+  "Environment variables use <VARIABLE> syntax.": "Aplinkos kintamieji naudoja <VARIABLE> sintaksę.",
+  "Change environment variable syntax": "Keisti aplinkos kintamųjų sintaksę"
 }

--- a/src/Languages/lang_mk.json
+++ b/src/Languages/lang_mk.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Нема пакети за експортирање.",
   "CSV file": "CSV датотека",
   "The file was saved to {0}": "Датотеката беше зачувана во {0}",
-  "The file could not be saved:": "Датотеката не можеше да се зачува:"
+  "The file could not be saved:": "Датотеката не можеше да се зачува:",
+  "Environment variables use %VARIABLE% syntax.": "Променливите на околината користат синтакса %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Променливите на околината користат синтакса <VARIABLE>.",
+  "Change environment variable syntax": "Промени ја синтаксата на променливите на околината"
 }

--- a/src/Languages/lang_mr.json
+++ b/src/Languages/lang_mr.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "निर्यात करण्यासाठी कोणतेही पॅकेज नाहीत.",
   "CSV file": "CSV फाइल",
   "The file was saved to {0}": "फाइल {0} मध्ये जतन केली गेली",
-  "The file could not be saved:": "फाइल जतन करता आली नाही:"
+  "The file could not be saved:": "फाइल जतन करता आली नाही:",
+  "Environment variables use %VARIABLE% syntax.": "एन्व्हायर्नमेंट व्हेरिएबल्स %VARIABLE% सिंटॅक्स वापरतात.",
+  "Environment variables use <VARIABLE> syntax.": "एन्व्हायर्नमेंट व्हेरिएबल्स <VARIABLE> सिंटॅक्स वापरतात.",
+  "Change environment variable syntax": "एन्व्हायर्नमेंट व्हेरिएबल सिंटॅक्स बदला"
 }

--- a/src/Languages/lang_nb.json
+++ b/src/Languages/lang_nb.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Det finnes ingen pakker å eksportere.",
   "CSV file": "CSV-fil",
   "The file was saved to {0}": "Filen ble lagret til {0}",
-  "The file could not be saved:": "Filen kunne ikke lagres:"
+  "The file could not be saved:": "Filen kunne ikke lagres:",
+  "Environment variables use %VARIABLE% syntax.": "Miljøvariabler bruker %VARIABLE%-syntaks.",
+  "Environment variables use <VARIABLE> syntax.": "Miljøvariabler bruker <VARIABLE>-syntaks.",
+  "Change environment variable syntax": "Endre syntaks for miljøvariabler"
 }

--- a/src/Languages/lang_nl.json
+++ b/src/Languages/lang_nl.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Er zijn geen pakketten om te exporteren.",
   "CSV file": "CSV-bestand",
   "The file was saved to {0}": "Het bestand is opgeslagen in {0}",
-  "The file could not be saved:": "Het bestand kon niet worden opgeslagen:"
+  "The file could not be saved:": "Het bestand kon niet worden opgeslagen:",
+  "Environment variables use %VARIABLE% syntax.": "Omgevingsvariabelen gebruiken de %VARIABLE%-syntaxis.",
+  "Environment variables use <VARIABLE> syntax.": "Omgevingsvariabelen gebruiken de <VARIABLE>-syntaxis.",
+  "Change environment variable syntax": "Syntaxis van omgevingsvariabelen wijzigen"
 }

--- a/src/Languages/lang_nn.json
+++ b/src/Languages/lang_nn.json
@@ -948,5 +948,8 @@
   "There are no packages to export.": "Det finst ingen pakkar å eksportere.",
   "CSV file": "CSV-fil",
   "The file was saved to {0}": "Fila vart lagra til {0}",
-  "The file could not be saved:": "Fila kunne ikkje lagrast:"
+  "The file could not be saved:": "Fila kunne ikkje lagrast:",
+  "Environment variables use %VARIABLE% syntax.": "Miljøvariablar bruker %VARIABLE%-syntaks.",
+  "Environment variables use <VARIABLE> syntax.": "Miljøvariablar bruker <VARIABLE>-syntaks.",
+  "Change environment variable syntax": "Endre syntaks for miljøvariablar"
 }

--- a/src/Languages/lang_pl.json
+++ b/src/Languages/lang_pl.json
@@ -948,5 +948,8 @@
   "All sources": "Wszystkie źródła",
   "Filter by source": "Filtruj według źródła",
   "[... {0} earlier lines omitted ...]": "[... pominięto {0} wcześniejszych wierszy ...]",
-  "Clear Scoop download cache on launch": "Wyczyść pamięć podręczną pobierania Scoop przy uruchomieniu"
+  "Clear Scoop download cache on launch": "Wyczyść pamięć podręczną pobierania Scoop przy uruchomieniu",
+  "Environment variables use %VARIABLE% syntax.": "Zmienne środowiskowe używają składni %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Zmienne środowiskowe używają składni <VARIABLE>.",
+  "Change environment variable syntax": "Zmień składnię zmiennych środowiskowych"
 }

--- a/src/Languages/lang_pt_BR.json
+++ b/src/Languages/lang_pt_BR.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Não há pacotes para exportar.",
   "CSV file": "Arquivo CSV",
   "The file was saved to {0}": "O arquivo foi salvo em {0}",
-  "The file could not be saved:": "Não foi possível salvar o arquivo:"
+  "The file could not be saved:": "Não foi possível salvar o arquivo:",
+  "Environment variables use %VARIABLE% syntax.": "As variáveis de ambiente usam a sintaxe %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "As variáveis de ambiente usam a sintaxe <VARIABLE>.",
+  "Change environment variable syntax": "Alterar a sintaxe das variáveis de ambiente"
 }

--- a/src/Languages/lang_pt_PT.json
+++ b/src/Languages/lang_pt_PT.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Não existem pacotes para exportar.",
   "CSV file": "Ficheiro CSV",
   "The file was saved to {0}": "O ficheiro foi guardado em {0}",
-  "The file could not be saved:": "Não foi possível guardar o ficheiro:"
+  "The file could not be saved:": "Não foi possível guardar o ficheiro:",
+  "Environment variables use %VARIABLE% syntax.": "As variáveis de ambiente usam a sintaxe %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "As variáveis de ambiente usam a sintaxe <VARIABLE>.",
+  "Change environment variable syntax": "Alterar a sintaxe das variáveis de ambiente"
 }

--- a/src/Languages/lang_ro.json
+++ b/src/Languages/lang_ro.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Nu există pachete de exportat.",
   "CSV file": "Fișier CSV",
   "The file was saved to {0}": "Fișierul a fost salvat în {0}",
-  "The file could not be saved:": "Fișierul nu a putut fi salvat:"
+  "The file could not be saved:": "Fișierul nu a putut fi salvat:",
+  "Environment variables use %VARIABLE% syntax.": "Variabilele de mediu folosesc sintaxa %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Variabilele de mediu folosesc sintaxa <VARIABLE>.",
+  "Change environment variable syntax": "Modifică sintaxa variabilelor de mediu"
 }

--- a/src/Languages/lang_ru.json
+++ b/src/Languages/lang_ru.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Нет пакетов для экспорта.",
   "CSV file": "Файл CSV",
   "The file was saved to {0}": "Файл сохранён в {0}",
-  "The file could not be saved:": "Не удалось сохранить файл:"
+  "The file could not be saved:": "Не удалось сохранить файл:",
+  "Environment variables use %VARIABLE% syntax.": "Переменные среды используют синтаксис %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Переменные среды используют синтаксис <VARIABLE>.",
+  "Change environment variable syntax": "Изменить синтаксис переменных среды"
 }

--- a/src/Languages/lang_sa.json
+++ b/src/Languages/lang_sa.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "निर्यातयितुं कानिचित् packages न सन्ति।",
   "CSV file": "CSV सञ्चिका",
   "The file was saved to {0}": "सञ्चिका {0} प्रति रक्षिता",
-  "The file could not be saved:": "सञ्चिका रक्षितुं न शक्यत:"
+  "The file could not be saved:": "सञ्चिका रक्षितुं न शक्यत:",
+  "Environment variables use %VARIABLE% syntax.": "पर्यावरण-चराः %VARIABLE% इति वाक्यविन्यासं प्रयुञ्जते।",
+  "Environment variables use <VARIABLE> syntax.": "पर्यावरण-चराः <VARIABLE> इति वाक्यविन्यासं प्रयुञ्जते।",
+  "Change environment variable syntax": "पर्यावरण-चराणां वाक्यविन्यासं परिवर्तयतु"
 }

--- a/src/Languages/lang_si.json
+++ b/src/Languages/lang_si.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "අපනයනය කිරීමට පැකේජ නොමැත.",
   "CSV file": "CSV ගොනුව",
   "The file was saved to {0}": "ගොනුව {0} වෙත සුරකින ලදී",
-  "The file could not be saved:": "ගොනුව සුරැකිය නොහැකි විය:"
+  "The file could not be saved:": "ගොනුව සුරැකිය නොහැකි විය:",
+  "Environment variables use %VARIABLE% syntax.": "පරිසර විචල්‍ය %VARIABLE% වාක්‍ය රීතිය භාවිත කරයි.",
+  "Environment variables use <VARIABLE> syntax.": "පරිසර විචල්‍ය <VARIABLE> වාක්‍ය රීතිය භාවිත කරයි.",
+  "Change environment variable syntax": "පරිසර විචල්‍ය වාක්‍ය රීතිය වෙනස් කරන්න"
 }

--- a/src/Languages/lang_sk.json
+++ b/src/Languages/lang_sk.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Nie sú žiadne balíčky na export.",
   "CSV file": "Súbor CSV",
   "The file was saved to {0}": "Súbor bol uložený do {0}",
-  "The file could not be saved:": "Súbor sa nepodarilo uložiť:"
+  "The file could not be saved:": "Súbor sa nepodarilo uložiť:",
+  "Environment variables use %VARIABLE% syntax.": "Premenné prostredia používajú syntax %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Premenné prostredia používajú syntax <VARIABLE>.",
+  "Change environment variable syntax": "Zmeniť syntax premenných prostredia"
 }

--- a/src/Languages/lang_sl.json
+++ b/src/Languages/lang_sl.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Ni paketov za izvoz.",
   "CSV file": "Datoteka CSV",
   "The file was saved to {0}": "Datoteka je bila shranjena v {0}",
-  "The file could not be saved:": "Datoteke ni bilo mogoče shraniti:"
+  "The file could not be saved:": "Datoteke ni bilo mogoče shraniti:",
+  "Environment variables use %VARIABLE% syntax.": "Okoljske spremenljivke uporabljajo sintakso %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Okoljske spremenljivke uporabljajo sintakso <VARIABLE>.",
+  "Change environment variable syntax": "Spremeni sintakso okoljskih spremenljivk"
 }

--- a/src/Languages/lang_sq.json
+++ b/src/Languages/lang_sq.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Nuk ka paketa për të eksportuar.",
   "CSV file": "Skedar CSV",
   "The file was saved to {0}": "Skedari u ruajt në {0}",
-  "The file could not be saved:": "Skedari nuk mundi të ruhej:"
+  "The file could not be saved:": "Skedari nuk mundi të ruhej:",
+  "Environment variables use %VARIABLE% syntax.": "Variablat e mjedisit përdorin sintaksën %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Variablat e mjedisit përdorin sintaksën <VARIABLE>.",
+  "Change environment variable syntax": "Ndrysho sintaksën e variablave të mjedisit"
 }

--- a/src/Languages/lang_sr.json
+++ b/src/Languages/lang_sr.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Нема пакета за извоз.",
   "CSV file": "CSV датотека",
   "The file was saved to {0}": "Датотека је сачувана у {0}",
-  "The file could not be saved:": "Датотеку није могуће сачувати:"
+  "The file could not be saved:": "Датотеку није могуће сачувати:",
+  "Environment variables use %VARIABLE% syntax.": "Променљиве окружења користе синтаксу %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Променљиве окружења користе синтаксу <VARIABLE>.",
+  "Change environment variable syntax": "Промени синтаксу променљивих окружења"
 }

--- a/src/Languages/lang_sv.json
+++ b/src/Languages/lang_sv.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Det finns inga paket att exportera.",
   "CSV file": "CSV-fil",
   "The file was saved to {0}": "Filen sparades till {0}",
-  "The file could not be saved:": "Filen kunde inte sparas:"
+  "The file could not be saved:": "Filen kunde inte sparas:",
+  "Environment variables use %VARIABLE% syntax.": "Miljövariabler använder %VARIABLE%-syntax.",
+  "Environment variables use <VARIABLE> syntax.": "Miljövariabler använder <VARIABLE>-syntax.",
+  "Change environment variable syntax": "Ändra syntax för miljövariabler"
 }

--- a/src/Languages/lang_ta.json
+++ b/src/Languages/lang_ta.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "ஏற்றுமதி செய்ய packages எதுவும் இல்லை.",
   "CSV file": "CSV கோப்பு",
   "The file was saved to {0}": "கோப்பு {0} இல் சேமிக்கப்பட்டது",
-  "The file could not be saved:": "கோப்பைச் சேமிக்க முடியவில்லை:"
+  "The file could not be saved:": "கோப்பைச் சேமிக்க முடியவில்லை:",
+  "Environment variables use %VARIABLE% syntax.": "சூழல் மாறிகள் %VARIABLE% தொடரியலைப் பயன்படுத்துகின்றன.",
+  "Environment variables use <VARIABLE> syntax.": "சூழல் மாறிகள் <VARIABLE> தொடரியலைப் பயன்படுத்துகின்றன.",
+  "Change environment variable syntax": "சூழல் மாறி தொடரியலை மாற்றவும்"
 }

--- a/src/Languages/lang_th.json
+++ b/src/Languages/lang_th.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "ไม่มีแพ็กเกจให้ส่งออก",
   "CSV file": "ไฟล์ CSV",
   "The file was saved to {0}": "บันทึกไฟล์ไปยัง {0} แล้ว",
-  "The file could not be saved:": "ไม่สามารถบันทึกไฟล์ได้:"
+  "The file could not be saved:": "ไม่สามารถบันทึกไฟล์ได้:",
+  "Environment variables use %VARIABLE% syntax.": "ตัวแปรสภาพแวดล้อมใช้ไวยากรณ์ %VARIABLE%",
+  "Environment variables use <VARIABLE> syntax.": "ตัวแปรสภาพแวดล้อมใช้ไวยากรณ์ <VARIABLE>",
+  "Change environment variable syntax": "เปลี่ยนไวยากรณ์ตัวแปรสภาพแวดล้อม"
 }

--- a/src/Languages/lang_tl.json
+++ b/src/Languages/lang_tl.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Walang mga package na i-e-export.",
   "CSV file": "CSV file",
   "The file was saved to {0}": "Na-save ang file sa {0}",
-  "The file could not be saved:": "Hindi ma-save ang file:"
+  "The file could not be saved:": "Hindi ma-save ang file:",
+  "Environment variables use %VARIABLE% syntax.": "Gumagamit ang mga environment variable ng %VARIABLE% na syntax.",
+  "Environment variables use <VARIABLE> syntax.": "Gumagamit ang mga environment variable ng <VARIABLE> na syntax.",
+  "Change environment variable syntax": "Baguhin ang syntax ng environment variable"
 }

--- a/src/Languages/lang_tr.json
+++ b/src/Languages/lang_tr.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Aktarılacak paket yok.",
   "CSV file": "CSV dosyası",
   "The file was saved to {0}": "Dosya {0} konumuna kaydedildi",
-  "The file could not be saved:": "Dosya kaydedilemedi:"
+  "The file could not be saved:": "Dosya kaydedilemedi:",
+  "Environment variables use %VARIABLE% syntax.": "Ortam değişkenleri %VARIABLE% sözdizimini kullanır.",
+  "Environment variables use <VARIABLE> syntax.": "Ortam değişkenleri <VARIABLE> sözdizimini kullanır.",
+  "Change environment variable syntax": "Ortam değişkeni sözdizimini değiştir"
 }

--- a/src/Languages/lang_uk.json
+++ b/src/Languages/lang_uk.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Немає пакетів для експорту.",
   "CSV file": "Файл CSV",
   "The file was saved to {0}": "Файл збережено до {0}",
-  "The file could not be saved:": "Не вдалося зберегти файл:"
+  "The file could not be saved:": "Не вдалося зберегти файл:",
+  "Environment variables use %VARIABLE% syntax.": "Змінні середовища використовують синтаксис %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Змінні середовища використовують синтаксис <VARIABLE>.",
+  "Change environment variable syntax": "Змінити синтаксис змінних середовища"
 }

--- a/src/Languages/lang_ur.json
+++ b/src/Languages/lang_ur.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "برآمد کرنے کے لیے کوئی پیکیجز نہیں ہیں۔",
   "CSV file": "CSV فائل",
   "The file was saved to {0}": "فائل {0} میں محفوظ کر دی گئی",
-  "The file could not be saved:": "فائل محفوظ نہیں کی جا سکی:"
+  "The file could not be saved:": "فائل محفوظ نہیں کی جا سکی:",
+  "Environment variables use %VARIABLE% syntax.": "ماحولیاتی متغیرات %VARIABLE% نحو استعمال کرتے ہیں۔",
+  "Environment variables use <VARIABLE> syntax.": "ماحولیاتی متغیرات <VARIABLE> نحو استعمال کرتے ہیں۔",
+  "Change environment variable syntax": "ماحولیاتی متغیر کی نحو تبدیل کریں"
 }

--- a/src/Languages/lang_vi.json
+++ b/src/Languages/lang_vi.json
@@ -949,5 +949,8 @@
   "There are no packages to export.": "Không có gói nào để xuất.",
   "CSV file": "Tệp CSV",
   "The file was saved to {0}": "Tệp đã được lưu tại {0}",
-  "The file could not be saved:": "Không thể lưu tệp:"
+  "The file could not be saved:": "Không thể lưu tệp:",
+  "Environment variables use %VARIABLE% syntax.": "Biến môi trường sử dụng cú pháp %VARIABLE%.",
+  "Environment variables use <VARIABLE> syntax.": "Biến môi trường sử dụng cú pháp <VARIABLE>.",
+  "Change environment variable syntax": "Thay đổi cú pháp biến môi trường"
 }

--- a/src/Languages/lang_zh_CN.json
+++ b/src/Languages/lang_zh_CN.json
@@ -947,5 +947,8 @@
   "There are no packages to export.": "没有可导出的软件包。",
   "CSV file": "CSV 文件",
   "The file was saved to {0}": "文件已保存至 {0}",
-  "The file could not be saved:": "无法保存文件："
+  "The file could not be saved:": "无法保存文件：",
+  "Environment variables use %VARIABLE% syntax.": "环境变量使用 %VARIABLE% 语法。",
+  "Environment variables use <VARIABLE> syntax.": "环境变量使用 <VARIABLE> 语法。",
+  "Change environment variable syntax": "更改环境变量语法"
 }

--- a/src/Languages/lang_zh_TW.json
+++ b/src/Languages/lang_zh_TW.json
@@ -950,5 +950,8 @@
   "There are no packages to export.": "沒有可匯出的套件。",
   "CSV file": "CSV 檔案",
   "The file was saved to {0}": "檔案已儲存至 {0}",
-  "The file could not be saved:": "無法儲存檔案："
+  "The file could not be saved:": "無法儲存檔案：",
+  "Environment variables use %VARIABLE% syntax.": "環境變數使用 %VARIABLE% 語法。",
+  "Environment variables use <VARIABLE> syntax.": "環境變數使用 <VARIABLE> 語法。",
+  "Change environment variable syntax": "變更環境變數語法"
 }


### PR DESCRIPTION
This pull request adds new translations for environment variable syntax messages across multiple language files. Specifically, it introduces strings explaining both `%VARIABLE%` and `<VARIABLE>` syntaxes, as well as a label for changing the environment variable syntax. These additions improve localization support for upcoming features related to environment variable handling.

**Localization updates:**

* Added the following new strings to each language file:  
  - "Environment variables use %VARIABLE% syntax."  
  - "Environment variables use <VARIABLE> syntax."  
  - "Change environment variable syntax"  

* Minor formatting fix: Added a missing comma after the "The file could not be saved:" string in each file, ensuring proper JSON formatting. 