### PR TITLE
Never show the main window on a daemon launch

### DIFF
--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -149,19 +149,6 @@ public partial class App : Application
             };
         }
 
-        if (CoreData.WasDaemon)
-        {
-            // Start silently: hide the window on first open only.
-            // Opened fires on every Show() in Avalonia, so we must unsubscribe
-            // immediately or every ShowFromTray() call would hide the window again.
-            void HideOnce(object? s, EventArgs e)
-            {
-                mainWindow.Opened -= HideOnce;
-                mainWindow.Hide();
-            }
-            mainWindow.Opened += HideOnce;
-        }
-
         if (splash is not null)
         {
             var splashRef = splash;
@@ -173,9 +160,10 @@ public partial class App : Application
             mainWindow.Opened += CloseSplashOnce;
         }
 
-        // Framework auto-show already passed (we deferred via Dispatcher.Post),
-        // so we have to open the window ourselves.
-        mainWindow.Show();
+        // Framework auto-show already passed (we deferred via Dispatcher.Post), so we have to
+        // open the window ourselves. Daemon mode never shows it at all.
+        if (!CoreData.WasDaemon)
+            mainWindow.Show();
 
         _ = StartupAsync(mainWindow);
     }
@@ -194,9 +182,9 @@ public partial class App : Application
                 // ShowDialog tries to attach to it as owner.
                 await Task.Yield();
 
-                // ShowDialog requires a visible owner. In daemon mode the main window
-                // is hidden, so temporarily show it and re-hide after the dialog closes.
-                bool reshide = CoreData.WasDaemon;
+                // The dialog is hosted inside the main window, so it is only reachable while
+                // that window is on screen. Bring it up for the dialog and put it back after.
+                bool reshide = !mainWindow.IsVisible;
                 if (reshide) mainWindow.Show();
                 await new CrashReportWindow(report).ShowDialog(mainWindow);
                 if (reshide) mainWindow.Hide();

--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -182,12 +182,7 @@ public partial class App : Application
                 // ShowDialog tries to attach to it as owner.
                 await Task.Yield();
 
-                // The dialog is hosted inside the main window, so it is only reachable while
-                // that window is on screen. Bring it up for the dialog and put it back after.
-                bool reshide = !mainWindow.IsVisible;
-                if (reshide) mainWindow.Show();
-                await new CrashReportWindow(report).ShowDialog(mainWindow);
-                if (reshide) mainWindow.Hide();
+                await mainWindow.ShowDialogAndRestoreVisibilityAsync(new CrashReportWindow(report));
             }
             catch { /* must not prevent normal startup */ }
         }

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -91,14 +91,30 @@ internal static class AvaloniaBootstrapper
     private static async Task ShowIntegrityViolationDialogAsync()
     {
         if (MainWindow.Instance is not { } owner) return;
-        await new IntegrityViolationDialog().ShowDialog(owner);
+        await ShowStartupDialogAsync(owner, new IntegrityViolationDialog());
     }
 
     private static async Task ShowMissingDependencyDialogAsync(
         ManagerDependency dep, int current, int total)
     {
         if (MainWindow.Instance is not { } owner) return;
-        await new MissingDependencyDialog(dep, current, total).ShowDialog(owner);
+        await ShowStartupDialogAsync(owner, new MissingDependencyDialog(dep, current, total));
+    }
+
+    // Startup dialogs live inside the main window, so they are unreachable — and never complete —
+    // while it is off screen (daemon launch). Bring it up for the dialog and put it back after.
+    private static async Task ShowStartupDialogAsync(MainWindow owner, ImmersiveDialog dialog)
+    {
+        bool reshide = !owner.IsVisible;
+        if (reshide) owner.Show();
+        try
+        {
+            await dialog.ShowDialog(owner);
+        }
+        finally
+        {
+            if (reshide) owner.Hide();
+        }
     }
 
     private static Task InitializeSharedServicesAsync()

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -91,30 +91,14 @@ internal static class AvaloniaBootstrapper
     private static async Task ShowIntegrityViolationDialogAsync()
     {
         if (MainWindow.Instance is not { } owner) return;
-        await ShowStartupDialogAsync(owner, new IntegrityViolationDialog());
+        await owner.ShowDialogAndRestoreVisibilityAsync(new IntegrityViolationDialog());
     }
 
     private static async Task ShowMissingDependencyDialogAsync(
         ManagerDependency dep, int current, int total)
     {
         if (MainWindow.Instance is not { } owner) return;
-        await ShowStartupDialogAsync(owner, new MissingDependencyDialog(dep, current, total));
-    }
-
-    // Startup dialogs live inside the main window, so they are unreachable — and never complete —
-    // while it is off screen (daemon launch). Bring it up for the dialog and put it back after.
-    private static async Task ShowStartupDialogAsync(MainWindow owner, ImmersiveDialog dialog)
-    {
-        bool reshide = !owner.IsVisible;
-        if (reshide) owner.Show();
-        try
-        {
-            await dialog.ShowDialog(owner);
-        }
-        finally
-        {
-            if (reshide) owner.Hide();
-        }
+        await owner.ShowDialogAndRestoreVisibilityAsync(new MissingDependencyDialog(dep, current, total));
     }
 
     private static Task InitializeSharedServicesAsync()

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1561,6 +1561,25 @@ public partial class MainWindow : Window
         await ShowImmersiveDialogAsync(dialog);
     }
 
+    // Immersive dialogs are hosted inside this window, so they are unreachable — and never complete —
+    // while it is off screen (daemon launch). Bring it up for the dialog and put it back after.
+    public async Task ShowDialogAndRestoreVisibilityAsync(ImmersiveDialog dialog)
+    {
+        bool reshide = !IsVisible;
+        if (reshide)
+            Show();
+
+        try
+        {
+            await dialog.ShowDialog(this);
+        }
+        finally
+        {
+            if (reshide)
+                Hide();
+        }
+    }
+
     public async Task ShowImmersiveDialogAsync(ImmersiveDialog dialog)
     {
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -829,6 +829,11 @@ public partial class MainWindow : Window
     {
         try
         {
+            // Width/Height stay NaN until the window has been laid out, which never happens on a
+            // daemon launch the user has not opened yet. Saving then would persist a 0x0 size.
+            if (double.IsNaN(Width) || double.IsNaN(Height))
+                return;
+
             int state = WindowState == WindowState.Maximized ? 1 : 0;
             string geometry = $"v2,{Position.X},{Position.Y},{(int)Width},{(int)Height},{state}";
             Settings.SetValue(Settings.K.WindowGeometry, geometry);


### PR DESCRIPTION
This pull request refactors how the main window is managed during daemon (background) launches and when showing dialogs at startup. The changes ensure that the main window is only shown when necessary, preventing unwanted window flashes and fixing issues where dialogs could not be displayed if the window was hidden. It also prevents saving invalid window geometry when the window hasn't been displayed yet.

**Window visibility and dialog management:**

* The logic that auto-hides the main window on first open during daemon launches has been removed, so the window is only shown if needed, preventing unnecessary window flashes.
* The main window is now only shown at startup if not in daemon mode, ensuring that daemon launches remain silent and do not display the main window.
* Dialogs that require the main window as an owner (such as crash reports and startup dialogs) now temporarily show the main window if it is hidden, and re-hide it after the dialog closes. This is implemented with a new helper method `ShowStartupDialogAsync` for consistency. 

**Window geometry persistence:**

* The `SaveGeometryNow` method now checks if the window has been laid out (i.e., has valid width and height) before saving geometry, preventing saving a 0x0 window size when the window hasn't been shown (such as in daemon launches).