### PR TITLE
Report PowerShell 5.x module operation failures instead of success

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.PowerShell/Helpers/PowerShellPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell/Helpers/PowerShellPkgOperationHelper.cs
@@ -7,6 +7,8 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager;
 
 internal sealed class PowerShellPkgOperationHelper : BasePkgOperationHelper
 {
+    internal const string ErrorVariableName = "UniGetUIOperationError";
+
     public PowerShellPkgOperationHelper(PowerShell manager)
         : base(manager) { }
 
@@ -53,18 +55,29 @@ internal sealed class PowerShellPkgOperationHelper : BasePkgOperationHelper
                 parameters.AddRange(["-RequiredVersion", options.Version]);
         }
 
-        parameters.AddRange(
-            operation switch
-            {
-                OperationType.Update => options.CustomParameters_Update,
-                OperationType.Uninstall => options.CustomParameters_Uninstall,
-                _ => options.CustomParameters_Install,
-            }
+        IReadOnlyList<string> customParameters = operation switch
+        {
+            OperationType.Update => options.CustomParameters_Update,
+            OperationType.Uninstall => options.CustomParameters_Uninstall,
+            _ => options.CustomParameters_Install,
+        };
+
+        bool bindsOwnErrorVariable = customParameters.Any(parameter =>
+            parameter.StartsWith("-ev", StringComparison.OrdinalIgnoreCase)
+            || parameter.StartsWith("-errorv", StringComparison.OrdinalIgnoreCase)
         );
+
+        if (!bindsOwnErrorVariable)
+            parameters.AddRange(["-ErrorVariable", ErrorVariableName]);
+
+        parameters.AddRange(customParameters);
 
         // Windows PowerShell 5.x defaults to TLS 1.0/1.1, which the PowerShell Gallery rejects; force TLS 1.2 so gallery operations can connect under -NoProfile
         if (operation is not OperationType.Uninstall)
             parameters.Insert(0, "[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;");
+
+        if (!bindsOwnErrorVariable)
+            parameters.Add($";if(${ErrorVariableName}){{exit(1)}}");
 
         return parameters;
     }

--- a/src/UniGetUI.PackageEngine.Tests/PowerShellManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PowerShellManagerTests.cs
@@ -95,6 +95,58 @@ public sealed class PowerShellManagerTests
         Assert.DoesNotContain("-Scope", parameters);
     }
 
+    [Theory]
+    [InlineData(OperationType.Install)]
+    [InlineData(OperationType.Update)]
+    [InlineData(OperationType.Uninstall)]
+    public void GetParameters_PropagatesNonTerminatingErrorsToTheExitCode(OperationType operation)
+    {
+        var manager = new PowerShell();
+        var package = BuildInstalledPackage(manager);
+
+        var parameters = manager.OperationHelper.GetParameters(package, new InstallOptions(), operation);
+
+        var errorVariableIndex = parameters.ToList().IndexOf("-ErrorVariable");
+        Assert.True(errorVariableIndex >= 0);
+        Assert.Equal(PowerShellPkgOperationHelper.ErrorVariableName, parameters[errorVariableIndex + 1]);
+        Assert.Equal(
+            $";if(${PowerShellPkgOperationHelper.ErrorVariableName}){{exit(1)}}",
+            parameters[^1]
+        );
+    }
+
+    [Theory]
+    [InlineData("-ErrorVariable")]
+    [InlineData("-ev")]
+    [InlineData("-errorvariable:mine")]
+    public void GetParameters_YieldsToACustomErrorVariable(string customParameter)
+    {
+        var manager = new PowerShell();
+        var package = BuildInstalledPackage(manager);
+
+        var options = new InstallOptions { CustomParameters_Update = [customParameter, "mine"] };
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.DoesNotContain(PowerShellPkgOperationHelper.ErrorVariableName, parameters);
+        Assert.DoesNotContain(
+            $";if(${PowerShellPkgOperationHelper.ErrorVariableName}){{exit(1)}}",
+            parameters
+        );
+    }
+
+    [Fact]
+    public void GetParameters_KeepsCustomParametersBoundToTheCmdlet()
+    {
+        var manager = new PowerShell();
+        var package = BuildInstalledPackage(manager);
+
+        var options = new InstallOptions { CustomParameters_Update = ["-Proxy", "http://proxy"] };
+        var parameters = manager.OperationHelper.GetParameters(package, options, OperationType.Update);
+
+        Assert.Equal("-Proxy", parameters[^3]);
+        Assert.Equal("http://proxy", parameters[^2]);
+    }
+
     [Fact]
     public void Capabilities_ScopeAppliesToInstallOnly()
     {


### PR DESCRIPTION
This pull request improves error handling in PowerShell package operations by ensuring that non-terminating errors are properly propagated to the exit code, unless the user explicitly overrides error variable handling. It also adds comprehensive tests to verify this behavior.

**PowerShell error handling improvements:**
- Added a constant `ErrorVariableName` to `PowerShellPkgOperationHelper` to standardize the error variable used for capturing errors.
- Modified parameter generation logic in `PowerShellPkgOperationHelper` to automatically add `-ErrorVariable` and an exit code check (`;if($ErrorVariableName){exit(1)}`) unless custom error variable parameters are supplied by the user.

**Testing enhancements:**
- Added tests to ensure non-terminating errors are correctly propagated to the exit code for all operation types, and that custom error variable parameters are respected and not overridden.
