### PR TITLE
Handle Pinget no-applicable upgrade result with zero exit code

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -267,13 +267,11 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             return OperationVeredict.Failure;
         }
 
-        // WinGet (CLI/COM) reports "not applicable" as 0x8A15002B; bundled pinget instead exits
-        // non-zero with "No applicable installer found" in its output.
         bool pingetReportedNotApplicable =
             ((WinGet)Manager).SelectedCliToolKind is WinGetCliToolKind.BundledPinget
-            && returnCode != 0
             && processOutput.Any(line =>
                 line.Contains("No applicable installer found", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("No applicable upgrade found", StringComparison.OrdinalIgnoreCase)
             );
 
         if (uintCode is 0x8A15002B || pingetReportedNotApplicable)

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -1181,6 +1181,29 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void WinGetUpdateNotApplicableViaPingetWithZeroExitCodeFails()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.BundledPinget);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.0.0")
+            .WithNewVersion("2.0.0")
+            .Build();
+
+        var veredict = manager.OperationHelper.GetResult(
+            package,
+            OperationType.Update,
+            ["No applicable upgrade found."],
+            0
+        );
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.True(WinGetPkgOperationHelper.IsStuckUpgradeLoop(package));
+    }
+
+    [Fact]
     public void WinGetGenericPingetFailureDoesNotRetry()
     {
         // A non-zero pinget exit without the "No applicable installer found" message


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [X] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [X] **Have you tested that the committed code can be executed without errors?**
- [x] **Have you confirmed that this issue is caused by UniGetUI itself, and not by the package manager or the package involved?**
If the same issue can be reproduced outside UniGetUI with the relevant package manager or with the package itself, please report it there first. UniGetUI should only be used to track issues that are specific to UniGetUI's behavior or integration.
-----
Pinget can return exit code 0 while printing `No applicable upgrade found.` UniGetUI previously treated this result as a successful upgrade.

This change recognizes Pinget's no-applicable output even when the exit code is 0 and routes it through UniGetUI's existing not-applicable upgrade handling.

