### PR TITLE
Skip packages with pending operations and clarify upgrade causes

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -761,6 +761,7 @@
   "{package} was updated successfully": "{package} was updated successfully",
   "Update failed": "Update failed",
   "{package} could not be updated": "{package} could not be updated",
+  "{package} was not updated because no applicable upgrade was found. It may already be up to date, or no available installer matches this system.": "{package} was not updated because no applicable upgrade was found. It may already be up to date, or no available installer matches this system.",
   "{package} Uninstall": "{package} Uninstall",
   "{0} is being uninstalled": "{0} is being uninstalled",
   "Uninstall succeeded": "Uninstall succeeded",

--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -761,7 +761,7 @@
   "{package} was updated successfully": "{package} was updated successfully",
   "Update failed": "Update failed",
   "{package} could not be updated": "{package} could not be updated",
-  "{package} was not updated because no applicable upgrade was found. It may already be up to date, or no available installer matches this system.": "{package} was not updated because no applicable upgrade was found. It may already be up to date, or no available installer matches this system.",
+  "{package} may already be up to date, or no installer matches this system": "{package} may already be up to date, or no installer matches this system",
   "{package} Uninstall": "{package} Uninstall",
   "{0} is being uninstalled": "{0} is being uninstalled",
   "Uninstall succeeded": "Uninstall succeeded",

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaPackageOperationHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaPackageOperationHelper.cs
@@ -29,22 +29,12 @@ namespace UniGetUI.Avalonia.Infrastructure;
 /// </summary>
 internal static class AvaloniaPackageOperationHelper
 {
-    internal static bool HasPendingOperation(IPackage package, OperationType role)
-    {
-        if (package.Tag is not (PackageTag.OnQueue or PackageTag.BeingProcessed))
-            return false;
-
-        Logger.Warn(
-            $"Skipping {role} of {package.Id} because an operation for this package is already queued or running");
-        return true;
-    }
-
     public static async Task UpdateAllAsync()
     {
         foreach (var pkg in UpgradablePackagesLoader.Instance.Packages.ToList())
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
-            if (HasPendingOperation(pkg, OperationType.Update)) continue;
+            if (PackageOperation.HasPendingOperation(pkg, OperationType.Update)) continue;
             var op = new UpdatePackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);
@@ -60,7 +50,7 @@ internal static class AvaloniaPackageOperationHelper
             .ToList())
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
-            if (HasPendingOperation(pkg, OperationType.Update)) continue;
+            if (PackageOperation.HasPendingOperation(pkg, OperationType.Update)) continue;
             var op = new UpdatePackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);
@@ -79,7 +69,7 @@ internal static class AvaloniaPackageOperationHelper
         }
 
         var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
-        if (HasPendingOperation(pkg, OperationType.Update)) return;
+        if (PackageOperation.HasPendingOperation(pkg, OperationType.Update)) return;
         var op = new UpdatePackageOperation(pkg, opts);
         op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
         op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaPackageOperationHelper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaPackageOperationHelper.cs
@@ -29,12 +29,22 @@ namespace UniGetUI.Avalonia.Infrastructure;
 /// </summary>
 internal static class AvaloniaPackageOperationHelper
 {
+    internal static bool HasPendingOperation(IPackage package, OperationType role)
+    {
+        if (package.Tag is not (PackageTag.OnQueue or PackageTag.BeingProcessed))
+            return false;
+
+        Logger.Warn(
+            $"Skipping {role} of {package.Id} because an operation for this package is already queued or running");
+        return true;
+    }
+
     public static async Task UpdateAllAsync()
     {
         foreach (var pkg in UpgradablePackagesLoader.Instance.Packages.ToList())
         {
-            if (pkg.Tag is PackageTag.BeingProcessed or PackageTag.OnQueue) continue;
             var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+            if (HasPendingOperation(pkg, OperationType.Update)) continue;
             var op = new UpdatePackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);
@@ -49,8 +59,8 @@ internal static class AvaloniaPackageOperationHelper
             .Where(p => p.Manager.Id == managerName)
             .ToList())
         {
-            if (pkg.Tag is PackageTag.BeingProcessed or PackageTag.OnQueue) continue;
             var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+            if (HasPendingOperation(pkg, OperationType.Update)) continue;
             var op = new UpdatePackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);
@@ -69,6 +79,7 @@ internal static class AvaloniaPackageOperationHelper
         }
 
         var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+        if (HasPendingOperation(pkg, OperationType.Update)) return;
         var op = new UpdatePackageOperation(pkg, opts);
         op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
         op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -1034,6 +1034,7 @@ public partial class PackagesPageViewModel : ViewModelBase
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, no_integrity: no_integrity);
+            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Install)) continue;
             var op = new InstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.SUCCESS, TEL_InstallReferral.DIRECT_SEARCH);
             op.OperationFailed += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.FAILED, TEL_InstallReferral.DIRECT_SEARCH);

--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -1034,7 +1034,7 @@ public partial class PackagesPageViewModel : ViewModelBase
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, no_integrity: no_integrity);
-            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Install)) continue;
+            if (PackageOperation.HasPendingOperation(pkg, OperationType.Install)) continue;
             var op = new InstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.SUCCESS, TEL_InstallReferral.DIRECT_SEARCH);
             op.OperationFailed += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.FAILED, TEL_InstallReferral.DIRECT_SEARCH);

--- a/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/PackageDetailsWindow.axaml.cs
@@ -524,6 +524,8 @@ public partial class PackageDetailsWindow : UniGetUI.Avalonia.Views.DialogPages.
             no_integrity: no_integrity,
             remove_data: remove_data);
 
+        if (PackageOperation.HasPendingOperation(pkg, role)) return;
+
         AbstractOperation op = role switch
         {
             OperationType.Install => new InstallPackageOperation(pkg, opts),

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
@@ -363,7 +363,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, remove_data: remove_data);
-            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Uninstall)) continue;
+            if (PackageOperation.HasPendingOperation(pkg, OperationType.Uninstall)) continue;
             var op = new UninstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.FAILED);
@@ -376,6 +376,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
     {
         if (package is null || package.Source.IsVirtualManager) return;
         var opts = await InstallOptionsFactory.LoadApplicableAsync(package);
+        if (PackageOperation.HasPendingOperation(package, OperationType.Install)) return;
         var op = new InstallPackageOperation(package, opts);
         op.OperationSucceeded += (_, _) => TelemetryHandler.InstallPackage(package, TEL_OP_RESULT.SUCCESS, TEL_InstallReferral.ALREADY_INSTALLED);
         op.OperationFailed += (_, _) => TelemetryHandler.InstallPackage(package, TEL_OP_RESULT.FAILED, TEL_InstallReferral.ALREADY_INSTALLED);
@@ -388,7 +389,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
         if (package is null || package.Source.IsVirtualManager) return;
         var uninstallOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
         var reinstallOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
-        if (AvaloniaPackageOperationHelper.HasPendingOperation(package, OperationType.Install)) return;
+        if (PackageOperation.HasPendingOperation(package, OperationType.Install)) return;
         var uninstallOp = new UninstallPackageOperation(package, uninstallOpts);
         uninstallOp.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.SUCCESS);
         uninstallOp.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.FAILED);

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/InstalledPackagesPage.cs
@@ -363,6 +363,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, remove_data: remove_data);
+            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Uninstall)) continue;
             var op = new UninstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.FAILED);
@@ -387,6 +388,7 @@ public class InstalledPackagesPage : AbstractPackagesPage
         if (package is null || package.Source.IsVirtualManager) return;
         var uninstallOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
         var reinstallOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
+        if (AvaloniaPackageOperationHelper.HasPendingOperation(package, OperationType.Install)) return;
         var uninstallOp = new UninstallPackageOperation(package, uninstallOpts);
         uninstallOp.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.SUCCESS);
         uninstallOp.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.FAILED);

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
@@ -272,6 +272,7 @@ public class PackageBundlesPage : AbstractPackagesPage
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, no_integrity: skiphash);
+            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Install)) continue;
             var op = new InstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.SUCCESS, TEL_InstallReferral.FROM_BUNDLE);
             op.OperationFailed += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.FAILED, TEL_InstallReferral.FROM_BUNDLE);

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
@@ -272,7 +272,7 @@ public class PackageBundlesPage : AbstractPackagesPage
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, no_integrity: skiphash);
-            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Install)) continue;
+            if (PackageOperation.HasPendingOperation(pkg, OperationType.Install)) continue;
             var op = new InstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.SUCCESS, TEL_InstallReferral.FROM_BUNDLE);
             op.OperationFailed += (_, _) => TelemetryHandler.InstallPackage(pkg, TEL_OP_RESULT.FAILED, TEL_InstallReferral.FROM_BUNDLE);

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -343,7 +343,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, no_integrity: no_integrity);
-            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Update)) continue;
+            if (PackageOperation.HasPendingOperation(pkg, OperationType.Update)) continue;
             var op = new UpdatePackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);
@@ -357,7 +357,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         foreach (var pkg in packages)
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
-            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Uninstall)) continue;
+            if (PackageOperation.HasPendingOperation(pkg, OperationType.Uninstall)) continue;
             var op = new UninstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.FAILED);
@@ -371,7 +371,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         if (package is null || package.Source.IsVirtualManager) return;
         var uninstallOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
         var updateOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
-        if (AvaloniaPackageOperationHelper.HasPendingOperation(package, OperationType.Update)) return;
+        if (PackageOperation.HasPendingOperation(package, OperationType.Update)) return;
         var uninstallOp = new UninstallPackageOperation(package, uninstallOpts);
         uninstallOp.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.SUCCESS);
         uninstallOp.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.FAILED);

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -343,6 +343,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(
                 pkg, elevated: elevated, interactive: interactive, no_integrity: no_integrity);
+            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Update)) continue;
             var op = new UpdatePackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UpdatePackage(pkg, TEL_OP_RESULT.FAILED);
@@ -356,6 +357,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         foreach (var pkg in packages)
         {
             var opts = await InstallOptionsFactory.LoadApplicableAsync(pkg);
+            if (AvaloniaPackageOperationHelper.HasPendingOperation(pkg, OperationType.Uninstall)) continue;
             var op = new UninstallPackageOperation(pkg, opts);
             op.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.SUCCESS);
             op.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(pkg, TEL_OP_RESULT.FAILED);
@@ -369,6 +371,7 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         if (package is null || package.Source.IsVirtualManager) return;
         var uninstallOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
         var updateOpts = await InstallOptionsFactory.LoadApplicableAsync(package);
+        if (AvaloniaPackageOperationHelper.HasPendingOperation(package, OperationType.Update)) return;
         var uninstallOp = new UninstallPackageOperation(package, uninstallOpts);
         uninstallOp.OperationSucceeded += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.SUCCESS);
         uninstallOp.OperationFailed += (_, _) => TelemetryHandler.UninstallPackage(package, TEL_OP_RESULT.FAILED);

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -283,14 +283,7 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             return OperationVeredict.Failure;
         }
 
-        bool pingetReportedNotApplicable =
-            ((WinGet)Manager).SelectedCliToolKind is WinGetCliToolKind.BundledPinget
-            && processOutput.Any(line =>
-                line.Contains("No applicable installer found", StringComparison.OrdinalIgnoreCase)
-                || line.Contains("No applicable upgrade found", StringComparison.OrdinalIgnoreCase)
-            );
-
-        if (uintCode is 0x8A15002B || pingetReportedNotApplicable)
+        if (ReportedUpdateNotApplicable(processOutput, returnCode))
         { // The update is not applicable to the platform
             // The scope/architecture we forced may exclude the only installer the package ships
             // (e.g. forcing --architecture x64 on a package that only has an x86 installer). Retry
@@ -421,6 +414,21 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             id,
             $"{count}{AttemptSeparator}{version}"
         );
+    }
+
+    internal bool ReportedUpdateNotApplicable(
+        IReadOnlyList<string> processOutput,
+        int returnCode
+    )
+    {
+        if ((uint)returnCode is 0x8A15002B)
+            return true;
+
+        return ((WinGet)Manager).SelectedCliToolKind is WinGetCliToolKind.BundledPinget
+            && processOutput.Any(line =>
+                line.Contains("No applicable installer found", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("No applicable upgrade found", StringComparison.OrdinalIgnoreCase)
+            );
     }
 
     public static void SuppressPhantomUpgrade(IPackage package)

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -225,6 +225,15 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             return PingetPackageDetailsProvider.TryGetInstallerHostsForVersion(package, version);
         }
 
+        public bool ReportedUpdateNotApplicable(
+            IReadOnlyList<string> processOutput,
+            int returnCode
+        )
+        {
+            return OperationHelper is WinGetPkgOperationHelper helper
+                && helper.ReportedUpdateNotApplicable(processOutput, returnCode);
+        }
+
         protected override IReadOnlyList<Package> FindPackages_UnSafe(string query)
         {
             return WinGetHelper.Instance.FindPackages_UnSafe(query);

--- a/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
@@ -33,6 +33,7 @@ public abstract partial class AbstractOperation : IDisposable
     private bool Disposed;
 
     private readonly List<(string, LineType)> LogList = [];
+    private readonly object LogListLock = new();
     private OperationStatus _status = OperationStatus.InQueue;
     public OperationStatus Status
     {
@@ -176,17 +177,27 @@ public abstract partial class AbstractOperation : IDisposable
     {
         // LogList stays raw: it is the source of truth for result parsing. Only display redacts.
         if (type != LineType.ProgressIndicator)
-            LogList.Add((line, type));
+        {
+            lock (LogListLock)
+                LogList.Add((line, type));
+        }
         LogLineAdded?.Invoke(this, (Logger.Redact(line), type));
     }
 
-    protected IReadOnlyList<(string, LineType)> GetRawOutput() => LogList;
+    protected IReadOnlyList<(string, LineType)> GetRawOutput()
+    {
+        lock (LogListLock)
+            return LogList.ToArray();
+    }
 
     public IReadOnlyList<(string, LineType)> GetOutput()
     {
-        if (!Logger.RedactUsername)
-            return LogList;
-        return LogList.Select(l => (Logger.Redact(l.Item1), l.Item2)).ToList();
+        lock (LogListLock)
+        {
+            if (!Logger.RedactUsername)
+                return LogList.ToArray();
+            return LogList.Select(l => (Logger.Redact(l.Item1), l.Item2)).ToArray();
+        }
     }
 
     public Task MainThread()

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -848,9 +848,33 @@ namespace UniGetUI.PackageEngine.Operations
             List<string> Output
         )
         {
-            return Task.FromResult(
-                Package.Manager.OperationHelper.GetResult(Package, Role, Output, ReturnCode)
+            var veredict = Package.Manager.OperationHelper.GetResult(
+                Package,
+                Role,
+                Output,
+                ReturnCode
             );
+
+            if (veredict is OperationVeredict.Failure && Role is OperationType.Update)
+                ExplainNotApplicableUpdate(Output, ReturnCode);
+
+            return Task.FromResult(veredict);
+        }
+
+        private void ExplainNotApplicableUpdate(List<string> output, int returnCode)
+        {
+#if WINDOWS
+            if (Package.Manager is not WinGet winget)
+                return;
+
+            if (!winget.ReportedUpdateNotApplicable(output, returnCode))
+                return;
+
+            Metadata.FailureMessage = CoreTools.Translate(
+                "{package} was not updated because no applicable upgrade was found. It may already be up to date, or no available installer matches this system.",
+                new Dictionary<string, object?> { { "package", Package.Name } }
+            );
+#endif
         }
 
         private static bool IsWinGetManager(IPackageManager manager)

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -119,6 +119,17 @@ namespace UniGetUI.PackageEngine.Operations
             OperationFailed += (_, _) => HandleFailure();
         }
 
+        public static bool HasPendingOperation(IPackage package, OperationType role)
+        {
+            if (package.Tag is not (PackageTag.OnQueue or PackageTag.BeingProcessed))
+                return false;
+
+            Logger.Warn(
+                $"Skipping {role} of {package.Id} because an operation for this package is already queued or running"
+            );
+            return true;
+        }
+
         private bool RequiresAdminRights() =>
             !Settings.Get(Settings.K.ProhibitElevation)
             && (Package.OverridenOptions.RunAsAdministrator is true || Options.RunAsAdministrator);
@@ -871,7 +882,7 @@ namespace UniGetUI.PackageEngine.Operations
                 return;
 
             Metadata.FailureMessage = CoreTools.Translate(
-                "{package} was not updated because no applicable upgrade was found. It may already be up to date, or no available installer matches this system.",
+                "{package} may already be up to date, or no installer matches this system",
                 new Dictionary<string, object?> { { "package", Package.Name } }
             );
 #endif

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -110,7 +110,11 @@ namespace UniGetUI.PackageEngine.Operations
 
                 Package.SetTag(PackageTag.OnQueue);
             };
-            CancelRequested += (_, _) => Package.SetTag(PackageTag.Default);
+            StatusChanged += (_, status) =>
+            {
+                if (status is OperationStatus.Canceled)
+                    Package.SetTag(PackageTag.Default);
+            };
             OperationSucceeded += (_, _) => HandleSuccess();
             OperationFailed += (_, _) => HandleFailure();
         }

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -400,6 +400,32 @@ public sealed class PackageOperationsTests
     }
 
     [Fact]
+    public async Task OutputSnapshotsDoNotThrowWhileLinesAreAppended()
+    {
+        using var operation = new LoggingStubOperation();
+        const int lines = 20_000;
+
+        var writer = Task.Run(() =>
+        {
+            for (int i = 0; i < lines; i++)
+                operation.EmitLine($"line {i}", AbstractOperation.LineType.Information);
+        });
+
+        var reader = Task.Run(() =>
+        {
+            while (!writer.IsCompleted)
+            {
+                foreach (var _ in operation.GetOutput()) { }
+                foreach (var _ in operation.RawOutputForTests()) { }
+            }
+        });
+
+        await Task.WhenAll(writer, reader);
+
+        Assert.Equal(lines, operation.GetOutput().Count);
+    }
+
+    [Fact]
     public void UsernameRedactionAppliesToDisplayOutputButNeverToResultParsingOutput()
     {
         // Regression: result parsing must see raw output; only display (GetOutput) may redact.

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -251,6 +251,41 @@ public sealed class PackageOperationsTests
     }
 
     [Fact]
+    public async Task InstallOperationCanceledByManagerClearsPackageTag()
+    {
+        var package = CreatePackage();
+        InitializeLoaders();
+        using var operation = new SimulatedInstallPackageOperation(
+            package,
+            new InstallOptions(),
+            OperationVeredict.Canceled
+        );
+
+        await operation.MainThread();
+
+        Assert.Equal(OperationStatus.Canceled, operation.Status);
+        Assert.Equal(PackageTag.Default, package.Tag);
+    }
+
+    [Fact]
+    public async Task InstallOperationCanceledWhileQueuedClearsPackageTag()
+    {
+        var package = CreatePackage();
+        InitializeLoaders();
+        using var operation = new SimulatedInstallPackageOperation(
+            package,
+            new InstallOptions(),
+            OperationVeredict.Success
+        );
+        operation.Enqueued += (_, _) => operation.Cancel();
+
+        await operation.MainThread();
+
+        Assert.Equal(OperationStatus.Canceled, operation.Status);
+        Assert.Equal(PackageTag.Default, package.Tag);
+    }
+
+    [Fact]
     public async Task InstallOperationSuccessfulRunPrefersAuthoritativeInstalledVersion()
     {
         TestPackageManager? manager = null;

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -8,6 +8,7 @@ using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.Managers.WingetManager;
 using UniGetUI.PackageEngine.ManagerClasses.Classes;
+using UniGetUI.PackageEngine.Operations;
 using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.Serializable;
 using UniGetUI.PackageEngine.Tests.Infrastructure.Assertions;
@@ -1541,6 +1542,83 @@ public sealed class WinGetManagerTests : IDisposable
             "Truncated": false
         }
         """;
+
+    [Fact]
+    public async Task WinGetUpdateNotApplicableExplainsTheFailureToTheUser()
+    {
+        var manager = new WinGet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Klocman.BulkCrapUninstaller")
+            .WithVersion("6.1")
+            .WithNewVersion("6.2")
+            .Build();
+        package.OverridenOptions.WinGet_DropArchAndScope = true;
+        using var operation = new VeredictProbingUpdateOperation(package, new InstallOptions());
+        string defaultMessage = operation.Metadata.FailureMessage;
+
+        var veredict = await operation.ProbeProcessVeredict(unchecked((int)0x8A15002B), []);
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.NotEqual(defaultMessage, operation.Metadata.FailureMessage);
+        Assert.Contains("may already be up to date", operation.Metadata.FailureMessage);
+        Assert.False(operation.Metadata.FailureMessage.EndsWith('.'));
+    }
+
+    [Fact]
+    public async Task WinGetUpdateNotApplicableExplainsTheFailureOnlyOnTheFinalAttempt()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Klocman.BulkCrapUninstaller")
+            .WithVersion("6.1")
+            .WithNewVersion("6.2")
+            .Build();
+        package.OverridenOptions.Scope = PackageScope.Machine;
+        using var operation = new VeredictProbingUpdateOperation(package, new InstallOptions());
+        string defaultMessage = operation.Metadata.FailureMessage;
+
+        var firstAttempt = await operation.ProbeProcessVeredict(unchecked((int)0x8A15002B), []);
+
+        OperationAssert.HasVeredict(firstAttempt, OperationVeredict.AutoRetry);
+        Assert.Equal(defaultMessage, operation.Metadata.FailureMessage);
+
+        var finalAttempt = await operation.ProbeProcessVeredict(unchecked((int)0x8A15002B), []);
+
+        OperationAssert.HasVeredict(finalAttempt, OperationVeredict.Failure);
+        Assert.Contains("may already be up to date", operation.Metadata.FailureMessage);
+    }
+
+    [Fact]
+    public async Task WinGetUpdateFailureUnrelatedToApplicabilityKeepsTheDefaultMessage()
+    {
+        var manager = new WinGet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Klocman.BulkCrapUninstaller")
+            .WithVersion("6.1")
+            .WithNewVersion("6.2")
+            .Build();
+        using var operation = new VeredictProbingUpdateOperation(package, new InstallOptions());
+        string defaultMessage = operation.Metadata.FailureMessage;
+
+        var veredict = await operation.ProbeProcessVeredict(1, []);
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.Equal(defaultMessage, operation.Metadata.FailureMessage);
+        Assert.DoesNotContain("may already be up to date", operation.Metadata.FailureMessage);
+    }
+
+    private sealed class VeredictProbingUpdateOperation : UpdatePackageOperation
+    {
+        public VeredictProbingUpdateOperation(IPackage package, InstallOptions options)
+            : base(package, options) { }
+
+        public Task<OperationVeredict> ProbeProcessVeredict(int returnCode, List<string> output)
+            => GetProcessVeredict(returnCode, output);
+    }
 
     private static void SetCliToolKind(WinGet manager, WinGetCliToolKind kind)
     {


### PR DESCRIPTION
This pull request introduces several improvements to package operation handling, focusing on preventing duplicate operations, enhancing user feedback for update failures, and improving internal logic and test coverage. The main themes are operation safety, user experience, and code maintainability.

**Operation Safety Improvements:**

* Added a new method `HasPendingOperation` in `AvaloniaPackageOperationHelper` to prevent starting install, update, or uninstall operations on a package that is already queued or being processed. This check is now used throughout the codebase for all relevant operations, reducing race conditions and redundant actions.

**User Experience Enhancements:**

* Improved user feedback for update failures: When an update is not applicable (e.g., no suitable installer found or the package is already up to date), a clear, user-friendly message is now displayed. This includes new logic to detect these cases and a new localized string in `lang_en.json`.

**Internal Logic and Maintainability:**

* Refactored package tag handling so that when an operation is canceled, the package tag is reset to `Default`, ensuring consistent state and preventing packages from being stuck in a queued or processing state.
* Added new tests to verify that canceling install operations (both by the manager and while queued) correctly clears the package tag, improving reliability and test coverage.
