### PR TITLE
Load bundle files passed on the command line

### DIFF
--- a/src/Shared/StartupBundleArguments.cs
+++ b/src/Shared/StartupBundleArguments.cs
@@ -1,0 +1,107 @@
+using UniGetUI.Interface;
+
+namespace UniGetUI.Shared;
+
+internal static class StartupBundleArguments
+{
+    private static readonly string[] BundleExtensions = [".ubundle", ".json", ".yaml", ".xml"];
+
+    private static readonly string[] ValueTakingArguments =
+    [
+        IpcTransportOptions.TransportArgument,
+        IpcTransportOptions.TcpPortArgument,
+        IpcTransportOptions.NamedPipeArgument,
+        IpcTransportOptions.CliTransportArgument,
+        IpcTransportOptions.CliTcpPortArgument,
+        IpcTransportOptions.CliNamedPipeArgument,
+    ];
+
+    public static List<string> Resolve(IReadOnlyList<string> args, string workingDirectory)
+    {
+        List<string> bundles = [];
+        foreach ((_, string path) in Enumerate(args, workingDirectory))
+        {
+            bundles.Add(path);
+        }
+
+        return bundles;
+    }
+
+    public static string[] Normalize(IReadOnlyList<string> args, string workingDirectory)
+    {
+        string[] normalized = [.. args];
+        foreach ((int index, string path) in Enumerate(args, workingDirectory))
+        {
+            normalized[index] = path;
+        }
+
+        return normalized;
+    }
+
+    private static IEnumerable<(int Index, string Path)> Enumerate(
+        IReadOnlyList<string> args,
+        string workingDirectory
+    )
+    {
+        for (int i = 0; i < args.Count; i++)
+        {
+            string arg = Unquote(args[i]);
+
+            if (arg.StartsWith('-'))
+            {
+                if (ValueTakingArguments.Contains(arg, StringComparer.Ordinal))
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (TryResolveBundleFile(arg, workingDirectory, out string path))
+            {
+                yield return (i, path);
+            }
+        }
+    }
+
+    private static bool TryResolveBundleFile(string arg, string workingDirectory, out string fullPath)
+    {
+        fullPath = string.Empty;
+
+        if (arg.Length == 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!BundleExtensions.Contains(Path.GetExtension(arg), StringComparer.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            string candidate = Path.GetFullPath(arg, workingDirectory);
+            if (!File.Exists(candidate))
+            {
+                return false;
+            }
+
+            fullPath = candidate;
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static string Unquote(string arg)
+    {
+        if (arg.Length > 1 && (arg[0] == '"' || arg[0] == '\'') && arg[^1] == arg[0])
+        {
+            return arg[1..^1];
+        }
+
+        return arg;
+    }
+}

--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -188,6 +188,14 @@ public partial class App : Application
         }
 
         await AvaloniaBootstrapper.InitializeAsync();
+
+        if (CoreData.WasDaemon)
+        {
+            StartupArgumentProcessor.WarnIfBundlesIgnored(
+                args, $"the launch requested {AvaloniaCliHandler.DAEMON}");
+            return;
+        }
+
         await StartupArgumentProcessor.ProcessAsync(args);
     }
 

--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -165,10 +165,10 @@ public partial class App : Application
         if (!CoreData.WasDaemon)
             mainWindow.Show();
 
-        _ = StartupAsync(mainWindow);
+        _ = StartupAsync(mainWindow, desktop.Args ?? []);
     }
 
-    private static async Task StartupAsync(MainWindow mainWindow)
+    private static async Task StartupAsync(MainWindow mainWindow, string[] args)
     {
         // Show crash report from the previous session and wait for the user
         // to dismiss it before continuing with normal startup.
@@ -188,6 +188,7 @@ public partial class App : Application
         }
 
         await AvaloniaBootstrapper.InitializeAsync();
+        await StartupArgumentProcessor.ProcessAsync(args);
     }
 
     private static void HandleSecondaryInstanceArgs(MainWindow mainWindow, string[] args)
@@ -214,6 +215,8 @@ public partial class App : Application
             return;
 
         mainWindow.ShowFromTray();
+
+        _ = StartupArgumentProcessor.ProcessAsync(args);
     }
 
     public static void ApplyTheme(string value)

--- a/src/UniGetUI.Avalonia/App.axaml.cs
+++ b/src/UniGetUI.Avalonia/App.axaml.cs
@@ -212,7 +212,11 @@ public partial class App : Application
         }
 
         if (isDaemonLaunch)
+        {
+            StartupArgumentProcessor.WarnIfBundlesIgnored(
+                args, $"the launch requested {AvaloniaCliHandler.DAEMON}");
             return;
+        }
 
         mainWindow.ShowFromTray();
 

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
@@ -19,7 +19,41 @@ public static class AvaloniaAppHost
     private static Mutex? _singleInstanceMutex;
     private static FileStream? _singleInstanceLock;
 
-    public static event Action<string[]>? SecondaryInstanceArgsReceived;
+    private static Action<string[]>? _secondaryInstanceArgsReceived;
+    private static readonly Queue<string[]> _bufferedSecondaryInstanceArgs = new();
+
+    public static event Action<string[]>? SecondaryInstanceArgsReceived
+    {
+        add
+        {
+            _secondaryInstanceArgsReceived += value;
+
+            if (value is null || _bufferedSecondaryInstanceArgs.Count == 0)
+                return;
+
+            string[][] buffered = [.. _bufferedSecondaryInstanceArgs];
+            _bufferedSecondaryInstanceArgs.Clear();
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                foreach (string[] bufferedArgs in buffered)
+                    value(bufferedArgs);
+            });
+        }
+        remove => _secondaryInstanceArgsReceived -= value;
+    }
+
+    private static void RaiseSecondaryInstanceArgs(string[] args)
+    {
+        if (_secondaryInstanceArgsReceived is null)
+        {
+            Logger.Info("Buffering forwarded arguments until the main window is ready");
+            _bufferedSecondaryInstanceArgs.Enqueue(args);
+            return;
+        }
+
+        _secondaryInstanceArgsReceived(args);
+    }
 
     public static void Run(string[] args)
     {
@@ -142,7 +176,7 @@ public static class AvaloniaAppHost
 
         if (createdNew)
         {
-            SingleInstanceRedirector.StartListener(a => SecondaryInstanceArgsReceived?.Invoke(a));
+            SingleInstanceRedirector.StartListener(RaiseSecondaryInstanceArgs);
             return true;
         }
 
@@ -176,7 +210,7 @@ public static class AvaloniaAppHost
             return true;
         }
 
-        SingleInstanceRedirector.StartListener(a => SecondaryInstanceArgsReceived?.Invoke(a));
+        SingleInstanceRedirector.StartListener(RaiseSecondaryInstanceArgs);
         return true;
     }
 }

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs
@@ -10,6 +10,7 @@ using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface;
+using UniGetUI.Shared;
 
 namespace UniGetUI.Avalonia.Infrastructure;
 
@@ -79,6 +80,8 @@ public static class AvaloniaAppHost
         // listener starts: if a second instance connects mid-startup, the listener's Dispatcher.UIThread.Post
         // would otherwise bind it to the worker thread and make Win32Platform.Initialize throw.
         _ = Dispatcher.UIThread;
+
+        args = StartupBundleArguments.Normalize(args, Environment.CurrentDirectory);
 
         if (!TryRegisterSingleInstance(args))
         {

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -22,6 +22,10 @@ namespace UniGetUI.Avalonia.Infrastructure;
 internal static class AvaloniaBootstrapper
 {
     private static bool _hasStarted;
+    private static readonly TaskCompletionSource _initialized =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static Task Initialized => _initialized.Task;
 
     // Coalesces broker-unavailable notifications: during bulk operations every failed
     // package raises the event, but only one dialog should be visible at a time.
@@ -38,12 +42,19 @@ internal static class AvaloniaBootstrapper
         _hasStarted = true;
         Logger.Info("Starting Avalonia shell bootstrap");
 
-        await Task.WhenAll(
-            InitializeSharedServicesAsync(),
-            InitializePackageEngineAsync()
-        );
+        try
+        {
+            await Task.WhenAll(
+                InitializeSharedServicesAsync(),
+                InitializePackageEngineAsync()
+            );
 
-        await RunPostLoadChecksAsync();
+            await RunPostLoadChecksAsync();
+        }
+        finally
+        {
+            _initialized.TrySetResult();
+        }
 
         Logger.Info("Avalonia shell bootstrap completed");
     }

--- a/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs
@@ -22,10 +22,10 @@ namespace UniGetUI.Avalonia.Infrastructure;
 internal static class AvaloniaBootstrapper
 {
     private static bool _hasStarted;
-    private static readonly TaskCompletionSource _initialized =
+    private static readonly TaskCompletionSource<bool> _initialized =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    public static Task Initialized => _initialized.Task;
+    public static Task<bool> Initialized => _initialized.Task;
 
     // Coalesces broker-unavailable notifications: during bulk operations every failed
     // package raises the event, but only one dialog should be visible at a time.
@@ -51,10 +51,13 @@ internal static class AvaloniaBootstrapper
 
             await RunPostLoadChecksAsync();
         }
-        finally
+        catch (Exception)
         {
-            _initialized.TrySetResult();
+            _initialized.TrySetResult(false);
+            throw;
         }
+
+        _initialized.TrySetResult(true);
 
         Logger.Info("Avalonia shell bootstrap completed");
     }

--- a/src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.cs
@@ -39,7 +39,12 @@ internal static class StartupArgumentProcessor
                 $"{bundles.Count} package bundles were passed on the command line; only {bundles[0]} will be loaded");
         }
 
-        await AvaloniaBootstrapper.Initialized;
+        if (!await AvaloniaBootstrapper.Initialized)
+        {
+            Logger.Warn(
+                $"Could not load the package bundle {bundles[0]}: UniGetUI failed to finish initializing");
+            return;
+        }
 
         if (MainWindow.Instance is not { } window)
         {

--- a/src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.cs
@@ -8,6 +8,18 @@ namespace UniGetUI.Avalonia.Infrastructure;
 
 internal static class StartupArgumentProcessor
 {
+    public static void WarnIfBundlesIgnored(IReadOnlyList<string> args, string reason)
+    {
+        if (args.Count == 0)
+            return;
+
+        List<string> bundles = StartupBundleArguments.Resolve(args, Environment.CurrentDirectory);
+        foreach (string bundle in bundles)
+        {
+            Logger.Warn($"Ignoring the package bundle {bundle}: {reason}");
+        }
+    }
+
     public static async Task ProcessAsync(IReadOnlyList<string> args)
     {
         if (args.Count == 0)

--- a/src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using UniGetUI.Avalonia.ViewModels;
+using UniGetUI.Avalonia.Views;
+using UniGetUI.Core.Logging;
+using UniGetUI.Shared;
+
+namespace UniGetUI.Avalonia.Infrastructure;
+
+internal static class StartupArgumentProcessor
+{
+    public static async Task ProcessAsync(IReadOnlyList<string> args)
+    {
+        if (args.Count == 0)
+        {
+            return;
+        }
+
+        List<string> bundles = StartupBundleArguments.Resolve(args, Environment.CurrentDirectory);
+        if (bundles.Count == 0)
+        {
+            return;
+        }
+
+        if (bundles.Count > 1)
+        {
+            Logger.Warn(
+                $"{bundles.Count} package bundles were passed on the command line; only {bundles[0]} will be loaded");
+        }
+
+        await AvaloniaBootstrapper.Initialized;
+
+        if (MainWindow.Instance is not { } window)
+        {
+            Logger.Warn($"Could not load the package bundle {bundles[0]}: the main window is not available");
+            return;
+        }
+
+        if (window.DataContext is not MainWindowViewModel viewModel)
+        {
+            Logger.Warn($"Could not load the package bundle {bundles[0]}: the main window has no view model");
+            return;
+        }
+
+        if (!window.IsVisible)
+        {
+            window.ShowFromTray();
+        }
+
+        Logger.ImportantInfo($"Loading the package bundle {bundles[0]} requested on the command line");
+        await viewModel.LoadBundleFromFileAsync(bundles[0]);
+    }
+}

--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -217,6 +217,7 @@
     <ItemGroup>
       <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
       <Compile Include="..\Shared\SharedPreUiCommandDispatcher.cs" Link="Shared\SharedPreUiCommandDispatcher.cs" />
+      <Compile Include="..\Shared\StartupBundleArguments.cs" Link="Shared\StartupBundleArguments.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -758,6 +758,12 @@ public partial class MainWindowViewModel : ViewModelBase
         await BundlesPage.OpenFromString(content, BundleFormatType.UBUNDLE, "GitHub Gist");
     }
 
+    public async Task LoadBundleFromFileAsync(string path)
+    {
+        NavigateTo(PageType.Bundles);
+        await BundlesPage.OpenFromFile(path);
+    }
+
     private async Task ShowAboutDialog()
     {
         Sidebar.SelectNavButtonForPage(PageType.Null);

--- a/src/UniGetUI.Tests/StartupBundleArgumentsTests.cs
+++ b/src/UniGetUI.Tests/StartupBundleArgumentsTests.cs
@@ -1,0 +1,141 @@
+using UniGetUI.Interface;
+using UniGetUI.Shared;
+
+namespace UniGetUI.Tests;
+
+public sealed class StartupBundleArgumentsTests : IDisposable
+{
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(),
+        nameof(StartupBundleArgumentsTests),
+        Guid.NewGuid().ToString("N")
+    );
+
+    public StartupBundleArgumentsTests()
+    {
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    private string CreateFile(string name)
+    {
+        string path = Path.Combine(_testRoot, name);
+        File.WriteAllText(path, "{}");
+        return path;
+    }
+
+    [Theory]
+    [InlineData("bundle.ubundle")]
+    [InlineData("bundle.json")]
+    [InlineData("bundle.yaml")]
+    [InlineData("bundle.xml")]
+    [InlineData("bundle.UBUNDLE")]
+    public void Resolve_AcceptsSupportedExtensionsAsRelativePaths(string name)
+    {
+        string expected = CreateFile(name);
+
+        List<string> bundles = StartupBundleArguments.Resolve([name], _testRoot);
+
+        Assert.Equal([expected], bundles);
+    }
+
+    [Fact]
+    public void Resolve_AcceptsFullyQualifiedPaths()
+    {
+        string expected = CreateFile("bundle.ubundle");
+
+        List<string> bundles = StartupBundleArguments.Resolve([expected], Path.GetTempPath());
+
+        Assert.Equal([expected], bundles);
+    }
+
+    [Fact]
+    public void Resolve_StripsSurroundingQuotes()
+    {
+        string expected = CreateFile("bundle.ubundle");
+
+        List<string> bundles = StartupBundleArguments.Resolve([$"\"{expected}\""], _testRoot);
+
+        Assert.Equal([expected], bundles);
+    }
+
+    [Fact]
+    public void Resolve_IgnoresMissingFiles()
+    {
+        Assert.Empty(StartupBundleArguments.Resolve(["missing.ubundle"], _testRoot));
+    }
+
+    [Fact]
+    public void Resolve_IgnoresUnsupportedExtensions()
+    {
+        CreateFile("bundle.txt");
+
+        Assert.Empty(StartupBundleArguments.Resolve(["bundle.txt"], _testRoot));
+    }
+
+    [Fact]
+    public void Resolve_IgnoresFlagsAndTheirValues()
+    {
+        string bundle = CreateFile("bundle.ubundle");
+
+        List<string> bundles = StartupBundleArguments.Resolve(
+            ["--daemon", IpcTransportOptions.CliNamedPipeArgument, bundle],
+            _testRoot
+        );
+
+        Assert.Empty(bundles);
+    }
+
+    [Fact]
+    public void Resolve_FindsBundlesAfterAFlagValuePair()
+    {
+        string bundle = CreateFile("bundle.ubundle");
+
+        List<string> bundles = StartupBundleArguments.Resolve(
+            [IpcTransportOptions.CliTcpPortArgument, "7058", "bundle.ubundle"],
+            _testRoot
+        );
+
+        Assert.Equal([bundle], bundles);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsEveryBundleInOrder()
+    {
+        string first = CreateFile("first.ubundle");
+        string second = CreateFile("second.json");
+
+        List<string> bundles = StartupBundleArguments.Resolve(
+            ["first.ubundle", "--daemon", "second.json"],
+            _testRoot
+        );
+
+        Assert.Equal([first, second], bundles);
+    }
+
+    [Fact]
+    public void Normalize_RewritesRelativeBundlePathsAndLeavesOtherArgumentsUntouched()
+    {
+        string bundle = CreateFile("bundle.ubundle");
+
+        string[] normalized = StartupBundleArguments.Normalize(
+            ["--daemon", "bundle.ubundle", "missing.ubundle"],
+            _testRoot
+        );
+
+        Assert.Equal(["--daemon", bundle, "missing.ubundle"], normalized);
+    }
+
+    [Fact]
+    public void Normalize_KeepsEmptyArgumentListsEmpty()
+    {
+        Assert.Empty(StartupBundleArguments.Normalize([], _testRoot));
+    }
+}

--- a/src/UniGetUI.Tests/UniGetUI.Tests.csproj
+++ b/src/UniGetUI.Tests/UniGetUI.Tests.csproj
@@ -45,6 +45,7 @@
     <ItemGroup>
         <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
         <Compile Include="..\Shared\SharedPreUiCommandDispatcher.cs" Link="Shared\SharedPreUiCommandDispatcher.cs" />
+        <Compile Include="..\Shared\StartupBundleArguments.cs" Link="Shared\StartupBundleArguments.cs" />
         <Compile Include="..\Shared\AutoUpdater.Helpers.cs" Link="AutoUpdater.Helpers.cs" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request introduces robust handling and processing of package bundle files passed as command-line arguments, including normalization, validation, and integration with the application startup process. It also adds comprehensive tests and improves the reliability of handling arguments across different application entry points.

**Startup bundle argument handling and processing:**

* Added the new `StartupBundleArguments` class to centralize the logic for identifying, validating, and normalizing package bundle file arguments (such as `.ubundle`, `.json`, `.yaml`, `.xml`) from the command line. This includes resolving relative paths, ignoring unsupported/missing files, and skipping arguments that are flags or their values. (`src/Shared/StartupBundleArguments.cs`, [src/Shared/StartupBundleArguments.csR1-R107](diffhunk://#diff-7e007fd822a6eaf2e046ddb7438ee2cb522977f86ea8c32ebfa1be7bddc72ae2R1-R107))
* Integrated `StartupBundleArguments` into the main application startup and single-instance logic, ensuring bundle files are correctly resolved and normalized before further processing. (`src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs`,

**Startup argument processing and user feedback:**

* Introduced the `StartupArgumentProcessor` to process bundle files on startup, load them into the main window, and log warnings if bundles are ignored (e.g., in daemon mode or if the main window/view model is unavailable). (`src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.cs`, [src/UniGetUI.Avalonia/Infrastructure/StartupArgumentProcessor.csR1-R64](diffhunk://#diff-c92518bcbeb13185b793c8874c9070133df0e072c8e3b93f3eca82b348fe0e7aR1-R64))
* Updated startup methods to pass command-line arguments through the new processor and handle bundles appropriately after the UI and services are initialized. (`src/UniGetUI.Avalonia/App.axaml.cs`,

**Reliability and single-instance improvements:**

* Improved buffering and dispatch of secondary instance arguments to ensure no arguments are lost before the main window is ready. (`src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.cs`, [src/UniGetUI.Avalonia/Infrastructure/AvaloniaAppHost.csL21-R56](diffhunk://#diff-91803e6a75dcc9bd9af4c369da76de5abf791649aac0a7bf64830a81e64c76f7L21-R56))
* Ensured bundle loading only occurs after the application bootstrapper signals initialization, preventing race conditions. (`src/UniGetUI.Avalonia/Infrastructure/AvaloniaBootstrapper.cs`,

**Testing and project structure:**

* Added a comprehensive test suite for `StartupBundleArguments`, covering supported extensions, path resolution, quoting, unsupported/missing files, and normalization logic. (`src/UniGetUI.Tests/StartupBundleArgumentsTests.cs`, [src/UniGetUI.Tests/StartupBundleArgumentsTests.csR1-R141](diffhunk://#diff-f2a0f7b075b3b8dfde7a4559c9ea4866101e111635cb4ae9b3d58c362398377aR1-R141))
* Updated project files to include the new shared logic in both the main application and test projects. (`src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj`, 

**View model support:**

* Added a method to the main window view model to load a bundle from a file, supporting the new startup argument processing workflow. (`src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.cs`, [src/UniGetUI.Avalonia/ViewModels/MainWindowViewModel.csR761-R766](diffhunk://#diff-c818e95c57ae4c047ac004861b308f6b15d1e90cdb718f5ce711bf29bd06c4ccR761-R766))