### PR TITLE
Align dark-mode accent colors and Operation History dialogs

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -366,6 +366,10 @@
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="CornerRadius" Value="4"/>
     </Style>
+    <Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
+        <Setter Property="RadiusX" Value="4"/>
+        <Setter Property="RadiusY" Value="4"/>
+    </Style>
     <!-- WinUI selection surfaces use rounded control corners rather than square highlights. -->
     <Style Selector="ListBoxItem">
         <Setter Property="CornerRadius" Value="4"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -13,6 +13,14 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColorDark2}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#37000000"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <!-- Bridge Avalonia's legacy Fluent accent aliases to the same palette. -->
+                    <SolidColorBrush x:Key="SystemControlBackgroundAccentBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <SolidColorBrush x:Key="SystemControlForegroundAccentBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <SolidColorBrush x:Key="SystemControlHighlightAccentBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <SolidColorBrush x:Key="SystemControlHighlightAltAccentBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <SolidColorBrush x:Key="SystemControlRevealFocusVisualBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="{DynamicResource SystemAccentColor}"/>
+                    <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="{DynamicResource SystemAccentColor}"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#09000000"/>
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#06000000"/>
@@ -45,6 +53,15 @@
                     <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush"    Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush"     Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="#FFFFFFFF"/>
+                    <!-- Avalonia's Button theme reads these keys from inside its control template. -->
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="AccentFillColorSecondaryBrush"/>
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="AccentFillColorTertiaryBrush"/>
+                    <StaticResource x:Key="AccentButtonBackgroundDisabled" ResourceKey="AccentFillColorDisabledBrush"/>
+                    <StaticResource x:Key="AccentButtonForeground" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+                    <StaticResource x:Key="AccentButtonForegroundPointerOver" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+                    <StaticResource x:Key="AccentButtonForegroundPressed" ResourceKey="TextOnAccentFillColorSecondaryBrush"/>
+                    <StaticResource x:Key="AccentButtonForegroundDisabled" ResourceKey="TextOnAccentFillColorDisabledBrush"/>
                     <!-- Settings cards -->
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#ECECEC"/>
@@ -114,6 +131,14 @@
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColor}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#28FFFFFF"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
+                    <!-- Avalonia's defaults keep the base accent in dark mode; WinUI uses Light2. -->
+                    <SolidColorBrush x:Key="SystemControlBackgroundAccentBrush" Color="{DynamicResource SystemAccentColorLight2}"/>
+                    <SolidColorBrush x:Key="SystemControlForegroundAccentBrush" Color="{DynamicResource SystemAccentColorLight2}"/>
+                    <SolidColorBrush x:Key="SystemControlHighlightAccentBrush" Color="{DynamicResource SystemAccentColorLight2}"/>
+                    <SolidColorBrush x:Key="SystemControlHighlightAltAccentBrush" Color="{DynamicResource SystemAccentColorLight2}"/>
+                    <SolidColorBrush x:Key="SystemControlRevealFocusVisualBrush" Color="{DynamicResource SystemAccentColorLight2}"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="{DynamicResource SystemAccentColorLight2}"/>
+                    <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="{DynamicResource SystemAccentColorLight2}"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#0FFFFFFF"/>
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush"  Color="#0AFFFFFF"/>
@@ -145,6 +170,15 @@
                     <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush"    Color="#80000000"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush"     Color="#87FFFFFF"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="#FFFFFFFF"/>
+                    <!-- Override the keys consumed by Avalonia's nested .accent button theme. -->
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="AccentFillColorDefaultBrush"/>
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="AccentFillColorSecondaryBrush"/>
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="AccentFillColorTertiaryBrush"/>
+                    <StaticResource x:Key="AccentButtonBackgroundDisabled" ResourceKey="AccentFillColorDisabledBrush"/>
+                    <StaticResource x:Key="AccentButtonForeground" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+                    <StaticResource x:Key="AccentButtonForegroundPointerOver" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+                    <StaticResource x:Key="AccentButtonForegroundPressed" ResourceKey="TextOnAccentFillColorSecondaryBrush"/>
+                    <StaticResource x:Key="AccentButtonForegroundDisabled" ResourceKey="TextOnAccentFillColorDisabledBrush"/>
                     <!-- Settings cards -->
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#0DFFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#393939"/>
@@ -213,6 +247,118 @@
 
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
 
+    <!-- Avalonia's Fluent controls still consume UWP-era accent resources, whose dark-theme
+         defaults use the base accent and white foreground. Bind every filled accent control to
+         the WinUI v2 tokens above so dark mode consistently uses a lighter fill and dark glyphs. -->
+    <Style Selector="Button.accent controls|SvgIcon,
+                     Button.accent:pointerover controls|SvgIcon">
+        <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="Button.accent:pressed controls|SvgIcon">
+        <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="Button.accent:disabled controls|SvgIcon">
+        <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorDisabledBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked /template/ Border#NormalRectangle,
+                     CheckBox:indeterminate /template/ Border#NormalRectangle">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked:pointerover /template/ Border#NormalRectangle,
+                     CheckBox:indeterminate:pointerover /template/ Border#NormalRectangle">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorSecondaryBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked:pressed /template/ Border#NormalRectangle,
+                     CheckBox:indeterminate:pressed /template/ Border#NormalRectangle">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorTertiaryBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorTertiaryBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked:disabled /template/ Border#NormalRectangle,
+                     CheckBox:indeterminate:disabled /template/ Border#NormalRectangle">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorDisabledBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDisabledBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked /template/ Path#CheckGlyph,
+                     CheckBox:indeterminate /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked:pointerover /template/ Path#CheckGlyph,
+                     CheckBox:indeterminate:pointerover /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked:pressed /template/ Path#CheckGlyph,
+                     CheckBox:indeterminate:pressed /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="CheckBox:checked:disabled /template/ Path#CheckGlyph,
+                     CheckBox:indeterminate:disabled /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorDisabledBrush}"/>
+    </Style>
+
+    <Style Selector="RadioButton:checked /template/ Ellipse#CheckOuterEllipse">
+        <Setter Property="Fill" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+    </Style>
+    <Style Selector="RadioButton:checked:pointerover /template/ Ellipse#CheckOuterEllipse">
+        <Setter Property="Fill" Value="{DynamicResource AccentFillColorSecondaryBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource AccentFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="RadioButton:checked:pressed /template/ Ellipse#CheckOuterEllipse">
+        <Setter Property="Fill" Value="{DynamicResource AccentFillColorTertiaryBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource AccentFillColorTertiaryBrush}"/>
+    </Style>
+    <Style Selector="RadioButton:checked:disabled /template/ Ellipse#CheckOuterEllipse">
+        <Setter Property="Fill" Value="{DynamicResource AccentFillColorDisabledBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource AccentFillColorDisabledBrush}"/>
+    </Style>
+    <Style Selector="RadioButton:checked /template/ Ellipse#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="RadioButton:checked:pointerover /template/ Ellipse#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="RadioButton:checked:pressed /template/ Ellipse#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="RadioButton:checked:disabled /template/ Ellipse#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorDisabledBrush}"/>
+    </Style>
+
+    <Style Selector="ToggleSwitch:checked /template/ Border#SwitchKnobBounds">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+    </Style>
+    <Style Selector="ToggleSwitch:checked:pointerover /template/ Border#SwitchKnobBounds">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorSecondaryBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="ToggleSwitch:checked:pressed /template/ Border#SwitchKnobBounds">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorTertiaryBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorTertiaryBrush}"/>
+    </Style>
+    <Style Selector="ToggleSwitch:checked:disabled /template/ Border#SwitchKnobBounds">
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorDisabledBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDisabledBrush}"/>
+    </Style>
+    <Style Selector="ToggleSwitch:checked /template/ Ellipse#SwitchKnobOn">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="ToggleSwitch:checked:pointerover /template/ Ellipse#SwitchKnobOn">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="ToggleSwitch:checked:pressed /template/ Ellipse#SwitchKnobOn">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="ToggleSwitch:checked:disabled /template/ Ellipse#SwitchKnobOn">
+        <Setter Property="Fill" Value="{DynamicResource TextOnAccentFillColorDisabledBrush}"/>
+    </Style>
+
+    <Style Selector="ProgressBar">
+        <Setter Property="Foreground" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+    </Style>
+
     <!-- DataGrid selection: WinUI-style border-only. Permanent transparent border reserves layout
          space so adjacent rows don't shift on select and the accent border isn't clipped on first/last rows. -->
     <Style Selector="DataGridRow">
@@ -262,7 +408,7 @@
         <Setter Property="Background" Value="{DynamicResource MenuDividerBrush}"/>
     </Style>
     <Style Selector="DataGridRow:selected">
-        <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
     </Style>
     <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="Transparent"/>
@@ -357,7 +503,7 @@
         <Setter Property="Background"   Value="{DynamicResource SettingsCardHoverBackground}"/>
     </Style>
     <Style Selector="Border.settings-card-focused">
-        <Setter Property="BorderBrush"     Value="{DynamicResource SystemAccentColor}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource AccentFillColorDefaultBrush}"/>
         <Setter Property="BorderThickness" Value="2"/>
     </Style>
 
@@ -376,7 +522,7 @@
 
     <!-- Hyperlink-style text (blue accent, underline) -->
     <Style Selector="TextBlock.hyperlink">
-        <Setter Property="Foreground"       Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+        <Setter Property="Foreground"       Value="{DynamicResource AccentTextFillColorPrimaryBrush}"/>
         <Setter Property="TextDecorations"  Value="Underline"/>
         <Setter Property="Cursor"           Value="Hand"/>
     </Style>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -364,6 +364,17 @@
     <Style Selector="DataGridRow">
         <Setter Property="BorderThickness" Value="2"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="CornerRadius" Value="4"/>
+    </Style>
+    <!-- WinUI selection surfaces use rounded control corners rather than square highlights. -->
+    <Style Selector="ListBoxItem">
+        <Setter Property="CornerRadius" Value="4"/>
+    </Style>
+    <Style Selector="ComboBoxItem">
+        <Setter Property="CornerRadius" Value="4"/>
+    </Style>
+    <Style Selector="TabItem">
+        <Setter Property="CornerRadius" Value="4"/>
     </Style>
     <!-- Column headers default to Avalonia's 12px bare-TextBlock size; WinUI renders them at 14px. -->
     <Style Selector="DataGridColumnHeader">

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -40,6 +40,8 @@ internal static class ConfirmationDialog
             Height = 32,
             Padding = new Thickness(11, 5, 11, 6),
             CornerRadius = new CornerRadius(4),
+            Background = GetBrush("AppDialogBackground"),
+            BorderThickness = new Thickness(0),
             FontSize = 14,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             HorizontalContentAlignment = HorizontalAlignment.Center,

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -28,6 +28,7 @@ internal static class ConfirmationDialog
             MinWidth = 320,
             MinHeight = 136,
             Title = CoreTools.Translate("Are you sure?"),
+            TitleMargin = new Thickness(24, 0, 0, 0),
             Background = GetBrush("AppDialogBackground"),
             HorizontalContentAlignment = HorizontalAlignment.Stretch,
             VerticalContentAlignment = VerticalAlignment.Stretch,
@@ -97,6 +98,8 @@ internal static class ConfirmationDialog
         var footer = new Border
         {
             Background = GetBrush("AppDialogDarkBackground"),
+            CornerRadius = new CornerRadius(0, 0, 7, 7),
+            ClipToBounds = true,
             Child = actions,
         };
         Grid.SetRow(footer, 1);

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -16,6 +16,11 @@ internal static class ConfirmationDialog
         if (MainWindow.Instance is not { } owner)
             return true;
 
+        IBrush? GetBrush(string key) =>
+            owner.TryFindResource(key, owner.ActualThemeVariant, out object? resource)
+                ? resource as IBrush
+                : null;
+
         bool confirmed = false;
         var dialog = new ImmersiveDialog
         {
@@ -23,7 +28,7 @@ internal static class ConfirmationDialog
             MinWidth = 320,
             MinHeight = 136,
             Title = CoreTools.Translate("Are you sure?"),
-            Background = Application.Current?.FindResource("AppDialogBackground") as IBrush,
+            Background = GetBrush("AppDialogBackground"),
             HorizontalContentAlignment = HorizontalAlignment.Stretch,
             VerticalContentAlignment = VerticalAlignment.Stretch,
         };
@@ -59,7 +64,7 @@ internal static class ConfirmationDialog
 
         var content = new Grid
         {
-            Background = Application.Current?.FindResource("AppDialogBackground") as IBrush,
+            Background = GetBrush("AppDialogBackground"),
         };
         content.RowDefinitions.Add(new RowDefinition(GridLength.Star));
         content.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
@@ -70,7 +75,7 @@ internal static class ConfirmationDialog
             FontSize = 14,
             LineHeight = 20,
             Margin = new Thickness(24, 12, 24, 24),
-            Foreground = Application.Current?.FindResource("TextFillColorPrimaryBrush") as IBrush,
+            Foreground = GetBrush("TextFillColorPrimaryBrush"),
             TextWrapping = TextWrapping.Wrap,
             VerticalAlignment = VerticalAlignment.Top,
         };
@@ -89,7 +94,7 @@ internal static class ConfirmationDialog
 
         var footer = new Border
         {
-            Background = Application.Current?.FindResource("AppDialogDarkBackground") as IBrush,
+            Background = GetBrush("AppDialogDarkBackground"),
             Child = actions,
         };
         Grid.SetRow(footer, 1);

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -20,7 +20,7 @@ internal static class ConfirmationDialog
         var dialog = new ImmersiveDialog
         {
             MaxWidth = 460,
-            MinHeight = 170,
+            MinWidth = 380,
             Title = CoreTools.Translate("Are you sure?"),
             Background = Application.Current?.FindResource("AppDialogBackground") as IBrush,
         };
@@ -28,10 +28,14 @@ internal static class ConfirmationDialog
         var noButton = new Button
         {
             Content = CoreTools.Translate("No"),
-            MinWidth = 100,
-            Height = 40,
-            Padding = new Thickness(12, 4),
+            MinWidth = 0,
+            Height = 36,
+            Padding = new Thickness(12, 3),
             CornerRadius = new CornerRadius(4),
+            Background = Application.Current?.FindResource("SettingsCardBackground") as IBrush,
+            BorderThickness = new Thickness(0),
+            Foreground = Application.Current?.FindResource("TextFillColorPrimaryBrush") as IBrush,
+            FontSize = 14,
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
         };
@@ -40,40 +44,50 @@ internal static class ConfirmationDialog
         var yesButton = new Button
         {
             Content = CoreTools.Translate("Yes"),
-            MinWidth = 100,
-            Height = 40,
-            Padding = new Thickness(12, 4),
+            MinWidth = 0,
+            Height = 36,
+            Padding = new Thickness(12, 3),
             CornerRadius = new CornerRadius(4),
+            FontSize = 14,
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
         };
         yesButton.Classes.Add("accent");
         yesButton.Click += (_, _) => { confirmed = true; dialog.Close(); };
 
-        var content = new Grid
-        {
-            Margin = new Thickness(20),
-        };
-        content.RowDefinitions.Add(new RowDefinition(GridLength.Star));
+        var content = new Grid();
+        content.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
         content.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
-        content.Children.Add(new TextBlock
+        var messageBlock = new TextBlock
         {
             Text = message,
-            Opacity = 0.82,
+            FontSize = 14,
+            LineHeight = 20,
+            Margin = new Thickness(20, 12, 20, 20),
+            Foreground = Application.Current?.FindResource("TextFillColorPrimaryBrush") as IBrush,
             TextWrapping = TextWrapping.Wrap,
-        });
-
-        var actions = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 8,
-            Margin = new Thickness(0, 20, 0, 0),
-            HorizontalAlignment = HorizontalAlignment.Right,
-            Children = { noButton, yesButton },
         };
-        Grid.SetRow(actions, 1);
-        content.Children.Add(actions);
+        content.Children.Add(messageBlock);
+
+        var actions = new Grid
+        {
+            ColumnSpacing = 8,
+            Margin = new Thickness(20, 12),
+        };
+        actions.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        actions.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        actions.Children.Add(noButton);
+        Grid.SetColumn(yesButton, 1);
+        actions.Children.Add(yesButton);
+
+        var footer = new Border
+        {
+            Background = Application.Current?.FindResource("AppWindowBackground") as IBrush,
+            Child = actions,
+        };
+        Grid.SetRow(footer, 1);
+        content.Children.Add(footer);
 
         dialog.Content = content;
 

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
 using UniGetUI.Avalonia.Views;
+using UniGetUI.Avalonia.Views.DialogPages;
 using UniGetUI.Core.Tools;
 
 namespace UniGetUI.Avalonia.Infrastructure;
@@ -16,47 +17,65 @@ internal static class ConfirmationDialog
             return true;
 
         bool confirmed = false;
-        var dialog = new Window
+        var dialog = new ImmersiveDialog
         {
-            Width = 460,
-            SizeToContent = SizeToContent.Height,
+            MaxWidth = 460,
             MinHeight = 170,
-            CanResize = false,
-            ShowInTaskbar = false,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
             Title = CoreTools.Translate("Are you sure?"),
+            Background = Application.Current?.FindResource("AppDialogBackground") as IBrush,
         };
 
-        var noButton = new Button { Content = CoreTools.Translate("No"), MinWidth = 100 };
+        var noButton = new Button
+        {
+            Content = CoreTools.Translate("No"),
+            MinWidth = 100,
+            Height = 40,
+            Padding = new Thickness(12, 4),
+            CornerRadius = new CornerRadius(4),
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
         noButton.Click += (_, _) => dialog.Close();
 
-        var yesButton = new Button { Content = CoreTools.Translate("Yes"), MinWidth = 100 };
+        var yesButton = new Button
+        {
+            Content = CoreTools.Translate("Yes"),
+            MinWidth = 100,
+            Height = 40,
+            Padding = new Thickness(12, 4),
+            CornerRadius = new CornerRadius(4),
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
         yesButton.Classes.Add("accent");
         yesButton.Click += (_, _) => { confirmed = true; dialog.Close(); };
 
-        dialog.Content = new StackPanel
+        var content = new Grid
         {
             Margin = new Thickness(20),
-            Spacing = 16,
-            Children =
-            {
-                new TextBlock
-                {
-                    Text = CoreTools.Translate("Are you sure?"),
-                    FontSize = 18,
-                    FontWeight = FontWeight.SemiBold,
-                    TextWrapping = TextWrapping.Wrap,
-                },
-                new TextBlock { Text = message, Opacity = 0.82, TextWrapping = TextWrapping.Wrap },
-                new StackPanel
-                {
-                    Orientation = Orientation.Horizontal,
-                    Spacing = 8,
-                    HorizontalAlignment = HorizontalAlignment.Right,
-                    Children = { noButton, yesButton },
-                },
-            },
         };
+        content.RowDefinitions.Add(new RowDefinition(GridLength.Star));
+        content.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+
+        content.Children.Add(new TextBlock
+        {
+            Text = message,
+            Opacity = 0.82,
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        var actions = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Margin = new Thickness(0, 20, 0, 0),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Children = { noButton, yesButton },
+        };
+        Grid.SetRow(actions, 1);
+        content.Children.Add(actions);
+
+        dialog.Content = content;
 
         await dialog.ShowDialog(owner);
         return confirmed;

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -19,23 +19,24 @@ internal static class ConfirmationDialog
         bool confirmed = false;
         var dialog = new ImmersiveDialog
         {
-            MaxWidth = 460,
-            MinWidth = 380,
+            MaxWidth = 548,
+            MinWidth = 320,
+            MinHeight = 136,
             Title = CoreTools.Translate("Are you sure?"),
             Background = Application.Current?.FindResource("AppDialogBackground") as IBrush,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Stretch,
         };
 
         var noButton = new Button
         {
             Content = CoreTools.Translate("No"),
             MinWidth = 0,
-            Height = 36,
-            Padding = new Thickness(12, 3),
+            Height = 32,
+            Padding = new Thickness(11, 5, 11, 6),
             CornerRadius = new CornerRadius(4),
-            Background = Application.Current?.FindResource("SettingsCardBackground") as IBrush,
-            BorderThickness = new Thickness(0),
-            Foreground = Application.Current?.FindResource("TextFillColorPrimaryBrush") as IBrush,
             FontSize = 14,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
         };
@@ -45,18 +46,22 @@ internal static class ConfirmationDialog
         {
             Content = CoreTools.Translate("Yes"),
             MinWidth = 0,
-            Height = 36,
-            Padding = new Thickness(12, 3),
+            Height = 32,
+            Padding = new Thickness(11, 5, 11, 6),
             CornerRadius = new CornerRadius(4),
             FontSize = 14,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
         };
         yesButton.Classes.Add("accent");
         yesButton.Click += (_, _) => { confirmed = true; dialog.Close(); };
 
-        var content = new Grid();
-        content.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+        var content = new Grid
+        {
+            Background = Application.Current?.FindResource("AppDialogBackground") as IBrush,
+        };
+        content.RowDefinitions.Add(new RowDefinition(GridLength.Star));
         content.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
         var messageBlock = new TextBlock
@@ -64,26 +69,27 @@ internal static class ConfirmationDialog
             Text = message,
             FontSize = 14,
             LineHeight = 20,
-            Margin = new Thickness(20, 12, 20, 20),
+            Margin = new Thickness(24, 12, 24, 24),
             Foreground = Application.Current?.FindResource("TextFillColorPrimaryBrush") as IBrush,
             TextWrapping = TextWrapping.Wrap,
+            VerticalAlignment = VerticalAlignment.Top,
         };
         content.Children.Add(messageBlock);
 
         var actions = new Grid
         {
             ColumnSpacing = 8,
-            Margin = new Thickness(20, 12),
+            Margin = new Thickness(24),
         };
         actions.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
         actions.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-        actions.Children.Add(noButton);
-        Grid.SetColumn(yesButton, 1);
         actions.Children.Add(yesButton);
+        Grid.SetColumn(noButton, 1);
+        actions.Children.Add(noButton);
 
         var footer = new Border
         {
-            Background = Application.Current?.FindResource("AppWindowBackground") as IBrush,
+            Background = Application.Current?.FindResource("AppDialogDarkBackground") as IBrush,
             Child = actions,
         };
         Grid.SetRow(footer, 1);

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -76,7 +76,7 @@ internal static class ConfirmationDialog
             Text = message,
             FontSize = 14,
             LineHeight = 20,
-            Margin = new Thickness(24, 12, 24, 24),
+            Margin = new Thickness(24),
             Foreground = GetBrush("TextFillColorPrimaryBrush"),
             TextWrapping = TextWrapping.Wrap,
             VerticalAlignment = VerticalAlignment.Top,

--- a/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/ConfirmationDialog.cs
@@ -98,7 +98,7 @@ internal static class ConfirmationDialog
         var footer = new Border
         {
             Background = GetBrush("AppDialogDarkBackground"),
-            CornerRadius = new CornerRadius(0, 0, 7, 7),
+            CornerRadius = new CornerRadius(0, 0, 8, 8),
             ClipToBounds = true,
             Child = actions,
         };

--- a/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryLogDialog.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryLogDialog.cs
@@ -7,6 +7,7 @@ using Avalonia.Platform.Storage;
 using UniGetUI.Avalonia.ViewModels.Pages.LogPages;
 using UniGetUI.Avalonia.Views;
 using UniGetUI.Avalonia.Views.Controls;
+using UniGetUI.Avalonia.Views.DialogPages;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Operations.History;
 
@@ -37,28 +38,27 @@ internal static class OperationHistoryLogDialog
         var editor = new LogTextEditor();
         editor.SetLines(lines);
 
-        var dialog = new Window
+        var dialog = new ImmersiveDialog
         {
-            Width = 780,
-            Height = 520,
+            MaxWidth = 780,
+            MaxHeight = 520,
             MinWidth = 460,
             MinHeight = 300,
-            ShowInTaskbar = false,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
             Title = CoreTools.Translate("Operation log") + (target.Length > 0 ? $" — {target}" : ""),
+            Background = Application.Current?.FindResource("AppDialogBackground") as IBrush,
         };
 
-        var copyButton = new Button { Content = CoreTools.Translate("Copy to clipboard") };
+        var copyButton = CreateDialogButton(CoreTools.Translate("Copy to clipboard"));
         copyButton.Click += async (_, _) =>
         {
             var clipboard = TopLevel.GetTopLevel(dialog)?.Clipboard;
             if (clipboard is not null) await clipboard.SetTextAsync(plainText);
         };
 
-        var exportButton = new Button { Content = CoreTools.Translate("Export to a file") };
+        var exportButton = CreateDialogButton(CoreTools.Translate("Export to a file"));
         exportButton.Click += async (_, _) =>
         {
-            var file = await dialog.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = CoreTools.Translate("Export log"),
                 SuggestedFileName = CoreTools.Translate("UniGetUI Log"),
@@ -68,7 +68,7 @@ internal static class OperationHistoryLogDialog
                 await File.WriteAllTextAsync(file.Path.LocalPath, plainText);
         };
 
-        var closeButton = new Button { Content = CoreTools.Translate("Close"), MinWidth = 100 };
+        var closeButton = CreateDialogButton(CoreTools.Translate("Close"), 100);
         closeButton.Classes.Add("accent");
         closeButton.Click += (_, _) => dialog.Close();
 
@@ -84,7 +84,7 @@ internal static class OperationHistoryLogDialog
         {
             CornerRadius = new CornerRadius(8),
             ClipToBounds = true,
-            Background = Application.Current?.FindResource("ApplicationPageBackgroundThemeBrush") as IBrush,
+            Background = Application.Current?.FindResource("AppDialogDarkBackground") as IBrush,
             Child = editor,
         };
         Grid.SetRow(editorBorder, 1);
@@ -108,4 +108,15 @@ internal static class OperationHistoryLogDialog
 
         await dialog.ShowDialog(owner);
     }
+
+    private static Button CreateDialogButton(string content, double minWidth = 0) => new()
+    {
+        Content = content,
+        MinWidth = minWidth,
+        Height = 40,
+        Padding = new Thickness(12, 4),
+        CornerRadius = new CornerRadius(4),
+        HorizontalContentAlignment = HorizontalAlignment.Center,
+        VerticalContentAlignment = VerticalAlignment.Center,
+    };
 }

--- a/src/UniGetUI.Avalonia/Infrastructure/SettingsAnchor.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/SettingsAnchor.cs
@@ -59,12 +59,12 @@ public static class SettingsAnchor
         var layer = AdornerLayer.GetAdornerLayer(target);
         if (layer is null) return;
 
-        Color accent = target.TryFindResource("SystemAccentColor", target.ActualThemeVariant, out var res)
-                       && res is Color c ? c : Colors.DodgerBlue;
+        IBrush accent = target.TryFindResource("AccentFillColorDefaultBrush", target.ActualThemeVariant, out var res)
+                        && res is IBrush brush ? brush : Brushes.DodgerBlue;
 
         var adorner = new Border
         {
-            BorderBrush = new SolidColorBrush(accent),
+            BorderBrush = accent,
             BorderThickness = new Thickness(2),
             CornerRadius = target is Border b ? b.CornerRadius : new CornerRadius(8),
             IsHitTestVisible = false,

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
@@ -88,10 +88,10 @@ public partial class InfoBar : UserControl
             SeverityIcon.ClearValue(ForegroundProperty);
             _severityStripBinding = SeverityStrip.Bind(
                 Border.BackgroundProperty,
-                this.GetResourceObservable("SystemAccentColor"));
+                this.GetResourceObservable("AccentFillColorDefaultBrush"));
             _severityIconBinding = SeverityIcon.Bind(
                 ForegroundProperty,
-                this.GetResourceObservable("SystemAccentColor"));
+                this.GetResourceObservable("AccentFillColorDefaultBrush"));
         }
     }
 }

--- a/src/UniGetUI.Avalonia/Views/Controls/UserAvatarControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/Controls/UserAvatarControl.axaml
@@ -42,7 +42,7 @@
                                 Padding="0"
                                 Background="Transparent"
                                 BorderThickness="0"
-                                Foreground="{DynamicResource SystemAccentColor}"
+                                Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                                 FontSize="11"
                                 Cursor="Hand"
                                 automation:AutomationProperties.Name="{t:Translate More details}"/>
@@ -77,7 +77,7 @@
                                 Padding="0"
                                 Background="Transparent"
                                 BorderThickness="0"
-                                Foreground="{DynamicResource SystemAccentColor}"
+                                Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                                 FontSize="11"
                                 Cursor="Hand"
                                 automation:AutomationProperties.Name="{t:Translate More details}"/>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ImmersiveDialog.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ImmersiveDialog.cs
@@ -20,6 +20,8 @@ public class ImmersiveDialog : ContentControl
     internal event EventHandler? CloseRequested;
     public event EventHandler<CancelEventArgs>? Closing;
 
+    public Thickness TitleMargin { get; set; } = new(20, 0, 0, 0);
+
     public string? Title
     {
         get => GetValue(TitleProperty);

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -196,7 +196,7 @@
                                     Classes="accent action-chevron"
                                     automation:AutomationProperties.Name="{Binding MainActionLabel}">
                                 <Path Data="M 0,0 L 4,4 L 8,0"
-                                      Stroke="White"
+                                      Stroke="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
                                       StrokeThickness="1.5"
                                       StrokeJoin="Miter"
                                       Fill="Transparent"

--- a/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml
@@ -39,8 +39,12 @@
                     Spacing="8"
                     Margin="0,4,0,0">
             <Button x:Name="DeclineButton" Content="{t:Translate Decline}" MinWidth="100"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
                     automation:AutomationProperties.Name="{t:Translate Decline}"/>
             <Button x:Name="AcceptButton"  Content="{t:Translate Accept}" MinWidth="100" Classes="accent"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
                     automation:AutomationProperties.Name="{t:Translate Accept}"/>
         </StackPanel>
 

--- a/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml
@@ -5,19 +5,20 @@
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.DialogPages.TelemetryDialog"
         Title="{t:Translate Share anonymous usage data}"
+        TitleMargin="24,0,0,0"
         IsCloseButtonVisible="False"
-        MaxWidth="520"
+        MaxWidth="548"
         MinWidth="420"
         MinHeight="250"
-
+        HorizontalContentAlignment="Stretch"
+        VerticalContentAlignment="Stretch"
         Background="{DynamicResource AppDialogBackground}">
 
-    <Grid Margin="20"
-          RowDefinitions="Auto,Auto"
-          RowSpacing="12">
+    <Grid RowDefinitions="*,Auto"
+          Background="{DynamicResource AppDialogBackground}">
 
         <!-- Body -->
-        <StackPanel Grid.Row="0" Spacing="8">
+        <StackPanel Grid.Row="0" Spacing="8" Margin="24">
             <TextBlock Text="{t:Translate UniGetUI collects anonymous usage data with the sole purpose of understanding and improving the user experience.}"
                        TextWrapping="Wrap" Opacity="0.85"/>
             <TextBlock x:Name="Body2" TextWrapping="Wrap" Opacity="0.85"/>
@@ -32,21 +33,41 @@
                        TextWrapping="Wrap" Opacity="0.85"/>
         </StackPanel>
 
-        <!-- Buttons -->
-        <StackPanel Grid.Row="1"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="8"
-                    Margin="0,4,0,0">
-            <Button x:Name="DeclineButton" Content="{t:Translate Decline}" MinWidth="100"
-                    HorizontalContentAlignment="Center"
-                    VerticalContentAlignment="Center"
-                    automation:AutomationProperties.Name="{t:Translate Decline}"/>
-            <Button x:Name="AcceptButton"  Content="{t:Translate Accept}" MinWidth="100" Classes="accent"
-                    HorizontalContentAlignment="Center"
-                    VerticalContentAlignment="Center"
-                    automation:AutomationProperties.Name="{t:Translate Accept}"/>
-        </StackPanel>
+        <!-- WinUI ContentDialog-style command area. -->
+        <Border Grid.Row="1"
+                Background="{DynamicResource AppDialogDarkBackground}"
+                CornerRadius="0,0,8,8"
+                ClipToBounds="True">
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="8" Margin="24">
+                <Button x:Name="AcceptButton"
+                        Grid.Column="0"
+                        Content="{t:Translate Accept}"
+                        Classes="accent"
+                        Height="32"
+                        MinWidth="0"
+                        Padding="11,5,11,6"
+                        CornerRadius="4"
+                        FontSize="14"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        automation:AutomationProperties.Name="{t:Translate Accept}"/>
+                <Button x:Name="DeclineButton"
+                        Grid.Column="1"
+                        Content="{t:Translate Decline}"
+                        Height="32"
+                        MinWidth="0"
+                        Padding="11,5,11,6"
+                        CornerRadius="4"
+                        FontSize="14"
+                        Background="{DynamicResource AppDialogBackground}"
+                        BorderThickness="0"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        automation:AutomationProperties.Name="{t:Translate Decline}"/>
+            </Grid>
+        </Border>
 
     </Grid>
 

--- a/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/TelemetryDialog.axaml.cs
@@ -15,7 +15,7 @@ public partial class TelemetryDialog : UniGetUI.Avalonia.Views.DialogPages.Immer
         Body2.Text = CoreTools.Translate("No personal information is collected nor sent, and the collected data is anonimized, so it can't be back-tracked to you.");
 
         DetailsLink.Bind(TextBlock.ForegroundProperty,
-            DetailsLink.GetResourceObservable("SystemControlHighlightAccentBrush"));
+            DetailsLink.GetResourceObservable("AccentTextFillColorPrimaryBrush"));
         DetailsLink.PointerPressed += (_, e) =>
         {
             if (e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -735,7 +735,8 @@
                     KeyboardNavigation.TabNavigation="Cycle"
                     BoxShadow="0 8 32 0 #59000000">
                 <Grid RowDefinitions="Auto,*">
-                    <Grid Grid.Row="0"
+                    <Grid x:Name="ModalHeader"
+                          Grid.Row="0"
                           Height="48"
                           Margin="20,0,0,0"
                           ColumnDefinitions="*,Auto">

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -728,8 +728,6 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Background="{DynamicResource AppDialogBackground}"
-                    BorderBrush="{DynamicResource AppBorderBrush}"
-                    BorderThickness="1"
                     CornerRadius="8"
                     ClipToBounds="True"
                     KeyboardNavigation.TabNavigation="Cycle"
@@ -763,6 +761,14 @@
                                     Grid.Row="1"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"/>
+                    <!-- Draw the outline above dialog content so opaque footer surfaces cannot
+                         cover the antialiased inner edge of the rounded border. -->
+                    <Border Grid.RowSpan="2"
+                            BorderBrush="{DynamicResource AppBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            IsHitTestVisible="False"
+                            ZIndex="10"/>
                 </Grid>
             </Border>
         </Grid>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -40,7 +40,7 @@
         <!-- Focus: accent underline (declared after hover so it wins when both apply). -->
         <Style Selector="Border#GlobalSearchContainer:focus-within Border#SearchFocusUnderline">
             <Setter Property="Opacity" Value="1"/>
-            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
         </Style>
         <Style Selector="Border#GlobalSearchContainer:focus-within">
             <Setter Property="Background" Value="{DynamicResource SearchBoxFocusedBackground}"/>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1657,6 +1657,7 @@ public partial class MainWindow : Window
         _modalTitleSubscription = dialog.GetObservable(ImmersiveDialog.TitleProperty)
             .SubscribeValue(title => ModalTitle.Text = title ?? "");
         ModalCloseButton.IsVisible = dialog.IsCloseButtonVisible;
+        ModalHeader.Margin = dialog.TitleMargin;
         ModalContent.Content = dialog;
         ModalLayer.IsVisible = true;
         UpdateModalSurfaceSize();

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
@@ -17,7 +17,19 @@
             <Setter Property="Padding" Value="12,6"/>
             <Setter Property="MinHeight" Value="0"/>
             <Setter Property="FontSize" Value="14"/>
+            <Setter Property="FontWeight" Value="Normal"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
+        </Style>
+        <Style Selector="TabItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+        </Style>
+        <Style Selector="TabItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+        </Style>
+        <Style Selector="TabItem:selected:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
         </Style>
         <Style Selector="TabItem /template/ #PART_SelectedPipe" x:SetterTargetType="Control">
             <Setter Property="IsVisible" Value="False"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
@@ -73,8 +73,8 @@
         </Style>
         <Style Selector="DataGridColumnHeader">
             <Setter Property="Background" Value="{DynamicResource PackageListHeaderBackground}"/>
-            <Setter Property="HorizontalContentAlignment" Value="Left"/>
-            <Setter Property="Padding" Value="8,0,0,0"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
             <Setter Property="AreSeparatorsVisible" Value="False"/>
             <Setter Property="SeparatorBrush" Value="Transparent"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
@@ -21,14 +21,13 @@
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
-        <Style Selector="TabItem:selected /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
-            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
-        </Style>
-        <Style Selector="TabItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Style Selector="TabItem:selected">
             <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
         </Style>
-        <Style Selector="TabItem:selected:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Style Selector="TabItem:selected:pointerover /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+        </Style>
+        <Style Selector="TabItem:selected:pressed /template/ Border#PART_LayoutRoot">
             <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
         </Style>
         <Style Selector="TabItem /template/ #PART_SelectedPipe" x:SetterTargetType="Control">

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
@@ -17,6 +17,7 @@
             <Setter Property="Padding" Value="12,6"/>
             <Setter Property="MinHeight" Value="0"/>
             <Setter Property="FontSize" Value="14"/>
+            <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="TabItem /template/ #PART_SelectedPipe" x:SetterTargetType="Control">
             <Setter Property="IsVisible" Value="False"/>
@@ -36,6 +37,17 @@
         </Style>
         <Style Selector="#HistoryActions Button:disabled">
             <Setter Property="Opacity" Value="0.4"/>
+        </Style>
+
+        <!-- These use the same Button + MenuFlyout path as the package-order picker. -->
+        <Style Selector="Button.history-filter">
+            <Setter Property="Padding" Value="10,6"/>
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
 
         <!-- DataGrid styled to match the package list (rounded inset header bar, no gridlines) -->
@@ -208,11 +220,14 @@
                 <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" Margin="0,4,0,0">
                     <Button Grid.Column="0"
                             Command="{Binding ClearCommand}"
-                            Padding="10,6"
+                            Height="40"
+                            Padding="10,4"
                             CornerRadius="4"
-                            Background="Transparent"
-                            BorderThickness="1"
-                            BorderBrush="{DynamicResource AppBorderBrush}"
+                            Background="{DynamicResource SettingsCardBackground}"
+                            BorderThickness="0"
+                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
                             automation:AutomationProperties.Name="{t:Translate Clear history}">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/delete.svg" Width="16" Height="16"/>
@@ -221,18 +236,39 @@
                     </Button>
 
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
-                        <ComboBox MinWidth="130"
-                                  ItemsSource="{Binding StatusOptions}"
-                                  SelectedItem="{Binding SelectedStatus}"
-                                  automation:AutomationProperties.Name="{t:Translate Filter by status}"/>
-                        <ComboBox MinWidth="130"
-                                  ItemsSource="{Binding KindOptions}"
-                                  SelectedItem="{Binding SelectedKind}"
-                                  automation:AutomationProperties.Name="{t:Translate Filter by type}"/>
-                        <ComboBox MinWidth="130"
-                                  ItemsSource="{Binding ManagerOptions}"
-                                  SelectedItem="{Binding SelectedManager}"
-                                  automation:AutomationProperties.Name="{t:Translate Filter by manager}"/>
+                        <Button Classes="history-filter" MinWidth="130" Tag="status"
+                                Click="FilterButton_Click"
+                                automation:AutomationProperties.Name="{t:Translate Filter by status}">
+                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                <TextBlock Text="{Binding SelectedStatus.Label}" VerticalAlignment="Center"/>
+                                <Path Grid.Column="1" Data="M 0,0 L 5,5 L 10,0"
+                                      Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                                      StrokeThickness="1.5" StrokeJoin="Miter" Fill="Transparent"
+                                      VerticalAlignment="Center"/>
+                            </Grid>
+                        </Button>
+                        <Button Classes="history-filter" MinWidth="130" Tag="kind"
+                                Click="FilterButton_Click"
+                                automation:AutomationProperties.Name="{t:Translate Filter by type}">
+                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                <TextBlock Text="{Binding SelectedKind.Label}" VerticalAlignment="Center"/>
+                                <Path Grid.Column="1" Data="M 0,0 L 5,5 L 10,0"
+                                      Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                                      StrokeThickness="1.5" StrokeJoin="Miter" Fill="Transparent"
+                                      VerticalAlignment="Center"/>
+                            </Grid>
+                        </Button>
+                        <Button Classes="history-filter" MinWidth="130" Tag="manager"
+                                Click="FilterButton_Click"
+                                automation:AutomationProperties.Name="{t:Translate Filter by manager}">
+                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                <TextBlock Text="{Binding SelectedManager.Label}" VerticalAlignment="Center"/>
+                                <Path Grid.Column="1" Data="M 0,0 L 5,5 L 10,0"
+                                      Stroke="{DynamicResource TextFillColorPrimaryBrush}"
+                                      StrokeThickness="1.5" StrokeJoin="Miter" Fill="Transparent"
+                                      VerticalAlignment="Center"/>
+                            </Grid>
+                        </Button>
                     </StackPanel>
                 </Grid>
             </Grid>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml.cs
@@ -117,6 +117,49 @@ public partial class OperationHistoryPage : UserControl, IEnterLeaveListener, IK
         },
     };
 
+    private void FilterButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: string facet } button) return;
+
+        (IEnumerable<HistoryFilterOption> options, HistoryFilterOption? selected) = facet switch
+        {
+            "status" => (_viewModel.StatusOptions, _viewModel.SelectedStatus),
+            "kind" => (_viewModel.KindOptions, _viewModel.SelectedKind),
+            "manager" => (_viewModel.ManagerOptions, _viewModel.SelectedManager),
+            _ => ([], null),
+        };
+
+        var flyout = new MenuFlyout { Placement = PlacementMode.TopEdgeAlignedRight };
+        foreach (HistoryFilterOption option in options)
+        {
+            var item = new MenuItem
+            {
+                Header = option.Label,
+                IsChecked = ReferenceEquals(option, selected),
+            };
+            item.Click += (_, _) => SetHistoryFilter(facet, option);
+            flyout.Items.Add(item);
+        }
+
+        flyout.ShowAt(button);
+    }
+
+    private void SetHistoryFilter(string facet, HistoryFilterOption option)
+    {
+        switch (facet)
+        {
+            case "status":
+                _viewModel.SelectedStatus = option;
+                break;
+            case "kind":
+                _viewModel.SelectedKind = option;
+                break;
+            case "manager":
+                _viewModel.SelectedManager = option;
+                break;
+        }
+    }
+
     // Copy details needs clipboard access (a top-level concern), so it uses a click handler rather than a command.
     private MenuItem BuildCopyDetailsItem(OperationHistoryRowViewModel row)
     {

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml.cs
@@ -135,6 +135,7 @@ public partial class OperationHistoryPage : UserControl, IEnterLeaveListener, IK
             var item = new MenuItem
             {
                 Header = option.Label,
+                ToggleType = MenuItemToggleType.Radio,
                 IsChecked = ReferenceEquals(option, selected),
             };
             item.Click += (_, _) => SetHistoryFilter(facet, option);

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/General.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/General.axaml.cs
@@ -66,7 +66,7 @@ public sealed partial class General : UserControl, ISettingsPage
             Cursor = new Cursor(StandardCursorType.Hand),
             Margin = new Thickness(4, 0, 0, 0),
         };
-        link.Bind(TextBlock.ForegroundProperty, link.GetResourceObservable("SystemControlHighlightAccentBrush"));
+        link.Bind(TextBlock.ForegroundProperty, link.GetResourceObservable("AccentTextFillColorPrimaryBrush"));
         link.PointerPressed += (_, _) =>
             CoreTools.Launch("https://github.com/Devolutions/UniGetUI/blob/main/TRANSLATION.md");
 

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SourceManagerCard.axaml
@@ -64,7 +64,7 @@
                           MinHeight="32">
                         <!-- Accent bar -->
                         <Border Grid.Column="0"
-                                Background="{DynamicResource SystemAccentColor}"
+                                Background="{DynamicResource AccentFillColorDefaultBrush}"
                                 CornerRadius="2"
                                 Margin="0,4"/>
                         <!-- Package icon + name -->

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -66,7 +66,7 @@
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
                     </StackPanel>
                     <!-- Update count bubble (InfoBadge-style), anchored to the icon's top-right in both rail and flyout -->
-                    <Border Background="{DynamicResource SystemAccentColor}"
+                    <Border Background="{DynamicResource AccentFillColorDefaultBrush}"
                             CornerRadius="8"
                             Padding="3,1"
                             MinWidth="16"
@@ -76,9 +76,9 @@
                             VerticalAlignment="Top"
                             Margin="26,5,0,0">
                         <TextBlock Text="{Binding UpdatesBadgeCount}"
-                                   FontSize="9"
+                                   FontSize="11"
                                    FontWeight="Bold"
-                                   Foreground="White"
+                                   Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"/>
                     </Border>

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -92,7 +92,7 @@
       <!-- Focus: accent underline (declared after hover so it wins when both apply). -->
       <Style Selector="Border#MegaQueryContainer:focus-within Border#MegaQueryUnderline">
          <Setter Property="Opacity" Value="1"/>
-         <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+         <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
       </Style>
       <Style Selector="Border#MegaQueryContainer:focus-within">
          <Setter Property="Background" Value="{DynamicResource SearchBoxFocusedBackground}"/>
@@ -540,7 +540,7 @@
                                                     <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/package.svg"
                                                                       Width="24" Height="24" IsVisible="{Binding !HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="{Binding TagBackdropIconPath}"
-                                                                      Foreground="{DynamicResource SystemAccentColor}"
+                                                                      Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                                                                       Width="20" Height="20"
                                                                       Margin="0,0,-3,-3"
                                                                       IsVisible="{Binding TagIconVisible}"
@@ -664,7 +664,7 @@
                                                     <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/package.svg"
                                                                       Width="44" Height="44" IsVisible="{Binding !HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="{Binding TagBackdropIconPath}"
-                                                                      Foreground="{DynamicResource SystemAccentColor}"
+                                                                      Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                                                                       Width="28" Height="28"
                                                                       Margin="0,0,-4,-4"
                                                                       IsVisible="{Binding TagIconVisible}"
@@ -774,7 +774,7 @@
                                                     <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/package.svg"
                                                                       Width="64" Height="64" IsVisible="{Binding !HasCustomIcon}"/>
                                                     <controls:SvgIcon Path="{Binding TagBackdropIconPath}"
-                                                                      Foreground="{DynamicResource SystemAccentColor}"
+                                                                      Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                                                                       Width="38" Height="38"
                                                                       Margin="0,0,-5,-5"
                                                                       IsVisible="{Binding TagIconVisible}"


### PR DESCRIPTION
UniGetUI originally used two sets of accent colors for dark / light mode UI:

- Light mode: white text on darker accent
<img width="1896" height="1239" alt="image" src="https://github.com/user-attachments/assets/8343cd8e-0920-4ba1-978c-1308cf18ffb2" />

- Dark mode: black text on brighter accent
<img width="1896" height="1239" alt="image" src="https://github.com/user-attachments/assets/810f8656-3584-43d8-a3d6-920e6303ac15" />

Avalonia version of UniGetUI however has not been applying that rule consistently, causing a mismatch in accent colors in various places. This PR attempts to address this behavior. 

- Before: 
<img width="1920" height="1280" alt="image" src="https://github.com/user-attachments/assets/c94e0405-e7de-43c5-8882-85390115e41f" />

- After: 
<img width="1920" height="1280" alt="image" src="https://github.com/user-attachments/assets/08676802-943a-4def-a783-44f0416af380" />
<img width="1920" height="1280" alt="image" src="https://github.com/user-attachments/assets/cb18db58-733e-4624-b422-beeb0f165dc3" />

- Comparison with pre-Avalonia UniGetUI: 
<img width="1896" height="1239" alt="image" src="https://github.com/user-attachments/assets/03f564e3-8f66-4655-8b32-7f483bdc904f" />

This PR also brings in some changes to the new operation history interface, making use of the refreshed button controls, immersive menus and drop-down theming for sake of consistency. 


