### PR TITLE
Add icon and screenshots for Bennewitz.Ninja.ClaudeForge (ninja-claudeforge)

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -28469,6 +28469,19 @@
       "icon": "",
       "images": []
     },
+    "ninja-claudeforge": {
+      "icon": "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/ClaudeForge.png",
+      "images": [
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/WelcomePage-Light.png",
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/EffectiveSettingsPage-Light.png",
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/PermissionsPage-Light.png",
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/HooksPage-Light.png",
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/EnvironmentPage-Light.png",
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/MemoryPage-Light.png",
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/PluginsPage-Light.png",
+        "https://raw.githubusercontent.com/JanusMael/ClaudeForge/main/docs/screenshots/BackupPage-Light.png"
+      ]
+    },
     "ninja-kitware": {
       "icon": "",
       "images": []


### PR DESCRIPTION
Adds an icon and screenshots for **ClaudeForge** (winget: `Bennewitz.Ninja.ClaudeForge`).

- **Key:** `ninja-claudeforge` — the normalized icon id UniGetUI derives for this package (the winget id with the publisher segment dropped: `Bennewitz.Ninja.ClaudeForge` → `Ninja.ClaudeForge` → `ninja-claudeforge`).
- **Icon:** 256×256 PNG (the application's own icon).
- **Screenshots:** 8 of the app's pages (light theme).

All assets are hosted from the project's own public repository ([JanusMael/ClaudeForge](https://github.com/JanusMael/ClaudeForge)). ClaudeForge is a cross-platform desktop editor for Claude Code and Claude Desktop configuration files.

The entry is placed alphabetically among the existing `ninja-*` keys — only the single entry is added (+13 lines, nothing else touched).
