### PR TITLE
Fall back to the system browser when no web view engine is available

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -443,6 +443,8 @@
   "Reload page": "Reload page",
   "View page on browser": "View page on browser",
   "The built-in browser is not supported on Linux yet.": "The built-in browser is not supported on Linux yet.",
+  "The built-in browser requires the Microsoft Edge WebView2 Runtime, which is not installed on this computer.": "The built-in browser requires the Microsoft Edge WebView2 Runtime, which is not installed on this computer.",
+  "The built-in browser could not be loaded on this computer.": "The built-in browser could not be loaded on this computer.",
   "Open in browser": "Open in browser",
   "Copy to clipboard": "Copy to clipboard",
   "Export to a file": "Export to a file",

--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -69,6 +69,19 @@ public partial class App : Application
                     && msg.Contains("child window for native control host"))
                 {
                     e.Handled = true;
+                    return;
+                }
+
+                // #5285: the web view reports adapter-initialization failures from an
+                // `async void` continuation, so they land here instead of at the call site.
+                // NativeWebViewSupport pre-checks the common cause (no WebView2 runtime), but
+                // a runtime that is present and broken can still fail this late.
+                if (NativeWebViewSupport.IsWebViewFailure(e.Exception))
+                {
+                    Logger.Error("The built-in browser failed to initialize; falling back to the system browser");
+                    Logger.Error(e.Exception);
+                    NativeWebViewSupport.MarkUnavailable();
+                    e.Handled = true;
                 }
             };
         }

--- a/src/UniGetUI.Avalonia/Infrastructure/NativeWebViewSupport.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/NativeWebViewSupport.cs
@@ -1,0 +1,255 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+/// <summary>
+/// Tells whether the embedded browser (Avalonia's NativeWebView) can actually be hosted on
+/// this machine, so the Help and Release Notes pages can show an "Open in browser" fallback
+/// instead of embedding a control that blows up while initializing.
+///
+/// #5285: Avalonia picks the WebView2 (Chromium) backend only when it finds the Edge WebView2
+/// runtime in the registry. When it doesn't, it silently falls back to the legacy EdgeHTML
+/// backend (Windows.Web.UI.Interop.WebViewControl). That component was removed from Windows 10
+/// together with legacy Edge, so creating it throws InvalidOperationException (0x80131509,
+/// "Unexpected HRESULT ... from a call to a COM component"). The throw happens inside an
+/// `async void` continuation deep in NativeWebViewControlHost, so nothing at the call site can
+/// catch it: it reaches the dispatcher as an unhandled exception and kills the process.
+/// Portable (zip) installs are the usual victims, since the installer is what normally brings
+/// the WebView2 runtime along.
+///
+/// The detection below deliberately mirrors Avalonia's own ManagedWebView2Loader lookup, so
+/// this class and Avalonia agree on which backend is about to be used.
+/// </summary>
+internal static class NativeWebViewSupport
+{
+    private const string EDGE_UPDATE_CLIENTSTATE_KEY = @"Software\Microsoft\EdgeUpdate\ClientState";
+    private const string BROWSER_FOLDER_OVERRIDE_VAR = "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER";
+
+    // EdgeUpdate channel identifiers, in the order Avalonia probes them.
+    private static readonly string[] CHANNEL_GUIDS =
+    [
+        "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}", // Stable
+        "{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}", // Beta
+        "{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}", // Dev
+        "{65C35B14-6C1D-4122-AC46-7148CC9D6497}", // Canary
+        "{BE59E8FD-089A-411B-A3B0-051D9E417818}", // Internal
+    ];
+
+    // Avalonia types that surface web view *initialization* failures: the two control hosts
+    // that await the adapter from an `async void`, the factory that picks the backend, and
+    // the Windows adapters themselves. The failing frames are the only reliable marker, since
+    // the exception is a plain InvalidOperationException/COMException with no web view
+    // specific type or message.
+    //
+    // Deliberately excludes plain `Avalonia.Controls.NativeWebView` frames: that class also
+    // raises NavigationStarted/NavigationCompleted, so matching it would silently swallow
+    // bugs in our own event handlers instead of letting them surface.
+    private static readonly string[] WEBVIEW_FRAME_MARKERS =
+    [
+        "Avalonia.Controls.NativeWebViewControlHost",
+        "Avalonia.Controls.NativeWebViewCompositorHost",
+        "Avalonia.Controls.WebViewAdapter",
+        "Avalonia.Controls.Win.WebView1",
+        "Avalonia.Controls.Win.WebView2",
+    ];
+
+    private static bool? _isAvailable;
+    private static bool _failedAtRuntime;
+
+    /// <summary>
+    /// Raised (on the UI thread) when a web view that was believed to work failed to
+    /// initialize, so pages currently showing one can switch to their fallback content.
+    /// </summary>
+    public static event Action? BecameUnavailable;
+
+    /// <summary>
+    /// False when embedding a web view is known to fail, in which case callers must not add
+    /// a <see cref="Views.Controls.UniGetUiWebView"/> to the visual tree.
+    /// </summary>
+    public static bool IsAvailable
+    {
+        get
+        {
+            if (_isAvailable is { } cached)
+                return cached;
+
+            bool available = DetectAvailability();
+            _isAvailable = available;
+            return available;
+        }
+    }
+
+    /// <summary>
+    /// Message explaining why the embedded browser is unavailable, ready to show to the user.
+    /// </summary>
+    public static string UnavailableReason
+    {
+        get
+        {
+            // A runtime failure says nothing about what is or isn't installed, so it gets the
+            // generic wording rather than the (possibly wrong) "not installed" one.
+            if (!_failedAtRuntime)
+            {
+                if (OperatingSystem.IsLinux())
+                    return CoreTools.Translate("The built-in browser is not supported on Linux yet.");
+
+                if (OperatingSystem.IsWindows())
+                    return CoreTools.Translate("The built-in browser requires the Microsoft Edge WebView2 Runtime, which is not installed on this computer.");
+            }
+
+            return CoreTools.Translate("The built-in browser could not be loaded on this computer.");
+        }
+    }
+
+    /// <summary>
+    /// Records that the embedded browser cannot be used, so later navigations go straight to
+    /// the fallback instead of retrying a code path that is known to crash.
+    /// </summary>
+    public static void MarkUnavailable()
+    {
+        if (_isAvailable is false)
+            return;
+
+        _isAvailable = false;
+        _failedAtRuntime = true;
+
+        try
+        {
+            BecameUnavailable?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            // Called from the dispatcher's unhandled-exception handler: letting anything
+            // escape here would defeat the point of catching the failure in the first place.
+            Logger.Error("Could not switch the open page to its built-in-browser fallback");
+            Logger.Error(ex);
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="exception"/> came out of web view initialization, and can
+    /// therefore be swallowed instead of taking the process down.
+    /// </summary>
+    public static bool IsWebViewFailure(Exception? exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is AggregateException aggregate)
+            {
+                foreach (Exception inner in aggregate.Flatten().InnerExceptions)
+                {
+                    if (HasWebViewFrame(inner))
+                        return true;
+                }
+            }
+
+            if (HasWebViewFrame(current))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasWebViewFrame(Exception exception)
+    {
+        if (exception.StackTrace is not { Length: > 0 } trace)
+            return false;
+
+        foreach (string marker in WEBVIEW_FRAME_MARKERS)
+        {
+            if (trace.Contains(marker, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool DetectAvailability()
+    {
+        // WKWebView is part of the OS and always available.
+        if (OperatingSystem.IsMacOS())
+            return true;
+
+        // WebKitGTK/WPE are not shipped with UniGetUI, and the Linux pages have always
+        // offered the fallback instead.
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            bool found = HasWebView2Runtime();
+            if (!found)
+            {
+                Logger.Warn("The Edge WebView2 runtime was not found; the built-in browser will be replaced " +
+                            "by a link to the system browser (see issue #5285)");
+            }
+
+            return found;
+        }
+        catch (Exception ex)
+        {
+            // A failed probe must not be treated as "runtime present": embedding the web view
+            // is the crashing path, showing the fallback is not.
+            Logger.Warn("Could not determine whether the Edge WebView2 runtime is installed");
+            Logger.Warn(ex);
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool HasWebView2Runtime()
+    {
+        string? overrideFolder = Environment.GetEnvironmentVariable(BROWSER_FOLDER_OVERRIDE_VAR);
+        if (!string.IsNullOrEmpty(overrideFolder) && File.Exists(GetLoaderPath(overrideFolder)))
+            return true;
+
+        foreach (RegistryHive hive in (ReadOnlySpan<RegistryHive>)[RegistryHive.LocalMachine, RegistryHive.CurrentUser])
+        {
+            foreach (string channelGuid in CHANNEL_GUIDS)
+            {
+                if (HasRuntimeInRegistry(hive, channelGuid))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool HasRuntimeInRegistry(RegistryHive hive, string channelGuid)
+    {
+        using RegistryKey root = RegistryKey.OpenBaseKey(hive, RegistryView.Registry32);
+        using RegistryKey? channel = root.OpenSubKey($@"{EDGE_UPDATE_CLIENTSTATE_KEY}\{channelGuid}");
+        if (channel is null)
+            return false;
+
+        foreach (string valueName in channel.GetValueNames())
+        {
+            if (channel.GetValue(valueName) is not string { Length: > 0 } value)
+                continue;
+
+            bool pointsAtRuntime = valueName is "EBWebView"
+                                   || (value.Contains("EBWebView", StringComparison.Ordinal) && Directory.Exists(value));
+
+            if (pointsAtRuntime && File.Exists(GetLoaderPath(value)))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string GetLoaderPath(string browserFolder)
+        => Path.Combine(browserFolder, "EBWebView", RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.Arm => "arm",
+            Architecture.Arm64 => "arm64",
+            Architecture.X86 => "x86",
+            _ => "x64",
+        }, "EmbeddedBrowserWebView.dll");
+}

--- a/src/UniGetUI.Avalonia/Infrastructure/NativeWebViewSupport.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/NativeWebViewSupport.cs
@@ -60,7 +60,10 @@ internal static class NativeWebViewSupport
     ];
 
     private static bool? _isAvailable;
-    private static bool _failedAtRuntime;
+
+    // Set whenever the web view is unusable for a reason we cannot pin on a missing runtime,
+    // so UnavailableReason stops offering remediation that may not apply.
+    private static bool _causeUnknown;
 
     /// <summary>
     /// Raised (on the UI thread) when a web view that was believed to work failed to
@@ -92,9 +95,10 @@ internal static class NativeWebViewSupport
     {
         get
         {
-            // A runtime failure says nothing about what is or isn't installed, so it gets the
-            // generic wording rather than the (possibly wrong) "not installed" one.
-            if (!_failedAtRuntime)
+            // A runtime failure, or a probe that could not complete, says nothing about what
+            // is or isn't installed: those get the generic wording rather than the (possibly
+            // wrong) "not installed" one.
+            if (!_causeUnknown)
             {
                 if (OperatingSystem.IsLinux())
                     return CoreTools.Translate("The built-in browser is not supported on Linux yet.");
@@ -117,7 +121,7 @@ internal static class NativeWebViewSupport
             return;
 
         _isAvailable = false;
-        _failedAtRuntime = true;
+        _causeUnknown = true;
 
         try
         {
@@ -195,7 +199,10 @@ internal static class NativeWebViewSupport
         catch (Exception ex)
         {
             // A failed probe must not be treated as "runtime present": embedding the web view
-            // is the crashing path, showing the fallback is not.
+            // is the crashing path, showing the fallback is not. It is no proof of absence
+            // either, though, so the user must not be told to go install something they may
+            // well already have.
+            _causeUnknown = true;
             Logger.Warn("Could not determine whether the Edge WebView2 runtime is installed");
             Logger.Warn(ex);
             return false;

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml
@@ -33,51 +33,52 @@
     <Grid RowDefinitions="Auto,2,*" Margin="8,4,8,8">
 
         <!-- Toolbar -->
-        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto" Margin="0,0,0,6">
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,6">
 
-            <Button Grid.Column="0"
-                    x:Name="BackButton"
-                    Classes="nav"
-                    Width="35" Height="35" Padding="6"
-                    CornerRadius="4,0,0,4"
-                    automation:AutomationProperties.Name="{t:Translate Go back}"
-                    Click="BackButton_Click">
-                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/backward.svg"
-                                  Width="16" Height="16"/>
-            </Button>
+            <!-- Grouped so the whole set can be hidden when the built-in browser is unavailable -->
+            <StackPanel Grid.Column="0" x:Name="NavigationButtons" Orientation="Horizontal">
 
-            <Button Grid.Column="1"
-                    x:Name="ForwardButton"
-                    Classes="nav"
-                    Width="35" Height="35" Padding="6"
-                    CornerRadius="0"
-                    automation:AutomationProperties.Name="{t:Translate Go forward}"
-                    Click="ForwardButton_Click">
-                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/forward.svg"
-                                  Width="16" Height="16"/>
-            </Button>
+                <Button x:Name="BackButton"
+                        Classes="nav"
+                        Width="35" Height="35" Padding="6"
+                        CornerRadius="4,0,0,4"
+                        automation:AutomationProperties.Name="{t:Translate Go back}"
+                        Click="BackButton_Click">
+                    <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/backward.svg"
+                                      Width="16" Height="16"/>
+                </Button>
+
+                <Button x:Name="ForwardButton"
+                        Classes="nav"
+                        Width="35" Height="35" Padding="6"
+                        CornerRadius="0"
+                        automation:AutomationProperties.Name="{t:Translate Go forward}"
+                        Click="ForwardButton_Click">
+                    <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/forward.svg"
+                                      Width="16" Height="16"/>
+                </Button>
+
+                <Button Classes="nav"
+                        Width="35" Height="35" Padding="6"
+                        CornerRadius="0"
+                        automation:AutomationProperties.Name="{t:Translate Go to home page}"
+                        Click="HomeButton_Click">
+                    <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/home.svg"
+                                      Width="16" Height="16"/>
+                </Button>
+
+                <Button Classes="nav"
+                        Width="35" Height="35" Padding="6"
+                        CornerRadius="0,4,4,0"
+                        automation:AutomationProperties.Name="{t:Translate Reload page}"
+                        Click="ReloadButton_Click">
+                    <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/reload.svg"
+                                      Width="16" Height="16"/>
+                </Button>
+
+            </StackPanel>
 
             <Button Grid.Column="2"
-                    Classes="nav"
-                    Width="35" Height="35" Padding="6"
-                    CornerRadius="0"
-                    automation:AutomationProperties.Name="{t:Translate Go to home page}"
-                    Click="HomeButton_Click">
-                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/home.svg"
-                                  Width="16" Height="16"/>
-            </Button>
-
-            <Button Grid.Column="3"
-                    Classes="nav"
-                    Width="35" Height="35" Padding="6"
-                    CornerRadius="0,4,4,0"
-                    automation:AutomationProperties.Name="{t:Translate Reload page}"
-                    Click="ReloadButton_Click">
-                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/reload.svg"
-                                  Width="16" Height="16"/>
-            </Button>
-
-            <Button Grid.Column="5"
                     Classes="flat"
                     Height="35"
                     Command="{Binding OpenInBrowserCommand}"
@@ -102,11 +103,12 @@
             <controls:UniGetUiWebView x:Name="WebViewControl"/>
         </Border>
 
-        <!-- Linux fallback -->
-        <StackPanel x:Name="LinuxFallbackPanel" Grid.Row="2"
+        <!-- Shown instead of the web view when no usable browser engine is embeddable
+             (Linux, or Windows without the Edge WebView2 runtime — see #5285) -->
+        <StackPanel x:Name="WebViewFallbackPanel" Grid.Row="2"
                     HorizontalAlignment="Center" VerticalAlignment="Center"
                     Spacing="12" IsVisible="False">
-            <TextBlock Text="{t:Translate The built-in browser is not supported on Linux yet.}"
+            <TextBlock x:Name="WebViewFallbackMessage"
                        TextAlignment="Center" TextWrapping="Wrap" MaxWidth="400"/>
             <Button Classes="flat" HorizontalAlignment="Center" Command="{Binding OpenInBrowserCommand}">
                 <TextBlock Text="{t:Translate Open in browser}"

--- a/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/HelpPage.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels.Pages;
 
 namespace UniGetUI.Avalonia.Views.Pages;
@@ -9,6 +10,7 @@ public partial class HelpPage : UserControl, IEnterLeaveListener, IDisposable
     private readonly HelpPageViewModel _viewModel;
     private string _pendingNavigation = HelpPageViewModel.HelpBaseUrl;
     private bool _adapterReady;
+    private bool _webViewDisabled;
     private bool _disposed;
 
     public HelpPage()
@@ -17,18 +19,29 @@ public partial class HelpPage : UserControl, IEnterLeaveListener, IDisposable
         DataContext = _viewModel;
         InitializeComponent();
 
-        if (OperatingSystem.IsLinux())
+        // #5285: embedding a web view where no browser engine can be hosted crashes the
+        // process from an async continuation we cannot catch, so the control must never
+        // reach the visual tree in that case.
+        if (!NativeWebViewSupport.IsAvailable)
         {
-            WebViewBorder.IsVisible = false;
-            LinuxFallbackPanel.IsVisible = true;
+            ShowFallback();
             return;
         }
 
+        NativeWebViewSupport.BecameUnavailable += ShowFallback;
+
+        // Every handler below bails out once the page has switched to the fallback: a
+        // callback still in flight at that point must not repaint over it or revive the
+        // web view state.
         WebViewControl.NavigationStarted += (_, _) =>
+        {
+            if (_webViewDisabled) return;
             NavProgressBar.IsVisible = true;
+        };
 
         WebViewControl.NavigationCompleted += (_, e) =>
         {
+            if (_webViewDisabled) return;
             NavProgressBar.IsVisible = false;
             _viewModel.CurrentUrl = WebViewControl.Source?.ToString() ?? HelpPageViewModel.HelpBaseUrl;
             BackButton.IsEnabled = WebViewControl.CanGoBack;
@@ -40,6 +53,7 @@ public partial class HelpPage : UserControl, IEnterLeaveListener, IDisposable
         // This mirrors WinUI's EnsureCoreWebView2Async() pattern.
         WebViewControl.AdapterCreated += (_, _) =>
         {
+            if (_webViewDisabled) return;
             _adapterReady = true;
             WebViewControl.Navigate(new Uri(_pendingNavigation));
         };
@@ -49,35 +63,62 @@ public partial class HelpPage : UserControl, IEnterLeaveListener, IDisposable
     {
         string url = _viewModel.GetInitialUrl(uriAttachment);
         _pendingNavigation = url;
+        _viewModel.CurrentUrl = url;
         if (_adapterReady)
             WebViewControl.Navigate(new Uri(url));
     }
 
     public void OnEnter()
     {
-        if (_adapterReady)
+        if (!_webViewDisabled && _adapterReady)
             WebViewControl.Navigate(new Uri(_pendingNavigation));
     }
 
     public void OnLeave() { }
 
+    // Swaps the web view for a message plus the "Open in browser" button. Detaching the
+    // control (rather than just hiding it) is what keeps it from initializing, since a
+    // collapsed control is still attached to the visual tree.
+    private void ShowFallback()
+    {
+        if (_webViewDisabled) return;
+        _webViewDisabled = true;
+        _adapterReady = false;
+
+        WebViewFallbackMessage.Text = NativeWebViewSupport.UnavailableReason;
+        WebViewFallbackPanel.IsVisible = true;
+        NavProgressBar.IsVisible = false;
+        NavigationButtons.IsVisible = false;
+        WebViewBorder.IsVisible = false;
+
+        // Last, because tearing down an already-broken native control can throw: by now the
+        // page is usable regardless of what happens here.
+        WebViewBorder.Child = null;
+    }
+
     private void BackButton_Click(object? sender, RoutedEventArgs e)
     {
-        if (WebViewControl.CanGoBack)
+        if (!_webViewDisabled && WebViewControl.CanGoBack)
             WebViewControl.GoBack();
     }
 
     private void ForwardButton_Click(object? sender, RoutedEventArgs e)
     {
-        if (WebViewControl.CanGoForward)
+        if (!_webViewDisabled && WebViewControl.CanGoForward)
             WebViewControl.GoForward();
     }
 
-    private void HomeButton_Click(object? sender, RoutedEventArgs e) =>
+    private void HomeButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_webViewDisabled) return;
         WebViewControl.Navigate(new Uri(HelpPageViewModel.HelpBaseUrl));
+    }
 
-    private void ReloadButton_Click(object? sender, RoutedEventArgs e) =>
+    private void ReloadButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_webViewDisabled) return;
         WebViewControl.Refresh();
+    }
 
     // Detach the WebView so its WebView2 host/controller is released; the page is
     // rebuilt fresh on next visit (MainWindowViewModel drops the cached instance).
@@ -85,8 +126,9 @@ public partial class HelpPage : UserControl, IEnterLeaveListener, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        if (!OperatingSystem.IsLinux())
-            WebViewControl.Stop();
+        NativeWebViewSupport.BecameUnavailable -= ShowFallback;
+        if (_webViewDisabled) return;
+        WebViewControl.Stop();
         WebViewBorder.Child = null;
     }
 }

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml
@@ -47,11 +47,12 @@
             <controls:UniGetUiWebView x:Name="WebViewControl"/>
         </Border>
 
-        <!-- Linux fallback -->
-        <StackPanel x:Name="LinuxFallbackPanel" Grid.Row="2"
+        <!-- Shown instead of the web view when no usable browser engine is embeddable
+             (Linux, or Windows without the Edge WebView2 runtime — see #5285) -->
+        <StackPanel x:Name="WebViewFallbackPanel" Grid.Row="2"
                     HorizontalAlignment="Center" VerticalAlignment="Center"
                     Spacing="12" IsVisible="False">
-            <TextBlock Text="{t:Translate The built-in browser is not supported on Linux yet.}"
+            <TextBlock x:Name="WebViewFallbackMessage"
                        TextAlignment="Center" TextWrapping="Wrap" MaxWidth="400"/>
             <Button HorizontalAlignment="Center" Command="{Binding OpenInBrowserCommand}">
                 <TextBlock Text="{t:Translate Open in browser}"

--- a/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/Pages/ReleaseNotesPage.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using UniGetUI.Avalonia.Infrastructure;
 using UniGetUI.Avalonia.ViewModels.Pages;
 
 namespace UniGetUI.Avalonia.Views.Pages;
@@ -8,6 +9,7 @@ public partial class ReleaseNotesPage : UserControl, IEnterLeaveListener, IDispo
     private readonly ReleaseNotesPageViewModel _viewModel;
     private bool _loaded;
     private bool _adapterReady;
+    private bool _webViewDisabled;
     private bool _disposed;
 
     public ReleaseNotesPage()
@@ -16,24 +18,36 @@ public partial class ReleaseNotesPage : UserControl, IEnterLeaveListener, IDispo
         DataContext = _viewModel;
         InitializeComponent();
 
-        if (OperatingSystem.IsLinux())
+        // #5285: embedding a web view where no browser engine can be hosted crashes the
+        // process from an async continuation we cannot catch, so the control must never
+        // reach the visual tree in that case.
+        if (!NativeWebViewSupport.IsAvailable)
         {
-            WebViewBorder.IsVisible = false;
-            LinuxFallbackPanel.IsVisible = true;
+            ShowFallback();
             return;
         }
 
+        NativeWebViewSupport.BecameUnavailable += ShowFallback;
+
+        // Every handler below bails out once the page has switched to the fallback: a
+        // callback still in flight at that point must not repaint over it or revive the
+        // web view state.
         WebViewControl.NavigationStarted += (_, _) =>
+        {
+            if (_webViewDisabled) return;
             NavProgressBar.IsVisible = true;
+        };
 
         WebViewControl.NavigationCompleted += (_, e) =>
         {
+            if (_webViewDisabled) return;
             NavProgressBar.IsVisible = false;
             _viewModel.CurrentUrl = WebViewControl.Source?.ToString() ?? _viewModel.ReleaseNotesUrl;
         };
 
         WebViewControl.AdapterCreated += (_, _) =>
         {
+            if (_webViewDisabled) return;
             _adapterReady = true;
             if (!_loaded)
             {
@@ -45,7 +59,7 @@ public partial class ReleaseNotesPage : UserControl, IEnterLeaveListener, IDispo
 
     public void OnEnter()
     {
-        if (!_loaded && _adapterReady)
+        if (!_webViewDisabled && !_loaded && _adapterReady)
         {
             WebViewControl.Navigate(new Uri(_viewModel.ReleaseNotesUrl));
             _loaded = true;
@@ -54,14 +68,34 @@ public partial class ReleaseNotesPage : UserControl, IEnterLeaveListener, IDispo
 
     public void OnLeave() { }
 
+    // Swaps the web view for a message plus the "Open in browser" button. Detaching the
+    // control (rather than just hiding it) is what keeps it from initializing, since a
+    // collapsed control is still attached to the visual tree.
+    private void ShowFallback()
+    {
+        if (_webViewDisabled) return;
+        _webViewDisabled = true;
+        _adapterReady = false;
+
+        WebViewFallbackMessage.Text = NativeWebViewSupport.UnavailableReason;
+        WebViewFallbackPanel.IsVisible = true;
+        NavProgressBar.IsVisible = false;
+        WebViewBorder.IsVisible = false;
+
+        // Last, because tearing down an already-broken native control can throw: by now the
+        // page is usable regardless of what happens here.
+        WebViewBorder.Child = null;
+    }
+
     // Detach the WebView so its WebView2 host/controller is released; the page is
     // rebuilt fresh on next visit (MainWindowViewModel drops the cached instance).
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        if (!OperatingSystem.IsLinux())
-            WebViewControl.Stop();
+        NativeWebViewSupport.BecameUnavailable -= ShowFallback;
+        if (_webViewDisabled) return;
+        WebViewControl.Stop();
         WebViewBorder.Child = null;
     }
 }


### PR DESCRIPTION
This pull request improves the reliability of the built-in browser (WebView) on Windows by detecting when the required Microsoft Edge WebView2 Runtime is missing or broken. It prevents crashes by proactively disabling the embedded browser and providing clear fallback messaging and UI. The changes also generalize the fallback mechanism for both the Help and Release Notes pages, ensuring users are guided to open content in their system browser when embedding is not possible.

**Built-in browser reliability and fallback improvements:**

* Added a new `NativeWebViewSupport` class to detect if the Edge WebView2 Runtime is available and working, mirroring Avalonia's own detection logic. This prevents the app from crashing by avoiding attempts to embed a web view when the runtime is missing or broken.
* Updated the global unhandled exception handler in `App.axaml.cs` to recognize and gracefully handle web view initialization failures, logging the error and switching to the fallback UI instead of crashing.
* Refactored the Help and Release Notes pages (`HelpPage.axaml`, `ReleaseNotesPage.axaml`, and their code-behind files) to use a unified fallback panel (`WebViewFallbackPanel`) with a dynamic message when the embedded browser is unavailable. The navigation button group is also hidden in this state. 
* Added new user-facing messages to `lang_en.json` to explain why the built-in browser is unavailable, distinguishing between unsupported platforms and missing or broken runtimes.

**UI and code structure enhancements:**

* Grouped navigation buttons in the Help page toolbar for easier visibility toggling and improved layout when the embedded browser is unavailable.
* Updated event handling and disposal logic in `HelpPage.axaml.cs` to ensure the web view is only interacted with when enabled, and to clean up event subscriptions properly.

These changes significantly improve user experience and application stability when the built-in browser cannot be used.
