### PR TITLE
Add icon for @edde746/Plezy (WinGet)

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -7,6 +7,10 @@
     "total_screenshots": 4140
   },
   "icons_and_screenshots": {
+    "edde746/plezy": {
+      "icon": "https://raw.githubusercontent.com/edde746/plezy/main/assets/plezy.png",
+      "images": []
+    },
     "bbk1ng/agent-orch": {
       "icon": "https://raw.githubusercontent.com/bbk1ng/agent-orch/main/docs/assets/orch-avatar.png",
       "images": []

--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -7,7 +7,7 @@
     "total_screenshots": 4140
   },
   "icons_and_screenshots": {
-    "edde746/plezy": {
+    "edde746/Plezy": {
       "icon": "https://raw.githubusercontent.com/edde746/plezy/main/assets/plezy.png",
       "images": []
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/Devolutions/UniGetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/Devolutions/UniGetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/Devolutions/UniGetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **Have you confirmed that this issue is caused by UniGetUI itself, and not by the package manager or the package involved?**

-----

<!-- optionally, explain here about the committed code -->
Adds the official icon from the `edde746/Plezy` project repo. winget reports `Inno` installer type. Looks like either the author didn't submit it as part of Inno setup parameters or winget manifest stripped it out.
