### PR TITLE
Square the window corners while maximized

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -90,6 +90,10 @@ public partial class MainWindow : Window
     private const uint WM_MOUSEMOVE = 0x0200;
     private const uint WM_SYSCOMMAND = 0x0112;
     private const uint WM_SETTINGCHANGE = 0x001A;
+    private const uint WM_SIZE = 0x0005;
+    private const uint WM_SHOWWINDOW = 0x0018;
+    private const nint SIZE_RESTORED = 0;
+    private const nint SIZE_MAXIMIZED = 2;
     private const uint WM_DWMCOLORIZATIONCOLORCHANGED = 0x0320;
     private const nint SC_MAXIMIZE = 0xF030;
     private const nint SC_RESTORE = 0xF120;
@@ -112,6 +116,7 @@ public partial class MainWindow : Window
     // accent-colored window border that tracks focus.
     private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
     private const int DWMWA_BORDER_COLOR = 34;
+    private const int DWMWCP_DONOTROUND = 1;
     private const int DWMWCP_ROUND = 2;
     private const int WINDOW_BORDER_COLOR_LIGHT = 0x00B9B9B9;
     private const int WINDOW_BORDER_COLOR_DARK = 0x004A4A4A;
@@ -218,6 +223,7 @@ public partial class MainWindow : Window
         }
 
         SetupMicaAndAccentBorder();
+        UpdateWindowCornerPreference();
 
         ActualThemeVariantChanged += (_, _) =>
         {
@@ -1042,15 +1048,23 @@ public partial class MainWindow : Window
             return;
         }
 
-        // The custom NCCALCSIZE frame keeps WS_THICKFRAME, so DWM still has a frame to round.
-        int corner = DWMWCP_ROUND;
-        NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
-
         // Transparent window + transparent MicaPageBackground (from Styles.WindowsMica) let
         // the backdrop show through the chrome and page area.
         Background = Brushes.Transparent;
 
         ApplyWindowBorderColor(handle);
+    }
+
+    private void UpdateWindowCornerPreference()
+    {
+        if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            return;
+
+        if (TryGetPlatformHandle()?.Handle is not { } handle || handle == 0)
+            return;
+
+        int corner = WindowState == WindowState.Normal ? DWMWCP_ROUND : DWMWCP_DONOTROUND;
+        NativeMethods.DwmSetWindowAttribute(handle, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
     }
 
     private void ApplyWindowBorderColor(nint handle)
@@ -1091,6 +1105,12 @@ public partial class MainWindow : Window
             && Instance is { } borderOwner && MicaWindowHelper.IsMicaEnabled())
         {
             borderOwner.ApplyWindowBorderColor(hWnd);
+        }
+
+        if ((msg == WM_SHOWWINDOW || (msg == WM_SIZE && (wParam == SIZE_RESTORED || wParam == SIZE_MAXIMIZED)))
+            && Instance is { } cornerOwner)
+        {
+            Dispatcher.UIThread.Post(cornerOwner.UpdateWindowCornerPreference);
         }
 
         if (msg == WM_SETTINGCHANGE && Instance is { } trayOwner)


### PR DESCRIPTION
This pull request enhances the window appearance handling in `MainWindow.axaml.cs`, specifically improving how window corner rounding is managed based on window state (normal or maximized). The changes ensure the window's corner preference updates dynamically, providing a more native and visually consistent look on Windows 11.

**Window Appearance Improvements:**

* Added constants for new window messages and corner rounding options, including `WM_SIZE`, `WM_SHOWWINDOW`, `SIZE_RESTORED`, `SIZE_MAXIMIZED`, and `DWMWCP_DONOTROUND`, to support more granular window state detection. 
* Introduced the `UpdateWindowCornerPreference` method to set rounded corners only when the window is in the normal state, and square corners when maximized, using `DwmSetWindowAttribute`.
* Called `UpdateWindowCornerPreference` during window opening and in response to relevant window messages (`WM_SHOWWINDOW`, `WM_SIZE`), ensuring corner appearance updates automatically as the window is shown or resized.

These changes collectively improve the visual integration of the application's window with the operating system, especially on Windows 11.