### PR TITLE
Bump Devolutions.Now.Policy packages to 2026.8.13

### DIFF
--- a/src/UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj
+++ b/src/UniGetUI.PackageEngine.AgentBroker/UniGetUI.PackageEngine.AgentBroker.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Now.Policy.Api" Version="2026.8.5" />
-        <PackageReference Include="Devolutions.Now.Policy.Client" Version="2026.8.5" />
+        <PackageReference Include="Devolutions.Now.Policy.Api" Version="2026.8.13" />
+        <PackageReference Include="Devolutions.Now.Policy.Client" Version="2026.8.13" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Bumps `Devolutions.Now.Policy.Api` and `Devolutions.Now.Policy.Client` from **2026.8.5** to **2026.8.13** in `UniGetUI.PackageEngine.AgentBroker`.

## Motivation

The new now-libraries release (Devolutions/now-libraries#91) reworks the package broker's `PackageIdentifier` wire validation to an explicit allowlist (`^[A-Za-z0-9._+@/:\[\],#$%{}-]+$`, 1–256 bytes). With this bump, the following identifiers now deserialize correctly over the wire:

- Scoped npm/Bun ids — `@scope/package`
- npm aliases with exact versions — `alias:pkg@7.20.0`
- vcpkg triplets — `curl:x64-windows`

No UniGetUI code changes are required: `BrokerRequestBuilder` passes `package.Id` through verbatim as a plain string.

## Verification

- `dotnet build` of `UniGetUI.PackageEngine.AgentBroker` — succeeded, no new warnings
- `dotnet test` of `UniGetUI.PackageEngine.Tests` (references AgentBroker) — 634/634 passed (253 net10.0 + 381 net10.0-windows)