### PR TITLE
Restore package icons missing from list views

### DIFF
--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -43,6 +43,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     private static readonly Dictionary<long, LinkedListNode<(long Hash, Bitmap Bitmap)>> _iconCache = new();
     private static readonly LinkedList<(long Hash, Bitmap Bitmap)> _iconCacheOrder = new();
     private static readonly Dictionary<long, long> _failedIcons = new();
+    private const int MaxFailedIconEntries = 512;
     private static readonly TimeSpan IconRetryInterval = TimeSpan.FromMinutes(5);
 
     private static Bitmap? GetCachedIcon(long hash)
@@ -77,7 +78,26 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     private static void MarkIconFailed(long hash)
     {
         lock (_iconCacheLock)
+        {
             _failedIcons[hash] = Environment.TickCount64;
+            if (_failedIcons.Count > MaxFailedIconEntries)
+                TrimFailedIcons();
+        }
+    }
+
+    private static void TrimFailedIcons()
+    {
+        long now = Environment.TickCount64;
+        long retryMs = (long)IconRetryInterval.TotalMilliseconds;
+        foreach (var expired in _failedIcons.Where(e => now - e.Value >= retryMs).ToArray())
+            _failedIcons.Remove(expired.Key);
+
+        int excess = _failedIcons.Count - MaxFailedIconEntries;
+        if (excess <= 0)
+            return;
+
+        foreach (var oldest in _failedIcons.OrderBy(e => e.Value).Take(excess).ToArray())
+            _failedIcons.Remove(oldest.Key);
     }
 
     private static void CacheIcon(long hash, Bitmap bitmap)

--- a/src/UniGetUI.Avalonia/Models/PackageCollections.cs
+++ b/src/UniGetUI.Avalonia/Models/PackageCollections.cs
@@ -40,10 +40,12 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     // reference the bitmap, so dropping it here only makes it GC-eligible.
     private const int MaxIconCacheEntries = 512;
     private static readonly object _iconCacheLock = new();
-    private static readonly Dictionary<long, LinkedListNode<(long Hash, Bitmap? Bitmap)>> _iconCache = new();
-    private static readonly LinkedList<(long Hash, Bitmap? Bitmap)> _iconCacheOrder = new();
+    private static readonly Dictionary<long, LinkedListNode<(long Hash, Bitmap Bitmap)>> _iconCache = new();
+    private static readonly LinkedList<(long Hash, Bitmap Bitmap)> _iconCacheOrder = new();
+    private static readonly Dictionary<long, long> _failedIcons = new();
+    private static readonly TimeSpan IconRetryInterval = TimeSpan.FromMinutes(5);
 
-    private static bool TryGetCachedIcon(long hash, out Bitmap? bitmap)
+    private static Bitmap? GetCachedIcon(long hash)
     {
         lock (_iconCacheLock)
         {
@@ -51,18 +53,39 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
             {
                 _iconCacheOrder.Remove(node);
                 _iconCacheOrder.AddFirst(node);
-                bitmap = node.Value.Bitmap;
-                return true;
+                return node.Value.Bitmap;
             }
         }
-        bitmap = null;
-        return false;
+        return null;
     }
 
-    private static void CacheIcon(long hash, Bitmap? bitmap)
+    private static bool HasRecentIconFailure(long hash)
     {
         lock (_iconCacheLock)
         {
+            if (!_failedIcons.TryGetValue(hash, out long failedAt))
+                return false;
+
+            if (Environment.TickCount64 - failedAt < (long)IconRetryInterval.TotalMilliseconds)
+                return true;
+
+            _failedIcons.Remove(hash);
+            return false;
+        }
+    }
+
+    private static void MarkIconFailed(long hash)
+    {
+        lock (_iconCacheLock)
+            _failedIcons[hash] = Environment.TickCount64;
+    }
+
+    private static void CacheIcon(long hash, Bitmap bitmap)
+    {
+        lock (_iconCacheLock)
+        {
+            _failedIcons.Remove(hash);
+
             if (_iconCache.TryGetValue(hash, out var existing))
             {
                 existing.Value = (hash, bitmap);
@@ -71,7 +94,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
                 return;
             }
 
-            var node = new LinkedListNode<(long, Bitmap?)>((hash, bitmap));
+            var node = new LinkedListNode<(long, Bitmap)>((hash, bitmap));
             _iconCache[hash] = node;
             _iconCacheOrder.AddFirst(node);
 
@@ -89,6 +112,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         {
             _iconCache.Clear();
             _iconCacheOrder.Clear();
+            _failedIcons.Clear();
         }
     }
 
@@ -265,17 +289,16 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     {
         CancellationToken token = _lifetimeCts.Token;
         long hash = Package.GetHash();
-        if (TryGetCachedIcon(hash, out Bitmap? cached))
+        if (GetCachedIcon(hash) is { } cached)
         {
-            if (cached is not null)
+            await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                await Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    if (!token.IsCancellationRequested) IconBitmap = cached;
-                });
-            }
+                if (!token.IsCancellationRequested) IconBitmap = cached;
+            });
             return;
         }
+
+        if (HasRecentIconFailure(hash)) return;
 
         try
         {
@@ -289,15 +312,17 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
             });
         }
         catch (OperationCanceledException) { /* row discarded before its icon finished loading */ }
-        catch { CacheIcon(hash, null); }
+        catch { MarkIconFailed(hash); }
     }
 
     private static Task<Bitmap?> GetSharedIconLoad(long hash, IPackage package)
     {
         lock (_inflightIconLoadsLock)
         {
-            if (TryGetCachedIcon(hash, out Bitmap? cached))
-                return Task.FromResult(cached);
+            if (GetCachedIcon(hash) is { } cached)
+                return Task.FromResult<Bitmap?>(cached);
+            if (HasRecentIconFailure(hash))
+                return Task.FromResult<Bitmap?>(null);
             if (_inflightIconLoads.TryGetValue(hash, out Task<Bitmap?>? existing))
                 return existing;
 
@@ -328,14 +353,14 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
         try
         {
             var uri = await Task.Run(package.GetIconUrlIfAny).ConfigureAwait(false);
-            if (uri is null) { CacheIcon(hash, null); return null; }
+            if (uri is null) { MarkIconFailed(hash); return null; }
 
             Bitmap? decoded;
             if (uri.IsFile)
             {
-                if (!IsSkiaDecodableExtension(uri.LocalPath))
+                if (IsKnownUndecodableExtension(uri.LocalPath))
                 {
-                    CacheIcon(hash, null);
+                    MarkIconFailed(hash);
                     return null;
                 }
                 decoded = await Task.Run(() => TryDecodeIcon(uri.LocalPath)).ConfigureAwait(false);
@@ -348,7 +373,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
                 response.EnsureSuccessStatusCode();
                 if (response.Content.Headers.ContentLength > MaxIconDownloadBytes)
                 {
-                    CacheIcon(hash, null);
+                    MarkIconFailed(hash);
                     return null;
                 }
 
@@ -356,14 +381,20 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
                 var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 decoded = TryDecodeIcon(bytes, uri.Host);
             }
-            else { CacheIcon(hash, null); return null; }
+            else { MarkIconFailed(hash); return null; }
+
+            if (decoded is null)
+            {
+                MarkIconFailed(hash);
+                return null;
+            }
 
             CacheIcon(hash, decoded);
             return decoded;
         }
         catch
         {
-            CacheIcon(hash, null);
+            MarkIconFailed(hash);
             return null;
         }
         finally
@@ -373,7 +404,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     }
 
     // Icons come from a shared on-disk cache that can hold empty or partial entries after an
-    // interrupted download; decoding those throws. Skip them quietly instead of surfacing an error.
+    // interrupted download; decoding those throws. Skip those entries instead of failing the row.
     private static Bitmap? TryDecodeIcon(string filePath)
     {
         var info = new FileInfo(filePath);
@@ -387,7 +418,7 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     private static Bitmap? TryDecodeIcon(Func<Bitmap> decode, string source)
     {
         try { return decode(); }
-        catch (Exception ex) { Logger.Debug($"Discarding undecodable icon '{source}': {ex.Message}"); return null; }
+        catch (Exception ex) { Logger.Warn($"Discarding undecodable icon '{source}': {ex.Message}"); return null; }
     }
 
     // Decode directly at the display-cache width. This avoids allocating a full-size bitmap first,
@@ -395,15 +426,13 @@ public sealed class PackageWrapper : INotifyPropertyChanged, IDisposable
     private static Bitmap DecodeDownscaled(Stream stream)
         => Bitmap.DecodeToWidth(stream, MaxIconSide, BitmapInterpolationMode.HighQuality);
 
-    private static bool IsSkiaDecodableExtension(string path)
+    private static bool IsKnownUndecodableExtension(string path)
     {
         string ext = Path.GetExtension(path);
-        return ext.Equals(".png", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".gif", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".webp", StringComparison.OrdinalIgnoreCase);
+        return ext.Equals(".svg", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".tif", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".tiff", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".avif", StringComparison.OrdinalIgnoreCase);
     }
 
     private void Package_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/Interface_PViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/Interface_PViewModel.cs
@@ -35,6 +35,7 @@ public partial class Interface_PViewModel : ViewModelBase
         try { Directory.Delete(CoreData.UniGetUICacheDirectory_Icons, true); }
         catch (Exception ex) { Logger.Error(ex); }
         global::UniGetUI.PackageEngine.PackageClasses.PackageWrapper.ClearIconCache();
+        global::UniGetUI.PackageEngine.PackageClasses.Package.ResetIconCache();
         RestartRequired?.Invoke(this, EventArgs.Empty);
         await LoadIconCacheSize();
     }

--- a/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
+++ b/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
@@ -455,7 +455,7 @@ namespace UniGetUI.Core.IconEngine
                     { "image/svg+xml", "svg" },
                     { "image/vnd.microsoft.icon", "ico" },
                     { "application/octet-stream", "ico" },
-                    { "image/image/x-icon", "ico" },
+                    { "image/x-icon", "ico" },
                     { "image/tiff", "tif" },
                 }
             );
@@ -471,7 +471,7 @@ namespace UniGetUI.Core.IconEngine
                     { "png", "image/png" },
                     { "webp", "image/webp" },
                     { "svg", "image/svg+xml" },
-                    { "ico", "image/image/x-icon" },
+                    { "ico", "image/x-icon" },
                     { "tif", "image/tiff" },
                 }
             );

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -28,7 +28,14 @@ namespace UniGetUI.PackageEngine.PackageClasses
         private readonly string _ignoredId;
         private readonly string _iconId;
 
-        private static readonly ConcurrentDictionary<int, Uri?> _cachedIconPaths = new();
+        private static readonly ConcurrentDictionary<int, Uri> _cachedIconPaths = new();
+        private static readonly ConcurrentDictionary<int, long> _failedIconLookups = new();
+        private static readonly TimeSpan _iconLookupRetryInterval = TimeSpan.FromMinutes(5);
+
+        public static TimeSpan? TEST_IconLookupRetryIntervalOverride { private get; set; }
+
+        private static TimeSpan IconLookupRetryInterval =>
+            TEST_IconLookupRetryIntervalOverride ?? _iconLookupRetryInterval;
 
         private IPackageDetails? __details;
         public IPackageDetails Details
@@ -162,12 +169,30 @@ namespace UniGetUI.PackageEngine.PackageClasses
 
         public virtual Uri? GetIconUrlIfAny()
         {
-            if (_cachedIconPaths.TryGetValue(this.GetHashCode(), out Uri? path))
+            int cacheKey = this.GetHashCode();
+            if (_cachedIconPaths.TryGetValue(cacheKey, out Uri? path))
             {
                 return path;
             }
+
+            if (
+                _failedIconLookups.TryGetValue(cacheKey, out long failedAt)
+                && Environment.TickCount64 - failedAt
+                    < (long)IconLookupRetryInterval.TotalMilliseconds
+            )
+            {
+                return null;
+            }
+
             var CachedIcon = LoadIconUrlIfAny();
-            _cachedIconPaths.TryAdd(this.GetHashCode(), CachedIcon);
+            if (CachedIcon is null)
+            {
+                _failedIconLookups[cacheKey] = Environment.TickCount64;
+                return null;
+            }
+
+            _failedIconLookups.TryRemove(cacheKey, out _);
+            _cachedIconPaths[cacheKey] = CachedIcon;
             return CachedIcon;
         }
 
@@ -377,6 +402,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
         public static void ResetIconCache()
         {
             _cachedIconPaths.Clear();
+            _failedIconLookups.Clear();
         }
 
         private static string GenerateIconId(Package p)

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -28,8 +28,8 @@ namespace UniGetUI.PackageEngine.PackageClasses
         private readonly string _ignoredId;
         private readonly string _iconId;
 
-        private static readonly ConcurrentDictionary<int, Uri> _cachedIconPaths = new();
-        private static readonly ConcurrentDictionary<int, long> _failedIconLookups = new();
+        private static readonly ConcurrentDictionary<long, Uri> _cachedIconPaths = new();
+        private static readonly ConcurrentDictionary<long, long> _failedIconLookups = new();
         private static readonly TimeSpan _iconLookupRetryInterval = TimeSpan.FromMinutes(5);
 
         public static TimeSpan? TEST_IconLookupRetryIntervalOverride { private get; set; }
@@ -169,7 +169,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
 
         public virtual Uri? GetIconUrlIfAny()
         {
-            int cacheKey = this.GetHashCode();
+            long cacheKey = _versionedHash;
             if (_cachedIconPaths.TryGetValue(cacheKey, out Uri? path))
             {
                 return path;

--- a/src/UniGetUI.PackageEngine.Tests/PackageIconLookupTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageIconLookupTests.cs
@@ -1,0 +1,148 @@
+using UniGetUI.Core.Data;
+using UniGetUI.Core.IconEngine;
+using UniGetUI.Core.SettingsEngine;
+using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Builders;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class PackageIconLookupTests : IDisposable
+{
+    private readonly string _testRoot;
+
+    public PackageIconLookupTests()
+    {
+        _testRoot = Path.Combine(
+            Path.GetTempPath(),
+            nameof(PackageIconLookupTests),
+            Guid.NewGuid().ToString("N")
+        );
+        CoreData.TEST_DataDirectoryOverride = Path.Combine(_testRoot, "Data");
+        SecureSettings.TEST_SecureSettingsRootOverride = Path.Combine(_testRoot, "SecureSettings");
+        Directory.CreateDirectory(CoreData.UniGetUIUserConfigurationDirectory);
+        Settings.ResetSettings();
+        Package.ResetIconCache();
+    }
+
+    public void Dispose()
+    {
+        Package.TEST_IconLookupRetryIntervalOverride = null;
+        Package.ResetIconCache();
+        Settings.ResetSettings();
+        CoreData.TEST_DataDirectoryOverride = null;
+        SecureSettings.TEST_SecureSettingsRootOverride = null;
+        if (Directory.Exists(_testRoot))
+            Directory.Delete(_testRoot, recursive: true);
+    }
+
+    [Fact]
+    public void GetIconUrlIfAny_DoesNotRetryFailedLookupWithinRetryInterval()
+    {
+        int lookups = 0;
+        var package = BuildPackage(
+            "Contoso.WithinInterval",
+            _ =>
+            {
+                lookups++;
+                return null;
+            }
+        );
+
+        Assert.Null(package.GetIconUrlIfAny());
+        Assert.Null(package.GetIconUrlIfAny());
+
+        Assert.Equal(1, lookups);
+    }
+
+    [Fact]
+    public void GetIconUrlIfAny_RetriesFailedLookupAfterRetryInterval()
+    {
+        Package.TEST_IconLookupRetryIntervalOverride = TimeSpan.Zero;
+        string iconPath = CreateIconFile();
+
+        int lookups = 0;
+        var package = BuildPackage(
+            "Contoso.AfterInterval",
+            _ =>
+            {
+                lookups++;
+                return lookups == 1 ? null : new CacheableIcon(iconPath);
+            }
+        );
+
+        Assert.Null(package.GetIconUrlIfAny());
+        Uri? retried = package.GetIconUrlIfAny();
+
+        Assert.Equal(2, lookups);
+        Assert.NotNull(retried);
+        Assert.True(retried.IsFile);
+        Assert.Equal(iconPath, retried.LocalPath);
+    }
+
+    [Fact]
+    public void GetIconUrlIfAny_DoesNotResolveResolvedIconAgain()
+    {
+        Package.TEST_IconLookupRetryIntervalOverride = TimeSpan.Zero;
+        string iconPath = CreateIconFile();
+
+        int lookups = 0;
+        var package = BuildPackage(
+            "Contoso.AlreadyResolved",
+            _ =>
+            {
+                lookups++;
+                return new CacheableIcon(iconPath);
+            }
+        );
+
+        Uri? first = package.GetIconUrlIfAny();
+        Uri? second = package.GetIconUrlIfAny();
+
+        Assert.Equal(1, lookups);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void ResetIconCache_AllowsFailedLookupToBeRetriedImmediately()
+    {
+        int lookups = 0;
+        var package = BuildPackage(
+            "Contoso.AfterReset",
+            _ =>
+            {
+                lookups++;
+                return null;
+            }
+        );
+
+        Assert.Null(package.GetIconUrlIfAny());
+        Package.ResetIconCache();
+        Assert.Null(package.GetIconUrlIfAny());
+
+        Assert.Equal(2, lookups);
+    }
+
+    private string CreateIconFile()
+    {
+        Directory.CreateDirectory(_testRoot);
+        string iconPath = Path.Combine(_testRoot, "icon.png");
+        File.WriteAllBytes(iconPath, [0x89, 0x50, 0x4E, 0x47]);
+        return iconPath;
+    }
+
+    private static Package BuildPackage(string id, Func<IPackage, CacheableIcon?> iconFactory)
+    {
+        var manager = new PackageManagerBuilder()
+            .ConfigureCapabilities(capabilities =>
+            {
+                capabilities.SupportsCustomPackageIcons = true;
+                return capabilities;
+            })
+            .ConfigureDetails(details => details.IconFactory = iconFactory)
+            .Build();
+
+        return new PackageBuilder().WithId(id).WithManager(manager).Build();
+    }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the icon caching and lookup system across the package engine, UI, and supporting infrastructure. The main focus is to prevent repeated attempts to load or decode icons that have previously failed, by tracking failures and introducing a retry interval. Additionally, the changes improve cache clearing, error logging, and test coverage for these behaviors.

**Icon caching and failure tracking improvements:**

- Added tracking for failed icon loads and lookups in both `PackageWrapper` and `Package`, preventing repeated attempts to load icons that have recently failed. A retry interval (default 5 minutes, test-overridable) is enforced before another attempt is made. 
- Updated cache clearing methods to also clear the failed icon tracking, ensuring that resets allow immediate retries of previously failed lookups. 

**Icon loading and decoding robustness:**

- Changed logic to mark icon loads as failed (instead of caching null) when decoding or retrieval fails, and to skip retries within the retry interval. Improved error logging for undecodable icons. 
- Updated file extension checks to more accurately identify known undecodable image types.

**Infrastructure and test coverage:**

- Added a new test suite (`PackageIconLookupTests`) to verify correct retry behavior, cache clearing, and icon lookup caching, including support for overriding the retry interval in tests.

**Minor corrections:**

- Fixed MIME type mappings for icon files in `IconCacheEngine.cs`.

---

**Icon caching and failure tracking:**
- Added dictionaries to track failed icon loads in `PackageWrapper` and failed icon lookups in `Package`, with logic to prevent repeated attempts within a configurable interval. 

**Icon loading and decoding:**
- Changed icon load failure handling to mark as failed (not cache null), and improved error logging for undecodable icons. 
- Updated logic to skip known undecodable extensions.

**Testing and infrastructure:**
- Added `PackageIconLookupTests` to verify retry, cache, and clearing behaviors, including a test-only override for the retry interval.

**Other:**
- Corrected MIME type mappings for icon files.