### PR TITLE
feat(broker): stream live output and status from remote agent operations

### DIFF
--- a/src/UniGetUI.PackageEngine.Interfaces/ManagerHelpers/IPackageOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Interfaces/ManagerHelpers/IPackageOperationHelper.cs
@@ -29,5 +29,18 @@ namespace UniGetUI.PackageEngine.Interfaces.ManagerProviders
             IReadOnlyList<string> processOutput,
             int returnCode
         );
+
+        /// <summary>
+        /// Applies manager-specific elevation requirements for the given operation, e.g. by
+        /// setting <c>package.OverridenOptions.RunAsAdministrator</c> when the package's
+        /// installer is known to require elevation. Called before the operation runs, on
+        /// both the local execution path and the agent-broker path, so that elevation is
+        /// requested consistently regardless of how the operation is executed.
+        /// </summary>
+        public void ApplyElevationRequirements(
+            IPackage package,
+            InstallOptions options,
+            OperationType operation
+        );
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -150,6 +150,37 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             }
         }
 
+        ApplyElevationRequirements(package, options, operation);
+
+        if (!usePinget)
+        {
+            parameters.Add(WinGet.GetProxyArgument());
+        }
+
+        parameters.AddRange(
+            operation switch
+            {
+                OperationType.Update => options.CustomParameters_Update,
+                OperationType.Uninstall => options.CustomParameters_Uninstall,
+                _ => options.CustomParameters_Install,
+            }
+        );
+        return parameters;
+    }
+
+    /// <summary>
+    /// Consults the WinGet native installer metadata to detect packages that require (or
+    /// prohibit) elevation, and updates <c>package.OverridenOptions.RunAsAdministrator</c>
+    /// accordingly. Used by both the local execution path (via
+    /// <see cref="_getOperationParameters"/>) and the agent-broker path, so that the
+    /// requested elevation matches regardless of where the operation runs.
+    /// </summary>
+    public override void ApplyElevationRequirements(
+        IPackage package,
+        InstallOptions options,
+        OperationType operation
+    )
+    {
         try
         {
             var installOptions = NativePackageHandler.GetInstallationOptions(
@@ -212,21 +243,6 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             Logger.Error("Recovered from fatal WinGet exception:");
             Logger.Error(ex);
         }
-
-        if (!usePinget)
-        {
-            parameters.Add(WinGet.GetProxyArgument());
-        }
-
-        parameters.AddRange(
-            operation switch
-            {
-                OperationType.Update => options.CustomParameters_Update,
-                OperationType.Uninstall => options.CustomParameters_Uninstall,
-                _ => options.CustomParameters_Install,
-            }
-        );
-        return parameters;
     }
 
     protected override OperationVeredict _getOperationResult(

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using UniGetUI.Core.Classes;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
@@ -18,6 +19,10 @@ using BrokerClientException = Devolutions.Now.Policy.Client.BrokerClientExceptio
 using BrokerClientOptions = Devolutions.Now.Policy.Client.BrokerClientOptions;
 using BrokerDecision = Devolutions.Now.Policy.Api.Decision;
 using BrokerElevation = Devolutions.Now.Policy.Api.Elevation;
+using BrokerEventFrame = Devolutions.Now.Policy.Api.EventFrame;
+using BrokerEventFrameException = Devolutions.Now.Policy.Api.EventFrameException;
+using BrokerExecutionResponse = Devolutions.Now.Policy.Api.ExecutionResponse;
+using BrokerOperationEventChannel = Devolutions.Now.Policy.Client.OperationEventChannel;
 using BrokerOperationStatus = Devolutions.Now.Policy.Api.OperationStatus;
 using BrokerStatusResponse = Devolutions.Now.Policy.Api.StatusResponse;
 using OperationCancelQuery = Devolutions.Now.Policy.Client.OperationCancelQuery;
@@ -290,16 +295,32 @@ namespace UniGetUI.PackageEngine.Operations
                 string operationId = execution.Operation.OperationId;
                 Line($"Broker accepted operation: {operationId}", LineType.VerboseDetails);
 
-                // NOTE: execution.Operation.EventChannel (live output streaming) is intentionally
-                // not consumed yet; brokered operations show no captured output until then.
-
-                BrokerStatusResponse status;
+                // Bound the whole tracking phase (streaming or polling) so a broker that
+                // never reports a terminal status cannot hang the operation forever.
                 using var operationTimeout = new CancellationTokenSource(BrokerOperationTimeout);
-                using var polling = CancellationTokenSource.CreateLinkedTokenSource(
+                using var tracking = CancellationTokenSource.CreateLinkedTokenSource(
                     CancellationToken, operationTimeout.Token);
                 try
                 {
-                    status = await WaitForBrokerTerminalStatus(client, operationId, polling.Token);
+                    // Prefer live status/output streaming over the per-operation event channel
+                    // when the broker advertises one; otherwise (or if streaming breaks) fall
+                    // back to plain status polling without live output.
+                    if (execution.Operation.EventChannel is not null)
+                    {
+                        OperationVeredict? streamed = await StreamBrokerOperationEvents(
+                            client, execution, operationId, tracking.Token);
+                        if (streamed is not null)
+                        {
+                            return streamed.Value;
+                        }
+                    }
+                    else
+                    {
+                        Logger.Info("[AgentBroker] The broker did not advertise an event channel; using status polling without live output.");
+                    }
+
+                    BrokerStatusResponse status = await WaitForBrokerTerminalStatus(client, operationId, tracking.Token);
+                    return await InterpretBrokerTerminalStatus(status);
                 }
                 catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
                 {
@@ -315,8 +336,6 @@ namespace UniGetUI.PackageEngine.Operations
                     Metadata.FailureMessage = timeoutMessage;
                     return OperationVeredict.Failure;
                 }
-
-                return await InterpretBrokerTerminalStatus(status);
             }
             catch (OperationCanceledException)
             {
@@ -338,6 +357,140 @@ namespace UniGetUI.PackageEngine.Operations
                 Metadata.FailureMessage = ex.Message;
                 return OperationVeredict.Failure;
             }
+        }
+
+        /// <summary>
+        /// Consumes the per-operation event channel advertised by the broker, emitting
+        /// live stdout/stderr output and reacting to status-change hints. Returns the
+        /// final operation veredict, or <c>null</c> when streaming could not be used and
+        /// the caller should fall back to plain status polling. The supplied token combines
+        /// user cancellation with the overall operation timeout; timeout-induced
+        /// cancellations propagate to the caller as <see cref="OperationCanceledException"/>.
+        /// </summary>
+        private async Task<OperationVeredict?> StreamBrokerOperationEvents(
+            BrokerClient client,
+            BrokerExecutionResponse execution,
+            string operationId,
+            CancellationToken trackingToken)
+        {
+            BrokerOperationEventChannel channel;
+            try
+            {
+                channel = await client.OpenEventChannel(execution, trackingToken);
+            }
+            catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+            {
+                return await CancelBrokerOperation(client, operationId);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.Warn($"[AgentBroker] Could not open the operation event channel; falling back to status polling: {ex}");
+                Line("Live output is not available for this operation; progress will be tracked via status polling.", LineType.Information);
+                return null;
+            }
+
+            Line("Live output streaming enabled via broker event channel.", LineType.VerboseDetails);
+            var stdout = new StreamedOutputLineBuffer(this, LineType.Information);
+            var stderr = new StreamedOutputLineBuffer(this, LineType.Error);
+
+            await using (channel.ConfigureAwait(false))
+            {
+                try
+                {
+                    BrokerOperationStatus? lastReportedStatus = null;
+                    await foreach (var frame in channel.ReadEvents(trackingToken))
+                    {
+                        switch (frame)
+                        {
+                            case BrokerEventFrame.Stdout frameData:
+                                stdout.Append(frameData.Data);
+                                break;
+                            case BrokerEventFrame.Stderr frameData:
+                                stderr.Append(frameData.Data);
+                                break;
+                            case BrokerEventFrame.StdoutOverflow overflow:
+                                Line($"Warning: {overflow.BytesSkipped} bytes of process output were skipped by the broker.", LineType.Information);
+                                break;
+                            case BrokerEventFrame.StderrOverflow overflow:
+                                Line($"Warning: {overflow.BytesSkipped} bytes of process error output were skipped by the broker.", LineType.Information);
+                                break;
+                            case BrokerEventFrame.StatusUpdated:
+                                var updated = await client.QueryStatus(
+                                    new OperationStatusQuery { OperationId = operationId },
+                                    trackingToken);
+                                if (updated.Status != lastReportedStatus)
+                                {
+                                    lastReportedStatus = updated.Status;
+                                    Line($"Broker operation status: {updated.Status}", LineType.VerboseDetails);
+                                }
+                                break;
+                            // Hello and Finish frames need no handling here: the channel
+                            // validates the handshake, and Finish ends the enumeration.
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+                {
+                    return await CancelBrokerOperationWhileStreaming(client, channel, operationId, stdout, stderr);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Operation-timeout cancellation: surface any buffered output before
+                    // letting the caller report the timeout failure.
+                    stdout.Flush();
+                    stderr.Flush();
+                    throw;
+                }
+                catch (Exception ex) when (ex is BrokerEventFrameException or IOException)
+                {
+                    // The frame stream is corrupt or the transport failed; the operation
+                    // itself is still running on the broker. Fall back to status polling.
+                    stdout.Flush();
+                    stderr.Flush();
+                    Logger.Warn($"[AgentBroker] The operation event channel failed mid-stream; falling back to status polling: {ex}");
+                    Line("Live output streaming was interrupted; progress will be tracked via status polling.", LineType.Information);
+                    return null;
+                }
+
+                stdout.Flush();
+                stderr.Flush();
+            }
+
+            BrokerStatusResponse status;
+            try
+            {
+                status = await QueryBrokerTerminalStatus(client, operationId, trackingToken);
+            }
+            catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+            {
+                return await CancelBrokerOperation(client, operationId);
+            }
+
+            return await InterpretBrokerTerminalStatus(status);
+        }
+
+        /// <summary>
+        /// Queries the broker for the operation status, and keeps polling until a
+        /// terminal status is reported. Unlike <see cref="WaitForBrokerTerminalStatus"/>,
+        /// the first query happens immediately (no initial delay).
+        /// </summary>
+        private static async Task<BrokerStatusResponse> QueryBrokerTerminalStatus(
+            BrokerClient client,
+            string operationId,
+            CancellationToken cancellationToken)
+        {
+            var status = await client.QueryStatus(
+                new OperationStatusQuery { OperationId = operationId },
+                cancellationToken);
+
+            if (status.Status is BrokerOperationStatus.Completed
+                or BrokerOperationStatus.Failed
+                or BrokerOperationStatus.Canceled)
+            {
+                return status;
+            }
+
+            return await WaitForBrokerTerminalStatus(client, operationId, cancellationToken);
         }
 
         /// <summary>
@@ -374,6 +527,63 @@ namespace UniGetUI.PackageEngine.Operations
         /// </summary>
         private async Task<OperationVeredict> CancelBrokerOperation(BrokerClient client, string operationId)
         {
+            await RequestBrokerCancel(client, operationId);
+            return await ConfirmBrokerCancellation(client, operationId);
+        }
+
+        /// <summary>
+        /// Cancellation flow used while consuming the event channel: after asking the
+        /// broker to cancel, keeps draining the channel (bounded) so the tail of the
+        /// process output and the Finish frame are honored, then confirms the terminal
+        /// status over the regular status endpoint. If draining fails, falls back to
+        /// the plain poll-based confirmation.
+        /// </summary>
+        private async Task<OperationVeredict> CancelBrokerOperationWhileStreaming(
+            BrokerClient client,
+            BrokerOperationEventChannel channel,
+            string operationId,
+            StreamedOutputLineBuffer stdout,
+            StreamedOutputLineBuffer stderr)
+        {
+            await RequestBrokerCancel(client, operationId);
+
+            try
+            {
+                using var drainTimeout = new CancellationTokenSource(BrokerCancelConfirmTimeout);
+                await foreach (var frame in channel.ReadEvents(drainTimeout.Token))
+                {
+                    switch (frame)
+                    {
+                        case BrokerEventFrame.Stdout frameData:
+                            stdout.Append(frameData.Data);
+                            break;
+                        case BrokerEventFrame.Stderr frameData:
+                            stderr.Append(frameData.Data);
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"[AgentBroker] Could not drain the event channel of canceled operation {operationId}: {ex}");
+            }
+            finally
+            {
+                stdout.Flush();
+                stderr.Flush();
+            }
+
+            return await ConfirmBrokerCancellation(client, operationId);
+        }
+
+        /// <summary>
+        /// Best-effort broker-side cancel request, bounded by
+        /// <see cref="BrokerCancelRequestTimeout"/>. Failures are logged but not
+        /// surfaced: the cancel request is idempotent, and the operation may already
+        /// have reached a terminal state.
+        /// </summary>
+        private async Task RequestBrokerCancel(BrokerClient client, string operationId)
+        {
             Line("Cancellation requested; asking broker to cancel the remote operation...", LineType.Information);
 
             try
@@ -386,16 +596,23 @@ namespace UniGetUI.PackageEngine.Operations
             }
             catch (Exception ex)
             {
-                // Best-effort: the cancel request is idempotent, and the operation may already
-                // have reached a terminal state. Still wait below for the terminal status.
                 Logger.Warn($"[AgentBroker] Cancel request for operation {operationId} failed: {ex}");
                 Line("Broker cancel request failed; checking final operation status...", LineType.Information);
             }
+        }
 
+        /// <summary>
+        /// Waits (bounded) for a canceled operation to reach a terminal status. The
+        /// remote process may win the race and complete or fail before the cancel takes
+        /// effect; in that case the terminal status is honored instead of reporting a
+        /// cancellation.
+        /// </summary>
+        private async Task<OperationVeredict> ConfirmBrokerCancellation(BrokerClient client, string operationId)
+        {
             try
             {
                 using var confirmTimeout = new CancellationTokenSource(BrokerCancelConfirmTimeout);
-                var status = await WaitForBrokerTerminalStatus(client, operationId, confirmTimeout.Token);
+                var status = await QueryBrokerTerminalStatus(client, operationId, confirmTimeout.Token);
 
                 if (status.Status is not BrokerOperationStatus.Canceled)
                 {
@@ -434,9 +651,18 @@ namespace UniGetUI.PackageEngine.Operations
 
             if (status.Status is BrokerOperationStatus.Completed)
             {
-                // Captured output is not available anymore over the status endpoint; live
-                // output will be restored through the per-operation event channel.
-                var veredict = await GetProcessVeredict(status.ExitCode ?? -1, []);
+                // Feed the accumulated output (including any live-streamed process
+                // output) to the manager's result parser, like the local process path.
+                List<string> output = [];
+                foreach (var line in GetRawOutput())
+                {
+                    if (line.Item2 is LineType.Error or LineType.Information)
+                    {
+                        output.Add(line.Item1);
+                    }
+                }
+
+                var veredict = await GetProcessVeredict(status.ExitCode ?? -1, output);
                 if (veredict is OperationVeredict.Success)
                 {
                     Line("Operation completed successfully via agent broker.", LineType.Information);
@@ -473,6 +699,71 @@ namespace UniGetUI.PackageEngine.Operations
             Metadata.FailureMessage = message;
             BrokerUnavailable?.Invoke(this, message);
             return OperationVeredict.Failure;
+        }
+
+        /// <summary>
+        /// Buffers streamed process output and emits it line by line through
+        /// <see cref="AbstractOperation.Line"/>, mirroring the local process reader:
+        /// LF-terminated text is emitted with the configured line type, while
+        /// CR-terminated text (progress bars) is emitted as a progress indicator and
+        /// promoted to a regular line when followed by a bare LF.
+        /// </summary>
+        private sealed class StreamedOutputLineBuffer(PackageOperation owner, LineType lineType)
+        {
+            private readonly StringBuilder _pending = new();
+            private string? _lastLineBeforeLF;
+
+            public void Append(string data)
+            {
+                foreach (char c in data)
+                {
+                    if (c == '\n')
+                    {
+                        if (_pending.Length == 0)
+                        {
+                            if (_lastLineBeforeLF is not null)
+                            {
+                                owner.Line(_lastLineBeforeLF, lineType);
+                                _lastLineBeforeLF = null;
+                            }
+                            continue;
+                        }
+
+                        owner.Line(_pending.ToString(), lineType);
+                        _pending.Clear();
+                    }
+                    else if (c == '\r')
+                    {
+                        if (_pending.Length == 0)
+                        {
+                            continue;
+                        }
+
+                        _lastLineBeforeLF = _pending.ToString();
+                        owner.Line(_lastLineBeforeLF, LineType.ProgressIndicator);
+                        _pending.Clear();
+                    }
+                    else
+                    {
+                        _pending.Append(c);
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Emits any remaining partial line (e.g. output not terminated by a newline
+            /// when the channel finished).
+            /// </summary>
+            public void Flush()
+            {
+                if (_pending.Length > 0)
+                {
+                    owner.Line(_pending.ToString(), lineType);
+                    _pending.Clear();
+                }
+
+                _lastLineBeforeLF = null;
+            }
         }
 
         private static BrokerClient CreateBrokerClient(bool requestedElevation) =>

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -240,11 +240,19 @@ namespace UniGetUI.PackageEngine.Operations
             && !package.Source.IsVirtualManager;
 
         /// <summary>
+        /// Raw process output streamed over the event channel of the current brokered
+        /// run, in emission order. Null when no streamed output was captured (no event
+        /// channel, or streaming failed); result parsers then receive an empty list.
+        /// </summary>
+        private List<string>? _brokerStreamedOutput;
+
+        /// <summary>
         /// Perform the package operation through the Devolutions Agent broker.
         /// Sends the request over named pipe and interprets the response.
         /// </summary>
         private async Task<OperationVeredict> PerformBrokerOperation()
         {
+            _brokerStreamedOutput = null;
             Line("Routing operation through Devolutions Agent broker...", LineType.Information);
 
             using var client = CreateBrokerClient(RequiresAdminRights());
@@ -390,8 +398,10 @@ namespace UniGetUI.PackageEngine.Operations
             }
 
             Line("Live output streaming enabled via broker event channel.", LineType.VerboseDetails);
-            var stdout = new StreamedOutputLineBuffer(this, LineType.Information);
-            var stderr = new StreamedOutputLineBuffer(this, LineType.Error);
+            var capturedOutput = new List<string>();
+            _brokerStreamedOutput = capturedOutput;
+            var stdout = new StreamedOutputLineBuffer(this, LineType.Information, capturedOutput);
+            var stderr = new StreamedOutputLineBuffer(this, LineType.Error, capturedOutput);
 
             await using (channel.ConfigureAwait(false))
             {
@@ -651,18 +661,10 @@ namespace UniGetUI.PackageEngine.Operations
 
             if (status.Status is BrokerOperationStatus.Completed)
             {
-                // Feed the accumulated output (including any live-streamed process
-                // output) to the manager's result parser, like the local process path.
-                List<string> output = [];
-                foreach (var line in GetRawOutput())
-                {
-                    if (line.Item2 is LineType.Error or LineType.Information)
-                    {
-                        output.Add(line.Item1);
-                    }
-                }
-
-                var veredict = await GetProcessVeredict(status.ExitCode ?? -1, output);
+                // Feed the process output streamed over the event channel (if any) to
+                // the manager's result parser, like the local process path does. Only
+                // real process output is passed; internal informational lines are not.
+                var veredict = await GetProcessVeredict(status.ExitCode ?? -1, _brokerStreamedOutput ?? []);
                 if (veredict is OperationVeredict.Success)
                 {
                     Line("Operation completed successfully via agent broker.", LineType.Information);
@@ -706,33 +708,56 @@ namespace UniGetUI.PackageEngine.Operations
         /// <see cref="AbstractOperation.Line"/>, mirroring the local process reader:
         /// LF-terminated text is emitted with the configured line type, while
         /// CR-terminated text (progress bars) is emitted as a progress indicator and
-        /// promoted to a regular line when followed by a bare LF.
+        /// promoted to a regular line when followed by a bare LF. Regular (non-progress)
+        /// lines are also recorded in <paramref name="capturedOutput"/> so the manager's
+        /// result parser receives only real process output.
         /// </summary>
-        private sealed class StreamedOutputLineBuffer(PackageOperation owner, LineType lineType)
+        private sealed class StreamedOutputLineBuffer(
+            PackageOperation owner,
+            LineType lineType,
+            List<string> capturedOutput)
         {
             private readonly StringBuilder _pending = new();
             private string? _lastLineBeforeLF;
 
             public void Append(string data)
             {
-                foreach (char c in data)
+                ReadOnlySpan<char> remaining = data;
+                while (!remaining.IsEmpty)
                 {
-                    if (c == '\n')
+                    int terminatorIndex = remaining.IndexOfAny('\r', '\n');
+                    if (terminatorIndex < 0)
+                    {
+                        _pending.Append(remaining);
+                        break;
+                    }
+
+                    _pending.Append(remaining[..terminatorIndex]);
+                    char terminator = remaining[terminatorIndex];
+                    remaining = remaining[(terminatorIndex + 1)..];
+
+                    if (terminator == '\n')
                     {
                         if (_pending.Length == 0)
                         {
+                            // A bare LF after a CR-terminated line (CRLF): promote the
+                            // progress line to a regular line.
                             if (_lastLineBeforeLF is not null)
                             {
-                                owner.Line(_lastLineBeforeLF, lineType);
+                                EmitLine(_lastLineBeforeLF);
                                 _lastLineBeforeLF = null;
                             }
+
                             continue;
                         }
 
-                        owner.Line(_pending.ToString(), lineType);
+                        EmitLine(_pending.ToString());
                         _pending.Clear();
+                        // New text arrived after the CR: the progress line was
+                        // superseded and must not be promoted by a later bare LF.
+                        _lastLineBeforeLF = null;
                     }
-                    else if (c == '\r')
+                    else
                     {
                         if (_pending.Length == 0)
                         {
@@ -742,10 +767,6 @@ namespace UniGetUI.PackageEngine.Operations
                         _lastLineBeforeLF = _pending.ToString();
                         owner.Line(_lastLineBeforeLF, LineType.ProgressIndicator);
                         _pending.Clear();
-                    }
-                    else
-                    {
-                        _pending.Append(c);
                     }
                 }
             }
@@ -758,11 +779,17 @@ namespace UniGetUI.PackageEngine.Operations
             {
                 if (_pending.Length > 0)
                 {
-                    owner.Line(_pending.ToString(), lineType);
+                    EmitLine(_pending.ToString());
                     _pending.Clear();
                 }
 
                 _lastLineBeforeLF = null;
+            }
+
+            private void EmitLine(string line)
+            {
+                owner.Line(line, lineType);
+                capturedOutput.Add(line);
             }
         }
 

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -434,8 +434,8 @@ namespace UniGetUI.PackageEngine.Operations
                                     Line($"Broker operation status: {updated.Status}", LineType.VerboseDetails);
                                 }
                                 break;
-                            // Hello and Finish frames need no handling here: the channel
-                            // validates the handshake, and Finish ends the enumeration.
+                                // Hello and Finish frames need no handling here: the channel
+                                // validates the handshake, and Finish ends the enumeration.
                         }
                     }
                 }

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -255,7 +255,14 @@ namespace UniGetUI.PackageEngine.Operations
             _brokerStreamedOutput = null;
             Line("Routing operation through Devolutions Agent broker...", LineType.Information);
 
-            using var client = CreateBrokerClient(RequiresAdminRights());
+            // Apply manager-specific elevation requirements (e.g. WinGet's detection of
+            // machine-scope or elevation-requiring installers) before deciding the requested
+            // elevation, mirroring the local execution path where this runs as part of
+            // building the process parameters.
+            Package.Manager.OperationHelper.ApplyElevationRequirements(Package, Options, Role);
+
+            bool requestElevated = RequiresAdminRights();
+            using var client = CreateBrokerClient(requestElevated);
 
             // Check broker availability. Brokered operations must not fall back to local
             // execution: policy evaluation and kill/pre/post actions are owned by the broker.
@@ -275,6 +282,7 @@ namespace UniGetUI.PackageEngine.Operations
             Line($"  Package: {request.Package.Id} ({request.Operation})", LineType.VerboseDetails);
             Line($"  Manager: {request.Manager}", LineType.VerboseDetails);
             Line($"  User: {GetEffectiveUser()}", LineType.VerboseDetails);
+            Line($"  Elevation: {(requestElevated ? "Elevated" : "Standard")}", LineType.VerboseDetails);
 
             try
             {

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
@@ -158,5 +158,11 @@ namespace UniGetUI.PackageEngine.Classes.Manager
             IReadOnlyList<string> processOutput,
             int returnCode
         ) => throw new NotImplementedException();
+
+        public void ApplyElevationRequirements(
+            IPackage package,
+            InstallOptions options,
+            OperationType operation
+        ) => throw new NotImplementedException();
     }
 }

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/BasePkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Helpers/BasePkgOperationHelper.cs
@@ -66,4 +66,16 @@ public abstract class BasePkgOperationHelper : IPackageOperationHelper
 
         return _getOperationResult(package, operation, processOutput, returnCode);
     }
+
+    /// <summary>
+    /// Default implementation: no manager-specific elevation requirements. Managers that
+    /// can detect that a package needs (or prohibits) elevation override this to update
+    /// <c>package.OverridenOptions.RunAsAdministrator</c> accordingly.
+    /// </summary>
+    public virtual void ApplyElevationRequirements(
+        IPackage package,
+        InstallOptions options,
+        OperationType operation
+    )
+    { }
 }

--- a/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestPackageOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestPackageOperationHelper.cs
@@ -14,6 +14,17 @@ public sealed class TestPackageOperationHelper(TestPackageManager manager)
     public Func<IPackage, OperationType, IReadOnlyList<string>, int, OperationVeredict> ResultFactory { get; set; } =
         static (_, _, _, returnCode) => returnCode == 0 ? OperationVeredict.Success : OperationVeredict.Failure;
 
+    public Action<IPackage, InstallOptions, OperationType>? ElevationRequirementsAction { get; set; }
+
+    public override void ApplyElevationRequirements(
+        IPackage package,
+        InstallOptions options,
+        OperationType operation
+    )
+    {
+        ElevationRequirementsAction?.Invoke(package, options, operation);
+    }
+
     protected override IReadOnlyList<string> _getOperationParameters(
         IPackage package,
         InstallOptions options,

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -1,5 +1,8 @@
+using System.Buffers.Binary;
 using System.Diagnostics;
+using System.IO.Pipes;
 using System.Reflection;
+using System.Text;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -19,6 +22,8 @@ using BrokerApiCapabilitiesResponse = Devolutions.Now.Policy.Api.CapabilitiesRes
 using BrokerApiConstants = Devolutions.Now.Policy.Api.BrokerApi;
 using BrokerApiDecision = Devolutions.Now.Policy.Api.Decision;
 using BrokerApiDecisionInfo = Devolutions.Now.Policy.Api.DecisionInfo;
+using BrokerApiEventChannel = Devolutions.Now.Policy.Api.EventChannel;
+using BrokerApiEventChannelKind = Devolutions.Now.Policy.Api.EventChannelKind;
 using BrokerApiExecutionResponse = Devolutions.Now.Policy.Api.ExecutionResponse;
 using BrokerApiHealthResponse = Devolutions.Now.Policy.Api.HealthResponse;
 using BrokerApiHealthStatus = Devolutions.Now.Policy.Api.HealthStatus;
@@ -36,6 +41,7 @@ using BrokerTransportKind = Devolutions.Now.Policy.Api.Transport;
 using BrokerTransportRequest = Devolutions.Now.Policy.Client.BrokerTransportRequest;
 using BrokerTransportResponse = Devolutions.Now.Policy.Client.BrokerTransportResponse;
 using IBrokerTransport = Devolutions.Now.Policy.Client.IBrokerTransport;
+using LineType = UniGetUI.PackageOperations.AbstractOperation.LineType;
 
 namespace UniGetUI.PackageEngine.Tests;
 
@@ -611,6 +617,10 @@ public sealed class PackageOperationsTests
         }
     }
 
+    private sealed record BrokeredRunResult(
+        OperationVeredict Veredict,
+        IReadOnlyList<(string, LineType)> Output);
+
     /// <summary>
     /// Runs an install operation against a scripted broker transport with the UseAgentBroker
     /// setting enabled, fast status polling, and short cancel timeouts. The caller scripts the
@@ -619,6 +629,23 @@ public sealed class PackageOperationsTests
     private static async Task<OperationVeredict> RunBrokeredOperation(
         ScriptedBrokerTransport transport,
         Action<CancellationTokenSource>? configureCancellation = null,
+        TimeSpan? operationTimeout = null)
+    {
+        var result = await RunBrokeredOperationWithOutput(
+            transport, configureCancellation, operationTimeout: operationTimeout);
+        return result.Veredict;
+    }
+
+    /// <summary>
+    /// Like <see cref="RunBrokeredOperation"/>, but also returns the operation's output
+    /// log and allows customizing the manager's operation helper (e.g. to inspect the
+    /// process output passed to the result parser) and hooking the created operation.
+    /// </summary>
+    private static async Task<BrokeredRunResult> RunBrokeredOperationWithOutput(
+        ScriptedBrokerTransport transport,
+        Action<CancellationTokenSource>? configureCancellation = null,
+        Action<TestPackageOperationHelper>? configureOperationHelper = null,
+        Action<AbstractOperation>? onOperationCreated = null,
         TimeSpan? operationTimeout = null)
     {
         bool originalSetting = Settings.Get(Settings.K.UseAgentBroker);
@@ -633,6 +660,7 @@ public sealed class PackageOperationsTests
                 m.ExecutablePath = "C:\\test-tools\\choco.exe";
                 m.ExecutableArguments = "--test";
             })
+            .ConfigureOperation(helper => configureOperationHelper?.Invoke(helper))
             .Build();
         var package = new PackageBuilder().WithManager(manager).Build();
         PackageOperation.BrokerTransportFactory = () => transport;
@@ -654,7 +682,10 @@ public sealed class PackageOperationsTests
                 configureCancellation(cancellationSource);
             }
 
-            return await operation.InvokePerformOperationForTests().WaitAsync(TimeSpan.FromSeconds(10));
+            onOperationCreated?.Invoke(operation);
+
+            var veredict = await operation.InvokePerformOperationForTests().WaitAsync(TimeSpan.FromSeconds(10));
+            return new BrokeredRunResult(veredict, operation.GetOutput());
         }
         finally
         {
@@ -740,6 +771,158 @@ public sealed class PackageOperationsTests
 
         Assert.Equal(OperationVeredict.Failure, veredict);
         Assert.Equal(0, transport.CancelRequestCount);
+    }
+
+    [Fact]
+    public async Task StreamedEventChannelOutputReachesOperationOutputAndResultParser()
+    {
+        var transport = new ScriptedBrokerTransport
+        {
+            StatusAfterCancel = BrokerApiOperationStatus.Completed,
+            CompletedExitCode = 0,
+        };
+        await using var server = new EventChannelPipeServer(async pipe =>
+        {
+            await pipe.WriteHello();
+            await pipe.WriteStdout("hello from broker\n");
+            await pipe.WriteStderr("an error line\n");
+            // Lines split across frames must be reassembled before being emitted.
+            await pipe.WriteStdout("par");
+            await pipe.WriteStdout("tial");
+            await pipe.WriteStdoutOverflow(42);
+            await pipe.WriteFinish();
+        });
+        transport.EventChannelPipeName = server.PipeName;
+
+        IReadOnlyList<string>? parsedOutput = null;
+        var result = await RunBrokeredOperationWithOutput(
+            transport,
+            configureOperationHelper: helper =>
+            {
+                var defaultFactory = helper.ResultFactory;
+                helper.ResultFactory = (package, operation, processOutput, returnCode) =>
+                {
+                    parsedOutput = processOutput;
+                    return defaultFactory(package, operation, processOutput, returnCode);
+                };
+            });
+
+        Assert.Equal(OperationVeredict.Success, result.Veredict);
+        Assert.Contains(("hello from broker", LineType.Information), result.Output);
+        Assert.Contains(("an error line", LineType.Error), result.Output);
+        // The trailing partial line is flushed when the stream finishes.
+        Assert.Contains(("partial", LineType.Information), result.Output);
+        Assert.Contains(result.Output, line =>
+            line.Item1.Contains("42 bytes") && line.Item2 is LineType.Information);
+        // FINISH triggered exactly one final status query; no polling loop ran.
+        Assert.Equal(1, transport.StatusQueryCount);
+        // The streamed output was fed back to the manager's result parser.
+        Assert.NotNull(parsedOutput);
+        Assert.Contains("hello from broker", parsedOutput);
+        Assert.Contains("an error line", parsedOutput);
+        Assert.Contains("partial", parsedOutput);
+    }
+
+    [Fact]
+    public async Task StatusUpdatedFrameTriggersStatusQueryAndFinishTriggersFinalStatus()
+    {
+        var transport = new ScriptedBrokerTransport
+        {
+            StatusAfterCancel = BrokerApiOperationStatus.Completed,
+            CompletedExitCode = 0,
+        };
+        transport.StatusScript.Enqueue(BrokerApiOperationStatus.Running);
+        await using var server = new EventChannelPipeServer(async pipe =>
+        {
+            await pipe.WriteHello();
+            await pipe.WriteStatusUpdated();
+            await pipe.WriteFinish();
+        });
+        transport.EventChannelPipeName = server.PipeName;
+
+        var result = await RunBrokeredOperationWithOutput(transport);
+
+        Assert.Equal(OperationVeredict.Success, result.Veredict);
+        // One query for the STATUS_UPDATED hint, one final query after FINISH.
+        Assert.Equal(2, transport.StatusQueryCount);
+    }
+
+    [Fact]
+    public async Task MissingEventChannelFallsBackToStatusPolling()
+    {
+        var transport = new ScriptedBrokerTransport
+        {
+            StatusAfterCancel = BrokerApiOperationStatus.Completed,
+            CompletedExitCode = 0,
+        };
+        transport.StatusScript.Enqueue(BrokerApiOperationStatus.Running);
+        transport.StatusScript.Enqueue(BrokerApiOperationStatus.Running);
+
+        var veredict = await RunBrokeredOperation(transport);
+
+        Assert.Equal(OperationVeredict.Success, veredict);
+        // The polling loop drained the Running statuses before the terminal one.
+        Assert.Equal(3, transport.StatusQueryCount);
+    }
+
+    [Fact]
+    public async Task EventChannelDecodeErrorFallsBackToStatusPolling()
+    {
+        var transport = new ScriptedBrokerTransport
+        {
+            StatusAfterCancel = BrokerApiOperationStatus.Completed,
+            CompletedExitCode = 0,
+        };
+        transport.StatusScript.Enqueue(BrokerApiOperationStatus.Running);
+        await using var server = new EventChannelPipeServer(async pipe =>
+        {
+            // Advertise an unsupported protocol major version: a fatal decode error.
+            await pipe.WriteHello(major: 2);
+        });
+        transport.EventChannelPipeName = server.PipeName;
+
+        var result = await RunBrokeredOperationWithOutput(transport);
+
+        Assert.Equal(OperationVeredict.Success, result.Veredict);
+        Assert.True(transport.StatusQueryCount >= 2);
+        Assert.Contains(result.Output, line => line.Item1.Contains("streaming was interrupted"));
+    }
+
+    [Fact]
+    public async Task CancelDuringEventChannelStreamingYieldsCanceledVeredict()
+    {
+        var transport = new ScriptedBrokerTransport();
+        var cancelRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        transport.OnCancelRequested = () => cancelRequested.TrySetResult();
+        await using var server = new EventChannelPipeServer(async pipe =>
+        {
+            await pipe.WriteHello();
+            await pipe.WriteStdout("streamed-line\n");
+            // Hold the channel open until the broker-side cancel request arrives, then
+            // emit the output tail and finish, as a real broker would.
+            await cancelRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await pipe.WriteStderr("shutting down\n");
+            await pipe.WriteStatusUpdated();
+            await pipe.WriteFinish();
+        });
+        transport.EventChannelPipeName = server.PipeName;
+
+        CancellationTokenSource? cancellationSource = null;
+        var result = await RunBrokeredOperationWithOutput(
+            transport,
+            configureCancellation: cancellation => cancellationSource = cancellation,
+            onOperationCreated: operation => operation.LogLineAdded += (_, line) =>
+            {
+                if (line.Item1 == "streamed-line")
+                    cancellationSource!.Cancel();
+            });
+
+        Assert.Equal(OperationVeredict.Canceled, result.Veredict);
+        Assert.Equal(1, transport.CancelRequestCount);
+        Assert.Contains("/v1/package-operations/cancel", transport.RequestedPaths);
+        Assert.Contains(("streamed-line", LineType.Information), result.Output);
+        // Output that arrived while the cancellation was being confirmed is preserved.
+        Assert.Contains(("shutting down", LineType.Error), result.Output);
     }
 
     private static IReadOnlyList<AbstractOperation.InnerOperation> GetInnerOperations(
@@ -851,6 +1034,13 @@ public sealed class PackageOperationsTests
         public int StatusQueryCount { get; private set; }
         public int CancelRequestCount { get; private set; }
         public Action? OnStatusQueried { get; set; }
+        public Action? OnCancelRequested { get; set; }
+
+        /// <summary>
+        /// When set, the execution response advertises a LocalPipe event channel with
+        /// this pipe name, and the client is expected to stream operation events from it.
+        /// </summary>
+        public string? EventChannelPipeName { get; set; }
 
         private bool cancelReceived;
 
@@ -912,6 +1102,7 @@ public sealed class PackageOperationsTests
             }
 
             cancelReceived = true;
+            OnCancelRequested?.Invoke();
             return Json(BrokerJson.Serialize(new BrokerApiCancelResponse
             {
                 ResponseKind = BrokerApiConstants.CancelResponseKind,
@@ -952,7 +1143,7 @@ public sealed class PackageOperationsTests
             ],
         };
 
-        private static BrokerApiExecutionResponse BuildExecutionResponse() => new()
+        private BrokerApiExecutionResponse BuildExecutionResponse() => new()
         {
             ResponseKind = BrokerApiConstants.ExecutionResponseKind,
             ResponseVersion = BrokerApiConstants.Version,
@@ -962,8 +1153,107 @@ public sealed class PackageOperationsTests
                 OperationId = OperationId,
                 Status = BrokerApiOperationStatus.Starting,
                 SubmittedAt = DateTimeOffset.UtcNow,
+                EventChannel = EventChannelPipeName is null
+                    ? null
+                    : new BrokerApiEventChannel
+                    {
+                        Kind = BrokerApiEventChannelKind.LocalPipe,
+                        Path = EventChannelPipeName,
+                    },
             },
         };
+    }
+
+    /// <summary>
+    /// Test-side server for the NOW_BROKER per-operation event channel: hosts a named
+    /// pipe that <c>BrokerClient.OpenEventChannel</c> connects to, and writes protocol
+    /// frames scripted by the test. Frame layout (little-endian):
+    /// <c>u32 body_size (excludes 6-byte header) | u16 kind | body</c>.
+    /// </summary>
+    private sealed class EventChannelPipeServer : IAsyncDisposable
+    {
+        private const ushort HelloKind = 0x0000;
+        private const ushort StatusUpdatedKind = 0x0001;
+        private const ushort FinishKind = 0x0002;
+        private const ushort StdoutKind = 0x0003;
+        private const ushort StderrKind = 0x0004;
+        private const ushort StdoutOverflowKind = 0x0005;
+
+        public string PipeName { get; } = $"unigetui-test-events-{Guid.NewGuid():N}";
+
+        private readonly NamedPipeServerStream _pipe;
+        private readonly Task _serverTask;
+
+        public EventChannelPipeServer(Func<EventChannelPipeServer, Task> script)
+        {
+            _pipe = new NamedPipeServerStream(
+                PipeName,
+                PipeDirection.Out,
+                maxNumberOfServerInstances: 1,
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous);
+            _serverTask = Run(script);
+        }
+
+        private async Task Run(Func<EventChannelPipeServer, Task> script)
+        {
+            await _pipe.WaitForConnectionAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            try
+            {
+                await script(this);
+            }
+            catch (IOException)
+            {
+                // The client may dispose the channel early (e.g. after a decode error).
+            }
+        }
+
+        public Task WriteHello(ushort major = 1, ushort minor = 0)
+        {
+            byte[] body = new byte[4];
+            BinaryPrimitives.WriteUInt16LittleEndian(body, major);
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(2), minor);
+            return WriteFrame(HelloKind, body);
+        }
+
+        public Task WriteStatusUpdated() => WriteFrame(StatusUpdatedKind, []);
+
+        public Task WriteFinish() => WriteFrame(FinishKind, []);
+
+        public Task WriteStdout(string text) => WriteFrame(StdoutKind, Encoding.UTF8.GetBytes(text));
+
+        public Task WriteStderr(string text) => WriteFrame(StderrKind, Encoding.UTF8.GetBytes(text));
+
+        public Task WriteStdoutOverflow(uint bytesSkipped)
+        {
+            byte[] body = new byte[4];
+            BinaryPrimitives.WriteUInt32LittleEndian(body, bytesSkipped);
+            return WriteFrame(StdoutOverflowKind, body);
+        }
+
+        private async Task WriteFrame(ushort kind, byte[] body)
+        {
+            byte[] header = new byte[6];
+            BinaryPrimitives.WriteUInt32LittleEndian(header, (uint)body.Length);
+            BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(4), kind);
+            await _pipe.WriteAsync(header);
+            await _pipe.WriteAsync(body);
+            await _pipe.FlushAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await _serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            catch (TimeoutException)
+            {
+                // Dispose below unblocks a stuck script.
+            }
+
+            await _pipe.DisposeAsync();
+        }
     }
 
     private class InspectableInstallPackageOperation : InstallPackageOperation

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -22,6 +22,7 @@ using BrokerApiCapabilitiesResponse = Devolutions.Now.Policy.Api.CapabilitiesRes
 using BrokerApiConstants = Devolutions.Now.Policy.Api.BrokerApi;
 using BrokerApiDecision = Devolutions.Now.Policy.Api.Decision;
 using BrokerApiDecisionInfo = Devolutions.Now.Policy.Api.DecisionInfo;
+using BrokerApiElevation = Devolutions.Now.Policy.Api.Elevation;
 using BrokerApiEventChannel = Devolutions.Now.Policy.Api.EventChannel;
 using BrokerApiEventChannelKind = Devolutions.Now.Policy.Api.EventChannelKind;
 using BrokerApiExecutionResponse = Devolutions.Now.Policy.Api.ExecutionResponse;
@@ -32,6 +33,7 @@ using BrokerApiManagerName = Devolutions.Now.Policy.Api.ManagerName;
 using BrokerApiOperation = Devolutions.Now.Policy.Api.Operation;
 using BrokerApiOperationStatus = Devolutions.Now.Policy.Api.OperationStatus;
 using BrokerApiOperationSubmission = Devolutions.Now.Policy.Api.OperationSubmission;
+using BrokerApiPackageRequest = Devolutions.Now.Policy.Api.PackageRequest;
 using BrokerApiServerContext = Devolutions.Now.Policy.Api.ServerContext;
 using BrokerApiStatusResponse = Devolutions.Now.Policy.Api.StatusResponse;
 using BrokerClientErrorKind = Devolutions.Now.Policy.Client.BrokerClientErrorKind;
@@ -774,6 +776,82 @@ public sealed class PackageOperationsTests
     }
 
     [Fact]
+    public async Task BrokeredOperationConsultsElevationRequirementsAndRequestsElevated()
+    {
+        var transport = new ScriptedBrokerTransport
+        {
+            StatusAfterCancel = BrokerApiOperationStatus.Completed,
+            CompletedExitCode = 0,
+        };
+
+        var result = await RunBrokeredOperationWithOutput(
+            transport,
+            configureOperationHelper: helper => helper.ElevationRequirementsAction =
+                (package, _, _) => package.OverridenOptions.RunAsAdministrator = true);
+
+        Assert.Equal(OperationVeredict.Success, result.Veredict);
+        Assert.Equal(
+            BrokerApiElevation.Elevated,
+            DeserializeExecuteRequest(transport).Client?.RequestedElevation);
+        Assert.Contains(result.Output, line => line.Item1.Contains("Elevation: Elevated"));
+    }
+
+    [Fact]
+    public async Task BrokeredOperationRequestsStandardElevationByDefault()
+    {
+        var transport = new ScriptedBrokerTransport
+        {
+            StatusAfterCancel = BrokerApiOperationStatus.Completed,
+            CompletedExitCode = 0,
+        };
+
+        var result = await RunBrokeredOperationWithOutput(transport);
+
+        Assert.Equal(OperationVeredict.Success, result.Veredict);
+        Assert.Equal(
+            BrokerApiElevation.Standard,
+            DeserializeExecuteRequest(transport).Client?.RequestedElevation);
+        Assert.Contains(result.Output, line => line.Item1.Contains("Elevation: Standard"));
+    }
+
+    [Fact]
+    public async Task ProhibitElevationSettingForcesStandardBrokerElevation()
+    {
+        bool originalProhibitElevation = Settings.Get(Settings.K.ProhibitElevation);
+        Settings.Set(Settings.K.ProhibitElevation, true);
+        try
+        {
+            var transport = new ScriptedBrokerTransport
+            {
+                StatusAfterCancel = BrokerApiOperationStatus.Completed,
+                CompletedExitCode = 0,
+            };
+
+            var result = await RunBrokeredOperationWithOutput(
+                transport,
+                configureOperationHelper: helper => helper.ElevationRequirementsAction =
+                    (package, _, _) => package.OverridenOptions.RunAsAdministrator = true);
+
+            Assert.Equal(OperationVeredict.Success, result.Veredict);
+            Assert.Equal(
+                BrokerApiElevation.Standard,
+                DeserializeExecuteRequest(transport).Client?.RequestedElevation);
+        }
+        finally
+        {
+            Settings.Set(Settings.K.ProhibitElevation, originalProhibitElevation);
+        }
+    }
+
+    private static BrokerApiPackageRequest DeserializeExecuteRequest(ScriptedBrokerTransport transport)
+    {
+        Assert.NotNull(transport.LastExecuteRequestBody);
+        var request = BrokerJson.Deserialize<BrokerApiPackageRequest>(transport.LastExecuteRequestBody);
+        Assert.NotNull(request);
+        return request;
+    }
+
+    [Fact]
     public async Task StreamedEventChannelOutputReachesOperationOutputAndResultParser()
     {
         var transport = new ScriptedBrokerTransport
@@ -1054,6 +1132,12 @@ public sealed class PackageOperationsTests
         /// </summary>
         public string? EventChannelPipeName { get; set; }
 
+        /// <summary>
+        /// Body of the last /v1/package-operations/execute request, for asserting on
+        /// the wire-level request (e.g. the requested elevation).
+        /// </summary>
+        public string? LastExecuteRequestBody { get; private set; }
+
         private bool cancelReceived;
 
         public BrokerTransportKind Kind => BrokerTransportKind.HttpNamedPipe;
@@ -1064,6 +1148,11 @@ public sealed class PackageOperationsTests
         )
         {
             RequestedPaths.Add(request.Path);
+            if (request.Path == "/v1/package-operations/execute")
+            {
+                LastExecuteRequestBody = request.Body;
+            }
+
             return request.Path switch
             {
                 "/v1/health" => Json(BrokerJson.Serialize(BuildHealthResponse())),

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -788,7 +788,11 @@ public sealed class PackageOperationsTests
             await pipe.WriteStderr("an error line\n");
             // Lines split across frames must be reassembled before being emitted.
             await pipe.WriteStdout("par");
-            await pipe.WriteStdout("tial");
+            await pipe.WriteStdout("tial\n");
+            // A CR progress line superseded by new text must not be re-emitted when a
+            // later bare LF arrives.
+            await pipe.WriteStdout("42%\rdone\n\n");
+            await pipe.WriteStdout("trailing");
             await pipe.WriteStdoutOverflow(42);
             await pipe.WriteFinish();
         });
@@ -810,17 +814,25 @@ public sealed class PackageOperationsTests
         Assert.Equal(OperationVeredict.Success, result.Veredict);
         Assert.Contains(("hello from broker", LineType.Information), result.Output);
         Assert.Contains(("an error line", LineType.Error), result.Output);
-        // The trailing partial line is flushed when the stream finishes.
         Assert.Contains(("partial", LineType.Information), result.Output);
+        Assert.Contains(("done", LineType.Information), result.Output);
+        // The superseded "42%" progress text was never promoted to a regular line.
+        Assert.DoesNotContain(("42%", LineType.Information), result.Output);
+        // The trailing partial line is flushed when the stream finishes.
+        Assert.Contains(("trailing", LineType.Information), result.Output);
         Assert.Contains(result.Output, line =>
             line.Item1.Contains("42 bytes") && line.Item2 is LineType.Information);
         // FINISH triggered exactly one final status query; no polling loop ran.
         Assert.Equal(1, transport.StatusQueryCount);
-        // The streamed output was fed back to the manager's result parser.
+        // The streamed output was fed back to the manager's result parser...
         Assert.NotNull(parsedOutput);
         Assert.Contains("hello from broker", parsedOutput);
         Assert.Contains("an error line", parsedOutput);
         Assert.Contains("partial", parsedOutput);
+        // ...but internal informational lines were not: the parser sees only raw
+        // process output.
+        Assert.DoesNotContain(parsedOutput, line => line.Contains("42 bytes"));
+        Assert.DoesNotContain(parsedOutput, line => line.Contains("Devolutions Agent broker"));
     }
 
     [Fact]


### PR DESCRIPTION
Brokered (remote agent) package operations now show **live process output** while they run. When an operation is routed through the Devolutions Agent broker, UniGetUI opens the broker's new per-operation event channel and streams the remote process's stdout/stderr straight into the operation output pane, line by line, exactly like a locally executed operation — including progress lines.

What this changes for users:

- **Live output**: brokered installs/updates/uninstalls display the package manager's output as it happens, instead of showing no output at all.
- **Instant status updates**: status changes (Starting → Running → Completed/Failed/Canceled) are picked up as soon as the broker signals them, rather than waiting for the next poll.
- **Restored result parsing**: since output is captured again, package managers can parse it to produce accurate operation results (e.g. detecting specific failure conditions in the output text).
- **Graceful fallback**: if the broker does not advertise an event channel, or the channel cannot be opened or breaks mid-stream, the operation transparently falls back to the previous status-polling behavior — the operation itself is never failed because live streaming was unavailable.
- **Cancellation**: canceling a streamed operation still requests a broker-side cancel; the tail of the process output is preserved while the cancellation is confirmed.

Stacked on #5253 (Devolutions.Now.Policy 2026.8.5 bump + remote cancellation); only the last commit belongs to this PR.

Issue: DGW-438