### PR TITLE
Add icon and screenshots for FileHasher (FSPProductions.FileHasher)

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -15801,6 +15801,17 @@
       "icon": "https://community.chocolatey.org/content/packageimages/fslogix-java.2.9.8361.52326.png",
       "images": []
     },
+    "FSPProductions.FileHasher": {
+      "icon": "https://raw.githubusercontent.com/fsantiago07044/filehasher/main/docs/filehasher-winget-PR-assets/app-icon/hash-icon-256.png",
+      "images": [
+        "https://raw.githubusercontent.com/fsantiago07044/filehasher/main/docs/filehasher-winget-PR-assets/app-ui-screenshots/main-ui-completion-state-simple.png",
+        "https://raw.githubusercontent.com/fsantiago07044/filehasher/main/docs/filehasher-winget-PR-assets/app-ui-screenshots/main-ui.png",
+        "https://raw.githubusercontent.com/fsantiago07044/filehasher/main/docs/filehasher-winget-PR-assets/app-ui-screenshots/main-ui-completion-inner-msi-scan.png",
+        "https://raw.githubusercontent.com/fsantiago07044/filehasher/main/docs/filehasher-winget-PR-assets/app-ui-screenshots/sidecar-file-explorer-view.png",
+        "https://raw.githubusercontent.com/fsantiago07044/filehasher/main/docs/filehasher-winget-PR-assets/app-ui-screenshots/sidecar-file-overwrite-dialog.png",
+        "https://raw.githubusercontent.com/fsantiago07044/filehasher/main/docs/filehasher-winget-PR-assets/app-ui-screenshots/completion-dialog-sidecars-overwritten.png"
+      ]
+    },
     "fspy": {
       "icon": "",
       "images": []


### PR DESCRIPTION
Adds an icon and six screenshots for **FileHasher** ([`FSPProductions.FileHasher`](https://github.com/microsoft/winget-pkgs/tree/master/manifests/f/FSPProductions/FileHasher) on winget), a Windows GUI utility for hashing files and folders, writing sidecar hash files, and exporting results to CSV.

I'm the package maintainer. The assets are hosted in the app's own GitHub repository ([fsantiago07044/filehasher](https://github.com/fsantiago07044/filehasher), `docs/filehasher-winget-PR-assets/`), so the URLs are stable and under the same ownership as the package.

- Key: exact WinGet package identifier (`FSPProductions.FileHasher`), inserted in case-insensitive alphabetical order.
- Icon: 256×256 PNG with transparency.
- Screenshots: completed run with results, idle main window, MSI inner-file scan, sidecar files in Explorer, and the sidecar-conflict / completion dialogs.

Follow-up to the guidance in discussion #4597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)