### PR TITLE
Adjust package details pane to match previous appearance

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -35,6 +35,8 @@
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#0F000000"/>
+                    <SolidColorBrush x:Key="SearchFieldBorderBrush"           Color="#0F000000"/>
+                    <Thickness x:Key="SearchFieldBorderThickness">0.5</Thickness>
                     <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
                     <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#F2F2F2"/>
                     <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#E0E0E0"/>
@@ -140,6 +142,8 @@
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#0FFFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#B31E1E1E"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#12FFFFFF"/>
+                    <SolidColorBrush x:Key="SearchFieldBorderBrush"           Color="Transparent"/>
+                    <Thickness x:Key="SearchFieldBorderThickness">1</Thickness>
                     <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
                     <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#393939"/>
                     <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#4A4A4A"/>
@@ -490,8 +494,8 @@
          coupling the title-bar search control to this reusable template. -->
     <Style Selector="TextBox.search-field-standalone">
         <Setter Property="Background" Value="{DynamicResource SearchBoxInactiveBackground}"/>
-        <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SearchFieldBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource SearchFieldBorderThickness}"/>
         <Setter Property="CornerRadius" Value="5"/>
         <Setter Property="ClipToBounds" Value="True"/>
         <Setter Property="FocusAdorner" Value="{x:Null}"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -11,6 +11,7 @@
                     <SolidColorBrush x:Key="AccentFillColorDefaultBrush"  Color="{DynamicResource SystemAccentColor}"/>
                     <SolidColorBrush x:Key="AccentFillColorSecondaryBrush" Color="{DynamicResource SystemAccentColorDark1}"/>
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColorDark2}"/>
+                    <SolidColorBrush x:Key="PackageActionHoverBackground" Color="{DynamicResource SystemAccentColorLight1}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#37000000"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
@@ -34,6 +35,9 @@
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#0F000000"/>
+                    <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
+                    <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#F2F2F2"/>
+                    <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#E0E0E0"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5C000000"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#FFFFFFFF"/>
                     <!-- Opaque WinUI menu surface and low-contrast divider. -->
@@ -112,6 +116,7 @@
                     <SolidColorBrush x:Key="AccentFillColorDefaultBrush"   Color="{DynamicResource SystemAccentColorLight2}"/>
                     <SolidColorBrush x:Key="AccentFillColorSecondaryBrush" Color="{DynamicResource SystemAccentColorLight1}"/>
                     <SolidColorBrush x:Key="AccentFillColorTertiaryBrush"  Color="{DynamicResource SystemAccentColor}"/>
+                    <SolidColorBrush x:Key="PackageActionHoverBackground" Color="{DynamicResource SystemAccentColorLight3}"/>
                     <SolidColorBrush x:Key="AccentFillColorDisabledBrush"  Color="#28FFFFFF"/>
                     <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{DynamicResource SystemAccentColor}"/>
                     <!-- Subtle fills (WinUI NavigationViewItem hover/selected backgrounds) -->
@@ -134,6 +139,9 @@
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#0FFFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#B31E1E1E"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#12FFFFFF"/>
+                    <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
+                    <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#393939"/>
+                    <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#4A4A4A"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5DFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#E4000000"/>
                     <!-- WinUI's dark flyout surface is an opaque #2C2C2C. -->
@@ -148,7 +156,7 @@
                     <!-- Settings cards -->
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#0DFFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#393939"/>
-                    <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#323232"/>
+                    <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#15FFFFFF"/>
                     <!-- WinUI dropdown controls use the same control/card fill as settings actions. -->
                     <StaticResource x:Key="ComboBoxBackground" ResourceKey="SettingsCardBackground"/>
                     <StaticResource x:Key="ComboBoxBackgroundUnfocused" ResourceKey="SettingsCardBackground"/>
@@ -464,6 +472,107 @@
                 </ResourceDictionary.ThemeDictionaries>
             </ResourceDictionary>
         </Style.Resources>
+    </Style>
+
+    <!-- Shared WinUI-style form-input underline. -->
+    <Style Selector="Border.search-field-underline">
+        <Setter Property="Opacity" Value="0"/>
+        <Setter Property="Background" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+        <Setter Property="Transitions">
+            <Transitions>
+                <DoubleTransition Property="Opacity" Duration="0:0:0.12"/>
+            </Transitions>
+        </Setter>
+    </Style>
+    <!-- Standalone form inputs use the search field's fill and underline treatment without
+         coupling the title-bar search control to this reusable template. -->
+    <Style Selector="TextBox.search-field-standalone">
+        <Setter Property="Background" Value="{DynamicResource SearchBoxInactiveBackground}"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="5"/>
+        <Setter Property="ClipToBounds" Value="True"/>
+        <Setter Property="FocusAdorner" Value="{x:Null}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="PlaceholderForeground" Value="{DynamicResource SearchBoxPlaceholderForeground}"/>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DataValidationErrors>
+                    <Panel>
+                        <Border Name="SearchFieldStandaloneContainer"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                MinWidth="{TemplateBinding MinWidth}"
+                                MinHeight="{TemplateBinding MinHeight}"/>
+                        <Border Margin="{TemplateBinding BorderThickness}">
+                            <ScrollViewer Name="PART_ScrollViewer"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                          VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                                          IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}">
+                                <Panel>
+                                    <TextBlock Name="PART_Placeholder"
+                                               Foreground="{TemplateBinding PlaceholderForeground}"
+                                               Text="{TemplateBinding PlaceholderText}"
+                                               TextAlignment="{TemplateBinding TextAlignment}"
+                                               TextWrapping="{TemplateBinding TextWrapping}"
+                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                        <TextBlock.IsVisible>
+                                            <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                                <Binding ElementName="PART_TextPresenter" Path="PreeditText" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
+                                                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
+                                            </MultiBinding>
+                                        </TextBlock.IsVisible>
+                                    </TextBlock>
+                                    <TextPresenter Name="PART_TextPresenter"
+                                                   Text="{TemplateBinding Text, Mode=TwoWay}"
+                                                   CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                                   CaretIndex="{TemplateBinding CaretIndex}"
+                                                   SelectionStart="{TemplateBinding SelectionStart}"
+                                                   SelectionEnd="{TemplateBinding SelectionEnd}"
+                                                   TextAlignment="{TemplateBinding TextAlignment}"
+                                                   TextWrapping="{TemplateBinding TextWrapping}"
+                                                   LineHeight="{TemplateBinding LineHeight}"
+                                                   LetterSpacing="{TemplateBinding LetterSpacing}"
+                                                   SelectionBrush="{TemplateBinding SelectionBrush}"
+                                                   SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                                   CaretBrush="{TemplateBinding CaretBrush}"
+                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                </Panel>
+                            </ScrollViewer>
+                        </Border>
+                        <Border Name="SearchFieldStandaloneUnderline"
+                                Classes="search-field-underline"
+                                Height="2" Margin="1,0,1,0"
+                                VerticalAlignment="Bottom"
+                                IsHitTestVisible="False"/>
+                    </Panel>
+                </DataValidationErrors>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="TextBox.search-field-standalone:pointerover /template/ Border#SearchFieldStandaloneUnderline">
+        <Setter Property="Opacity" Value="1"/>
+    </Style>
+    <Style Selector="TextBox.search-field-standalone:focus-within">
+        <Setter Property="Background" Value="{DynamicResource SearchBoxFocusedBackground}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SearchBoxFocusedBorderBrush}"/>
+    </Style>
+    <Style Selector="TextBox.search-field-standalone:focus-within /template/ Border#SearchFieldStandaloneUnderline">
+        <Setter Property="Opacity" Value="1"/>
+        <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+    </Style>
+    <Style Selector="TextBox.search-field-standalone.multiline">
+        <Setter Property="MinHeight" Value="32"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="VerticalContentAlignment" Value="Top"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled"/>
     </Style>
 
 </Styles>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -35,21 +35,6 @@
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#0F000000"/>
-                    <!-- WinUI's light controls use a 1-DIP elevation stroke, not a flat
-                         half-DIP low-alpha outline.  Its stronger lower edge is what keeps
-                         pale controls legible on similarly pale surfaces. -->
-                    <LinearGradientBrush x:Key="ControlElevationBorderBrush"
-                                         StartPoint="0%,0%" EndPoint="0%,100%">
-                        <GradientStop Offset="0" Color="#0F000000"/>
-                        <GradientStop Offset="1" Color="#29000000"/>
-                    </LinearGradientBrush>
-                    <SolidColorBrush x:Key="ControlStrokeDefaultBrush" Color="#0F000000"/>
-                    <StaticResource x:Key="SearchFieldBorderBrush" ResourceKey="ControlElevationBorderBrush"/>
-                    <Thickness x:Key="SearchFieldBorderThickness">1</Thickness>
-                    <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
-                    <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#F2F2F2"/>
-                    <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#E0E0E0"/>
-                    <SolidColorBrush x:Key="InstallOptionsTabHoverBackground" Color="#E8E8E8"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5C000000"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#FFFFFFFF"/>
                     <!-- Opaque WinUI menu surface and low-contrast divider. -->
@@ -122,6 +107,17 @@
                     <!-- Toast: failure-badge red and drop shadow (light) -->
                     <SolidColorBrush x:Key="ToastBadgeBrush"              Color="#C42B1C"/>
                     <BoxShadows x:Key="ToastShadow">0 4 16 0 #33000000</BoxShadows>
+                    <!-- Package-details-only surfaces live at the end of the theme dictionary
+                         so the independent global-theme PR can extend shared control tokens. -->
+                    <LinearGradientBrush x:Key="SearchFieldBorderBrush"
+                                         StartPoint="0%,0%" EndPoint="0%,100%">
+                        <GradientStop Offset="0" Color="#0F000000"/>
+                        <GradientStop Offset="1" Color="#29000000"/>
+                    </LinearGradientBrush>
+                    <Thickness x:Key="SearchFieldBorderThickness">1</Thickness>
+                    <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#F2F2F2"/>
+                    <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#E0E0E0"/>
+                    <SolidColorBrush x:Key="InstallOptionsTabHoverBackground" Color="#E8E8E8"/>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
                     <!-- Accent fills (lighter accents on dark bg) -->
@@ -171,7 +167,7 @@
                     <!-- Settings cards -->
                     <SolidColorBrush x:Key="SettingsCardBackground"      Color="#0DFFFFFF"/>
                     <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#393939"/>
-                    <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#15FFFFFF"/>
+                    <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#323232"/>
                     <!-- WinUI dropdown controls use the same control/card fill as settings actions. -->
                     <StaticResource x:Key="ComboBoxBackground" ResourceKey="SettingsCardBackground"/>
                     <StaticResource x:Key="ComboBoxBackgroundUnfocused" ResourceKey="SettingsCardBackground"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -38,6 +38,7 @@
                     <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
                     <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#F2F2F2"/>
                     <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#E0E0E0"/>
+                    <SolidColorBrush x:Key="InstallOptionsTabHoverBackground" Color="#E8E8E8"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5C000000"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#FFFFFFFF"/>
                     <!-- Opaque WinUI menu surface and low-contrast divider. -->
@@ -142,6 +143,7 @@
                     <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
                     <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#393939"/>
                     <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#4A4A4A"/>
+                    <SolidColorBrush x:Key="InstallOptionsTabHoverBackground" Color="#15FFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorDisabledBrush"  Color="#5DFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorInverseBrush"   Color="#E4000000"/>
                     <!-- WinUI's dark flyout surface is an opaque #2C2C2C. -->

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -35,8 +35,17 @@
                     <SolidColorBrush x:Key="SearchBoxInactiveBackground"      Color="#B3FFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBackground"       Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="SearchBoxFocusedBorderBrush"      Color="#0F000000"/>
-                    <SolidColorBrush x:Key="SearchFieldBorderBrush"           Color="#0F000000"/>
-                    <Thickness x:Key="SearchFieldBorderThickness">0.5</Thickness>
+                    <!-- WinUI's light controls use a 1-DIP elevation stroke, not a flat
+                         half-DIP low-alpha outline.  Its stronger lower edge is what keeps
+                         pale controls legible on similarly pale surfaces. -->
+                    <LinearGradientBrush x:Key="ControlElevationBorderBrush"
+                                         StartPoint="0%,0%" EndPoint="0%,100%">
+                        <GradientStop Offset="0" Color="#0F000000"/>
+                        <GradientStop Offset="1" Color="#29000000"/>
+                    </LinearGradientBrush>
+                    <SolidColorBrush x:Key="ControlStrokeDefaultBrush" Color="#0F000000"/>
+                    <StaticResource x:Key="SearchFieldBorderBrush" ResourceKey="ControlElevationBorderBrush"/>
+                    <Thickness x:Key="SearchFieldBorderThickness">1</Thickness>
                     <!-- Opaque package-details layers remain distinct even when the dialog uses Mica. -->
                     <SolidColorBrush x:Key="InstallOptionsSectionBackground" Color="#F2F2F2"/>
                     <SolidColorBrush x:Key="InstallOptionsTabSelectedBackground" Color="#E0E0E0"/>

--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.WindowsMica.axaml
@@ -58,7 +58,7 @@
             <SolidColorBrush x:Key="SettingsCardBorderBrush"     Color="#26FFFFFF"/>
             <!-- Package list: near-transparent so Mica shows through, matching WinUI's SystemFillColorNeutralBackground -->
             <SolidColorBrush x:Key="PackageListBackground"       Color="#08FFFFFF"/>
-            <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#66383838"/>
+            <SolidColorBrush x:Key="SettingsCardHoverBackground" Color="#15FFFFFF"/>
             <SolidColorBrush x:Key="AppSplitterBackground"       Color="#66000000"/>
             <SolidColorBrush x:Key="AppOperationsPanelBackground" Color="#66202020"/>
             <SolidColorBrush x:Key="AppBorderBrush"              Color="#33FFFFFF"/>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -74,10 +74,10 @@
             <Setter Property="CornerRadius" Value="8,8,0,0"/>
         </Style>
         <Style Selector="TabControl.install-options-tabs TabItem:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SettingsCardHoverBackground}"/>
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsTabHoverBackground}"/>
         </Style>
         <Style Selector="TabControl.install-options-tabs TabItem:pointerover /template/ Border#PART_LayoutRoot">
-            <Setter Property="Background" Value="{DynamicResource SettingsCardHoverBackground}"/>
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsTabHoverBackground}"/>
         </Style>
         <Style Selector="TabControl.install-options-tabs TabItem:selected">
             <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -8,11 +8,85 @@
              x:DataType="vm:InstallOptionsViewModel">
 
     <UserControl.Styles>
+        <Style Selector="ComboBox.install-option-input">
+            <Setter Property="Background" Value="{DynamicResource SearchBoxInactiveBackground}"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="ComboBox.install-option-input:pointerover">
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+        </Style>
+        <Style Selector="ComboBox.install-option-input:focus-within">
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+        </Style>
+
         <!-- WinUI-style rich tabs: roomy headers that hold an icon + two text lines. -->
-        <Style Selector="TabItem">
+        <Style Selector="TabControl.install-options-tabs">
+            <Setter Property="Background" Value="{DynamicResource AppDialogDarkBackground}"/>
+            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="ItemsPanel">
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </Setter>
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            ClipToBounds="True">
+                        <DockPanel>
+                            <ScrollViewer DockPanel.Dock="Top"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          VerticalScrollBarVisibility="Disabled">
+                                <ItemsPresenter Name="PART_ItemsPresenter"
+                                                ItemsPanel="{TemplateBinding ItemsPanel}"/>
+                            </ScrollViewer>
+                            <Panel ClipToBounds="True">
+                                <ContentPresenter Name="PART_SelectedContentHost2"
+                                                  Margin="{TemplateBinding Padding}"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  IsVisible="False"/>
+                                <ContentPresenter Name="PART_SelectedContentHost"
+                                                  Margin="{TemplateBinding Padding}"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            </Panel>
+                        </DockPanel>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="TabControl.install-options-tabs TabItem">
             <Setter Property="Padding" Value="12,6"/>
             <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Margin" Value="0,4,0,0"/>
+            <Setter Property="VerticalAlignment" Value="Stretch"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="CornerRadius" Value="8,8,0,0"/>
+        </Style>
+        <Style Selector="TabControl.install-options-tabs TabItem:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardHoverBackground}"/>
+        </Style>
+        <Style Selector="TabControl.install-options-tabs TabItem:pointerover /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardHoverBackground}"/>
+        </Style>
+        <Style Selector="TabControl.install-options-tabs TabItem:selected">
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>
+        </Style>
+        <Style Selector="TabControl.install-options-tabs TabItem:selected /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>
+        </Style>
+        <Style Selector="TabControl.install-options-tabs TabItem:selected:pointerover /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>
         </Style>
         <!-- WinUI tabs have no accent underline; the selected tab is shown by its background. -->
         <Style Selector="TabItem /template/ #PART_SelectedPipe" x:SetterTargetType="Control">
@@ -21,8 +95,16 @@
         <Style Selector="TabItem:selected /template/ #PART_SelectedPipe" x:SetterTargetType="Control">
             <Setter Property="IsVisible" Value="False"/>
         </Style>
+        <!-- Blur the locked options themselves; the overlay remains sharp above them. -->
+        <Style Selector="StackPanel.lockable-options.locked">
+            <Setter Property="Effect">
+                <BlurEffect Radius="6"/>
+            </Setter>
+        </Style>
     </UserControl.Styles>
 
+    <Border Background="{DynamicResource InstallOptionsSectionBackground}"
+            CornerRadius="8" Padding="16">
     <StackPanel Spacing="12">
 
         <!-- ── Header: icon · title · profile selector ── -->
@@ -45,6 +127,7 @@
                            Text="{Binding ProfileLabel}"
                            FontSize="14" Opacity="0.7"/>
                 <ComboBox x:Name="ProfileSelectorComboBox"
+                          Classes="install-option-input"
                           ItemsSource="{Binding ProfileOptions}"
                           SelectedItem="{Binding SelectedProfile}"
                           automation:AutomationProperties.LabeledBy="{Binding #ProfileLabelBlock}"
@@ -53,7 +136,7 @@
         </Grid>
 
         <!-- ── Follow-global-options card ── -->
-        <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="8" Padding="16,8">
+        <Border Background="{DynamicResource AppDialogDarkBackground}" CornerRadius="8" Padding="16,8">
             <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" ColumnSpacing="8">
                 <TextBlock x:Name="FollowGlobalLabelBlock"
                            Grid.Row="0" Grid.Column="0"
@@ -76,7 +159,9 @@
 
         <!-- ── Options area + lock overlay ── -->
         <Grid>
-          <StackPanel Spacing="12">
+          <StackPanel Spacing="12"
+                      Classes="lockable-options"
+                      Classes.locked="{Binding FollowGlobal}">
 
             <!-- Explainer (applies to every tab, like WinUI) -->
             <TextBlock Text="{Binding GeneralInfoLabel}"
@@ -84,8 +169,8 @@
                        TextWrapping="Wrap"
                        Margin="4,0"/>
 
-            <TabControl IsEnabled="{Binding IsCustomMode}"
-                        Background="Transparent">
+            <TabControl Classes="install-options-tabs"
+                        IsEnabled="{Binding IsCustomMode}">
 
             <!-- Tab 0: General -->
             <TabItem>
@@ -99,7 +184,7 @@
                         </StackPanel>
                     </StackPanel>
                 </TabItem.Header>
-                <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
+                <Border Background="{DynamicResource AppDialogDarkBackground}" Padding="16">
                     <StackPanel Spacing="8">
 
                         <WrapPanel Orientation="Horizontal">
@@ -135,6 +220,7 @@
                                        Text="{Binding VersionLabel}"
                                        VerticalAlignment="Center"/>
                             <ComboBox Grid.Column="1"
+                                      Classes="install-option-input"
                                       ItemsSource="{Binding VersionOptions}"
                                       SelectedItem="{Binding SelectedVersion}"
                                       IsEnabled="{Binding VersionEnabled}"
@@ -160,6 +246,7 @@
                                 <TextBlock Text="{Binding SkipMinorLevelPrefix_Content, FallbackValue='Ignore changes after the first'}"
                                            VerticalAlignment="Center" Margin="0,0,8,0" TextWrapping="Wrap"/>
                                 <ComboBox ItemsSource="{Binding SkipMinorLevelOptions}"
+                                          Classes="install-option-input"
                                           SelectedIndex="{Binding SkipMinorLevelIndex}"
                                           automation:AutomationProperties.Name="{Binding SkipMinorLevelPrefix_Content}"
                                           VerticalAlignment="Center" MinWidth="64"/>
@@ -184,12 +271,13 @@
                         </StackPanel>
                     </StackPanel>
                 </TabItem.Header>
-                <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
+                <Border Background="{DynamicResource AppDialogDarkBackground}" Padding="16">
                     <StackPanel Spacing="8">
 
                         <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
                             <TextBlock x:Name="ArchLabelBlock" Text="{Binding ArchLabel}" VerticalAlignment="Center"/>
                             <ComboBox Grid.Column="1"
+                                      Classes="install-option-input"
                                       ItemsSource="{Binding ArchOptions}"
                                       SelectedItem="{Binding SelectedArch}"
                                       IsEnabled="{Binding ArchEnabled}"
@@ -203,6 +291,7 @@
                         <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
                             <TextBlock x:Name="ScopeLabelBlock" Text="{Binding ScopeLabel}" VerticalAlignment="Center"/>
                             <ComboBox Grid.Column="1"
+                                      Classes="install-option-input"
                                       ItemsSource="{Binding ScopeOptions}"
                                       SelectedItem="{Binding SelectedScope}"
                                       IsEnabled="{Binding ScopeEnabled}"
@@ -216,6 +305,7 @@
                         <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="6">
                             <TextBlock x:Name="LocationLabelBlock" Text="{Binding LocationLabel}" VerticalAlignment="Center"/>
                             <Button Grid.Column="1"
+                                    Classes="secondary-action"
                                     Content="{Binding SelectDirLabel}"
                                     automation:AutomationProperties.Name="{Binding SelectDirLabel}"
                                     automation:AutomationProperties.HelpText="{Binding LocationLabel}"
@@ -223,6 +313,7 @@
                                     Padding="8,3" CornerRadius="4"
                                     Click="SelectDir_Click"/>
                             <Button Grid.Column="2"
+                                    Classes="secondary-action"
                                     Content="{Binding ResetDirLabel}"
                                     automation:AutomationProperties.Name="{Binding ResetDirLabel}"
                                     automation:AutomationProperties.HelpText="{Binding LocationLabel}"
@@ -231,7 +322,9 @@
                                     Command="{Binding ResetLocationCommand}"/>
                         </Grid>
 
-                        <TextBox Text="{Binding LocationText}"
+                        <TextBox Classes="install-option-input search-field-standalone multiline"
+                                 Text="{Binding LocationText}"
+                                 AcceptsReturn="True"
                                  IsEnabled="{Binding LocationEnabled}"
                                  automation:AutomationProperties.LabeledBy="{Binding #LocationLabelBlock}"
                                  FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
@@ -268,7 +361,7 @@
                         </StackPanel>
                     </StackPanel>
                 </TabItem.Header>
-                <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
+                <Border Background="{DynamicResource AppDialogDarkBackground}" Padding="16">
                     <StackPanel Spacing="8">
 
                       <!-- Security warning shown when custom CLI arguments are disabled -->
@@ -309,7 +402,9 @@
                         <TextBlock x:Name="ParamsInstallLabelBlock" Text="{Binding ParamsInstallLabel}"
                                    VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1"
+                                 Classes="install-option-input search-field-standalone multiline"
                                  Text="{Binding ParamsInstall}"
+                                 AcceptsReturn="True"
                                  automation:AutomationProperties.LabeledBy="{Binding #ParamsInstallLabelBlock}"
                                  FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                  FontSize="14"/>
@@ -318,7 +413,9 @@
                                    Text="{Binding ParamsUpdateLabel}"
                                    VerticalAlignment="Center"/>
                         <TextBox Grid.Row="1" Grid.Column="1"
+                                 Classes="install-option-input search-field-standalone multiline"
                                  Text="{Binding ParamsUpdate}"
+                                 AcceptsReturn="True"
                                  automation:AutomationProperties.LabeledBy="{Binding #ParamsUpdateLabelBlock}"
                                  FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                  FontSize="14"/>
@@ -327,7 +424,9 @@
                                    Text="{Binding ParamsUninstallLabel}"
                                    VerticalAlignment="Center"/>
                         <TextBox Grid.Row="2" Grid.Column="1"
+                                 Classes="install-option-input search-field-standalone multiline"
                                  Text="{Binding ParamsUninstall}"
+                                 AcceptsReturn="True"
                                  automation:AutomationProperties.LabeledBy="{Binding #ParamsUninstallLabelBlock}"
                                  FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                  FontSize="14"/>
@@ -356,7 +455,7 @@
                         </StackPanel>
                     </StackPanel>
                 </TabItem.Header>
-                <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
+                <Border Background="{DynamicResource AppDialogDarkBackground}" Padding="16">
                     <StackPanel Spacing="8">
 
                         <TextBlock Text="{Binding KillProcessesDescriptionLabel}"
@@ -364,6 +463,7 @@
                                    Opacity="0.7"/>
 
                         <TextBox x:Name="KillProcessNewEntryBox"
+                                 Classes="install-option-input search-field-standalone"
                                  Text="{Binding KillProcessNewEntry}"
                                  PlaceholderText="{Binding KillProcessesPlaceholderLabel}"
                                  HorizontalAlignment="Stretch"
@@ -378,6 +478,7 @@
                                                    FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                                    FontSize="14"/>
                                         <Button Grid.Column="1"
+                                                Classes="secondary-action"
                                                 Content="✕"
                                                 Command="{Binding RemoveCommand}"
                                                 Padding="6,2" Margin="8,0,0,0"
@@ -410,7 +511,7 @@
                         </StackPanel>
                     </StackPanel>
                 </TabItem.Header>
-                <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="0,8,8,8" Padding="16">
+                <Border Background="{DynamicResource AppDialogDarkBackground}" Padding="16">
                     <StackPanel Spacing="10">
 
                         <!-- Security warning shown when pre/post scripts are disabled -->
@@ -426,19 +527,21 @@
 
                         <!-- Install -->
                         <Grid ColumnDefinitions="*,*"
-                              RowDefinitions="Auto,56,Auto"
+                              RowDefinitions="Auto,Auto,Auto"
                               ColumnSpacing="8" RowSpacing="4"
                               IsEnabled="{Binding PrePostEnabled}">
                             <TextBlock x:Name="PreInstallLabelBlock" Text="{Binding PreInstallLabel}" FontSize="12"/>
                             <TextBlock x:Name="PostInstallLabelBlock" Grid.Column="1"
                                        Text="{Binding PostInstallLabel}" FontSize="12"/>
                             <TextBox Grid.Row="1"
+                                     Classes="install-option-input search-field-standalone multiline"
                                      Text="{Binding PreInstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PreInstallLabelBlock}"
                                      FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                      FontSize="14"/>
                             <TextBox Grid.Row="1" Grid.Column="1"
+                                     Classes="install-option-input search-field-standalone multiline"
                                      Text="{Binding PostInstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PostInstallLabelBlock}"
@@ -455,19 +558,21 @@
 
                         <!-- Update -->
                         <Grid ColumnDefinitions="*,*"
-                              RowDefinitions="Auto,56,Auto"
+                              RowDefinitions="Auto,Auto,Auto"
                               ColumnSpacing="8" RowSpacing="4"
                               IsEnabled="{Binding PrePostEnabled}">
                             <TextBlock x:Name="PreUpdateLabelBlock" Text="{Binding PreUpdateLabel}" FontSize="12"/>
                             <TextBlock x:Name="PostUpdateLabelBlock" Grid.Column="1"
                                        Text="{Binding PostUpdateLabel}" FontSize="12"/>
                             <TextBox Grid.Row="1"
+                                     Classes="install-option-input search-field-standalone multiline"
                                      Text="{Binding PreUpdateText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PreUpdateLabelBlock}"
                                      FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                      FontSize="14"/>
                             <TextBox Grid.Row="1" Grid.Column="1"
+                                     Classes="install-option-input search-field-standalone multiline"
                                      Text="{Binding PostUpdateText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PostUpdateLabelBlock}"
@@ -484,19 +589,21 @@
 
                         <!-- Uninstall -->
                         <Grid ColumnDefinitions="*,*"
-                              RowDefinitions="Auto,56,Auto"
+                              RowDefinitions="Auto,Auto,Auto"
                               ColumnSpacing="8" RowSpacing="4"
                               IsEnabled="{Binding PrePostEnabled}">
                             <TextBlock x:Name="PreUninstallLabelBlock" Text="{Binding PreUninstallLabel}" FontSize="12"/>
                             <TextBlock x:Name="PostUninstallLabelBlock" Grid.Column="1"
                                        Text="{Binding PostUninstallLabel}" FontSize="12"/>
                             <TextBox Grid.Row="1"
+                                     Classes="install-option-input search-field-standalone multiline"
                                      Text="{Binding PreUninstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PreUninstallLabelBlock}"
                                      FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                      FontSize="14"/>
                             <TextBox Grid.Row="1" Grid.Column="1"
+                                     Classes="install-option-input search-field-standalone multiline"
                                      Text="{Binding PostUninstallText}"
                                      AcceptsReturn="True"
                                      automation:AutomationProperties.LabeledBy="{Binding #PostUninstallLabelBlock}"
@@ -516,9 +623,8 @@
 
           </StackPanel>
 
-          <!-- Lock overlay shown while following the default options. A translucent solid
-               layer (composites over the in-app tabs so they show faintly behind); Avalonia
-               has no in-app gaussian blur, so this is the closest readable equivalent. -->
+          <!-- Lock overlay shown while following the default options. The options content
+               beneath it is Gaussian-blurred by the conditional style above. -->
           <Panel IsVisible="{Binding FollowGlobal}">
             <Border Background="{DynamicResource AppDialogBackground}" Opacity="0.7" IsHitTestVisible="True"/>
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
@@ -527,6 +633,7 @@
                          FontSize="20" FontWeight="SemiBold"
                          TextAlignment="Center" TextWrapping="Wrap"/>
               <Button Content="{Binding UnlockLabel}"
+                      Classes="secondary-action"
                       HorizontalAlignment="Center"
                       Padding="12,5" CornerRadius="4"
                       Command="{Binding UnlockCommand}"/>
@@ -535,12 +642,13 @@
         </Grid>
 
         <!-- ── Command-line preview ── -->
-        <Border Background="{DynamicResource AppDialogPanelBackground}" CornerRadius="8" Padding="12">
+        <Border Background="{DynamicResource AppDialogDarkBackground}" CornerRadius="8" Padding="12">
             <StackPanel Spacing="6">
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
                     <TextBlock Grid.Column="0" Text="{Binding CommandPreviewLabel}" Opacity="0.7"
                                VerticalAlignment="Center"/>
                     <Button Grid.Column="1" x:Name="ManualButton"
+                            Classes="secondary-action"
                             Content="{Binding ManualActionLabel}"
                             automation:AutomationProperties.Name="{Binding ManualActionLabel}"
                             Padding="10,4" CornerRadius="4"
@@ -557,4 +665,5 @@
         </Border>
 
     </StackPanel>
+    </Border>
 </UserControl>

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -10,18 +10,18 @@
     <UserControl.Styles>
         <Style Selector="ComboBox.install-option-input">
             <Setter Property="Background" Value="{DynamicResource SearchBoxInactiveBackground}"/>
-            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="ComboBox.install-option-input:pointerover">
             <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>
-            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}"/>
         </Style>
         <Style Selector="ComboBox.install-option-input:focus-within">
             <Setter Property="Background" Value="{DynamicResource InstallOptionsTabSelectedBackground}"/>
-            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPressed}"/>
         </Style>
 
         <!-- WinUI-style rich tabs: roomy headers that hold an icon + two text lines. -->

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml
@@ -7,16 +7,30 @@
         xmlns:t="using:UniGetUI.Avalonia.MarkupExtensions"
         x:Class="UniGetUI.Avalonia.Views.PackageDetailsWindow"
         x:DataType="vm:PackageDetailsViewModel"
-        MaxWidth="1000"
-        MinWidth="640"
-        MaxHeight="720"
-        MinHeight="420"
+        MaxWidth="1200"
+        MinWidth="720"
+        MaxHeight="800"
+        MinHeight="480"
         Background="{DynamicResource AppDialogBackground}"
         Title="{t:Translate Package details}">
 
     <dialogs:ImmersiveDialog.Styles>
-        <Style Selector="Expander /template/ ToggleButton#ExpanderHeader">
-            <Setter Property="Background" Value="{DynamicResource SettingsCardBackground}"/>
+        <Style Selector="Expander#InstallOptionsExpander /template/ ToggleButton#ExpanderHeader">
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsSectionBackground}"/>
+            <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+        <!-- Fluent's Expander template applies direction-specific content borders to its own
+             template borders.  Clear every border owned by this Expander template; borders in
+             the hosted installation-options control are outside this template scope. -->
+        <Style Selector="Expander#InstallOptionsExpander /template/ Border">
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+        </Style>
+        <Style Selector="Expander#InstallOptionsExpander /template/ ToggleButton#ExpanderHeader:pointerover /template/ Border#ToggleButtonBackground">
+            <Setter Property="Background" Value="{DynamicResource InstallOptionsSectionBackground}"/>
+        </Style>
+        <Style Selector="Expander#InstallOptionsExpander /template/ ToggleButton#ExpanderHeader:pointerover /template/ Border#ExpandCollapseChevronBorder">
+            <Setter Property="Background" Value="{DynamicResource SettingsCardHoverBackground}"/>
         </Style>
 
         <!-- Tag pill -->
@@ -37,6 +51,7 @@
         <!-- Split action button: fused look -->
         <Style Selector="Button.action-main">
             <Setter Property="Height" Value="40"/>
+            <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="CornerRadius" Value="8,0,0,8"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>
             <Setter Property="HorizontalContentAlignment" Value="Center"/>
@@ -47,10 +62,17 @@
             <Setter Property="Width" Value="34"/>
             <Setter Property="Height" Value="40"/>
             <Setter Property="Padding" Value="0"/>
-            <Setter Property="Margin" Value="1,0,0,0"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="CornerRadius" Value="0,8,8,0"/>
             <Setter Property="HorizontalContentAlignment" Value="Center"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.action-main:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PackageActionHoverBackground}"/>
+        </Style>
+        <Style Selector="Button.action-chevron:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PackageActionHoverBackground}"/>
         </Style>
 
         <!-- Screenshot pip dots (Button hosting an Ellipse) -->
@@ -185,14 +207,17 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="10000*" MaxWidth="260"/>
                         </Grid.ColumnDefinitions>
-                        <Grid ColumnDefinitions="*,Auto">
+                        <Grid ColumnDefinitions="*,0.5,Auto">
                             <Button x:Name="MainActionButton"
                                     Grid.Column="0"
                                     Classes="accent action-main"
                                     Content="{Binding MainActionLabel}"
                                     automation:AutomationProperties.Name="{Binding MainActionLabel}"/>
+                            <Border Grid.Column="1"
+                                    Background="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                                    IsHitTestVisible="False"/>
                             <Button x:Name="ActionVariantsButton"
-                                    Grid.Column="1"
+                                    Grid.Column="2"
                                     Classes="accent action-chevron"
                                     automation:AutomationProperties.Name="{Binding MainActionLabel}">
                                 <Path Data="M 0,0 L 4,4 L 8,0"
@@ -207,14 +232,20 @@
                     </Grid>
 
                     <!-- ── Installation options (collapsible) ── -->
-                    <Border x:Name="InstallOptionsBorder" VerticalAlignment="Top">
+                    <Border x:Name="InstallOptionsBorder"
+                            VerticalAlignment="Top"
+                            Background="{DynamicResource InstallOptionsSectionBackground}"
+                            CornerRadius="8"
+                            BorderThickness="0">
                         <Expander x:Name="InstallOptionsExpander"
                                   HorizontalAlignment="Stretch"
                                   HorizontalContentAlignment="Stretch"
                                   VerticalAlignment="Top"
                                   IsExpanded="False"
                                   CornerRadius="8"
-                                  Padding="4">
+                                  Padding="0"
+                                  BorderThickness="0"
+                                  Background="Transparent">
                             <Expander.Header>
                                 <Grid ColumnDefinitions="Auto,*,Auto"
                                       ColumnSpacing="12">
@@ -239,7 +270,7 @@
                                 </Grid>
                             </Expander.Header>
                             <ContentControl x:Name="InstallOptionsHolder"
-                                            Margin="0,8,0,4"/>
+                                            Margin="16,12,16,16"/>
                         </Expander>
                     </Border>
                 </StackPanel>
@@ -278,7 +309,7 @@
 
                                 <!-- Contributor banner shown when no screenshots -->
                                 <Grid IsVisible="{Binding !HasScreenshots}"
-                                      Background="{DynamicResource AppDialogSubtleBackground}"
+                                      Background="{DynamicResource AppDialogDarkBackground}"
                                       ColumnDefinitions="*,Auto"
                                       Margin="0"
                                       ColumnSpacing="12">
@@ -289,6 +320,7 @@
                                                Margin="18,12"/>
                                     <Button Grid.Column="1"
                                             x:Name="ContributeButton"
+                                            Classes="secondary-action"
                                             Content="{Binding LabelContribute}"
                                             VerticalAlignment="Center"
                                             Margin="0,12,18,12"/>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml
@@ -171,8 +171,7 @@
                           VerticalAlignment="Stretch"
                           IsVisible="{Binding OperationsSplitterVisible}"
                           automation:AutomationProperties.AccessibilityView="Raw"
-                          Background="{DynamicResource AppSplitterBackground}"
-                          Opacity="0.8"/>
+                          Background="Transparent"/>
 
             <!-- ── Operations panel ── -->
             <Border Grid.Row="2"
@@ -224,11 +223,15 @@
 
                         <!-- Bulk-ops menu -->
                         <Button Grid.Column="2"
-                                Width="28" Height="24" Padding="4"
+                                Width="28" Height="24" Padding="0" Margin="0,0,4,0"
                                 Background="Transparent" BorderThickness="0" CornerRadius="4"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
                                 automation:AutomationProperties.Name="{t:Translate Bulk operations}"
                                 ToolTip.Tip="{t:Translate Bulk operations}">
                             <TextBlock Text="⋯" FontSize="13"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
                                        automation:AutomationProperties.AccessibilityView="Raw"/>
                             <Button.Flyout>
                                 <MenuFlyout>

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1715,7 +1715,7 @@ public partial class MainWindow : Window
         if (ModalContent.Content is not ImmersiveDialog dialog)
             return;
 
-        const double maximumSurfaceWidth = 1100;
+        const double maximumSurfaceWidth = 1200;
         const double maximumSurfaceHeight = 900;
         double layerWidth = ModalLayer.Bounds.Width > 0 ? ModalLayer.Bounds.Width : Bounds.Width;
         double layerHeight = ModalLayer.Bounds.Height > 0 ? ModalLayer.Bounds.Height : Bounds.Height;

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
@@ -135,11 +135,13 @@
                                 Command="{Binding ResetLocationCommand}"
                                 IsEnabled="{Binding LocationResetEnabled}"/>
                     </Grid>
-                    <SelectableTextBlock Text="{Binding LocationText}"
-                               FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
-                               FontSize="14"
-                               Opacity="0.6"
-                               TextWrapping="Wrap"/>
+                    <TextBox Text="{Binding LocationText}"
+                             Classes="search-field-standalone multiline"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
+                             FontSize="14"
+                             Opacity="0.6"/>
 
                     <!-- CLI disabled warning -->
                     <TextBlock Text="{Binding CliDisabledLabel}"
@@ -177,7 +179,9 @@
                                    FontSize="14"
                                    Opacity="{Binding CliOpacity}"/>
                         <TextBox   Grid.Row="0" Grid.Column="1"
+                                   Classes="search-field-standalone multiline"
                                    Text="{Binding CustomInstall}"
+                                   AcceptsReturn="True"
                                    IsEnabled="{Binding CliSectionEnabled}"
                                    FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                    FontSize="14"
@@ -191,7 +195,9 @@
                                    FontSize="14"
                                    Opacity="{Binding CliOpacity}"/>
                         <TextBox   Grid.Row="1" Grid.Column="1"
+                                   Classes="search-field-standalone multiline"
                                    Text="{Binding CustomUpdate}"
+                                   AcceptsReturn="True"
                                    IsEnabled="{Binding CliSectionEnabled}"
                                    FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                    FontSize="14"
@@ -205,7 +211,9 @@
                                    FontSize="14"
                                    Opacity="{Binding CliOpacity}"/>
                         <TextBox   Grid.Row="2" Grid.Column="1"
+                                   Classes="search-field-standalone multiline"
                                    Text="{Binding CustomUninstall}"
+                                   AcceptsReturn="True"
                                    IsEnabled="{Binding CliSectionEnabled}"
                                    FontFamily="Consolas,Cascadia Mono,Menlo,monospace"
                                    FontSize="14"


### PR DESCRIPTION
New: 
<img width="1920" height="1280" alt="image" src="https://github.com/user-attachments/assets/a32e2912-2612-42f8-be83-271b09dfb9d5" />
<img width="1920" height="1280" alt="image" src="https://github.com/user-attachments/assets/1c5843ea-01b5-4d60-8462-9173b0575d4e" />
<img width="3072" height="1920" alt="image" src="https://github.com/user-attachments/assets/1aae8b0b-62e8-40ef-b64a-f8b88533efcc" />



Previous UI: 
<img width="1890" height="1268" alt="image" src="https://github.com/user-attachments/assets/aff92cb1-8d96-4be9-ab05-5e63a59087c1" />
<img width="1890" height="1268" alt="image" src="https://github.com/user-attachments/assets/2d3ad934-97e3-4579-b70f-df5321384209" />
<img width="3072" height="1920" alt="image" src="https://github.com/user-attachments/assets/09aff7d8-4a29-4918-ae01-84554aaaacc8" />

The operations splitter is also refined to remove the black bar above the border and to center the expansion glyph. 
<img width="1943" height="333" alt="image" src="https://github.com/user-attachments/assets/e6aad3f0-eb29-4504-8594-630deab29e00" />


