### PR TITLE
feat: customize package page action label from reload

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -41,6 +41,7 @@ public enum ReloadReason
 
 public struct PackagesPageData
 {
+    public string ReloadButtonLabel;
     public bool DisableAutomaticPackageLoadOnStart;
     public bool MegaQueryBlockEnabled;
     public bool PackagesAreCheckedByDefault;
@@ -148,6 +149,7 @@ public partial class PackagesPageViewModel : ViewModelBase
     public readonly string NoPackagesText;
     public readonly string NoMatchesText;
     public readonly string SearchBoxPlaceholder;
+    public readonly string ReloadButtonLabel;
     private readonly string _noPackagesSubtitleBase;
     private readonly string _stillLoadingSubtitle;
     private readonly bool _showLastCheckedTime;
@@ -247,6 +249,9 @@ public partial class PackagesPageViewModel : ViewModelBase
         RoleIsUpdateLike = data.PageRole == OperationType.Update;
         NewVersionHeaderVisible = RoleIsUpdateLike;
         ReloadButtonVisible = !DisableReload;
+        ReloadButtonLabel = string.IsNullOrWhiteSpace(data.ReloadButtonLabel)
+            ? CoreTools.Translate("Reload")
+            : data.ReloadButtonLabel;
         SearchBoxPlaceholder = CoreTools.Translate("Search for packages");
 
         AllPackagesChecked = data.PackagesAreCheckedByDefault;

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -84,7 +84,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
         // Reload button added before subclass toolbar items (mirrors WinUI AbstractPackagesPage)
         if (!ViewModel.DisableReload)
         {
-            var reloadBtn = ViewModel.AddToolbarButton("reload", CoreTools.Translate("Reload"),
+            var reloadBtn = ViewModel.AddToolbarButton("reload", ViewModel.ReloadButtonLabel,
                 ViewModel.TriggerReload);
             UpdateReloadButtonTooltip(reloadBtn);
         }

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/DiscoverSoftwarePage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/DiscoverSoftwarePage.cs
@@ -30,6 +30,7 @@ public class DiscoverSoftwarePage : AbstractPackagesPage
         PageTitle = CoreTools.Translate("Discover Packages"),
         IconName = "DiscoverPackage",
         PageRole = OperationType.Install,
+        ReloadButtonLabel = CoreTools.Translate("Scan"),
         Loader = DiscoverablePackagesLoader.Instance ?? new DiscoverablePackagesLoader([]),
         MegaQueryBlockEnabled = true,
         DisableSuggestedResultsRadio = false,

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
@@ -42,6 +42,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
         PageTitle = CoreTools.Translate("Installed Packages"),
         IconName = "InstalledPackages",
         PageRole = OperationType.Uninstall,
+        ReloadButtonLabel = CoreTools.Translate("Scan installed"),
         Loader = InstalledPackagesLoader.Instance ?? new InstalledPackagesLoader([]),
         MegaQueryBlockEnabled = false,
         DisableSuggestedResultsRadio = true,

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -34,6 +34,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         PageTitle = CoreTools.Translate("Software Updates"),
         IconName = "update",
         PageRole = OperationType.Update,
+        ReloadButtonLabel = CoreTools.Translate("Check for updates"),
         Loader = UpgradablePackagesLoader.Instance ?? new UpgradablePackagesLoader([]),
         MegaQueryBlockEnabled = false,
         DisableSuggestedResultsRadio = true,


### PR DESCRIPTION
### EN
- Added configurable reload button label per package page to match the action context.
- PackagesPageData now accepts optional ReloadButtonLabel.
- PackagesPageViewModel now resolves label with fallback to Reload.
- AbstractPackagesPage uses ViewModel.ReloadButtonLabel for toolbar button text.
- Set labels:
  - Discover: Scan
  - Installed: Scan installed
  - Updates: Check for updates

### Testing
- dotnet build src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj -v minimal
  (fails at restore: missing required NuGet packages in this environment; no compile errors from changed files yet.

### AR
- أضفنا دعم تسمية زر إعادة التحميل بشكل مختلف لكل صفحة بدل النص الافتراضي الواحد.
- PackagesPageData صار يقبل ReloadButtonLabel اختيارياً.
- PackagesPageViewModel يحط قيمة افتراضية Reload إذا ماكو قيمة مخصصة.
- AbstractPackagesPage صار يستخدم ViewModel.ReloadButtonLabel.
- القيم المضافة:
  - Discover: Scan
  - Installed: Scan installed
  - Updates: Check for updates

### ملاحظات تحقق
- محاولة البناء فشلت بسبب مشاكل Restore (NU1100 في بيئة التشغيل الحالية) مو بسبب تغييرات الكود.
