### PR TITLE
Keep Scoop package listings working when scoop commands fail

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopPkgDetailsHelper.cs
@@ -72,9 +72,10 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             );
 
             p.Start();
+            Task<string> stdErr = ScoopProcess.ReadStdErrAsync(p);
             string JsonString = p.StandardOutput.ReadToEnd();
             logger.AddToStdOut(JsonString);
-            logger.AddToStdErr(p.StandardError.ReadToEnd());
+            logger.AddToStdErr(stdErr.GetAwaiter().GetResult());
 
             if (JsonNode.Parse(JsonString) is not JsonObject contents)
             {

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopProcess.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopProcess.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+using UniGetUI.Core.Logging;
+using UniGetUI.PackageEngine.ManagerClasses.Classes;
+
+namespace UniGetUI.PackageEngine.Managers.ScoopManager
+{
+    internal static class ScoopProcess
+    {
+        public static IReadOnlyList<string> ReadLines(Process p, IProcessTaskLogger logger)
+        {
+            Task<string> stdErr = ReadStdErrAsync(p);
+
+            List<string> lines = [];
+            string? line;
+            while ((line = p.StandardOutput.ReadLine()) is not null)
+            {
+                logger.AddToStdOut(line);
+                lines.Add(line);
+            }
+
+            Finish(p, logger, stdErr);
+            return lines;
+        }
+
+        public static string ReadToEnd(Process p, IProcessTaskLogger logger)
+        {
+            Task<string> stdErr = ReadStdErrAsync(p);
+
+            string stdOut = p.StandardOutput.ReadToEnd();
+            logger.AddToStdOut(stdOut);
+
+            Finish(p, logger, stdErr);
+            return stdOut;
+        }
+
+        public static Task<string> ReadStdErrAsync(Process p) =>
+            Task.Run(p.StandardError.ReadToEnd);
+
+        public static Task<string> ReadStdOutAsync(Process p) =>
+            Task.Run(p.StandardOutput.ReadToEnd);
+
+        public static string ReadWithTimeout(Task<string> read, int millisecondsTimeout)
+        {
+            try
+            {
+                return read.Wait(millisecondsTimeout) ? read.Result.Trim() : "";
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Could not read the output of a Scoop process: {ex.Message}");
+                return "";
+            }
+        }
+
+        private static void Finish(Process p, IProcessTaskLogger logger, Task<string> stdErr)
+        {
+            logger.AddToStdErr(stdErr.GetAwaiter().GetResult());
+            p.WaitForExit();
+            logger.Close(p.ExitCode);
+        }
+    }
+}

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopSourceHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Helpers/ScoopSourceHelper.cs
@@ -66,19 +66,9 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             );
 
             p.Start();
+            p.StandardInput.Close();
 
-            List<string> lines = [];
-            string? line;
-            while ((line = p.StandardOutput.ReadLine()) is not null)
-            {
-                logger.AddToStdOut(line);
-                lines.Add(line);
-            }
-            logger.AddToStdErr(p.StandardError.ReadToEnd());
-            p.WaitForExit();
-            logger.Close(p.ExitCode);
-
-            return ParseSources(lines);
+            return ParseSources(ScoopProcess.ReadLines(p, logger));
         }
 
         internal IReadOnlyList<IManagerSource> ParseSources(IEnumerable<string> lines)

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
@@ -33,6 +33,9 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             "removed,",
         ];
 
+        private const int VersionProbeTimeout = 20_000;
+        private const int StreamDrainTimeout = 5_000;
+
         private long LastScoopSourceUpdateTime;
 
         public Scoop()
@@ -391,10 +394,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
                     proc
                 );
                 proc.Start();
-                aux_logger.AddToStdOut(proc.StandardOutput.ReadToEnd());
-                aux_logger.AddToStdErr(proc.StandardError.ReadToEnd());
-                proc.WaitForExit();
-                aux_logger.Close(proc.ExitCode);
+                ScoopProcess.ReadToEnd(proc, aux_logger);
                 path = "scoop-search.exe";
             }
 
@@ -415,23 +415,14 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.FindPackages, p);
 
             p.Start();
+            RegisterListingProcess(p);
 
-            List<string> lines = [];
-            string? line;
-            while ((line = p.StandardOutput.ReadLine()) is not null)
-            {
-                logger.AddToStdOut(line);
-                lines.Add(line);
-            }
-            logger.AddToStdErr(p.StandardError.ReadToEnd());
-            p.WaitForExit();
-            logger.Close(p.ExitCode);
-            return ParseSearchOutput(lines);
+            return ParseSearchOutput(ScoopProcess.ReadLines(p, logger));
         }
 
         protected override IReadOnlyList<Package> GetAvailableUpdates_UnSafe()
         {
-            IReadOnlyList<IPackage> installedPackages = GetInstalledPackages();
+            IReadOnlyList<IPackage> installedPackages = GetInstalledPackages_UnSafe();
 
             using Process p = new()
             {
@@ -449,18 +440,9 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.ListUpdates, p);
 
             p.Start();
+            RegisterListingProcess(p);
 
-            List<string> lines = [];
-            string? line;
-            while ((line = p.StandardOutput.ReadLine()) is not null)
-            {
-                logger.AddToStdOut(line);
-                lines.Add(line);
-            }
-            logger.AddToStdErr(p.StandardError.ReadToEnd());
-            p.WaitForExit();
-            logger.Close(p.ExitCode);
-            return ParseAvailableUpdates(lines, installedPackages);
+            return ParseAvailableUpdates(ScoopProcess.ReadLines(p, logger), installedPackages);
         }
 
         protected override IReadOnlyList<Package> GetInstalledPackages_UnSafe() =>
@@ -487,17 +469,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             );
             p.Start();
 
-            List<string> lines = [];
-            string? line;
-            while ((line = p.StandardOutput.ReadLine()) is not null)
-            {
-                logger.AddToStdOut(line);
-                lines.Add(line);
-            }
-            logger.AddToStdErr(p.StandardError.ReadToEnd());
-            p.WaitForExit();
-            logger.Close(p.ExitCode);
-            return ParseInstalledPackages(lines);
+            return ParseInstalledPackages(ScoopProcess.ReadLines(p, logger));
         }
 
         public override void RefreshPackageIndexes()
@@ -525,10 +497,10 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             p.StartInfo = StartInfo;
             IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.RefreshIndexes, p);
             p.Start();
-            logger.AddToStdOut(p.StandardOutput.ReadToEnd());
-            logger.AddToStdErr(p.StandardError.ReadToEnd());
-            p.WaitForExit();
-            logger.Close(p.ExitCode);
+            RegisterListingProcess(p);
+            p.StandardInput.Close();
+
+            ScoopProcess.ReadToEnd(p, logger);
         }
 
         public override IReadOnlyList<string> FindCandidateExecutableFiles() =>
@@ -567,7 +539,36 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
                 },
             };
             process.Start();
-            version = process.StandardOutput.ReadToEnd().Trim();
+            Task<string> stdOut = ScoopProcess.ReadStdOutAsync(process);
+            Task<string> stdErr = ScoopProcess.ReadStdErrAsync(process);
+
+            if (!process.WaitForExit(VersionProbeTimeout))
+            {
+                Logger.Warn(
+                    $"\"scoop --version\" did not finish after {VersionProbeTimeout / 1000} seconds, "
+                        + "it will be killed and Scoop will be loaded with an unknown version"
+                );
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn($"Could not kill the timed-out scoop version process: {ex.Message}");
+                }
+            }
+
+            string errors = ScoopProcess.ReadWithTimeout(stdErr, StreamDrainTimeout);
+            if (errors.Length > 0)
+            {
+                Logger.Warn($"\"scoop --version\" reported errors: {errors}");
+            }
+
+            version = ScoopProcess.ReadWithTimeout(stdOut, StreamDrainTimeout);
+            if (version.Length == 0)
+            {
+                version = CoreTools.Translate("Unknown");
+            }
         }
 
         protected override void _performExtraLoadingSteps()

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
@@ -301,7 +301,38 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                 }
         }
 
-        private T RunListingTaskWithTimeout<T>(Func<T> method, string taskName)
+        private void RefreshPackageIndexesSafely()
+        {
+            try
+            {
+                RunListingTaskWithTimeout<object?>(
+                    () =>
+                    {
+                        RefreshPackageIndexes();
+                        return null;
+                    },
+                    "RefreshPackageIndexes",
+                    allowDisablingTimeout: false
+                );
+            }
+            catch (Exception e)
+            {
+                while (e is AggregateException)
+                    e = e.InnerException ?? new InvalidOperationException("How did we get here?");
+
+                Logger.Warn(
+                    $"Manager {DisplayName} could not refresh its package indexes "
+                        + $"({e.GetType().Name}: {e.Message}). The available updates will be listed "
+                        + "with the indexes as they are, which may result in an incomplete list."
+                );
+            }
+        }
+
+        private T RunListingTaskWithTimeout<T>(
+            Func<T> method,
+            string taskName,
+            bool allowDisablingTimeout = true
+        )
         {
             List<Process> processes = [];
             var task = Task.Run(() =>
@@ -312,7 +343,10 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
 
             if (!task.Wait(TimeSpan.FromSeconds(PackageListingTaskTimeout)))
             {
-                if (!Settings.Get(Settings.K.DisableTimeoutOnPackageListingTasks))
+                if (
+                    !allowDisablingTimeout
+                    || !Settings.Get(Settings.K.DisableTimeoutOnPackageListingTasks)
+                )
                 {
                     KillListingProcesses(processes);
                     CoreTools.FinalizeDangerousTask(task);
@@ -397,8 +431,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
             }
             try
             {
-                Task.Run(RefreshPackageIndexes)
-                    .Wait(TimeSpan.FromSeconds(PackageListingTaskTimeout));
+                RefreshPackageIndexesSafely();
 
                 var packages = RunListingTaskWithTimeout(
                     GetAvailableUpdates_UnSafe,

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
@@ -352,8 +352,12 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                     CoreTools.FinalizeDangerousTask(task);
                     throw new TimeoutException(
                         $"Task {taskName} for manager {Name} did not finish after "
-                            + $"{PackageListingTaskTimeout} seconds, aborting.  You may disable "
-                            + $"timeouts from UniGetUI Advanced Settings"
+                            + $"{PackageListingTaskTimeout} seconds, aborting."
+                            + (
+                                allowDisablingTimeout
+                                    ? "  You may disable timeouts from UniGetUI Advanced Settings"
+                                    : ""
+                            )
                     );
                 }
 

--- a/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestProcessTaskLogger.cs
+++ b/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestProcessTaskLogger.cs
@@ -1,0 +1,39 @@
+using UniGetUI.PackageEngine.ManagerClasses.Classes;
+
+namespace UniGetUI.PackageEngine.Tests.Infrastructure.Fakes;
+
+public sealed class TestProcessTaskLogger : IProcessTaskLogger
+{
+    public List<string> StdOut { get; } = [];
+    public List<string> StdErr { get; } = [];
+    public List<string> StdIn { get; } = [];
+    public int? ReturnCode { get; private set; }
+
+    public void AddToStdOut(IReadOnlyList<string> lines) => StdOut.AddRange(lines);
+
+    public void AddToStdOut(string? line)
+    {
+        if (line is not null)
+            StdOut.Add(line);
+    }
+
+    public void AddToStdErr(IReadOnlyList<string> lines) => StdErr.AddRange(lines);
+
+    public void AddToStdErr(string? line)
+    {
+        if (line is not null)
+            StdErr.Add(line);
+    }
+
+    public void AddToStdIn(IReadOnlyList<string> lines) => StdIn.AddRange(lines);
+
+    public void AddToStdIn(string? line)
+    {
+        if (line is not null)
+            StdIn.Add(line);
+    }
+
+    public IReadOnlyList<string> AsColoredString(bool verbose = false) => [];
+
+    public void Close(int returnCode) => ReturnCode = returnCode;
+}

--- a/src/UniGetUI.PackageEngine.Tests/ScoopProcessTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/ScoopProcessTests.cs
@@ -1,0 +1,88 @@
+#if WINDOWS
+using System.Diagnostics;
+using UniGetUI.PackageEngine.Managers.ScoopManager;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Fakes;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class ScoopProcessTests
+{
+    private const int StdErrLines = 2000;
+    private const int StdErrLineLength = 80;
+    private const int PipeBufferBytes = 4096;
+    private static readonly TimeSpan Patience = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public void ReadLinesReturnsStdOutWhenTheProcessFloodsStdErr()
+    {
+        using Process p = StartNoisyProcess();
+        TestProcessTaskLogger logger = new();
+
+        var task = Task.Run(() => ScoopProcess.ReadLines(p, logger));
+        AssertCompleted(task, p);
+
+        Assert.Equal(["pkg-a 1.0.0 main", "pkg-b 2.0.0 extras"], task.Result);
+        Assert.Equal(["pkg-a 1.0.0 main", "pkg-b 2.0.0 extras"], logger.StdOut);
+        Assert.True(
+            logger.StdErr.Sum(entry => entry.Length) > PipeBufferBytes,
+            "The process did not write more than a pipe buffer to standard error"
+        );
+        Assert.Equal(0, logger.ReturnCode);
+    }
+
+    [Fact]
+    public void ReadToEndReturnsStdOutWhenTheProcessFloodsStdErr()
+    {
+        using Process p = StartNoisyProcess();
+        TestProcessTaskLogger logger = new();
+
+        var task = Task.Run(() => ScoopProcess.ReadToEnd(p, logger));
+        AssertCompleted(task, p);
+
+        Assert.Contains("pkg-a 1.0.0 main", task.Result);
+        Assert.Contains("pkg-b 2.0.0 extras", task.Result);
+        Assert.Equal(0, logger.ReturnCode);
+    }
+
+    private static void AssertCompleted(Task task, Process p)
+    {
+        if (task.Wait(Patience))
+            return;
+
+        try
+        {
+            p.Kill(entireProcessTree: true);
+        }
+        catch (Exception)
+        {
+        }
+
+        Assert.Fail(
+            $"Reading the output of the process did not finish after {Patience.TotalSeconds} seconds"
+        );
+    }
+
+    private static Process StartNoisyProcess()
+    {
+        Process p = new()
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                Arguments =
+                    "-NoProfile -ExecutionPolicy Bypass -Command \"$e = [Console]::Error; "
+                    + $"1..{StdErrLines} | ForEach-Object {{ $e.WriteLine('x' * {StdErrLineLength}) }}; "
+                    + "'pkg-a 1.0.0 main'; 'pkg-b 2.0.0 extras'\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
+            },
+        };
+
+        p.Start();
+        return p;
+    }
+}
+#endif


### PR DESCRIPTION
This pull request refactors how process output is read and logged in the Scoop package manager integration, improving reliability when dealing with processes that produce large amounts of output, especially on standard error. It introduces a new `ScoopProcess` helper class to centralize and streamline process output handling, replaces duplicated code with calls to this helper, and adds robust timeout and error handling. Comprehensive tests are also added to ensure the new logic handles edge cases like pipe buffer overflows.

**Process Output Handling Improvements**
* Introduced the `ScoopProcess` helper class to encapsulate logic for reading process standard output and error streams, supporting both line-by-line and full-output reads, and ensuring proper logging and process cleanup. This prevents deadlocks and handles large error outputs robustly.
* Refactored all usages in `Scoop.cs`, `ScoopPkgDetailsHelper.cs`, and `ScoopSourceHelper.cs` to use `ScoopProcess.ReadLines` and `ScoopProcess.ReadToEnd` instead of duplicating output reading and logging logic, simplifying these methods and improving reliability. 

**Timeouts and Error Handling**
* Enhanced version probing and stream draining with explicit timeouts and error logging in `_loadManagerVersion`, preventing hangs and reporting issues if the process does not respond in time. 
* Improved the `RunListingTaskWithTimeout` logic in `PackageManager.cs` to allow disabling timeouts only when appropriate, and added a `RefreshPackageIndexesSafely` method to handle exceptions gracefully and warn the user if index refresh fails. 

**Testing Enhancements**
* Added a `TestProcessTaskLogger` fake for unit testing process output logging.
* Added comprehensive tests in `ScoopProcessTests` to verify that reading process output works even when the standard error stream is flooded, ensuring the new logic is robust against pipe buffer limitations.