### PR TITLE
Add navigation to Software Updates when the updates toast is tapped and fix update count display

### DIFF
--- a/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
@@ -6,6 +6,7 @@ using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageOperations;
 
@@ -109,7 +110,8 @@ internal static partial class MacOsNotificationBridge
                 title = CoreTools.Translate("Updates found!");
                 message = CoreTools.Translate("{0} packages can be updated", upgradable.Count);
             }
-            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Success);
+            DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Success,
+                launchAction: NotificationArguments.ShowOnUpdatesTab);
         }
         catch (Exception ex)
         {
@@ -195,13 +197,14 @@ internal static partial class MacOsNotificationBridge
         string title,
         string message,
         MainWindow.RuntimeNotificationLevel level,
-        bool allowInAppFallback = true)
+        bool allowInAppFallback = true,
+        string? launchAction = null)
     {
         if (MainWindow.IsWindowOnScreen)
         {
             if (allowInAppFallback)
                 Dispatcher.UIThread.Post(() =>
-                    MainWindow.Instance?.ShowRuntimeNotification(title, message, level));
+                    MainWindow.Instance?.ShowRuntimeNotification(title, message, level, launchAction));
             return;
         }
 

--- a/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs
@@ -111,7 +111,7 @@ internal static partial class MacOsNotificationBridge
                 message = CoreTools.Translate("{0} packages can be updated", upgradable.Count);
             }
             DeliverNotification(title, message, MainWindow.RuntimeNotificationLevel.Success,
-                launchAction: NotificationArguments.ShowOnUpdatesTab);
+                inAppLaunchAction: NotificationArguments.ShowOnUpdatesTab);
         }
         catch (Exception ex)
         {
@@ -198,13 +198,13 @@ internal static partial class MacOsNotificationBridge
         string message,
         MainWindow.RuntimeNotificationLevel level,
         bool allowInAppFallback = true,
-        string? launchAction = null)
+        string? inAppLaunchAction = null)
     {
         if (MainWindow.IsWindowOnScreen)
         {
             if (allowInAppFallback)
                 Dispatcher.UIThread.Post(() =>
-                    MainWindow.Instance?.ShowRuntimeNotification(title, message, level, launchAction));
+                    MainWindow.Instance?.ShowRuntimeNotification(title, message, level, inAppLaunchAction));
             return;
         }
 

--- a/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/WindowsAppNotificationBridge.cs
@@ -244,19 +244,20 @@ internal static class WindowsAppNotificationBridge
         }
 #endif
 
-        return allowInAppFallback && ShowInAppBanner(title, message, level);
+        return allowInAppFallback && ShowInAppBanner(title, message, level, launchAction);
     }
 
     private static bool ShowInAppBanner(
         string title,
         string message,
-        MainWindow.RuntimeNotificationLevel level)
+        MainWindow.RuntimeNotificationLevel level,
+        string launchAction)
     {
         var mainWindow = MainWindow.Instance;
         if (mainWindow is null)
             return false;
 
-        mainWindow.ShowRuntimeNotification(title, message, level);
+        mainWindow.ShowRuntimeNotification(title, message, level, launchAction);
         return true;
     }
 

--- a/src/UniGetUI.Avalonia/ViewModels/InfoBarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/InfoBarViewModel.cs
@@ -16,6 +16,12 @@ public partial class InfoBarViewModel : ObservableObject
     [ObservableProperty] private string _actionButtonText = "";
     [ObservableProperty] private ICommand? _actionButtonCommand;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsBodyClickable))]
+    private ICommand? _bodyCommand;
+
+    public bool IsBodyClickable => BodyCommand is not null;
+
     public Action? OnClosed { get; set; }
 
     partial void OnIsOpenChanged(bool value)

--- a/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs
@@ -12,6 +12,7 @@ public partial class SidebarViewModel : ViewModelBase
 {
     // ─── Badge properties ─────────────────────────────────────────────────────
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UpdatesBadgeText))]
     private int _updatesBadgeCount;
 
     [ObservableProperty]
@@ -19,6 +20,8 @@ public partial class SidebarViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _bundlesBadgeVisible;
+
+    public string UpdatesBadgeText => UpdatesBadgeCount > 99 ? "99+" : UpdatesBadgeCount.ToString();
 
     // When the count changes, sync the badge visibility
     partial void OnUpdatesBadgeCountChanged(int value) =>

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
@@ -23,6 +23,9 @@
             <Setter Property="Background"   Value="{DynamicResource StatusInfoBackground}"/>
             <Setter Property="BorderBrush"  Value="{DynamicResource StatusInfoBorderBrush}"/>
         </Style>
+        <Style Selector="Border#BodyBorder.clickable">
+            <Setter Property="Cursor" Value="Hand"/>
+        </Style>
         <!-- Toast entrance: slide in from the right + fade. Gated on the .animate-in class
              (added in code-behind only when motion is allowed). Animate TranslateTransform.X,
              not RenderTransform (the latter has no Avalonia animator). -->
@@ -44,6 +47,7 @@
 
     <Border x:Name="BodyBorder"
             IsVisible="{Binding IsOpen}"
+            Tapped="Body_Tapped"
             BorderThickness="1"
             CornerRadius="6"
             ClipToBounds="True"

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml
@@ -26,6 +26,10 @@
         <Style Selector="Border#BodyBorder.clickable">
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
+        <Style Selector="Border#BodyBorder.body-focused">
+            <Setter Property="BorderBrush"     Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+            <Setter Property="BorderThickness" Value="2"/>
+        </Style>
         <!-- Toast entrance: slide in from the right + fade. Gated on the .animate-in class
              (added in code-behind only when motion is allowed). Animate TranslateTransform.X,
              not RenderTransform (the latter has no Avalonia animator). -->

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
@@ -21,6 +23,10 @@ public partial class InfoBar : UserControl
     {
         InitializeComponent();
         DataContextChanged += OnDataContextChanged;
+        KeyDown += OnKeyDown;
+        GotFocus += (_, e) =>
+            BodyBorder.Classes.Set("body-focused", _vm?.IsBodyClickable == true && e.Source == this);
+        LostFocus += (_, _) => BodyBorder.Classes.Remove("body-focused");
 
         // Play the slide-in entrance only when the OS isn't set to minimize motion.
         if (!MotionPreference.ReducedMotion)
@@ -51,8 +57,19 @@ public partial class InfoBar : UserControl
             ApplyClickable();
     }
 
-    private void ApplyClickable() =>
-        BodyBorder.Classes.Set("clickable", _vm?.IsBodyClickable == true);
+    private void ApplyClickable()
+    {
+        bool clickable = _vm?.IsBodyClickable == true;
+        BodyBorder.Classes.Set("clickable", clickable);
+        Focusable = clickable;
+
+        var controlType = clickable ? (AutomationControlType?)AutomationControlType.Button : null;
+        AutomationProperties.SetControlTypeOverride(this, controlType);
+        AutomationProperties.SetControlTypeOverride(BodyBorder, controlType);
+
+        if (!clickable)
+            BodyBorder.Classes.Remove("body-focused");
+    }
 
     private void Body_Tapped(object? sender, TappedEventArgs e)
     {
@@ -64,6 +81,20 @@ public partial class InfoBar : UserControl
 
         if (command.CanExecute(null))
             command.Execute(null);
+    }
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (_vm?.BodyCommand is not { } command)
+            return;
+
+        if (e.Source != this) return;
+        if (e.Key is not (Key.Enter or Key.Space)) return;
+        if (e.KeyModifiers is not KeyModifiers.None) return;
+
+        if (command.CanExecute(null))
+            command.Execute(null);
+        e.Handled = true;
     }
 
     private void ApplySeverity(InfoBarSeverity severity)

--- a/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/InfoBar.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.VisualTree;
 using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels;
 
@@ -38,12 +40,30 @@ public partial class InfoBar : UserControl
         _vm?.PropertyChanged += OnViewModelPropertyChanged;
         if (_vm is not null)
             ApplySeverity(_vm.Severity);
+        ApplyClickable();
     }
 
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(InfoBarViewModel.Severity) && _vm is not null)
             ApplySeverity(_vm.Severity);
+        else if (e.PropertyName == nameof(InfoBarViewModel.IsBodyClickable))
+            ApplyClickable();
+    }
+
+    private void ApplyClickable() =>
+        BodyBorder.Classes.Set("clickable", _vm?.IsBodyClickable == true);
+
+    private void Body_Tapped(object? sender, TappedEventArgs e)
+    {
+        if (_vm?.BodyCommand is not { } command)
+            return;
+
+        if (e.Source is Visual source && source.FindAncestorOfType<Button>(includeSelf: true) is not null)
+            return;
+
+        if (command.CanExecute(null))
+            command.Execute(null);
     }
 
     private void ApplySeverity(InfoBarSeverity severity)

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1796,7 +1796,7 @@ public partial class MainWindow : Window
 
     // ─── Public API (legacy compat) ───────────────────────────────────────────
     // Surfaces a fresh, auto-dismissing toast per call (name kept for pre-toast callers).
-    public void ShowBanner(string title, string message, RuntimeNotificationLevel level)
+    public void ShowBanner(string title, string message, RuntimeNotificationLevel level, string? launchAction = null)
     {
         if (level == RuntimeNotificationLevel.Progress) return;
 
@@ -1816,6 +1816,16 @@ public partial class MainWindow : Window
             IsOpen = true,
         };
         toast.OnClosed = () => ViewModel.DismissToast(toast);
+
+        if (launchAction == UniGetUI.Interface.Enums.NotificationArguments.ShowOnUpdatesTab)
+        {
+            toast.BodyCommand = new CommunityToolkit.Mvvm.Input.RelayCommand(() =>
+            {
+                ViewModel.NavigateTo(PageType.Updates);
+                ViewModel.DismissToast(toast);
+            });
+        }
+
         ViewModel.ShowToast(toast);
     }
 
@@ -1837,8 +1847,8 @@ public partial class MainWindow : Window
     private void UpdateOnScreenState()
         => _isOnScreen = IsVisible && WindowState != WindowState.Minimized;
 
-    public void ShowRuntimeNotification(string title, string message, RuntimeNotificationLevel level) =>
-        ShowBanner(title, message, level);
+    public void ShowRuntimeNotification(string title, string message, RuntimeNotificationLevel level, string? launchAction = null) =>
+        ShowBanner(title, message, level, launchAction);
 
     // ─── BackgroundAPI integration ────────────────────────────────────────────
     public void ShowFromTray()

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -74,9 +74,9 @@
                             IsVisible="{Binding UpdatesBadgeVisible}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Top"
-                            Margin="26,5,0,0">
-                        <TextBlock Text="{Binding UpdatesBadgeCount}"
-                                   FontSize="11"
+                            Margin="26,5,-20,0">
+                        <TextBlock Text="{Binding UpdatesBadgeText}"
+                                   FontSize="9"
                                    FontWeight="Bold"
                                    Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
                                    HorizontalAlignment="Center"


### PR DESCRIPTION
This pull request introduces improvements to the notification and toast system, enhances badge display in the sidebar, and adds support for clickable notification bodies. The main changes include adding a "launch action" to notifications (allowing, for example, a toast to navigate to the Updates tab when clicked), updating the sidebar badge to display "99+" when the count is high, and making InfoBar notifications optionally clickable.

**Notification and Toast System Improvements:**
- Added a `launchAction` parameter to notification delivery methods in `MacOsNotificationBridge` and `WindowsAppNotificationBridge`, enabling actions such as navigating to the Updates tab when a notification is clicked. (`src/UniGetUI.Avalonia/Infrastructure/MacOsNotificationBridge.cs` )
- Updated `MainWindow.ShowRuntimeNotification` and `ShowBanner` to accept and process the `launchAction` parameter, wiring up navigation logic for the "ShowOnUpdatesTab" action. (`src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs`

**Sidebar Badge Enhancements:**
- Modified the sidebar updates badge to display "99+" if the count exceeds 99, reduced font size for better fit, and ensured the badge text updates reactively. (`src/UniGetUI.Avalonia/ViewModels/SidebarViewModel.cs`); 

- Added support for making InfoBar bodies clickable when a command is provided, including visual feedback (cursor change) and event handling to execute the command without interfering with existing buttons. (`src/UniGetUI.Avalonia/ViewModels/InfoBarViewModel.cs`

These changes collectively improve notification interactivity and visual clarity in the application.