### PR TITLE
Migrate NuGet-backed managers to the V3 API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,91 @@ Each manager also provides three helper classes (in a `Helpers/` subfolder):
 
 The constructor sets `Capabilities`, `Properties`, and wires the helpers. See `src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs` as a clean reference implementation.
 
+## NuGet-backed managers (.NET Tool, PowerShell, PowerShell 7, Chocolatey)
+
+These four managers share `BaseNuGet` / `BaseNuGetDetailsHelper`, which talk to a NuGet feed
+over HTTP. Each source picks its protocol independently, in `NuGetV3ServiceIndex.GetServiceIndexUrl`:
+
+- A source URL whose path ends in `index.json`, or whose last path segment is `v3`, is a
+  **NuGet V3** feed. Its service index is fetched once per session and cached.
+- Every other source URL is treated as a **V2/OData** feed and keeps the legacy code path.
+
+Detection is purely by URL shape, so it costs no probe request and no V2 feed changes behaviour.
+
+### V3 resources used
+
+| Resource `@type` | Used for |
+|---|---|
+| `SearchQueryService` (3.5.0 → 3.0.0-beta → unversioned) | package search |
+| `PackageBaseAddress/3.0.0` | version enumeration, update detection, `.nupkg` and embedded-icon URLs |
+| `RegistrationsBaseUrl` (3.6.0 → 3.4.0 → 3.0.0-rc → 3.0.0-beta → unversioned) | package metadata, listed/unlisted checks |
+
+A feed needs `PackageBaseAddress` or `RegistrationsBaseUrl` to be usable. If it advertises no
+`SearchQueryService` — or its search returns nothing — search degrades to an exact
+package-id lookup against the flat container. Flat-container version lists include unlisted
+versions, so an update candidate is confirmed against its registration leaf before being
+surfaced.
+
+### Fallback behaviour
+
+There is no V2 fallback for a URL that looks like a V3 service index: such a URL is not a
+valid V2 root, so a failed or malformed service index is reported as an error rather than
+retried against a fabricated V2 endpoint. V2-only feeds never enter the V3 path at all.
+
+### Which feed is which
+
+- **.NET Tool** — `https://api.nuget.org/v3/index.json`. Safe to repoint because the manager
+  does not support custom sources and never passes the source URL to the `dotnet` CLI. Also
+  filters search on `packageType=DotnetTool`.
+- **PowerShell / PowerShell 7** — sources are enumerated from `Get-PSRepository`, so the URL is
+  CLI-owned identity (`PowerShellSourceHelper` compares it literally to choose
+  `Register-PSRepository -Default`) and must not be rewritten. The PowerShell Gallery serves no
+  V3 service index, so it stays on V2; a V3-capable custom repository (Azure Artifacts, GitHub
+  Packages, JFrog, MyGet) is picked up automatically.
+- **Chocolatey** — sources come from `choco source list` and `community.chocolatey.org` serves no
+  `index.json`, so it stays on V2. Note that only its updates and version listing are CLI-driven;
+  its search, details and icons run through the shared `BaseNuGet` HTTP path.
+
+V3 has no `IsLatestVersion`, so the client picks "latest" itself using the comparator described
+in the next section.
+
+## Version comparison across ecosystems
+
+`CoreTools.VersionStringToStruct` treats `-`, `_`, `/` and `#` as plain numeric separators and
+drops the letters around them. That is correct for ecosystems where a trailing suffix is a build
+or port revision, and wrong for ecosystems where it is a pre-release - the same string orders
+the opposite way depending on the feed it came from:
+
+| String | Debian / Scoop / Homebrew / vcpkg | npm / crates.io / NuGet | PyPI |
+|---|---|---|---|
+| `1.0.0-1` | **newer** (revision) | **older** (pre-release) | **newer** (implicit post-release) |
+| `1.0.0rc1` | n/a | n/a | **older** (pre-release) |
+
+So the comparison is per-manager, not global. `IPackageManager.CompareVersions(a, b)` returns the
+usual negative/zero/positive, or `null` when two versions cannot be meaningfully compared:
+
+- **Default** (`PackageManager.CompareVersions`) - the numeric comparison above. Used by Scoop,
+  WinGet, Apt, Dnf, Pacman, Homebrew, vcpkg, Snap and Flatpak.
+- **`SemanticVersion`** in `UniGetUI.Core.Tools` - SemVer 2.0 with NuGet's fourth numeric segment
+  allowed. Used by `BaseNuGet` (so Chocolatey, .NET Tool, Windows PowerShell and PowerShell 7),
+  npm, Bun and Cargo.
+- **`PythonVersion`** in `UniGetUI.Core.Tools` - PEP 440, matching Python's packaging library.
+  Used by Pip.
+
+Each override falls back to the base implementation when its own parser rejects the input, so an
+unparseable version behaves exactly as it did before.
+
+Three call sites consume it: `Package.NewerVersionIsInstalled()`, which decides whether an update
+is offered at all; `BaseNuGet.KeepUpdatesNewerThanInstalled`; and the
+`UninstallPreviousVersionsOnUpdate` match, which removes superseded copies. Display sorting
+deliberately does not - those lists mix managers, and a comparison between two packages from
+different ecosystems has no single correct answer.
+
+When adding a manager, pick the comparator its registry actually uses. Getting it wrong hides
+real updates or offers downgrades, and the tests in `PackageTests.cs` assert both directions:
+that SemVer and PEP 440 managers order pre-releases below their releases, and that revision
+ecosystems keep reading a trailing suffix as newer.
+
 ## Build & Test
 
 ```shell

--- a/src/UniGetUI.Core.Tools/PythonVersion.cs
+++ b/src/UniGetUI.Core.Tools/PythonVersion.cs
@@ -1,0 +1,328 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace UniGetUI.Core.Tools
+{
+    /// <summary>
+    /// PEP 440 version ordering, as implemented by Python's packaging library.
+    /// Python spells a pre-release without a dash ("1.0.0rc1") and it is OLDER than the release
+    /// it precedes, while a bare trailing dash-number ("1.0.0-1") is an implicit post-release and
+    /// so is NEWER. Neither <see cref="SemanticVersion"/> nor
+    /// <see cref="CoreTools.VersionStringToStruct"/> can order those correctly.
+    /// </summary>
+    public readonly partial struct PythonVersion
+        : IComparable<PythonVersion>,
+            IEquatable<PythonVersion>
+    {
+        private const int PreCategoryDevOnly = -1;
+        private const int PreCategoryPresent = 0;
+        private const int PreCategoryAbsent = 1;
+
+        private static readonly int[] NoRelease = [];
+
+        private readonly int _epoch;
+        private readonly int[] _release;
+        private readonly int _preCategory;
+        private readonly int _preRank;
+        private readonly int _preNumber;
+        private readonly int? _post;
+        private readonly int? _dev;
+        private readonly string[]? _local;
+
+        public string Original { get; }
+        public bool IsValid { get; }
+
+        public bool IsPreRelease =>
+            IsValid && (_preCategory is PreCategoryPresent || _dev is not null);
+
+        private PythonVersion(
+            string original,
+            int epoch,
+            int[] release,
+            int preCategory,
+            int preRank,
+            int preNumber,
+            int? post,
+            int? dev,
+            string[]? local
+        )
+        {
+            Original = original;
+            IsValid = true;
+            _epoch = epoch;
+            _release = release;
+            _preCategory = preCategory;
+            _preRank = preRank;
+            _preNumber = preNumber;
+            _post = post;
+            _dev = dev;
+            _local = local;
+        }
+
+        [GeneratedRegex(
+            @"^v?(?:(?:(?<epoch>[0-9]+)!)?(?<release>[0-9]+(?:\.[0-9]+)*)"
+                + @"(?:[-_\.]?(?<pre_l>alpha|a|beta|b|preview|pre|c|rc)[-_\.]?(?<pre_n>[0-9]+)?)?"
+                + @"(?:(?:-(?<post_n1>[0-9]+))|(?:[-_\.]?(?<post_l>post|rev|r)[-_\.]?(?<post_n2>[0-9]+)?))?"
+                + @"(?<dev>[-_\.]?dev[-_\.]?(?<dev_n>[0-9]+)?)?)"
+                + @"(?:\+(?<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?$",
+            RegexOptions.CultureInvariant
+        )]
+        private static partial Regex Pep440Pattern();
+
+        public static bool TryParse(string? value, out PythonVersion version)
+        {
+            version = default;
+
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            string candidate = value.Trim().ToLowerInvariant();
+            Match match = Pep440Pattern().Match(candidate);
+            if (!match.Success)
+                return false;
+
+            int epoch = ParseNumber(match.Groups["epoch"], 0);
+
+            string[] releaseParts = match.Groups["release"].Value.Split('.');
+            int[] release = new int[releaseParts.Length];
+            for (int i = 0; i < releaseParts.Length; i++)
+            {
+                if (
+                    !int.TryParse(
+                        releaseParts[i],
+                        NumberStyles.None,
+                        CultureInfo.InvariantCulture,
+                        out release[i]
+                    )
+                )
+                    return false;
+            }
+
+            int preCategory = PreCategoryAbsent;
+            int preRank = 0;
+            int preNumber = 0;
+            if (match.Groups["pre_l"].Success)
+            {
+                preCategory = PreCategoryPresent;
+                preRank = match.Groups["pre_l"].Value switch
+                {
+                    "a" or "alpha" => 0,
+                    "b" or "beta" => 1,
+                    _ => 2,
+                };
+                preNumber = ParseNumber(match.Groups["pre_n"], 0);
+            }
+
+            int? post = null;
+            if (match.Groups["post_n1"].Success)
+                post = ParseNumber(match.Groups["post_n1"], 0);
+            else if (match.Groups["post_l"].Success)
+                post = ParseNumber(match.Groups["post_n2"], 0);
+
+            int? dev = match.Groups["dev"].Success
+                ? ParseNumber(match.Groups["dev_n"], 0)
+                : null;
+
+            string[]? local = match.Groups["local"].Success
+                ? match.Groups["local"].Value.Split(['.', '-', '_'], StringSplitOptions.RemoveEmptyEntries)
+                : null;
+
+            if (preCategory is PreCategoryAbsent && post is null && dev is not null)
+                preCategory = PreCategoryDevOnly;
+
+            version = new PythonVersion(
+                value,
+                epoch,
+                StripTrailingZeros(release),
+                preCategory,
+                preRank,
+                preNumber,
+                post,
+                dev,
+                local
+            );
+            return true;
+        }
+
+        private static int ParseNumber(Group group, int fallback) =>
+            group.Success
+            && int.TryParse(
+                group.Value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int parsed
+            )
+                ? parsed
+                : fallback;
+
+        private static int[] StripTrailingZeros(int[] release)
+        {
+            int length = release.Length;
+            while (length > 0 && release[length - 1] is 0)
+                length--;
+
+            if (length == release.Length)
+                return release;
+            if (length is 0)
+                return NoRelease;
+
+            int[] trimmed = new int[length];
+            Array.Copy(release, trimmed, length);
+            return trimmed;
+        }
+
+        public int CompareTo(PythonVersion other)
+        {
+            if (!IsValid || !other.IsValid)
+                return IsValid.CompareTo(other.IsValid);
+
+            int comparison = _epoch.CompareTo(other._epoch);
+            if (comparison is not 0)
+                return comparison;
+
+            comparison = CompareRelease(_release, other._release);
+            if (comparison is not 0)
+                return comparison;
+
+            comparison = _preCategory.CompareTo(other._preCategory);
+            if (comparison is not 0)
+                return comparison;
+
+            if (_preCategory is PreCategoryPresent)
+            {
+                comparison = _preRank.CompareTo(other._preRank);
+                if (comparison is not 0)
+                    return comparison;
+
+                comparison = _preNumber.CompareTo(other._preNumber);
+                if (comparison is not 0)
+                    return comparison;
+            }
+
+            comparison = CompareLowestFirst(_post, other._post);
+            if (comparison is not 0)
+                return comparison;
+
+            comparison = CompareHighestWhenAbsent(_dev, other._dev);
+            if (comparison is not 0)
+                return comparison;
+
+            return CompareLocal(_local, other._local);
+        }
+
+        private static int CompareRelease(int[] left, int[] right)
+        {
+            int length = Math.Max(left.Length, right.Length);
+            for (int i = 0; i < length; i++)
+            {
+                int a = i < left.Length ? left[i] : 0;
+                int b = i < right.Length ? right[i] : 0;
+                int comparison = a.CompareTo(b);
+                if (comparison is not 0)
+                    return comparison;
+            }
+
+            return 0;
+        }
+
+        private static int CompareLowestFirst(int? left, int? right) =>
+            (left, right) switch
+            {
+                (null, null) => 0,
+                (null, _) => -1,
+                (_, null) => 1,
+                _ => left.Value.CompareTo(right.Value),
+            };
+
+        private static int CompareHighestWhenAbsent(int? left, int? right) =>
+            (left, right) switch
+            {
+                (null, null) => 0,
+                (null, _) => 1,
+                (_, null) => -1,
+                _ => left.Value.CompareTo(right.Value),
+            };
+
+        private static int CompareLocal(string[]? left, string[]? right)
+        {
+            if (left is null && right is null)
+                return 0;
+            if (left is null)
+                return -1;
+            if (right is null)
+                return 1;
+
+            int length = Math.Max(left.Length, right.Length);
+            for (int i = 0; i < length; i++)
+            {
+                if (i >= left.Length)
+                    return -1;
+                if (i >= right.Length)
+                    return 1;
+
+                bool leftNumeric = int.TryParse(
+                    left[i],
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out int leftValue
+                );
+                bool rightNumeric = int.TryParse(
+                    right[i],
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out int rightValue
+                );
+
+                if (leftNumeric && rightNumeric)
+                {
+                    int comparison = leftValue.CompareTo(rightValue);
+                    if (comparison is not 0)
+                        return comparison;
+                }
+                else if (leftNumeric)
+                {
+                    return 1;
+                }
+                else if (rightNumeric)
+                {
+                    return -1;
+                }
+                else
+                {
+                    int comparison = string.CompareOrdinal(left[i], right[i]);
+                    if (comparison is not 0)
+                        return comparison;
+                }
+            }
+
+            return 0;
+        }
+
+        public bool Equals(PythonVersion other) => CompareTo(other) is 0;
+
+        public override bool Equals(object? obj) => obj is PythonVersion other && Equals(other);
+
+        public override int GetHashCode() =>
+            IsValid ? HashCode.Combine(_epoch, _release.Length, _preCategory, _post, _dev) : 0;
+
+        public override string ToString() => Original ?? string.Empty;
+
+        public static bool operator >(PythonVersion left, PythonVersion right) =>
+            left.CompareTo(right) > 0;
+
+        public static bool operator <(PythonVersion left, PythonVersion right) =>
+            left.CompareTo(right) < 0;
+
+        public static bool operator >=(PythonVersion left, PythonVersion right) =>
+            left.CompareTo(right) >= 0;
+
+        public static bool operator <=(PythonVersion left, PythonVersion right) =>
+            left.CompareTo(right) <= 0;
+
+        public static bool operator ==(PythonVersion left, PythonVersion right) =>
+            left.Equals(right);
+
+        public static bool operator !=(PythonVersion left, PythonVersion right) =>
+            !left.Equals(right);
+    }
+}

--- a/src/UniGetUI.Core.Tools/SemanticVersion.cs
+++ b/src/UniGetUI.Core.Tools/SemanticVersion.cs
@@ -4,11 +4,20 @@ namespace UniGetUI.Core.Tools
 {
     /// <summary>
     /// Semantic Versioning 2.0 ordering, with NuGet's fourth numeric segment allowed.
+    /// Pre-release labels compare case-sensitively by default, as SemVer 2.0 requires (ASCII
+    /// order, so "1.0.0-RC" precedes "1.0.0-rc"). NuGet's own comparer is case-insensitive, so
+    /// feeds using NuGet semantics must parse with <see cref="SemVerLabels.CaseInsensitive"/>.
     /// Use it only for ecosystems where a dash introduces a pre-release that is OLDER than the
     /// release it precedes (NuGet, npm, crates.io). Ecosystems whose dash, underscore or hash
     /// introduces a build or port revision that is NEWER than the base version - Debian, Scoop,
     /// Homebrew, vcpkg - must keep using <see cref="CoreTools.VersionStringToStruct"/> instead.
     /// </summary>
+    public enum SemVerLabels
+    {
+        CaseSensitive,
+        CaseInsensitive,
+    }
+
     public readonly struct SemanticVersion : IComparable<SemanticVersion>, IEquatable<SemanticVersion>
     {
         private static readonly int[] EmptyNumbers = [0, 0, 0, 0];
@@ -16,23 +25,38 @@ namespace UniGetUI.Core.Tools
 
         private readonly int[] _numbers;
         private readonly string[] _labels;
+        private readonly SemVerLabels _labelComparison;
 
         public string Original { get; }
         public bool IsValid { get; }
         public bool IsPreRelease => _labels is { Length: > 0 };
 
-        private SemanticVersion(string original, int[] numbers, string[] labels, bool isValid)
+        private SemanticVersion(
+            string original,
+            int[] numbers,
+            string[] labels,
+            bool isValid,
+            SemVerLabels labelComparison
+        )
         {
             Original = original;
             _numbers = numbers;
             _labels = labels;
             IsValid = isValid;
+            _labelComparison = labelComparison;
         }
 
         public static SemanticVersion Invalid(string original) =>
-            new(original, EmptyNumbers, NoLabels, false);
+            new(original, EmptyNumbers, NoLabels, false, SemVerLabels.CaseSensitive);
 
-        public static bool TryParse(string? value, out SemanticVersion version)
+        public static bool TryParse(string? value, out SemanticVersion version) =>
+            TryParse(value, SemVerLabels.CaseSensitive, out version);
+
+        public static bool TryParse(
+            string? value,
+            SemVerLabels labelComparison,
+            out SemanticVersion version
+        )
         {
             version = Invalid(value ?? string.Empty);
 
@@ -78,7 +102,7 @@ namespace UniGetUI.Core.Tools
                 numbers[i] = number;
             }
 
-            version = new SemanticVersion(value, numbers, labels, true);
+            version = new SemanticVersion(value, numbers, labels, true, labelComparison);
             return true;
         }
 
@@ -100,7 +124,12 @@ namespace UniGetUI.Core.Tools
             int shared = Math.Min(_labels.Length, other._labels.Length);
             for (int i = 0; i < shared; i++)
             {
-                int comparison = CompareLabel(_labels[i], other._labels[i]);
+                int comparison = CompareLabel(
+                    _labels[i],
+                    other._labels[i],
+                    _labelComparison is SemVerLabels.CaseInsensitive
+                        || other._labelComparison is SemVerLabels.CaseInsensitive
+                );
                 if (comparison is not 0)
                     return comparison;
             }
@@ -108,7 +137,7 @@ namespace UniGetUI.Core.Tools
             return _labels.Length.CompareTo(other._labels.Length);
         }
 
-        private static int CompareLabel(string left, string right)
+        private static int CompareLabel(string left, string right, bool caseInsensitive)
         {
             bool leftNumeric = int.TryParse(
                 left,
@@ -130,7 +159,9 @@ namespace UniGetUI.Core.Tools
             if (rightNumeric)
                 return 1;
 
-            return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+            return caseInsensitive
+                ? string.Compare(left, right, StringComparison.OrdinalIgnoreCase)
+                : string.CompareOrdinal(left, right);
         }
 
         public bool Equals(SemanticVersion other) => CompareTo(other) is 0;

--- a/src/UniGetUI.Core.Tools/SemanticVersion.cs
+++ b/src/UniGetUI.Core.Tools/SemanticVersion.cs
@@ -1,0 +1,163 @@
+using System.Globalization;
+
+namespace UniGetUI.Core.Tools
+{
+    /// <summary>
+    /// Semantic Versioning 2.0 ordering, with NuGet's fourth numeric segment allowed.
+    /// Use it only for ecosystems where a dash introduces a pre-release that is OLDER than the
+    /// release it precedes (NuGet, npm, crates.io). Ecosystems whose dash, underscore or hash
+    /// introduces a build or port revision that is NEWER than the base version - Debian, Scoop,
+    /// Homebrew, vcpkg - must keep using <see cref="CoreTools.VersionStringToStruct"/> instead.
+    /// </summary>
+    public readonly struct SemanticVersion : IComparable<SemanticVersion>, IEquatable<SemanticVersion>
+    {
+        private static readonly int[] EmptyNumbers = [0, 0, 0, 0];
+        private static readonly string[] NoLabels = [];
+
+        private readonly int[] _numbers;
+        private readonly string[] _labels;
+
+        public string Original { get; }
+        public bool IsValid { get; }
+        public bool IsPreRelease => _labels is { Length: > 0 };
+
+        private SemanticVersion(string original, int[] numbers, string[] labels, bool isValid)
+        {
+            Original = original;
+            _numbers = numbers;
+            _labels = labels;
+            IsValid = isValid;
+        }
+
+        public static SemanticVersion Invalid(string original) =>
+            new(original, EmptyNumbers, NoLabels, false);
+
+        public static bool TryParse(string? value, out SemanticVersion version)
+        {
+            version = Invalid(value ?? string.Empty);
+
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            string candidate = value.Trim();
+            if (candidate.StartsWith('v') || candidate.StartsWith('V'))
+                candidate = candidate[1..];
+
+            int metadataIndex = candidate.IndexOf('+');
+            if (metadataIndex >= 0)
+                candidate = candidate[..metadataIndex];
+
+            string[] labels = NoLabels;
+            int labelIndex = candidate.IndexOf('-');
+            if (labelIndex >= 0)
+            {
+                string labelPart = candidate[(labelIndex + 1)..];
+                candidate = candidate[..labelIndex];
+                labels = labelPart.Split('.', StringSplitOptions.RemoveEmptyEntries);
+                if (labels.Length is 0)
+                    labels = NoLabels;
+            }
+
+            string[] parts = candidate.Split('.');
+            if (parts.Length is 0 or > 4)
+                return false;
+
+            int[] numbers = [0, 0, 0, 0];
+            for (int i = 0; i < parts.Length; i++)
+            {
+                if (
+                    !int.TryParse(
+                        parts[i],
+                        NumberStyles.None,
+                        CultureInfo.InvariantCulture,
+                        out int number
+                    )
+                )
+                    return false;
+
+                numbers[i] = number;
+            }
+
+            version = new SemanticVersion(value, numbers, labels, true);
+            return true;
+        }
+
+        public int CompareTo(SemanticVersion other)
+        {
+            if (!IsValid || !other.IsValid)
+                return IsValid.CompareTo(other.IsValid);
+
+            for (int i = 0; i < 4; i++)
+            {
+                int comparison = _numbers[i].CompareTo(other._numbers[i]);
+                if (comparison is not 0)
+                    return comparison;
+            }
+
+            if (_labels.Length is 0 || other._labels.Length is 0)
+                return other._labels.Length.CompareTo(_labels.Length);
+
+            int shared = Math.Min(_labels.Length, other._labels.Length);
+            for (int i = 0; i < shared; i++)
+            {
+                int comparison = CompareLabel(_labels[i], other._labels[i]);
+                if (comparison is not 0)
+                    return comparison;
+            }
+
+            return _labels.Length.CompareTo(other._labels.Length);
+        }
+
+        private static int CompareLabel(string left, string right)
+        {
+            bool leftNumeric = int.TryParse(
+                left,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int leftValue
+            );
+            bool rightNumeric = int.TryParse(
+                right,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int rightValue
+            );
+
+            if (leftNumeric && rightNumeric)
+                return leftValue.CompareTo(rightValue);
+            if (leftNumeric)
+                return -1;
+            if (rightNumeric)
+                return 1;
+
+            return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool Equals(SemanticVersion other) => CompareTo(other) is 0;
+
+        public override bool Equals(object? obj) => obj is SemanticVersion other && Equals(other);
+
+        public override int GetHashCode() =>
+            IsValid
+                ? HashCode.Combine(_numbers[0], _numbers[1], _numbers[2], _numbers[3], _labels.Length)
+                : 0;
+
+        public override string ToString() => Original ?? string.Empty;
+
+        public static bool operator >(SemanticVersion left, SemanticVersion right) =>
+            left.CompareTo(right) > 0;
+
+        public static bool operator <(SemanticVersion left, SemanticVersion right) =>
+            left.CompareTo(right) < 0;
+
+        public static bool operator >=(SemanticVersion left, SemanticVersion right) =>
+            left.CompareTo(right) >= 0;
+
+        public static bool operator <=(SemanticVersion left, SemanticVersion right) =>
+            left.CompareTo(right) <= 0;
+
+        public static bool operator ==(SemanticVersion left, SemanticVersion right) => left.Equals(right);
+
+        public static bool operator !=(SemanticVersion left, SemanticVersion right) => !left.Equals(right);
+    }
+}

--- a/src/UniGetUI.PackageEngine.Interfaces/IPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.Interfaces/IPackageManager.cs
@@ -31,6 +31,16 @@ namespace UniGetUI.PackageEngine.Interfaces
         public bool InstallerUrlFollowsPackageVersion { get; }
 
         /// <summary>
+        /// Compares two version strings using this manager's ecosystem semantics, returning a
+        /// negative number, zero or a positive number in the usual way, or null when the two
+        /// versions cannot be meaningfully compared.
+        /// A dash means opposite things across ecosystems - a Debian or Scoop revision is newer
+        /// than its base version, while a SemVer pre-release is older than its release - so the
+        /// shared numeric comparison cannot be right for every manager at once.
+        /// </summary>
+        public int? CompareVersions(string versionA, string versionB);
+
+        /// <summary>
         /// Initializes the Package Manager (asynchronously). Must be run before using any other method of the manager.
         /// </summary>
         public void Initialize();

--- a/src/UniGetUI.PackageEngine.Managers.Bun/Bun.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Bun/Bun.cs
@@ -220,6 +220,17 @@ namespace UniGetUI.PackageEngine.Managers.BunManager
             callArguments = "";
         }
 
+        public override int? CompareVersions(string versionA, string versionB)
+        {
+            if (
+                SemanticVersion.TryParse(versionA, out SemanticVersion parsedA)
+                && SemanticVersion.TryParse(versionB, out SemanticVersion parsedB)
+            )
+                return parsedA.CompareTo(parsedB);
+
+            return base.CompareVersions(versionA, versionB);
+        }
+
         protected override void _loadManagerVersion(out string version)
         {
             using Process process = new()

--- a/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
@@ -236,6 +236,17 @@ public partial class Cargo : PackageManager
         callArguments = "";
     }
 
+    public override int? CompareVersions(string versionA, string versionB)
+    {
+        if (
+            SemanticVersion.TryParse(versionA, out SemanticVersion parsedA)
+            && SemanticVersion.TryParse(versionB, out SemanticVersion parsedB)
+        )
+            return parsedA.CompareTo(parsedB);
+
+        return base.CompareVersions(versionA, versionB);
+    }
+
     protected override void _loadManagerVersion(out string version)
     {
         using Process p = GetProcess(Status.ExecutablePath, "--version");

--- a/src/UniGetUI.PackageEngine.Managers.Dotnet/DotNet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Dotnet/DotNet.cs
@@ -62,17 +62,23 @@ namespace UniGetUI.PackageEngine.Managers.DotNetManager
                 DefaultSource = new ManagerSource(
                     this,
                     "nuget.org",
-                    new Uri("https://www.nuget.org/api/v2")
+                    new Uri("https://api.nuget.org/v3/index.json")
                 ),
                 KnownSources =
                 [
-                    new ManagerSource(this, "nuget.org", new Uri("https://www.nuget.org/api/v2")),
+                    new ManagerSource(
+                        this,
+                        "nuget.org",
+                        new Uri("https://api.nuget.org/v3/index.json")
+                    ),
                 ],
             };
 
             DetailsHelper = new DotNetDetailsHelper(this);
             OperationHelper = new DotNetPkgOperationHelper(this);
         }
+
+        protected override string? V3PackageType => "DotnetTool";
 
         protected override IReadOnlyList<Package> _getInstalledPackages_UnSafe()
         {

--- a/src/UniGetUI.PackageEngine.Managers.Dotnet/Helpers/DotNetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Dotnet/Helpers/DotNetPkgOperationHelper.cs
@@ -30,16 +30,15 @@ internal sealed class DotNetPkgOperationHelper : BasePkgOperationHelper
             package.Id,
         ];
 
-        if (options.CustomInstallLocation != "")
+        bool usesCustomToolPath = options.CustomInstallLocation != "";
+        if (usesCustomToolPath)
             parameters.AddRange(["--tool-path", CoreTools.EscapeCommandLineArgument(options.CustomInstallLocation)]);
 
-        if (
-            package.OverridenOptions.Scope is PackageScope.Global
-            || (
-                package.OverridenOptions.Scope is null
-                && options.InstallationScope is PackageScope.Global
-            )
-        )
+        string? requestedScope =
+            package.OverridenOptions.Scope
+            ?? (options.InstallationScope.Length > 0 ? options.InstallationScope : null);
+
+        if (!usesCustomToolPath && requestedScope != PackageScope.Local)
             parameters.Add("--global");
 
         if (operation is OperationType.Install or OperationType.Update)

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
@@ -45,8 +45,16 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
         public override int? CompareVersions(string versionA, string versionB)
         {
             if (
-                SemanticVersion.TryParse(versionA, out SemanticVersion parsedA)
-                && SemanticVersion.TryParse(versionB, out SemanticVersion parsedB)
+                SemanticVersion.TryParse(
+                    versionA,
+                    SemVerLabels.CaseInsensitive,
+                    out SemanticVersion parsedA
+                )
+                && SemanticVersion.TryParse(
+                    versionB,
+                    SemVerLabels.CaseInsensitive,
+                    out SemanticVersion parsedB
+                )
             )
                 return parsedA.CompareTo(parsedB);
 
@@ -220,7 +228,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                             this
                         );
                         Packages.Add(nativePackage);
-                        Manifests[nativePackage.GetHash()] = package.manifest;
+                        Manifests[nativePackage.GetVersionedHash()] = package.manifest;
                     }
                 }
                 catch (Exception ex)
@@ -285,7 +293,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                 packages.Add(nativePackage);
 
                 if (!result.IsExactIdFallback)
-                    V3IconUrls[nativePackage.GetHash()] = result.IconUrl ?? string.Empty;
+                    V3IconUrls[nativePackage.GetVersionedHash()] = result.IconUrl ?? string.Empty;
             }
 
             return packages;
@@ -322,12 +330,18 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                             pair.Key,
                             pair.Value,
                             canPrerelease,
-                            logger
+                            logger,
+                            out int v3Errors
                         );
                         if (v3Updates is null)
+                        {
                             errors++;
+                        }
                         else
+                        {
                             Packages.AddRange(v3Updates);
+                            errors += v3Errors;
+                        }
 
                         continue;
                     }
@@ -398,8 +412,17 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             IReadOnlyList<IPackage> installedPackages,
             bool canPrerelease,
             INativeTaskLogger logger
+        ) => GetAvailableUpdatesV3(source, installedPackages, canPrerelease, logger, out _);
+
+        internal IReadOnlyList<Package>? GetAvailableUpdatesV3(
+            IManagerSource source,
+            IReadOnlyList<IPackage> installedPackages,
+            bool canPrerelease,
+            INativeTaskLogger logger,
+            out int errors
         )
         {
+            errors = 0;
             NuGetV3ServiceIndex? index = NuGetV3ServiceIndex.Resolve(source);
             if (index is null)
             {
@@ -416,7 +439,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
             var scopeMap = BuildInstalledScopeMap(installedPackages);
             var candidates = new ConcurrentDictionary<string, string>();
-            var failures = new ConcurrentDictionary<string, Exception>();
+            var failures = new ConcurrentDictionary<string, Exception?>();
 
             Parallel.ForEach(
                 installed,
@@ -432,10 +455,13 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                             index,
                             entry.Value.Id,
                             entry.Value.Version,
-                            canPrerelease
+                            canPrerelease,
+                            out bool requestFailed
                         );
 
-                        if (candidate is not null)
+                        if (requestFailed)
+                            failures[entry.Key] = null;
+                        else if (candidate is not null)
                             candidates[entry.Key] = candidate;
                     }
                     catch (Exception ex)
@@ -450,8 +476,11 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                 logger.Error(
                     $"Failed to check updates for {installed[failure.Key].Id} on source {source.Name}"
                 );
-                logger.Error(failure.Value);
+                if (failure.Value is { } exception)
+                    logger.Error(exception);
             }
+
+            errors = failures.Count;
 
             List<Package> packages = [];
             foreach (var candidate in candidates)
@@ -591,7 +620,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                     new OverridenInstallationOptions(packageIdScope.GetValueOrDefault(id.ToLower()))
                 );
                 packages.Add(nativePackage);
-                Manifests[nativePackage.GetHash()] = match.Value;
+                Manifests[nativePackage.GetVersionedHash()] = match.Value;
             }
 
             return packages;

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGet.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -8,6 +9,7 @@ using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.ManagerClasses.Classes;
 using UniGetUI.PackageEngine.ManagerClasses.Manager;
+using UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal;
 using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.Structs;
 
@@ -16,15 +18,40 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
     public abstract class BaseNuGet : PackageManager
     {
         /// <summary>
-        /// When true, searches use Packages()?$filter=substringof(query,Id) which searches by
-        /// package name only but returns reliable results (e.g. PSGallery's Search() endpoint
-        /// silently omits some packages). When false, the standard Search() endpoint is used
-        /// which supports full-text search across name, description, and tags.
+        /// Only applies to V2 sources. When true, searches use
+        /// Packages()?$filter=substringof(query,Id) which searches by package name only but
+        /// returns reliable results (e.g. PSGallery's Search() endpoint silently omits some
+        /// packages). When false, the standard Search() endpoint is used which supports
+        /// full-text search across name, description, and tags. V3 sources use
+        /// SearchQueryService and fall back to an exact package-id lookup when the feed
+        /// advertises no search service or returns no results.
         /// </summary>
         protected virtual bool UseSubstringSearch => false;
+
+        /// <summary>
+        /// Only applies to V3 sources. When set, searches are restricted to packages
+        /// advertising this package type (for example "DotnetTool"). V2 sources have no
+        /// equivalent filter and ignore it.
+        /// </summary>
+        protected virtual string? V3PackageType => null;
+
         public static Dictionary<long, string> Manifests = new();
 
+        internal static readonly ConcurrentDictionary<long, string> V3IconUrls = new();
+        internal static readonly ConcurrentDictionary<long, V3CatalogEntry> V3Entries = new();
+
         public override bool InstallerUrlFollowsPackageVersion => true;
+
+        public override int? CompareVersions(string versionA, string versionB)
+        {
+            if (
+                SemanticVersion.TryParse(versionA, out SemanticVersion parsedA)
+                && SemanticVersion.TryParse(versionB, out SemanticVersion parsedB)
+            )
+                return parsedA.CompareTo(parsedB);
+
+            return base.CompareVersions(versionA, versionB);
+        }
 
         public sealed override void Initialize()
         {
@@ -81,6 +108,12 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             {
                 try
                 {
+                    if (NuGetV3ServiceIndex.IsV3Source(source))
+                    {
+                        Packages.AddRange(FindPackagesV3(source, query, canPrerelease, logger));
+                        continue;
+                    }
+
                     string versionFilter = canPrerelease ? "IsAbsoluteLatestVersion eq true" : "IsLatestVersion eq true";
                     string odataQuery = HttpUtility.UrlEncode(query.Replace("'", "''"));
                     Uri? SearchUrl = UseSubstringSearch
@@ -203,6 +236,61 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             return Packages;
         }
 
+        internal IReadOnlyList<Package> FindPackagesV3(
+            IManagerSource source,
+            string query,
+            bool canPrerelease,
+            INativeTaskLogger logger
+        )
+        {
+            NuGetV3ServiceIndex? index = NuGetV3ServiceIndex.Resolve(source);
+            if (index is null)
+            {
+                logger.Error(
+                    $"Could not resolve the NuGet V3 service index for source {source.Name} "
+                        + $"at Url={source.Url} on manager {Name}"
+                );
+                return [];
+            }
+
+            logger.Log(
+                $"Begin V3 package search for query={query} on source {source.Name} of manager {Name}"
+            );
+
+            List<Package> packages = [];
+            foreach (
+                V3SearchResult result in NuGetV3Client.Search(
+                    index,
+                    query,
+                    canPrerelease,
+                    V3PackageType,
+                    50
+                )
+            )
+            {
+                if (result.Id is null || result.Version is null)
+                    continue;
+
+                logger.Log(
+                    $"Found package {result.Id} version {result.Version} on source {source.Name}"
+                );
+
+                var nativePackage = new Package(
+                    CoreTools.FormatAsName(result.Id),
+                    result.Id,
+                    result.Version,
+                    source,
+                    this
+                );
+                packages.Add(nativePackage);
+
+                if (!result.IsExactIdFallback)
+                    V3IconUrls[nativePackage.GetHash()] = result.IconUrl ?? string.Empty;
+            }
+
+            return packages;
+        }
+
         protected override IReadOnlyList<Package> GetAvailableUpdates_UnSafe()
         {
             int errors = 0;
@@ -228,6 +316,22 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             {
                 try
                 {
+                    if (NuGetV3ServiceIndex.IsV3Source(pair.Key))
+                    {
+                        var v3Updates = GetAvailableUpdatesV3(
+                            pair.Key,
+                            pair.Value,
+                            canPrerelease,
+                            logger
+                        );
+                        if (v3Updates is null)
+                            errors++;
+                        else
+                            Packages.AddRange(v3Updates);
+
+                        continue;
+                    }
+
                     var packageIds = new StringBuilder();
                     var packageVers = new StringBuilder();
                     var packageIdVersion = new Dictionary<string, string>();
@@ -285,20 +389,144 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
                 }
             }
 
-            var maxVersions = new Dictionary<string, CoreTools.Version?>();
-            foreach (var pkg in installedPackages)
+            logger.Close(errors);
+            return KeepUpdatesNewerThanInstalled(Packages, installedPackages);
+        }
+
+        internal IReadOnlyList<Package>? GetAvailableUpdatesV3(
+            IManagerSource source,
+            IReadOnlyList<IPackage> installedPackages,
+            bool canPrerelease,
+            INativeTaskLogger logger
+        )
+        {
+            NuGetV3ServiceIndex? index = NuGetV3ServiceIndex.Resolve(source);
+            if (index is null)
             {
-                maxVersions.TryGetValue(pkg.Id, out var ver);
-                if (ver is null || ver < pkg.NormalizedVersion)
+                logger.Error(
+                    $"Could not resolve the NuGet V3 service index for source {source.Name} "
+                        + $"at Url={source.Url} on manager {Name}"
+                );
+                return null;
+            }
+
+            var installed = new Dictionary<string, (string Id, string Version)>();
+            foreach (var package in installedPackages)
+                installed[package.Id.ToLower()] = (package.Id, package.VersionString);
+
+            var scopeMap = BuildInstalledScopeMap(installedPackages);
+            var candidates = new ConcurrentDictionary<string, string>();
+            var failures = new ConcurrentDictionary<string, Exception>();
+
+            Parallel.ForEach(
+                installed,
+                new ParallelOptions
                 {
-                    maxVersions[pkg.Id.ToLower()] = pkg.NormalizedVersion;
+                    MaxDegreeOfParallelism = NuGetV3Client.MaxConcurrentRequests,
+                },
+                entry =>
+                {
+                    try
+                    {
+                        string? candidate = NuGetV3Client.GetUpdateCandidate(
+                            index,
+                            entry.Value.Id,
+                            entry.Value.Version,
+                            canPrerelease
+                        );
+
+                        if (candidate is not null)
+                            candidates[entry.Key] = candidate;
+                    }
+                    catch (Exception ex)
+                    {
+                        failures[entry.Key] = ex;
+                    }
+                }
+            );
+
+            foreach (var failure in failures)
+            {
+                logger.Error(
+                    $"Failed to check updates for {installed[failure.Key].Id} on source {source.Name}"
+                );
+                logger.Error(failure.Value);
+            }
+
+            List<Package> packages = [];
+            foreach (var candidate in candidates)
+            {
+                (string id, string installedVersion) = installed[candidate.Key];
+                logger.Log(
+                    $"Found package {id} version {candidate.Value} on source {source.Name}"
+                );
+
+                packages.Add(
+                    new Package(
+                        CoreTools.FormatAsName(id),
+                        id,
+                        installedVersion,
+                        candidate.Value,
+                        source,
+                        this,
+                        new OverridenInstallationOptions(scopeMap.GetValueOrDefault(candidate.Key))
+                    )
+                );
+            }
+
+            return packages;
+        }
+
+        /// <summary>
+        /// Drops any update whose new version is not newer than the highest version already
+        /// installed under the same id, so a copy installed in another scope does not get
+        /// offered an update it already satisfies. Comparisons go through the manager so a
+        /// NuGet pre-release is ordered below its stable release.
+        /// </summary>
+        internal IReadOnlyList<Package> KeepUpdatesNewerThanInstalled(
+            IReadOnlyList<Package> candidates,
+            IReadOnlyList<IPackage> installedPackages
+        )
+        {
+            var highestInstalledById = new Dictionary<string, string>();
+            foreach (var package in installedPackages)
+            {
+                string key = package.Id.ToLower();
+                if (
+                    !highestInstalledById.TryGetValue(key, out string? highest)
+                    || CompareVersions(package.VersionString, highest) > 0
+                )
+                {
+                    highestInstalledById[key] = package.VersionString;
                 }
             }
 
-            logger.Close(errors);
-            return Packages
-                .Where(p => maxVersions[p.Id.ToLower()] < p.NormalizedNewVersion)
-                .ToArray();
+            List<Package> kept = [];
+            foreach (var candidate in candidates)
+            {
+                if (
+                    !highestInstalledById.TryGetValue(
+                        candidate.Id.ToLower(),
+                        out string? highestInstalled
+                    )
+                )
+                {
+                    kept.Add(candidate);
+                    continue;
+                }
+
+                bool isNewer =
+                    CompareVersions(highestInstalled, candidate.NewVersionString)
+                    is { } comparison
+                        ? comparison < 0
+                        : CoreTools.VersionStringToStruct(highestInstalled)
+                            < candidate.NormalizedNewVersion;
+
+                if (isNewer)
+                    kept.Add(candidate);
+            }
+
+            return kept;
         }
 
         /// <summary>
@@ -321,7 +549,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
         }
 
         /// <summary>
-        /// Parses a NuGet OData GetUpdates() response into update packages, carrying each
+        /// Parses a V2 NuGet OData GetUpdates() response into update packages, carrying each
         /// installed package's scope onto its update so operations (e.g. Update-PSResource
         /// -Scope) don't silently fall back to CurrentUser (regression guard for issue #5163).
         /// </summary>

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
@@ -322,7 +322,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             NuGetV3ServiceIndex index
         )
         {
-            long hash = package.GetHash();
+            long hash = package.GetVersionedHash();
             if (BaseNuGet.V3Entries.TryGetValue(hash, out V3CatalogEntry? cached))
             {
                 Logger.Debug(
@@ -401,21 +401,29 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
         private static CacheableIcon? GetIconV3(IPackage package)
         {
-            if (BaseNuGet.V3IconUrls.TryGetValue(package.GetHash(), out string? cachedIconUrl))
-            {
-                if (string.IsNullOrWhiteSpace(cachedIconUrl))
-                    return null;
+            long hash = package.GetVersionedHash();
+            bool searchReported = BaseNuGet.V3IconUrls.TryGetValue(
+                hash,
+                out string? searchIconUrl
+            );
 
-                return Uri.TryCreate(cachedIconUrl, UriKind.Absolute, out Uri? cachedUri)
-                    ? new CacheableIcon(cachedUri, package.VersionString)
+            if (searchReported && !string.IsNullOrWhiteSpace(searchIconUrl))
+            {
+                return Uri.TryCreate(searchIconUrl, UriKind.Absolute, out Uri? searchUri)
+                    ? new CacheableIcon(searchUri, package.VersionString)
                     : null;
             }
+
+            V3CatalogEntry? entry = BaseNuGet.V3Entries.GetValueOrDefault(hash);
+
+            if (entry is null && searchReported)
+                return null;
 
             NuGetV3ServiceIndex? index = NuGetV3ServiceIndex.Resolve(package.Source);
             if (index is null)
                 return null;
 
-            V3CatalogEntry? entry = GetOrFetchCatalogEntry(package, index);
+            entry ??= GetOrFetchCatalogEntry(package, index);
             if (entry is null)
                 return null;
 

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
@@ -432,14 +432,8 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
             if (
                 !string.IsNullOrWhiteSpace(entry.IconFile)
-                && index.PackageBaseAddress is not null
-                && Uri.TryCreate(
-                    $"{index.PackageBaseAddress.AbsoluteUri.TrimEnd('/')}"
-                        + $"/{NuGetV3Client.EscapeId(package.Id)}"
-                        + $"/{NuGetV3Client.EscapeVersion(package.VersionString)}/icon",
-                    UriKind.Absolute,
-                    out Uri? embeddedIconUrl
-                )
+                && NuGetV3Client.GetEmbeddedIconUrl(index, package.Id, package.VersionString)
+                    is { } embeddedIconUrl
             )
                 return new CacheableIcon(embeddedIconUrl, package.VersionString);
 

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsHelper.cs
@@ -6,6 +6,7 @@ using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Classes.Manager.BaseProviders;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.ManagerClasses.Classes;
 using UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal;
 
 namespace UniGetUI.PackageEngine.Managers.PowerShellManager
@@ -20,6 +21,12 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.LoadPackageDetails);
             try
             {
+                if (NuGetV3ServiceIndex.IsV3Source(details.Package.Source))
+                {
+                    logger.Close(GetDetailsV3(details, logger) ? 0 : 1);
+                    return;
+                }
+
                 details.ManifestUrl = NuGetManifestLoader.GetManifestUrl(details.Package);
                 string? PackageManifestContents = NuGetManifestLoader.GetManifestContent(
                     details.Package
@@ -223,8 +230,148 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             }
         }
 
+        private static bool GetDetailsV3(IPackageDetails details, INativeTaskLogger logger)
+        {
+            IPackage package = details.Package;
+            NuGetV3ServiceIndex? index = NuGetV3ServiceIndex.Resolve(package.Source);
+            if (index is null)
+            {
+                logger.Error(
+                    $"Could not resolve the NuGet V3 service index for source {package.Source.Name} "
+                        + $"at Url={package.Source.Url} on manager {package.Manager.Name}"
+                );
+                return false;
+            }
+
+            details.ManifestUrl =
+                NuGetV3Client.GetRegistrationLeafUrl(index, package.Id, package.VersionString)
+                ?? NuGetV3Client.GetNuspecUrl(index, package.Id, package.VersionString);
+
+            V3CatalogEntry? entry = GetOrFetchCatalogEntry(package, index);
+            if (entry is null)
+            {
+                logger.Error(
+                    $"No V3 metadata could be loaded for package {package.Id} on manager "
+                        + $"{package.Manager.Name}, returning empty PackageDetails"
+                );
+                return false;
+            }
+
+            details.InstallerType = CoreTools.Translate("NuPkg (zipped manifest)");
+            details.Description = FirstNonEmpty(entry.Description, entry.Summary);
+            details.UpdateDate = entry.Published;
+            details.ReleaseNotes = entry.ReleaseNotes;
+            details.License = string.IsNullOrWhiteSpace(entry.LicenseExpression)
+                ? null
+                : entry.LicenseExpression;
+            details.InstallerHash = entry.PackageHash;
+            details.Tags = entry.GetTags().ToArray();
+
+            string? authors = entry.GetAuthors();
+            if (!string.IsNullOrWhiteSpace(authors))
+            {
+                details.Author = authors;
+                details.Publisher = authors;
+            }
+
+            if (Uri.TryCreate(entry.ProjectUrl, UriKind.Absolute, out Uri? projectUrl))
+                details.HomepageUrl = projectUrl;
+
+            if (Uri.TryCreate(entry.LicenseUrl, UriKind.Absolute, out Uri? licenseUrl))
+                details.LicenseUrl = licenseUrl;
+
+            Uri? installerUrl =
+                Uri.TryCreate(entry.PackageContent, UriKind.Absolute, out Uri? packageContent)
+                    ? packageContent
+                    : NuGetV3Client.GetPackageContentUrl(index, package.Id, package.VersionString);
+            details.InstallerUrl = installerUrl;
+
+            if (entry.PackageSize > 0)
+                details.InstallerSize = entry.PackageSize;
+            else if (installerUrl is not null)
+                details.InstallerSize = CoreTools.GetFileSizeAsLong(installerUrl);
+
+            details.Dependencies.Clear();
+            HashSet<string> alreadyAdded = new(StringComparer.OrdinalIgnoreCase);
+            foreach (V3DependencyGroup group in entry.DependencyGroups ?? [])
+            {
+                foreach (V3Dependency dependency in group.Dependencies ?? [])
+                {
+                    if (
+                        string.IsNullOrWhiteSpace(dependency.Id)
+                        || !alreadyAdded.Add(dependency.Id)
+                    )
+                        continue;
+
+                    details.Dependencies.Add(
+                        new()
+                        {
+                            Name = dependency.Id,
+                            Version = FormatDependencyRange(dependency.Range),
+                            Mandatory = true,
+                        }
+                    );
+                }
+            }
+
+            return true;
+        }
+
+        private static V3CatalogEntry? GetOrFetchCatalogEntry(
+            IPackage package,
+            NuGetV3ServiceIndex index
+        )
+        {
+            long hash = package.GetHash();
+            if (BaseNuGet.V3Entries.TryGetValue(hash, out V3CatalogEntry? cached))
+            {
+                Logger.Debug(
+                    $"Loading cached NuGet V3 metadata for package {package.Id} on manager {package.Manager.Name}"
+                );
+                return cached;
+            }
+
+            V3CatalogEntry? entry = NuGetV3Client.GetCatalogEntry(
+                index,
+                package.Id,
+                package.VersionString
+            );
+
+            if (entry is not null)
+                BaseNuGet.V3Entries[hash] = entry;
+
+            return entry;
+        }
+
+        private static string? FirstNonEmpty(params string?[] values)
+        {
+            foreach (string? value in values)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                    return value;
+            }
+
+            return null;
+        }
+
+        internal static string FormatDependencyRange(string? range)
+        {
+            if (string.IsNullOrWhiteSpace(range))
+                return string.Empty;
+
+            string value = range.Trim();
+            if (!value.StartsWith('[') && !value.StartsWith('('))
+                return value;
+
+            string lowerBound = value.Trim('[', ']', '(', ')').Split(',')[0].Trim();
+            return lowerBound.Length is 0 ? value : lowerBound;
+        }
+
         protected override CacheableIcon? GetIcon_UnSafe(IPackage package)
         {
+            if (NuGetV3ServiceIndex.IsV3Source(package.Source))
+                return GetIconV3(package);
+
             string? ManifestContent = NuGetManifestLoader.GetManifestContent(package);
             if (ManifestContent is null)
             {
@@ -252,6 +399,45 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             );
         }
 
+        private static CacheableIcon? GetIconV3(IPackage package)
+        {
+            if (BaseNuGet.V3IconUrls.TryGetValue(package.GetHash(), out string? cachedIconUrl))
+            {
+                if (string.IsNullOrWhiteSpace(cachedIconUrl))
+                    return null;
+
+                return Uri.TryCreate(cachedIconUrl, UriKind.Absolute, out Uri? cachedUri)
+                    ? new CacheableIcon(cachedUri, package.VersionString)
+                    : null;
+            }
+
+            NuGetV3ServiceIndex? index = NuGetV3ServiceIndex.Resolve(package.Source);
+            if (index is null)
+                return null;
+
+            V3CatalogEntry? entry = GetOrFetchCatalogEntry(package, index);
+            if (entry is null)
+                return null;
+
+            if (Uri.TryCreate(entry.IconUrl, UriKind.Absolute, out Uri? iconUrl))
+                return new CacheableIcon(iconUrl, package.VersionString);
+
+            if (
+                !string.IsNullOrWhiteSpace(entry.IconFile)
+                && index.PackageBaseAddress is not null
+                && Uri.TryCreate(
+                    $"{index.PackageBaseAddress.AbsoluteUri.TrimEnd('/')}"
+                        + $"/{NuGetV3Client.EscapeId(package.Id)}"
+                        + $"/{NuGetV3Client.EscapeVersion(package.VersionString)}/icon",
+                    UriKind.Absolute,
+                    out Uri? embeddedIconUrl
+                )
+            )
+                return new CacheableIcon(embeddedIconUrl, package.VersionString);
+
+            return null;
+        }
+
         protected override IReadOnlyList<Uri> GetScreenshots_UnSafe(IPackage package)
         {
             throw new NotImplementedException();
@@ -259,6 +445,21 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
         protected override IReadOnlyList<string> GetInstallableVersions_UnSafe(IPackage package)
         {
+            if (NuGetV3ServiceIndex.IsV3Source(package.Source))
+            {
+                NuGetV3ServiceIndex? index = NuGetV3ServiceIndex.Resolve(package.Source);
+                if (index is null)
+                {
+                    Logger.Warn(
+                        $"Could not resolve the NuGet V3 service index for source {package.Source.Name} "
+                            + $"to load versions of package {package.Id}"
+                    );
+                    return [];
+                }
+
+                return NuGetV3Client.GetVersionsDescending(index, package.Id);
+            }
+
             Uri SearchUrl = new($"{package.Source.Url}/FindPackagesById()?id='{package.Id}'");
             Logger.Debug(
                 $"Begin package version search with url={SearchUrl} on manager {Manager.Name}"

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetManifestLoader.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetManifestLoader.cs
@@ -27,15 +27,23 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
         /// <returns>A Uri object</returns>
         public static Uri GetNuPkgUrl(IPackage package)
         {
-            if (NuGetV3ServiceIndex.Resolve(package.Source) is { } index)
+            if (NuGetV3ServiceIndex.IsV3Source(package.Source))
             {
-                Uri? contentUrl = NuGetV3Client.GetPackageContentUrl(
-                    index,
-                    package.Id,
-                    package.VersionString
-                );
-                if (contentUrl is not null)
+                if (
+                    NuGetV3ServiceIndex.Resolve(package.Source) is { } index
+                    && NuGetV3Client.GetPackageContentUrl(
+                        index,
+                        package.Id,
+                        package.VersionString
+                    )
+                        is { } contentUrl
+                )
                     return contentUrl;
+
+                throw new InvalidOperationException(
+                    $"Could not resolve a V3 package content address for {package.Id} "
+                        + $"{package.VersionString} on source {package.Source.Url}"
+                );
             }
 
             return new Uri($"{package.Source.Url}/package/{package.Id}/{package.VersionString}");
@@ -48,7 +56,7 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
         /// <returns>A string containing the contents of the manifest</returns>
         public static string? GetManifestContent(IPackage package)
         {
-            if (BaseNuGet.Manifests.TryGetValue(package.GetHash(), out string? manifest))
+            if (BaseNuGet.Manifests.TryGetValue(package.GetVersionedHash(), out string? manifest))
             {
                 Logger.Debug(
                     $"Loading cached NuGet manifest for package {package.Id} on manager {package.Manager.Name}"
@@ -107,7 +115,7 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             }
 
             string packageManifestContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-            BaseNuGet.Manifests[package.GetHash()] = packageManifestContent;
+            BaseNuGet.Manifests[package.GetVersionedHash()] = packageManifestContent;
             return packageManifestContent;
         }
     }

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetManifestLoader.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetManifestLoader.cs
@@ -27,6 +27,17 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
         /// <returns>A Uri object</returns>
         public static Uri GetNuPkgUrl(IPackage package)
         {
+            if (NuGetV3ServiceIndex.Resolve(package.Source) is { } index)
+            {
+                Uri? contentUrl = NuGetV3Client.GetPackageContentUrl(
+                    index,
+                    package.Id,
+                    package.VersionString
+                );
+                if (contentUrl is not null)
+                    return contentUrl;
+            }
+
             return new Uri($"{package.Source.Url}/package/{package.Id}/{package.VersionString}");
         }
 

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
@@ -9,12 +9,18 @@ using UniGetUI.Core.Tools;
 
 namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
 {
+    internal enum ListedStatus
+    {
+        Listed,
+        Unlisted,
+        Unknown,
+    }
+
     internal static class NuGetV3Client
     {
         public const int MaxConcurrentRequests = 8;
 
         private static readonly TimeSpan VersionCacheLifetime = TimeSpan.FromMinutes(10);
-        private const int MaxUnlistedProbes = 5;
         private const int MaxSearchPages = 5;
 
         private static readonly ConcurrentDictionary<
@@ -231,8 +237,19 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             ];
         }
 
-        public static IReadOnlyList<string> GetVersions(NuGetV3ServiceIndex index, string packageId)
+        public static IReadOnlyList<string> GetVersions(
+            NuGetV3ServiceIndex index,
+            string packageId
+        ) => GetVersions(index, packageId, out _);
+
+        public static IReadOnlyList<string> GetVersions(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            out bool requestFailed
+        )
         {
+            requestFailed = false;
+
             if (index.PackageBaseAddress is null)
                 return [];
 
@@ -253,7 +270,10 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
                 return [];
 
             if (!TryDownloadString(versionsUrl, out string content))
+            {
+                requestFailed = true;
                 return [];
+            }
 
             try
             {
@@ -269,6 +289,7 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             {
                 Logger.Warn($"Malformed NuGet V3 version index at Url={versionsUrl}");
                 Logger.Warn(e);
+                requestFailed = true;
                 return [];
             }
         }
@@ -322,13 +343,34 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             string packageId,
             string installedVersion,
             bool includePreRelease
+        ) => GetUpdateCandidate(index, packageId, installedVersion, includePreRelease, out _);
+
+        public static string? GetUpdateCandidate(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string installedVersion,
+            bool includePreRelease,
+            out bool requestFailed
         )
         {
+            requestFailed = false;
+
             if (!SemanticVersion.TryParse(installedVersion, out SemanticVersion installed))
                 return null;
 
+            IReadOnlyList<string> allVersions = GetVersions(
+                index,
+                packageId,
+                out bool versionsFailed
+            );
+            if (versionsFailed)
+            {
+                requestFailed = true;
+                return null;
+            }
+
             List<(SemanticVersion Parsed, string Raw)> newer = [];
-            foreach (string version in GetVersions(index, packageId))
+            foreach (string version in allVersions)
             {
                 if (!SemanticVersion.TryParse(version, out SemanticVersion parsed))
                     continue;
@@ -345,28 +387,53 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
 
             newer.Sort((left, right) => right.Parsed.CompareTo(left.Parsed));
 
-            int probes = 0;
+            if (index.RegistrationsBaseUrl is null)
+                return newer[0].Raw;
+
             foreach ((SemanticVersion _, string raw) in newer)
             {
-                if (probes >= MaxUnlistedProbes)
-                    break;
+                switch (GetListedStatus(index, packageId, raw))
+                {
+                    case ListedStatus.Listed:
+                        return raw;
 
-                probes++;
-                if (IsListed(index, packageId, raw))
-                    return raw;
+                    case ListedStatus.Unlisted:
+                        Logger.Debug(
+                            $"Skipping unlisted NuGet version {packageId} {raw} while looking for updates"
+                        );
+                        continue;
 
-                Logger.Debug(
-                    $"Skipping unlisted NuGet version {packageId} {raw} while looking for updates"
-                );
+                    default:
+                        Logger.Warn(
+                            $"Could not establish the listed status of {packageId} {raw}; "
+                                + "reporting the update check for this package as failed"
+                        );
+                        requestFailed = true;
+                        return null;
+                }
             }
 
             return null;
         }
 
-        public static bool IsListed(NuGetV3ServiceIndex index, string packageId, string version)
+        public static ListedStatus GetListedStatus(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
         {
+            if (index.RegistrationsBaseUrl is null)
+                return ListedStatus.Unknown;
+
             V3RegistrationLeaf? leaf = GetRegistrationLeaf(index, packageId, version);
-            return leaf?.Listed ?? true;
+            if (leaf is null)
+                return ListedStatus.Unknown;
+
+            return leaf.Listed switch
+            {
+                false => ListedStatus.Unlisted,
+                _ => ListedStatus.Listed,
+            };
         }
 
         private static V3RegistrationLeaf? GetRegistrationLeaf(

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
@@ -263,7 +263,14 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             requestFailed = false;
 
             if (index.PackageBaseAddress is null)
+            {
+                Logger.Warn(
+                    $"The feed at {index.ServiceIndexUrl} advertises no PackageBaseAddress, "
+                        + $"so the versions of {packageId} cannot be enumerated"
+                );
+                requestFailed = true;
                 return [];
+            }
 
             string cacheKey = $"{index.PackageBaseAddress.AbsoluteUri}|{packageId.ToLowerInvariant()}";
             if (

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
@@ -1,0 +1,713 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using System.Web;
+using System.Xml.Linq;
+using UniGetUI.Core.Data;
+using UniGetUI.Core.Logging;
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
+{
+    internal static class NuGetV3Client
+    {
+        public const int MaxConcurrentRequests = 8;
+
+        private static readonly TimeSpan VersionCacheLifetime = TimeSpan.FromMinutes(10);
+        private const int MaxUnlistedProbes = 5;
+        private const int MaxSearchPages = 5;
+
+        private static readonly ConcurrentDictionary<
+            string,
+            (DateTime FetchedAt, IReadOnlyList<string> Versions)
+        > VersionCache = new();
+
+        private static readonly ConcurrentDictionary<
+            string,
+            (DateTime FetchedAt, V3RegistrationLeaf? Leaf)
+        > LeafCache = new();
+
+        internal static void ClearCaches()
+        {
+            VersionCache.Clear();
+            LeafCache.Clear();
+        }
+
+        public static bool TryDownloadString(Uri url, out string content)
+        {
+            content = string.Empty;
+
+            try
+            {
+                using HttpClient client = new(CoreTools.GenericHttpClientParameters);
+
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                using HttpResponseMessage response = client.Send(request);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    Logger.Debug(
+                        $"NuGet V3 request to Url={url} failed with status code {response.StatusCode}"
+                    );
+                    return false;
+                }
+
+                content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                return true;
+            }
+            catch (Exception e)
+            {
+                Logger.Warn($"NuGet V3 request to Url={url} threw an exception");
+                Logger.Warn(e);
+                return false;
+            }
+        }
+
+        public static IReadOnlyList<V3SearchResult> Search(
+            NuGetV3ServiceIndex index,
+            string query,
+            bool includePreRelease,
+            string? packageType,
+            int take
+        )
+        {
+            if (index.SearchQueryService is null)
+                return SearchByExactId(index, query, includePreRelease, packageType);
+
+            Dictionary<string, V3SearchResult> highestById = new(
+                StringComparer.OrdinalIgnoreCase
+            );
+            List<string> order = [];
+            int skip = 0;
+
+            for (int page = 0; page < MaxSearchPages && order.Count < take; page++)
+            {
+                int requestedTake = take - order.Count;
+                (int TotalHits, IReadOnlyList<V3SearchResult> Results)? pageResult = SearchPage(
+                    index,
+                    query,
+                    includePreRelease,
+                    packageType,
+                    skip,
+                    requestedTake
+                );
+
+                if (pageResult is not { Results.Count: > 0 } current)
+                    break;
+
+                foreach (V3SearchResult result in current.Results)
+                {
+                    string id = result.Id!;
+                    if (!highestById.TryGetValue(id, out V3SearchResult? existing))
+                    {
+                        highestById[id] = result;
+                        order.Add(id);
+                        continue;
+                    }
+
+                    if (IsHigherVersion(result.Version!, existing.Version!))
+                        highestById[id] = result;
+                }
+
+                skip += current.Results.Count;
+
+                bool moreAvailable =
+                    current.TotalHits > 0
+                        ? skip < current.TotalHits
+                        : current.Results.Count >= requestedTake;
+
+                if (!moreAvailable)
+                    break;
+            }
+
+            if (order.Count is 0)
+                return SearchByExactId(index, query, includePreRelease, packageType);
+
+            List<V3SearchResult> results = [];
+            foreach (string id in order)
+                results.Add(highestById[id]);
+
+            return results;
+        }
+
+        private static (int TotalHits, IReadOnlyList<V3SearchResult> Results)? SearchPage(
+            NuGetV3ServiceIndex index,
+            string query,
+            bool includePreRelease,
+            string? packageType,
+            int skip,
+            int take
+        )
+        {
+            var url = new StringBuilder(index.SearchQueryService!.AbsoluteUri.TrimEnd('/'));
+            url.Append("?q=").Append(HttpUtility.UrlEncode(query));
+            url.Append(CultureInfo.InvariantCulture, $"&skip={skip}");
+            url.Append(CultureInfo.InvariantCulture, $"&take={take}");
+            url.Append(CultureInfo.InvariantCulture, $"&prerelease={(includePreRelease ? "true" : "false")}");
+            url.Append("&semVerLevel=2.0.0");
+
+            if (!string.IsNullOrEmpty(packageType))
+                url.Append("&packageType=").Append(HttpUtility.UrlEncode(packageType));
+
+            if (!Uri.TryCreate(url.ToString(), UriKind.Absolute, out Uri? searchUrl))
+                return null;
+
+            if (!TryDownloadString(searchUrl, out string content))
+                return null;
+
+            try
+            {
+                V3SearchResponse? response = NuGetV3Json.DeserializeSearchResponse(content);
+                if (response?.Data is not { Count: > 0 })
+                    return (response?.TotalHits ?? 0, []);
+
+                List<V3SearchResult> results = [];
+                foreach (V3SearchResult result in response.Data)
+                {
+                    if (
+                        !string.IsNullOrWhiteSpace(result.Id)
+                        && !string.IsNullOrWhiteSpace(result.Version)
+                    )
+                        results.Add(result);
+                }
+
+                return (response.TotalHits, results);
+            }
+            catch (Exception e)
+            {
+                Logger.Warn($"Malformed NuGet V3 search response at Url={searchUrl}");
+                Logger.Warn(e);
+                return null;
+            }
+        }
+
+        private static bool IsHigherVersion(string candidate, string current)
+        {
+            if (!SemanticVersion.TryParse(candidate, out SemanticVersion parsedCandidate))
+                return false;
+            if (!SemanticVersion.TryParse(current, out SemanticVersion parsedCurrent))
+                return true;
+
+            return parsedCandidate > parsedCurrent;
+        }
+
+        private static IReadOnlyList<V3SearchResult> SearchByExactId(
+            NuGetV3ServiceIndex index,
+            string query,
+            bool includePreRelease,
+            string? requiredPackageType
+        )
+        {
+            string candidate = query.Trim();
+            if (candidate.Length is 0)
+                return [];
+
+            string? version = SelectHighestVersion(GetVersions(index, candidate), includePreRelease);
+            if (version is null)
+                return [];
+
+            if (!string.IsNullOrEmpty(requiredPackageType))
+            {
+                V3CatalogEntry? entry = GetNuspecMetadata(index, candidate, version);
+                if (entry is null || !entry.HasPackageType(requiredPackageType))
+                {
+                    Logger.Debug(
+                        $"Discarding exact-id match {candidate} {version}: it does not advertise "
+                            + $"the {requiredPackageType} package type"
+                    );
+                    return [];
+                }
+            }
+
+            return
+            [
+                new V3SearchResult
+                {
+                    Id = candidate,
+                    Version = version,
+                    IsExactIdFallback = true,
+                },
+            ];
+        }
+
+        public static IReadOnlyList<string> GetVersions(NuGetV3ServiceIndex index, string packageId)
+        {
+            if (index.PackageBaseAddress is null)
+                return [];
+
+            string cacheKey = $"{index.PackageBaseAddress.AbsoluteUri}|{packageId.ToLowerInvariant()}";
+            if (
+                VersionCache.TryGetValue(cacheKey, out var cached)
+                && DateTime.UtcNow - cached.FetchedAt < VersionCacheLifetime
+            )
+                return cached.Versions;
+
+            if (
+                !Uri.TryCreate(
+                    $"{index.PackageBaseAddress.AbsoluteUri.TrimEnd('/')}/{EscapeId(packageId)}/index.json",
+                    UriKind.Absolute,
+                    out Uri? versionsUrl
+                )
+            )
+                return [];
+
+            if (!TryDownloadString(versionsUrl, out string content))
+                return [];
+
+            try
+            {
+                V3FlatContainerIndex? parsed = NuGetV3Json.DeserializeFlatContainerIndex(content);
+                IReadOnlyList<string> versions = parsed?.Versions is { Count: > 0 }
+                    ? parsed.Versions
+                    : [];
+
+                VersionCache[cacheKey] = (DateTime.UtcNow, versions);
+                return versions;
+            }
+            catch (Exception e)
+            {
+                Logger.Warn($"Malformed NuGet V3 version index at Url={versionsUrl}");
+                Logger.Warn(e);
+                return [];
+            }
+        }
+
+        public static IReadOnlyList<string> GetVersionsDescending(
+            NuGetV3ServiceIndex index,
+            string packageId
+        )
+        {
+            List<(SemanticVersion Parsed, string Raw)> parsed = [];
+            foreach (string version in GetVersions(index, packageId))
+            {
+                parsed.Add(
+                    SemanticVersion.TryParse(version, out SemanticVersion semVer)
+                        ? (semVer, version)
+                        : (SemanticVersion.Invalid(version), version)
+                );
+            }
+
+            parsed.Sort((left, right) => right.Parsed.CompareTo(left.Parsed));
+            return parsed.Select(entry => entry.Raw).ToArray();
+        }
+
+        public static string? SelectHighestVersion(
+            IEnumerable<string> versions,
+            bool includePreRelease
+        )
+        {
+            string? best = null;
+            SemanticVersion bestParsed = default;
+
+            foreach (string version in versions)
+            {
+                if (!SemanticVersion.TryParse(version, out SemanticVersion parsed))
+                    continue;
+                if (parsed.IsPreRelease && !includePreRelease)
+                    continue;
+
+                if (best is null || parsed > bestParsed)
+                {
+                    best = version;
+                    bestParsed = parsed;
+                }
+            }
+
+            return best;
+        }
+
+        public static string? GetUpdateCandidate(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string installedVersion,
+            bool includePreRelease
+        )
+        {
+            if (!SemanticVersion.TryParse(installedVersion, out SemanticVersion installed))
+                return null;
+
+            List<(SemanticVersion Parsed, string Raw)> newer = [];
+            foreach (string version in GetVersions(index, packageId))
+            {
+                if (!SemanticVersion.TryParse(version, out SemanticVersion parsed))
+                    continue;
+                if (parsed.IsPreRelease && !includePreRelease)
+                    continue;
+                if (parsed <= installed)
+                    continue;
+
+                newer.Add((parsed, version));
+            }
+
+            if (newer.Count is 0)
+                return null;
+
+            newer.Sort((left, right) => right.Parsed.CompareTo(left.Parsed));
+
+            int probes = 0;
+            foreach ((SemanticVersion _, string raw) in newer)
+            {
+                if (probes >= MaxUnlistedProbes)
+                    break;
+
+                probes++;
+                if (IsListed(index, packageId, raw))
+                    return raw;
+
+                Logger.Debug(
+                    $"Skipping unlisted NuGet version {packageId} {raw} while looking for updates"
+                );
+            }
+
+            return null;
+        }
+
+        public static bool IsListed(NuGetV3ServiceIndex index, string packageId, string version)
+        {
+            V3RegistrationLeaf? leaf = GetRegistrationLeaf(index, packageId, version);
+            return leaf?.Listed ?? true;
+        }
+
+        private static V3RegistrationLeaf? GetRegistrationLeaf(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
+        {
+            if (GetRegistrationLeafUrl(index, packageId, version) is not { } leafUrl)
+                return null;
+
+            string cacheKey = leafUrl.AbsoluteUri;
+            if (
+                LeafCache.TryGetValue(cacheKey, out var cached)
+                && DateTime.UtcNow - cached.FetchedAt < VersionCacheLifetime
+            )
+                return cached.Leaf;
+
+            if (!TryDownloadString(leafUrl, out string content))
+                return null;
+
+            try
+            {
+                V3RegistrationLeaf? leaf = NuGetV3Json.DeserializeRegistrationLeaf(content);
+                LeafCache[cacheKey] = (DateTime.UtcNow, leaf);
+                return leaf;
+            }
+            catch (Exception e)
+            {
+                Logger.Warn($"Malformed NuGet V3 registration leaf at Url={leafUrl}");
+                Logger.Warn(e);
+                return null;
+            }
+        }
+
+        public static V3CatalogEntry? GetCatalogEntry(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
+        {
+            try
+            {
+                V3RegistrationLeaf? leaf = GetRegistrationLeaf(index, packageId, version);
+                if (leaf is null)
+                    return GetNuspecMetadata(index, packageId, version);
+
+                V3CatalogEntry? inline = NuGetV3Json.DeserializeCatalogEntry(leaf.CatalogEntry);
+                if (inline is not null)
+                {
+                    inline.PackageContent ??= leaf.PackageContent;
+                    inline.Published ??= leaf.Published;
+                    inline.Listed ??= leaf.Listed;
+                    return inline;
+                }
+
+                if (
+                    leaf.CatalogEntry.ValueKind is System.Text.Json.JsonValueKind.String
+                    && Uri.TryCreate(
+                        leaf.CatalogEntry.GetString(),
+                        UriKind.Absolute,
+                        out Uri? catalogUrl
+                    )
+                    && TryDownloadString(catalogUrl, out string catalogContent)
+                )
+                {
+                    V3CatalogEntry? entry = NuGetV3Json.DeserializeCatalogEntry(catalogContent);
+                    if (entry is not null)
+                    {
+                        entry.PackageContent ??= leaf.PackageContent;
+                        entry.Published ??= leaf.Published;
+                        entry.Listed ??= leaf.Listed;
+                    }
+
+                    return entry;
+                }
+
+                return GetNuspecMetadata(index, packageId, version);
+            }
+            catch (Exception e)
+            {
+                Logger.Warn(
+                    $"Malformed NuGet V3 package metadata for {packageId} {version} on feed "
+                        + index.ServiceIndexUrl
+                );
+                Logger.Warn(e);
+                return null;
+            }
+        }
+
+        public static Uri? GetNuspecUrl(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
+        {
+            if (index.PackageBaseAddress is null)
+                return null;
+
+            string id = EscapeId(packageId);
+            string url =
+                $"{index.PackageBaseAddress.AbsoluteUri.TrimEnd('/')}"
+                + $"/{id}/{EscapeVersion(version)}/{id}.nuspec";
+
+            return Uri.TryCreate(url, UriKind.Absolute, out Uri? nuspecUrl) ? nuspecUrl : null;
+        }
+
+        internal static V3CatalogEntry? GetNuspecMetadata(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
+        {
+            if (GetNuspecUrl(index, packageId, version) is not { } nuspecUrl)
+                return null;
+
+            if (!TryDownloadString(nuspecUrl, out string content))
+                return null;
+
+            try
+            {
+                return ParseNuspec(content, packageId, version, GetPackageContentUrl(index, packageId, version));
+            }
+            catch (Exception e)
+            {
+                Logger.Warn($"Malformed NuGet nuspec at Url={nuspecUrl}");
+                Logger.Warn(e);
+                return null;
+            }
+        }
+
+        internal static V3CatalogEntry? ParseNuspec(
+            string content,
+            string packageId,
+            string version,
+            Uri? packageContent
+        )
+        {
+            XElement? metadata = XDocument.Parse(content).Root?.Elements()
+                .FirstOrDefault(element =>
+                    element.Name.LocalName.Equals("metadata", StringComparison.OrdinalIgnoreCase)
+                );
+
+            if (metadata is null)
+                return null;
+
+            string? Value(string name) =>
+                metadata
+                    .Elements()
+                    .FirstOrDefault(element =>
+                        element.Name.LocalName.Equals(name, StringComparison.OrdinalIgnoreCase)
+                    )
+                    ?.Value.Trim() is { Length: > 0 } value
+                    ? value
+                    : null;
+
+            var entry = new V3CatalogEntry
+            {
+                Id = Value("id") ?? packageId,
+                Version = Value("version") ?? version,
+                Description = Value("description"),
+                Summary = Value("summary"),
+                LicenseUrl = Value("licenseUrl"),
+                ProjectUrl = Value("projectUrl"),
+                ReleaseNotes = Value("releaseNotes"),
+                IconUrl = Value("iconUrl"),
+                IconFile = Value("icon"),
+                PackageContent = packageContent?.AbsoluteUri,
+            };
+
+            if (Value("license") is { } license)
+                entry.LicenseExpression = license;
+
+            if (Value("authors") is { } authors)
+                entry.AuthorsOverride = authors;
+
+            if (Value("tags") is { } tags)
+                entry.TagsOverride = tags.Split(
+                    ' ',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                );
+
+            XElement? packageTypes = metadata
+                .Elements()
+                .FirstOrDefault(element =>
+                    element.Name.LocalName.Equals(
+                        "packageTypes",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                );
+
+            if (packageTypes is not null)
+            {
+                List<V3PackageType> types = [];
+                foreach (XElement packageType in packageTypes.Elements())
+                {
+                    if (
+                        !packageType.Name.LocalName.Equals(
+                            "packageType",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                        continue;
+
+                    string? name = packageType.Attribute("name")?.Value;
+                    if (!string.IsNullOrWhiteSpace(name))
+                        types.Add(new V3PackageType { Name = name });
+                }
+
+                if (types.Count > 0)
+                    entry.PackageTypes = types;
+            }
+
+            XElement? dependencies = metadata
+                .Elements()
+                .FirstOrDefault(element =>
+                    element.Name.LocalName.Equals(
+                        "dependencies",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                );
+
+            if (dependencies is not null)
+            {
+                List<V3Dependency> flat = [];
+                foreach (XElement dependency in dependencies.Descendants())
+                {
+                    if (
+                        !dependency.Name.LocalName.Equals(
+                            "dependency",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                        continue;
+
+                    string? id = dependency.Attribute("id")?.Value;
+                    if (string.IsNullOrWhiteSpace(id))
+                        continue;
+
+                    flat.Add(
+                        new V3Dependency { Id = id, Range = dependency.Attribute("version")?.Value }
+                    );
+                }
+
+                if (flat.Count > 0)
+                    entry.DependencyGroups =
+                    [
+                        new V3DependencyGroup { Dependencies = flat },
+                    ];
+            }
+
+            return entry;
+        }
+
+        public static Uri? GetRegistrationLeafUrl(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
+        {
+            if (index.RegistrationsBaseUrl is null)
+                return null;
+
+            string url =
+                $"{index.RegistrationsBaseUrl.AbsoluteUri.TrimEnd('/')}"
+                + $"/{EscapeId(packageId)}/{EscapeVersion(version)}.json";
+
+            return Uri.TryCreate(url, UriKind.Absolute, out Uri? leafUrl) ? leafUrl : null;
+        }
+
+        public static Uri? GetPackageContentUrl(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
+        {
+            if (index.PackageBaseAddress is null)
+                return null;
+
+            string id = EscapeId(packageId);
+            string normalized = EscapeVersion(version);
+            string url =
+                $"{index.PackageBaseAddress.AbsoluteUri.TrimEnd('/')}"
+                + $"/{id}/{normalized}/{id}.{normalized}.nupkg";
+
+            return Uri.TryCreate(url, UriKind.Absolute, out Uri? contentUrl) ? contentUrl : null;
+        }
+
+        internal static string EscapeId(string packageId) =>
+            Uri.EscapeDataString(packageId.Trim().ToLowerInvariant());
+
+        internal static string EscapeVersion(string version) =>
+            Uri.EscapeDataString(NormalizeVersion(version));
+
+        internal static string NormalizeVersion(string version)
+        {
+            string candidate = version.Trim();
+            if (candidate.Length is 0)
+                return candidate;
+
+            int metadataIndex = candidate.IndexOf('+');
+            if (metadataIndex >= 0)
+                candidate = candidate[..metadataIndex];
+
+            string labels = string.Empty;
+            int labelIndex = candidate.IndexOf('-');
+            if (labelIndex >= 0)
+            {
+                labels = candidate[labelIndex..];
+                candidate = candidate[..labelIndex];
+            }
+
+            string[] parts = candidate.Split('.');
+            if (parts.Length is 0 or > 4)
+                return version.Trim().ToLowerInvariant();
+
+            int[] numbers = [0, 0, 0, 0];
+            for (int i = 0; i < parts.Length; i++)
+            {
+                if (
+                    !int.TryParse(
+                        parts[i],
+                        NumberStyles.None,
+                        CultureInfo.InvariantCulture,
+                        out int number
+                    )
+                )
+                    return version.Trim().ToLowerInvariant();
+
+                numbers[i] = number;
+            }
+
+            var normalized = new StringBuilder();
+            normalized.Append(CultureInfo.InvariantCulture, $"{numbers[0]}");
+            normalized.Append(CultureInfo.InvariantCulture, $".{numbers[1]}");
+            normalized.Append(CultureInfo.InvariantCulture, $".{numbers[2]}");
+            if (numbers[3] is not 0)
+                normalized.Append(CultureInfo.InvariantCulture, $".{numbers[3]}");
+
+            normalized.Append(labels);
+            return normalized.ToString().ToLowerInvariant();
+        }
+    }
+}

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
@@ -209,7 +209,19 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             if (candidate.Length is 0)
                 return [];
 
-            string? version = SelectHighestVersion(GetVersions(index, candidate), includePreRelease);
+            List<(SemanticVersion Parsed, string Raw)> available = DescendingCandidates(
+                GetVersions(index, candidate),
+                includePreRelease,
+                null
+            );
+
+            string? version = SelectNewestNotUnlisted(
+                index,
+                candidate,
+                available,
+                acceptUnresolvedStatus: true,
+                out _
+            );
             if (version is null)
                 return [];
 
@@ -369,28 +381,75 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
                 return null;
             }
 
-            List<(SemanticVersion Parsed, string Raw)> newer = [];
-            foreach (string version in allVersions)
+            List<(SemanticVersion Parsed, string Raw)> newer = DescendingCandidates(
+                allVersions,
+                includePreRelease,
+                installed
+            );
+
+            string? selected = SelectNewestNotUnlisted(
+                index,
+                packageId,
+                newer,
+                acceptUnresolvedStatus: false,
+                out bool statusUnresolved
+            );
+
+            if (statusUnresolved)
+                requestFailed = true;
+
+            return selected;
+        }
+
+        private static List<(SemanticVersion Parsed, string Raw)> DescendingCandidates(
+            IEnumerable<string> versions,
+            bool includePreRelease,
+            SemanticVersion? mustExceed
+        )
+        {
+            List<(SemanticVersion Parsed, string Raw)> candidates = [];
+            foreach (string version in versions)
             {
                 if (!TryParseNuGetVersion(version, out SemanticVersion parsed))
                     continue;
                 if (parsed.IsPreRelease && !includePreRelease)
                     continue;
-                if (parsed <= installed)
+                if (mustExceed is { } floor && parsed <= floor)
                     continue;
 
-                newer.Add((parsed, version));
+                candidates.Add((parsed, version));
             }
 
-            if (newer.Count is 0)
+            candidates.Sort((left, right) => right.Parsed.CompareTo(left.Parsed));
+            return candidates;
+        }
+
+        /// <summary>
+        /// Returns the newest candidate that is not known to be unlisted. The flat container
+        /// lists withdrawn versions, so every selection made from it goes through here.
+        /// A feed advertising no registration resource cannot answer at all and its newest
+        /// candidate is taken as-is. When the status of a candidate cannot be established,
+        /// update selection reports the check as failed rather than guessing, while an
+        /// exact-id search - where the user named the package explicitly and there is no
+        /// failure channel - shows it instead of hiding it.
+        /// </summary>
+        private static string? SelectNewestNotUnlisted(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            List<(SemanticVersion Parsed, string Raw)> descending,
+            bool acceptUnresolvedStatus,
+            out bool statusUnresolved
+        )
+        {
+            statusUnresolved = false;
+
+            if (descending.Count is 0)
                 return null;
 
-            newer.Sort((left, right) => right.Parsed.CompareTo(left.Parsed));
-
             if (index.RegistrationsBaseUrl is null)
-                return newer[0].Raw;
+                return descending[0].Raw;
 
-            foreach ((SemanticVersion _, string raw) in newer)
+            foreach ((SemanticVersion _, string raw) in descending)
             {
                 switch (GetListedStatus(index, packageId, raw))
                 {
@@ -398,17 +457,18 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
                         return raw;
 
                     case ListedStatus.Unlisted:
-                        Logger.Debug(
-                            $"Skipping unlisted NuGet version {packageId} {raw} while looking for updates"
-                        );
+                        Logger.Debug($"Skipping unlisted NuGet version {packageId} {raw}");
                         continue;
 
                     default:
+                        if (acceptUnresolvedStatus)
+                            return raw;
+
                         Logger.Warn(
                             $"Could not establish the listed status of {packageId} {raw}; "
                                 + "reporting the update check for this package as failed"
                         );
-                        requestFailed = true;
+                        statusUnresolved = true;
                         return null;
                 }
             }

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Client.cs
@@ -190,9 +190,9 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
 
         private static bool IsHigherVersion(string candidate, string current)
         {
-            if (!SemanticVersion.TryParse(candidate, out SemanticVersion parsedCandidate))
+            if (!TryParseNuGetVersion(candidate, out SemanticVersion parsedCandidate))
                 return false;
-            if (!SemanticVersion.TryParse(current, out SemanticVersion parsedCurrent))
+            if (!TryParseNuGetVersion(current, out SemanticVersion parsedCurrent))
                 return true;
 
             return parsedCandidate > parsedCurrent;
@@ -303,7 +303,7 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             foreach (string version in GetVersions(index, packageId))
             {
                 parsed.Add(
-                    SemanticVersion.TryParse(version, out SemanticVersion semVer)
+                    TryParseNuGetVersion(version, out SemanticVersion semVer)
                         ? (semVer, version)
                         : (SemanticVersion.Invalid(version), version)
                 );
@@ -323,7 +323,7 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
 
             foreach (string version in versions)
             {
-                if (!SemanticVersion.TryParse(version, out SemanticVersion parsed))
+                if (!TryParseNuGetVersion(version, out SemanticVersion parsed))
                     continue;
                 if (parsed.IsPreRelease && !includePreRelease)
                     continue;
@@ -355,7 +355,7 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
         {
             requestFailed = false;
 
-            if (!SemanticVersion.TryParse(installedVersion, out SemanticVersion installed))
+            if (!TryParseNuGetVersion(installedVersion, out SemanticVersion installed))
                 return null;
 
             IReadOnlyList<string> allVersions = GetVersions(
@@ -372,7 +372,7 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             List<(SemanticVersion Parsed, string Raw)> newer = [];
             foreach (string version in allVersions)
             {
-                if (!SemanticVersion.TryParse(version, out SemanticVersion parsed))
+                if (!TryParseNuGetVersion(version, out SemanticVersion parsed))
                     continue;
                 if (parsed.IsPreRelease && !includePreRelease)
                     continue;
@@ -704,6 +704,29 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
             return Uri.TryCreate(url, UriKind.Absolute, out Uri? leafUrl) ? leafUrl : null;
         }
 
+        internal static bool SupportsEmbeddedIconRoute(Uri packageBaseAddress) =>
+            packageBaseAddress.Host.Equals("nuget.org", StringComparison.OrdinalIgnoreCase)
+            || packageBaseAddress.Host.EndsWith(".nuget.org", StringComparison.OrdinalIgnoreCase);
+
+        public static Uri? GetEmbeddedIconUrl(
+            NuGetV3ServiceIndex index,
+            string packageId,
+            string version
+        )
+        {
+            if (
+                index.PackageBaseAddress is not { } packageBase
+                || !SupportsEmbeddedIconRoute(packageBase)
+            )
+                return null;
+
+            string url =
+                $"{packageBase.AbsoluteUri.TrimEnd('/')}"
+                + $"/{EscapeId(packageId)}/{EscapeVersion(version)}/icon";
+
+            return Uri.TryCreate(url, UriKind.Absolute, out Uri? iconUrl) ? iconUrl : null;
+        }
+
         public static Uri? GetPackageContentUrl(
             NuGetV3ServiceIndex index,
             string packageId,
@@ -721,6 +744,9 @@ namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
 
             return Uri.TryCreate(url, UriKind.Absolute, out Uri? contentUrl) ? contentUrl : null;
         }
+
+        internal static bool TryParseNuGetVersion(string? value, out SemanticVersion version) =>
+            SemanticVersion.TryParse(value, SemVerLabels.CaseInsensitive, out version);
 
         internal static string EscapeId(string packageId) =>
             Uri.EscapeDataString(packageId.Trim().ToLowerInvariant());

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Json.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3Json.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
+{
+    internal sealed class V3ServiceIndex
+    {
+        [JsonPropertyName("resources")]
+        public List<V3Resource>? Resources { get; set; }
+    }
+
+    internal sealed class V3Resource
+    {
+        [JsonPropertyName("@id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("@type")]
+        public JsonElement Type { get; set; }
+    }
+
+    internal sealed class V3SearchResponse
+    {
+        [JsonPropertyName("totalHits")]
+        public int TotalHits { get; set; }
+
+        [JsonPropertyName("data")]
+        public List<V3SearchResult>? Data { get; set; }
+    }
+
+    internal sealed class V3SearchResult
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("summary")]
+        public string? Summary { get; set; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        [JsonPropertyName("iconUrl")]
+        public string? IconUrl { get; set; }
+
+        [JsonPropertyName("licenseUrl")]
+        public string? LicenseUrl { get; set; }
+
+        [JsonPropertyName("projectUrl")]
+        public string? ProjectUrl { get; set; }
+
+        [JsonPropertyName("authors")]
+        public JsonElement Authors { get; set; }
+
+        [JsonPropertyName("tags")]
+        public JsonElement Tags { get; set; }
+
+        [JsonIgnore]
+        public bool IsExactIdFallback { get; set; }
+    }
+
+    internal sealed class V3FlatContainerIndex
+    {
+        [JsonPropertyName("versions")]
+        public List<string>? Versions { get; set; }
+    }
+
+    internal sealed class V3RegistrationLeaf
+    {
+        [JsonPropertyName("catalogEntry")]
+        public JsonElement CatalogEntry { get; set; }
+
+        [JsonPropertyName("packageContent")]
+        public string? PackageContent { get; set; }
+
+        [JsonPropertyName("published")]
+        public string? Published { get; set; }
+
+        [JsonPropertyName("listed")]
+        public bool? Listed { get; set; }
+    }
+
+    internal sealed class V3CatalogEntry
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("summary")]
+        public string? Summary { get; set; }
+
+        [JsonPropertyName("iconUrl")]
+        public string? IconUrl { get; set; }
+
+        [JsonPropertyName("iconFile")]
+        public string? IconFile { get; set; }
+
+        [JsonPropertyName("licenseUrl")]
+        public string? LicenseUrl { get; set; }
+
+        [JsonPropertyName("licenseExpression")]
+        public string? LicenseExpression { get; set; }
+
+        [JsonPropertyName("projectUrl")]
+        public string? ProjectUrl { get; set; }
+
+        [JsonPropertyName("releaseNotes")]
+        public string? ReleaseNotes { get; set; }
+
+        [JsonPropertyName("published")]
+        public string? Published { get; set; }
+
+        [JsonPropertyName("listed")]
+        public bool? Listed { get; set; }
+
+        [JsonPropertyName("packageHash")]
+        public string? PackageHash { get; set; }
+
+        [JsonPropertyName("packageHashAlgorithm")]
+        public string? PackageHashAlgorithm { get; set; }
+
+        [JsonPropertyName("packageSize")]
+        public long PackageSize { get; set; }
+
+        [JsonPropertyName("packageContent")]
+        public string? PackageContent { get; set; }
+
+        [JsonPropertyName("authors")]
+        public JsonElement Authors { get; set; }
+
+        [JsonPropertyName("tags")]
+        public JsonElement Tags { get; set; }
+
+        [JsonPropertyName("dependencyGroups")]
+        public List<V3DependencyGroup>? DependencyGroups { get; set; }
+
+        [JsonPropertyName("packageTypes")]
+        public List<V3PackageType>? PackageTypes { get; set; }
+
+        [JsonIgnore]
+        public string? AuthorsOverride { get; set; }
+
+        [JsonIgnore]
+        public IReadOnlyList<string>? TagsOverride { get; set; }
+
+        public string? GetAuthors() => AuthorsOverride ?? NuGetV3Json.AsJoinedString(Authors);
+
+        public IReadOnlyList<string> GetTags() =>
+            TagsOverride ?? NuGetV3Json.AsStringList(Tags);
+
+        public bool HasPackageType(string name)
+        {
+            if (PackageTypes is not { Count: > 0 })
+                return false;
+
+            foreach (V3PackageType packageType in PackageTypes)
+            {
+                if (string.Equals(packageType.Name, name, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    internal sealed class V3PackageType
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+    }
+
+    internal sealed class V3DependencyGroup
+    {
+        [JsonPropertyName("targetFramework")]
+        public string? TargetFramework { get; set; }
+
+        [JsonPropertyName("dependencies")]
+        public List<V3Dependency>? Dependencies { get; set; }
+    }
+
+    internal sealed class V3Dependency
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("range")]
+        public string? Range { get; set; }
+    }
+
+    [JsonSourceGenerationOptions(AllowTrailingCommas = true)]
+    [JsonSerializable(typeof(V3ServiceIndex))]
+    [JsonSerializable(typeof(V3SearchResponse))]
+    [JsonSerializable(typeof(V3FlatContainerIndex))]
+    [JsonSerializable(typeof(V3RegistrationLeaf))]
+    [JsonSerializable(typeof(V3CatalogEntry))]
+    internal sealed partial class NuGetV3JsonContext : JsonSerializerContext;
+
+    internal static class NuGetV3Json
+    {
+        public static V3ServiceIndex? DeserializeServiceIndex(string json) =>
+            Deserialize<V3ServiceIndex>(json);
+
+        public static V3SearchResponse? DeserializeSearchResponse(string json) =>
+            Deserialize<V3SearchResponse>(json);
+
+        public static V3FlatContainerIndex? DeserializeFlatContainerIndex(string json) =>
+            Deserialize<V3FlatContainerIndex>(json);
+
+        public static V3RegistrationLeaf? DeserializeRegistrationLeaf(string json) =>
+            Deserialize<V3RegistrationLeaf>(json);
+
+        public static V3CatalogEntry? DeserializeCatalogEntry(string json) =>
+            Deserialize<V3CatalogEntry>(json);
+
+        public static V3CatalogEntry? DeserializeCatalogEntry(JsonElement element) =>
+            element.ValueKind is JsonValueKind.Object
+                ? element.Deserialize(GetTypeInfo<V3CatalogEntry>())
+                : null;
+
+        public static IReadOnlyList<string> AsStringList(JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.String:
+                    string? single = element.GetString();
+                    if (string.IsNullOrWhiteSpace(single))
+                        return [];
+                    return single.Contains(',')
+                        ? single
+                            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                            .ToArray()
+                        : [single.Trim()];
+
+                case JsonValueKind.Array:
+                    List<string> values = [];
+                    foreach (JsonElement item in element.EnumerateArray())
+                    {
+                        if (item.ValueKind is not JsonValueKind.String)
+                            continue;
+
+                        string? value = item.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                            values.Add(value.Trim());
+                    }
+                    return values;
+
+                default:
+                    return [];
+            }
+        }
+
+        public static string? AsJoinedString(JsonElement element)
+        {
+            IReadOnlyList<string> values = AsStringList(element);
+            return values.Count is 0 ? null : string.Join(", ", values);
+        }
+
+        private static T? Deserialize<T>(string json)
+        {
+            return JsonSerializer.Deserialize(json, GetTypeInfo<T>());
+        }
+
+        private static JsonTypeInfo<T> GetTypeInfo<T>()
+        {
+            return (JsonTypeInfo<T>?)NuGetV3JsonContext.Default.GetTypeInfo(typeof(T))
+                ?? throw new InvalidOperationException(
+                    $"NuGet V3 JSON metadata for {typeof(T).FullName} was not generated."
+                );
+        }
+    }
+}

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3ServiceIndex.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/Internal/NuGetV3ServiceIndex.cs
@@ -1,0 +1,196 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using UniGetUI.Core.Logging;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal
+{
+    internal sealed class NuGetV3ServiceIndex
+    {
+        private static readonly string[] SearchQueryServiceTypes =
+        [
+            "SearchQueryService/3.5.0",
+            "SearchQueryService/3.0.0-rc",
+            "SearchQueryService/3.0.0-beta",
+            "SearchQueryService",
+        ];
+
+        private static readonly string[] RegistrationsBaseUrlTypes =
+        [
+            "RegistrationsBaseUrl/3.6.0",
+            "RegistrationsBaseUrl/3.4.0",
+            "RegistrationsBaseUrl/3.0.0-rc",
+            "RegistrationsBaseUrl/3.0.0-beta",
+            "RegistrationsBaseUrl",
+        ];
+
+        private static readonly string[] PackageBaseAddressTypes =
+        [
+            "PackageBaseAddress/3.0.0",
+            "PackageBaseAddress",
+        ];
+
+        private static readonly ConcurrentDictionary<string, NuGetV3ServiceIndex> ResolvedIndexes =
+            new();
+
+        public Uri ServiceIndexUrl { get; }
+        public Uri? SearchQueryService { get; }
+        public Uri? RegistrationsBaseUrl { get; }
+        public Uri? PackageBaseAddress { get; }
+
+        private NuGetV3ServiceIndex(
+            Uri serviceIndexUrl,
+            Uri? searchQueryService,
+            Uri? registrationsBaseUrl,
+            Uri? packageBaseAddress
+        )
+        {
+            ServiceIndexUrl = serviceIndexUrl;
+            SearchQueryService = searchQueryService;
+            RegistrationsBaseUrl = registrationsBaseUrl;
+            PackageBaseAddress = packageBaseAddress;
+        }
+
+        public static bool IsV3Source(IManagerSource? source) =>
+            GetServiceIndexUrl(source) is not null;
+
+        internal static Uri? GetServiceIndexUrl(IManagerSource? source)
+        {
+            if (source?.Url is not { IsAbsoluteUri: true } url)
+                return null;
+
+            string path = url.AbsolutePath.TrimEnd('/');
+
+            if (path.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
+                return new Uri(url.GetLeftPart(UriPartial.Path).TrimEnd('/'));
+
+            if (path.EndsWith("/v3", StringComparison.OrdinalIgnoreCase))
+                return new Uri($"{url.GetLeftPart(UriPartial.Path).TrimEnd('/')}/index.json");
+
+            return null;
+        }
+
+        public static NuGetV3ServiceIndex? Resolve(IManagerSource? source)
+        {
+            if (GetServiceIndexUrl(source) is not { } serviceIndexUrl)
+                return null;
+
+            string key = NormalizeCacheKey(serviceIndexUrl);
+            if (ResolvedIndexes.TryGetValue(key, out NuGetV3ServiceIndex? cached))
+                return cached;
+
+            NuGetV3ServiceIndex? resolved = Fetch(serviceIndexUrl);
+            if (resolved is not null)
+                ResolvedIndexes[key] = resolved;
+
+            return resolved;
+        }
+
+        private static string NormalizeCacheKey(Uri serviceIndexUrl) =>
+            $"{serviceIndexUrl.Scheme.ToLowerInvariant()}://"
+            + $"{serviceIndexUrl.Authority.ToLowerInvariant()}"
+            + serviceIndexUrl.AbsolutePath.TrimEnd('/');
+
+        internal static void ClearCache() => ResolvedIndexes.Clear();
+
+        private static NuGetV3ServiceIndex? Fetch(Uri serviceIndexUrl)
+        {
+            if (!NuGetV3Client.TryDownloadString(serviceIndexUrl, out string content))
+            {
+                Logger.Warn($"Could not load the NuGet V3 service index at Url={serviceIndexUrl}");
+                return null;
+            }
+
+            V3ServiceIndex? index;
+            try
+            {
+                index = NuGetV3Json.DeserializeServiceIndex(content);
+            }
+            catch (Exception e)
+            {
+                Logger.Warn($"Malformed NuGet V3 service index at Url={serviceIndexUrl}");
+                Logger.Warn(e);
+                return null;
+            }
+
+            if (index?.Resources is not { Count: > 0 })
+            {
+                Logger.Warn(
+                    $"The NuGet V3 service index at Url={serviceIndexUrl} advertises no resources"
+                );
+                return null;
+            }
+
+            Dictionary<string, string> resourcesByType = new(StringComparer.OrdinalIgnoreCase);
+            foreach (V3Resource resource in index.Resources)
+            {
+                if (string.IsNullOrWhiteSpace(resource.Id))
+                    continue;
+
+                foreach (string type in ReadTypes(resource.Type))
+                    resourcesByType.TryAdd(type, resource.Id);
+            }
+
+            Uri? search = SelectResource(resourcesByType, SearchQueryServiceTypes);
+            Uri? registration = SelectResource(resourcesByType, RegistrationsBaseUrlTypes);
+            Uri? packageBase = SelectResource(resourcesByType, PackageBaseAddressTypes);
+
+            if (packageBase is null && registration is null)
+            {
+                Logger.Warn(
+                    $"The NuGet V3 service index at Url={serviceIndexUrl} exposes neither "
+                        + "PackageBaseAddress nor RegistrationsBaseUrl"
+                );
+                return null;
+            }
+
+            Logger.Debug(
+                $"Resolved NuGet V3 service index at Url={serviceIndexUrl} "
+                    + $"(search={search}, registration={registration}, content={packageBase})"
+            );
+
+            return new NuGetV3ServiceIndex(serviceIndexUrl, search, registration, packageBase);
+        }
+
+        private static IEnumerable<string> ReadTypes(JsonElement type)
+        {
+            switch (type.ValueKind)
+            {
+                case JsonValueKind.String:
+                    string? single = type.GetString();
+                    if (!string.IsNullOrWhiteSpace(single))
+                        yield return single;
+                    break;
+
+                case JsonValueKind.Array:
+                    foreach (JsonElement item in type.EnumerateArray())
+                    {
+                        if (item.ValueKind is not JsonValueKind.String)
+                            continue;
+
+                        string? value = item.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                            yield return value;
+                    }
+                    break;
+            }
+        }
+
+        private static Uri? SelectResource(
+            IReadOnlyDictionary<string, string> resourcesByType,
+            IReadOnlyList<string> preferredTypes
+        )
+        {
+            foreach (string type in preferredTypes)
+            {
+                if (
+                    resourcesByType.TryGetValue(type, out string? id)
+                    && Uri.TryCreate(id, UriKind.Absolute, out Uri? uri)
+                )
+                    return uri;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/UniGetUI.PackageEngine.Managers.Npm/Npm.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Npm/Npm.cs
@@ -206,6 +206,17 @@ namespace UniGetUI.PackageEngine.Managers.NpmManager
             callArguments = "";
         }
 
+        public override int? CompareVersions(string versionA, string versionB)
+        {
+            if (
+                SemanticVersion.TryParse(versionA, out SemanticVersion parsedA)
+                && SemanticVersion.TryParse(versionB, out SemanticVersion parsedB)
+            )
+                return parsedA.CompareTo(parsedB);
+
+            return base.CompareVersions(versionA, versionB);
+        }
+
         protected override void _loadManagerVersion(out string version)
         {
             using Process process = new()

--- a/src/UniGetUI.PackageEngine.Managers.Pip/Pip.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Pip/Pip.cs
@@ -494,6 +494,17 @@ namespace UniGetUI.PackageEngine.Managers.PipManager
             callArguments = "-m pip ";
         }
 
+        public override int? CompareVersions(string versionA, string versionB)
+        {
+            if (
+                PythonVersion.TryParse(versionA, out PythonVersion parsedA)
+                && PythonVersion.TryParse(versionB, out PythonVersion parsedB)
+            )
+                return parsedA.CompareTo(parsedB);
+
+            return base.CompareVersions(versionA, versionB);
+        }
+
         protected override void _loadManagerVersion(out string version)
         {
             using Process process = new()

--- a/src/UniGetUI.PackageEngine.Operations/History/OperationHistoryRecord.cs
+++ b/src/UniGetUI.PackageEngine.Operations/History/OperationHistoryRecord.cs
@@ -86,8 +86,10 @@ public sealed class OperationHistoryRecord
                     record.VersionBefore = pop.Role is OperationType.Install ? "" : pop.Package.VersionString;
                     record.VersionAfter = pop.Role switch
                     {
-                        OperationType.Update => pop.Package.NewVersionString,
                         OperationType.Uninstall => "",
+                        _ when pop.Options.Version is { Length: > 0 } pinnedVersion =>
+                            pinnedVersion,
+                        OperationType.Update => pop.Package.NewVersionString,
                         _ => pop.Package.VersionString,
                     };
                     record.OptionsJson = pop.Options.AsJsonString();

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -1064,10 +1064,16 @@ namespace UniGetUI.PackageEngine.Operations
             else if (role is OperationType.Uninstall && opts.PostUninstallCommand.Any())
                 l.Add(new(new PrePostOperation(opts.PostUninstallCommand), false));
 
+            static bool IsSupersededBy(IPackage installed, IPackage update) =>
+                update.Manager.CompareVersions(installed.VersionString, update.NewVersionString)
+                    is { } comparison
+                    ? comparison < 0
+                    : installed.NormalizedVersion < update.NormalizedNewVersion;
+
             if (role is OperationType.Update && opts.UninstallPreviousVersionsOnUpdate)
             {
                 var matches = InstalledPackagesLoader.Instance.Packages.Where(p =>
-                    p.IsEquivalentTo(package) && p.NormalizedVersion < package.NormalizedNewVersion
+                    p.IsEquivalentTo(package) && IsSupersededBy(p, package)
                 );
                 foreach (var match in matches)
                 {

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
@@ -26,6 +26,17 @@ namespace UniGetUI.PackageEngine.Classes.Manager
         public ManagerStatus Status { get; }
         public Encoding OutputEncoding => Encoding.UTF8;
         public bool InstallerUrlFollowsPackageVersion => false;
+
+        public int? CompareVersions(string versionA, string versionB)
+        {
+            var parsedA = CoreTools.VersionStringToStruct(versionA);
+            var parsedB = CoreTools.VersionStringToStruct(versionB);
+
+            if (parsedA == CoreTools.Version.Null || parsedB == CoreTools.Version.Null)
+                return null;
+
+            return parsedA.CompareTo(parsedB);
+        }
         public string Id
         {
             get => string.IsNullOrWhiteSpace(Properties.Id) ? Properties.Name : Properties.Id;

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
@@ -46,6 +46,17 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         public virtual Encoding OutputEncoding => Encoding.UTF8;
         public virtual bool InstallerUrlFollowsPackageVersion => false;
 
+        public virtual int? CompareVersions(string versionA, string versionB)
+        {
+            var parsedA = CoreTools.VersionStringToStruct(versionA);
+            var parsedB = CoreTools.VersionStringToStruct(versionB);
+
+            if (parsedA == CoreTools.Version.Null || parsedB == CoreTools.Version.Null)
+                return null;
+
+            return parsedA.CompareTo(parsedB);
+        }
+
         private readonly bool _baseConstructorCalled;
         private bool _ready;
 

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -319,12 +319,12 @@ namespace UniGetUI.PackageEngine.PackageClasses
         {
             foreach (var p in GetInstalledPackages())
             {
-                if (p.NormalizedVersion == CoreTools.Version.Null || this.NormalizedNewVersion == CoreTools.Version.Null)
+                if (Manager.CompareVersions(p.VersionString, this.NewVersionString) is not { } comparison)
                 {
                     continue;
                 }
 
-                if (p.NormalizedVersion >= this.NormalizedNewVersion)
+                if (comparison >= 0)
                 {
                     return true;
                 }

--- a/src/UniGetUI.PackageEngine.Tests/DotNetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/DotNetManagerTests.cs
@@ -1,11 +1,134 @@
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Managers.DotNetManager;
+using UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal;
+using UniGetUI.PackageEngine.Serializable;
 using UniGetUI.PackageEngine.Structs;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Builders;
 
 namespace UniGetUI.PackageEngine.Tests;
 
 public sealed class DotNetManagerTests
 {
+    // A `dotnet tool install` with neither --global nor --tool-path is a manifest-scoped LOCAL
+    // install: it writes into a dotnet-tools.json tied to the working directory. UniGetUI runs
+    // its own `dotnet tool list` from its install directory, so it can never enumerate a
+    // manifest created anywhere else - the tool appears installed once and then vanishes, and
+    // is never considered for updates. Global is therefore the default, and local must be asked
+    // for explicitly.
+    [Fact]
+    public void InstallDefaultsToGlobalWhenNoScopeIsRequested()
+    {
+        var manager = new DotNet();
+        var package = new PackageBuilder().WithManager(manager).WithId("dotnetsay").Build();
+
+        var parameters = manager.OperationHelper.GetParameters(
+            package,
+            new InstallOptions(),
+            OperationType.Install
+        );
+
+        Assert.Contains("--global", parameters);
+    }
+
+    [Theory]
+    [InlineData(PackageScope.User, false)]
+    [InlineData(PackageScope.Machine, true)]
+    public void InstallHonoursAnExplicitlyRequestedScope(string scope, bool expectGlobal)
+    {
+        var manager = new DotNet();
+        var package = new PackageBuilder().WithManager(manager).WithId("dotnetsay").Build();
+
+        var parameters = manager.OperationHelper.GetParameters(
+            package,
+            new InstallOptions { InstallationScope = scope },
+            OperationType.Install
+        );
+
+        Assert.Equal(expectGlobal, parameters.Contains("--global"));
+    }
+
+    [Theory]
+    [InlineData(PackageScope.Local, false)]
+    [InlineData(PackageScope.Global, true)]
+    public void OperationsPreserveTheScopeAnInstalledToolWasFoundIn(
+        string scope,
+        bool expectGlobal
+    )
+    {
+        var manager = new DotNet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("dotnetsay")
+            .WithOptions(new OverridenInstallationOptions(scope))
+            .Build();
+
+        foreach (var operation in new[] { OperationType.Update, OperationType.Uninstall })
+        {
+            var parameters = manager.OperationHelper.GetParameters(
+                package,
+                new InstallOptions(),
+                operation
+            );
+
+            Assert.Equal(expectGlobal, parameters.Contains("--global"));
+        }
+    }
+
+    // dotnet rejects --global and --tool-path together, so a custom location must suppress the
+    // global default rather than produce a command line that cannot run.
+    [Fact]
+    public void ACustomInstallLocationSuppressesTheGlobalFlag()
+    {
+        var manager = new DotNet();
+        var package = new PackageBuilder().WithManager(manager).WithId("dotnetsay").Build();
+
+        var parameters = manager.OperationHelper.GetParameters(
+            package,
+            new InstallOptions { CustomInstallLocation = "C:\\tools" },
+            OperationType.Install
+        );
+
+        Assert.Contains("--tool-path", parameters);
+        Assert.DoesNotContain("--global", parameters);
+    }
+
+    [Fact]
+    public void ACustomInstallLocationSuppressesTheGlobalFlagEvenWhenGlobalIsRequested()
+    {
+        var manager = new DotNet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("dotnetsay")
+            .WithOptions(new OverridenInstallationOptions(PackageScope.Global))
+            .Build();
+
+        var parameters = manager.OperationHelper.GetParameters(
+            package,
+            new InstallOptions { CustomInstallLocation = "C:\\tools" },
+            OperationType.Install
+        );
+
+        Assert.Contains("--tool-path", parameters);
+        Assert.DoesNotContain("--global", parameters);
+    }
+
+    [Fact]
+    public void DefaultAndKnownSourcesPointAtTheNuGetV3ServiceIndex()
+    {
+        var manager = new DotNet();
+
+        Assert.Equal(
+            "https://api.nuget.org/v3/index.json",
+            manager.Properties.DefaultSource.Url.AbsoluteUri
+        );
+        Assert.All(
+            manager.Properties.KnownSources,
+            source =>
+                Assert.Equal("https://api.nuget.org/v3/index.json", source.Url.AbsoluteUri)
+        );
+        Assert.True(NuGetV3ServiceIndex.IsV3Source(manager.Properties.DefaultSource));
+    }
+
     [Fact]
     public void ParseInstalledPackages_SkipsHeadersAndFalseRows()
     {

--- a/src/UniGetUI.PackageEngine.Tests/Infrastructure/Helpers/TestHttpServer.cs
+++ b/src/UniGetUI.PackageEngine.Tests/Infrastructure/Helpers/TestHttpServer.cs
@@ -7,18 +7,40 @@ internal sealed class TestHttpServer : IDisposable
 {
     private readonly HttpListener _listener = new();
     private readonly Func<HttpListenerRequest, (int StatusCode, string Content, string ContentType)> _handler;
+    private readonly bool _handleConcurrently;
+    private int _inFlight;
+    private int _peakInFlight;
     private readonly List<string> _requestPaths = [];
+    private readonly List<string> _requestMethods = [];
     private readonly Task _backgroundTask;
 
     public TestHttpServer(
-        Func<HttpListenerRequest, (int StatusCode, string Content, string ContentType)> handler
+        Func<HttpListenerRequest, (int StatusCode, string Content, string ContentType)> handler,
+        bool handleConcurrently = false
     )
     {
         _handler = handler;
-        int port = GetAvailablePort();
-        BaseUri = new Uri($"http://127.0.0.1:{port}/");
-        _listener.Prefixes.Add(BaseUri.AbsoluteUri);
-        _listener.Start();
+        _handleConcurrently = handleConcurrently;
+
+        // A free port can be taken between probing it and binding it, which turns into a random
+        // failure once many fixtures run in one suite. Retry on a fresh port instead.
+        for (int attempt = 1; ; attempt++)
+        {
+            int port = GetAvailablePort();
+            BaseUri = new Uri($"http://127.0.0.1:{port}/");
+
+            try
+            {
+                _listener.Prefixes.Clear();
+                _listener.Prefixes.Add(BaseUri.AbsoluteUri);
+                _listener.Start();
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 5)
+            {
+            }
+        }
+
         _backgroundTask = Task.Run(ListenAsync);
     }
 
@@ -31,6 +53,19 @@ internal sealed class TestHttpServer : IDisposable
             lock (_requestPaths)
             {
                 return _requestPaths.ToArray();
+            }
+        }
+    }
+
+    public int PeakConcurrentRequests => Volatile.Read(ref _peakInFlight);
+
+    public IReadOnlyList<string> RequestMethods
+    {
+        get
+        {
+            lock (_requestPaths)
+            {
+                return _requestMethods.ToArray();
             }
         }
     }
@@ -57,15 +92,23 @@ internal sealed class TestHttpServer : IDisposable
                 lock (_requestPaths)
                 {
                     _requestPaths.Add(context.Request.RawUrl ?? context.Request.Url?.AbsolutePath ?? string.Empty);
+                    _requestMethods.Add(context.Request.HttpMethod);
                 }
 
-                var (statusCode, content, contentType) = _handler(context.Request);
-                context.Response.StatusCode = statusCode;
-                context.Response.ContentType = contentType;
-                using StreamWriter writer = new(context.Response.OutputStream);
-                await writer.WriteAsync(content);
-                await writer.FlushAsync();
-                context.Response.Close();
+                if (_handleConcurrently)
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await RespondAsync(context);
+                        }
+                        catch
+                        {
+                            // a detached response must never surface as an unobserved exception
+                        }
+                    });
+                else
+                    await RespondAsync(context);
             }
             catch (HttpListenerException)
             {
@@ -75,6 +118,38 @@ internal sealed class TestHttpServer : IDisposable
             {
                 break;
             }
+        }
+    }
+
+    private async Task RespondAsync(HttpListenerContext context)
+    {
+        int current = Interlocked.Increment(ref _inFlight);
+        int peak = Volatile.Read(ref _peakInFlight);
+        while (current > peak
+            && Interlocked.CompareExchange(ref _peakInFlight, current, peak) != peak)
+        {
+            peak = Volatile.Read(ref _peakInFlight);
+        }
+
+        try
+        {
+            var (statusCode, content, contentType) = _handler(context.Request);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = contentType;
+            await using StreamWriter writer = new(context.Response.OutputStream);
+            await writer.WriteAsync(content);
+            await writer.FlushAsync();
+            context.Response.Close();
+        }
+        catch (HttpListenerException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _inFlight);
         }
     }
 

--- a/src/UniGetUI.PackageEngine.Tests/NuGetManifestLoaderTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetManifestLoaderTests.cs
@@ -39,7 +39,7 @@ public sealed class NuGetManifestLoaderTests
         BaseNuGet.Manifests.Clear();
         var manager = new PackageManagerBuilder().Build();
         var package = new PackageBuilder().WithManager(manager).WithId("Contoso.Tool").Build();
-        BaseNuGet.Manifests[package.GetHash()] = "<cached />";
+        BaseNuGet.Manifests[package.GetVersionedHash()] = "<cached />";
 
         Assert.Equal("<cached />", NuGetManifestLoader.GetManifestContent(package));
     }

--- a/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
@@ -467,14 +467,152 @@ public sealed class NuGetV3ClientTests
         Assert.Null(NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0"));
     }
 
+    // A registration lookup that cannot be completed must not be reported as "listed": the flat
+    // container includes unlisted versions, so treating an unknown result as listed would let a
+    // transient failure surface a withdrawn release as an update.
     [Fact]
-    public void IsListedTreatsAMalformedRegistrationLeafAsListed()
+    public void AMalformedRegistrationLeafYieldsAnUnknownListedStatus()
     {
         using var feed = new FakeV3Feed { RegistrationLeafBody = "{ oops" };
         var index = feed.Resolve();
         Assert.NotNull(index);
 
-        Assert.True(NuGetV3Client.IsListed(index, "Contoso.Tool", "2.0.0"));
+        Assert.Equal(
+            ListedStatus.Unknown,
+            NuGetV3Client.GetListedStatus(index, "Contoso.Tool", "2.0.0")
+        );
+    }
+
+    [Fact]
+    public void AFeedWithoutRegistrationsYieldsAnUnknownListedStatus()
+    {
+        using var feed = new FakeV3Feed { AdvertiseRegistrations = false };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(
+            ListedStatus.Unknown,
+            NuGetV3Client.GetListedStatus(index, "Contoso.Tool", "2.0.0")
+        );
+    }
+
+    [Theory]
+    [InlineData(true, ListedStatus.Listed)]
+    [InlineData(false, ListedStatus.Unlisted)]
+    internal void AnExplicitListedFlagIsReported(bool listed, ListedStatus expected)
+    {
+        using var feed = new FakeV3Feed
+        {
+            RegistrationLeafBody = $"{{\"listed\":{(listed ? "true" : "false")}}}",
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(expected, NuGetV3Client.GetListedStatus(index, "Contoso.Tool", "2.0.0"));
+    }
+
+    // Registration predates the listed field, so a feed that omits it is treated as listed
+    // rather than blocking every update on that feed.
+    [Fact]
+    public void AnOmittedListedFlagIsTreatedAsListed()
+    {
+        using var feed = new FakeV3Feed { RegistrationLeafBody = "{\"published\":\"2026-01-02T03:04:05Z\"}" };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(
+            ListedStatus.Listed,
+            NuGetV3Client.GetListedStatus(index, "Contoso.Tool", "2.0.0")
+        );
+    }
+
+    // Previously capped at five probes, which hid a valid update when the newest few versions
+    // had been unlisted.
+    [Fact]
+    public void GetUpdateCandidateWalksPastMoreThanFiveUnlistedVersions()
+    {
+        using var feed = new FakeV3Feed
+        {
+            Versions = ["1.0.0", "2.0.1", "2.0.2", "2.0.3", "2.0.4", "2.0.5", "2.0.6", "2.0.7"],
+            UnlistedVersions = ["2.0.7", "2.0.6", "2.0.5", "2.0.4", "2.0.3", "2.0.2"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(
+            "2.0.1",
+            NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false, out bool failed)
+        );
+        Assert.False(failed);
+    }
+
+    // A feed outage must be reported, not silently converted into "no update available".
+    [Fact]
+    public void GetUpdateCandidateReportsAFailedVersionRequest()
+    {
+        using var feed = new FakeV3Feed { FlatContainerStatusCode = 500 };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Null(
+            NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false, out bool failed)
+        );
+        Assert.True(failed);
+    }
+
+    [Fact]
+    public void GetUpdateCandidateReportsAnUnresolvableListedStatus()
+    {
+        using var feed = new FakeV3Feed
+        {
+            Versions = ["1.0.0", "2.0.0"],
+            RegistrationLeafStatusCode = 500,
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Null(
+            NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false, out bool failed)
+        );
+        Assert.True(failed);
+    }
+
+    // A registration-less feed cannot answer listed status at all, so the newest matching
+    // version is accepted rather than reporting every check as failed.
+    [Fact]
+    public void GetUpdateCandidateAcceptsTheNewestVersionOnARegistrationLessFeed()
+    {
+        using var feed = new FakeV3Feed
+        {
+            AdvertiseRegistrations = false,
+            Versions = ["1.0.0", "2.0.0"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(
+            "2.0.0",
+            NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false, out bool failed)
+        );
+        Assert.False(failed);
+    }
+
+    [Fact]
+    public void GetVersionsDistinguishesAFailedRequestFromAnEmptyFeedAnswer()
+    {
+        using var feed = new FakeV3Feed { FlatContainerStatusCode = 500 };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Empty(NuGetV3Client.GetVersions(index, "Contoso.Tool", out bool failed));
+        Assert.True(failed);
+
+        using var empty = new FakeV3Feed { FlatContainerBody = "{\"versions\":[]}" };
+        var emptyIndex = empty.Resolve();
+        Assert.NotNull(emptyIndex);
+
+        Assert.Empty(NuGetV3Client.GetVersions(emptyIndex, "Contoso.Tool", out bool emptyFailed));
+        Assert.False(emptyFailed);
     }
 
     [Fact]
@@ -897,6 +1035,50 @@ public sealed class NuGetV3ClientTests
         Assert.True(dependency.Mandatory);
     }
 
+    // The metadata cache must be keyed by version. Package.GetHash() covers only
+    // manager + source + id, so keying on it made details for one version answer requests for
+    // every other version of the same package - serving the wrong installer URL, dependencies
+    // and publication date.
+    [Fact]
+    public void DetailsForOneVersionDoNotLeakIntoAnotherVersionOfTheSamePackage()
+    {
+        using var feed = new FakeV3Feed();
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.V3Entries.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+
+        PackageDetails LoadFor(string version)
+        {
+            var package = new PackageBuilder()
+                .WithManager(manager)
+                .WithSource(manager.Properties.DefaultSource)
+                .WithId("Contoso.Tool")
+                .WithVersion(version)
+                .Build();
+            var details = new PackageDetailsBuilder().Build(package);
+            manager.ExposedDetailsHelper.LoadDetails(details);
+            return details;
+        }
+
+        var first = LoadFor("2.0.0");
+        var second = LoadFor("1.0.0");
+
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/2.0.0/contoso.tool.2.0.0.nupkg",
+            first.InstallerUrl?.AbsoluteUri
+        );
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/1.0.0/contoso.tool.1.0.0.nupkg",
+            second.InstallerUrl?.AbsoluteUri
+        );
+        Assert.Equal(
+            $"{feed.BaseUri}registration-gz-semver2/contoso.tool/1.0.0.json",
+            second.ManifestUrl?.AbsoluteUri
+        );
+    }
+
     [Fact]
     public void GetDetailsDoesNotTouchTheNetworkTwiceForDetailsAndIcon()
     {
@@ -964,7 +1146,7 @@ public sealed class NuGetV3ClientTests
             .WithId("Contoso.Tool")
             .WithVersion("2.0.0")
             .Build();
-        BaseNuGet.V3IconUrls[package.GetHash()] = string.Empty;
+        BaseNuGet.V3IconUrls[package.GetVersionedHash()] = string.Empty;
 
         Assert.Null(manager.ExposedDetailsHelper.LoadIcon(package));
         Assert.Empty(feed.Server.RequestPaths);
@@ -1060,6 +1242,10 @@ public sealed class NuGetV3ClientTests
 
         public string? NuspecPackageType { get; init; }
 
+        public int FlatContainerStatusCode { get; init; } = 200;
+
+        public int RegistrationLeafStatusCode { get; init; } = 200;
+
         public bool AdvertiseSearchService { get; init; } = true;
 
         public bool AdvertiseRegistrations { get; init; } = true;
@@ -1103,10 +1289,20 @@ public sealed class NuGetV3ClientTests
                 return (200, NuspecBody ?? RenderedNuspec, "text/xml");
 
             if (path.Contains("/flatcontainer/", StringComparison.OrdinalIgnoreCase))
+            {
+                if (FlatContainerStatusCode is not 200)
+                    return (FlatContainerStatusCode, string.Empty, "application/json");
+
                 return Json(FlatContainerBody ?? BuildFlatContainerIndex());
+            }
 
             if (path.Contains("/registration-gz-semver2/", StringComparison.OrdinalIgnoreCase))
+            {
+                if (RegistrationLeafStatusCode is not 200)
+                    return (RegistrationLeafStatusCode, string.Empty, "application/json");
+
                 return Json(RegistrationLeafBody ?? BuildRegistrationLeaf(path));
+            }
 
             if (path.Contains("/catalog/", StringComparison.OrdinalIgnoreCase))
                 return Json(CatalogEntry);

--- a/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
@@ -703,6 +703,75 @@ public sealed class NuGetV3ClientTests
         Assert.False(entry.HasPackageType("DotnetTool"));
     }
 
+    // A search service returns nothing for a package precisely when it has been withdrawn, so
+    // the exact-id fallback must not resurrect an unlisted version from the flat container -
+    // which does list withdrawn versions.
+    [Fact]
+    public void TheExactIdFallbackSkipsUnlistedVersions()
+    {
+        using var feed = new FakeV3Feed
+        {
+            SearchTotalPackages = 0,
+            Versions = ["1.0.0", "2.0.0", "3.0.0"],
+            UnlistedVersions = ["3.0.0", "2.0.0"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var result = Assert.Single(NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50));
+        Assert.Equal("1.0.0", result.Version);
+    }
+
+    [Fact]
+    public void TheExactIdFallbackReturnsNothingWhenEveryVersionIsUnlisted()
+    {
+        using var feed = new FakeV3Feed
+        {
+            SearchTotalPackages = 0,
+            Versions = ["1.0.0", "2.0.0"],
+            UnlistedVersions = ["1.0.0", "2.0.0"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Empty(NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50));
+    }
+
+    // Unlike update selection, an exact-id search has no failure channel and the user named the
+    // package explicitly, so an unresolvable listed status shows the package rather than hiding
+    // it. Update selection reports the same condition as a failed check instead.
+    [Fact]
+    public void TheExactIdFallbackShowsThePackageWhenListedStatusCannotBeEstablished()
+    {
+        using var feed = new FakeV3Feed
+        {
+            SearchTotalPackages = 0,
+            Versions = ["1.0.0", "2.0.0"],
+            RegistrationLeafStatusCode = 500,
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var result = Assert.Single(NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50));
+        Assert.Equal("2.0.0", result.Version);
+    }
+
+    [Fact]
+    public void TheExactIdFallbackTakesTheNewestVersionOnARegistrationLessFeed()
+    {
+        using var feed = new FakeV3Feed
+        {
+            AdvertiseSearchService = false,
+            AdvertiseRegistrations = false,
+            Versions = ["1.0.0", "2.0.0"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var result = Assert.Single(NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50));
+        Assert.Equal("2.0.0", result.Version);
+    }
+
     [Fact]
     public void GetVersionsDescendingOrdersBySemanticVersion()
     {

--- a/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
@@ -1104,8 +1104,11 @@ public sealed class NuGetV3ClientTests
         Assert.Equal(requestsAfterDetails, feed.Server.RequestPaths.Count);
     }
 
+    // The flat container defines no /{id}/{version}/icon route - it is a nuget.org extension - so
+    // an embedded icon must not be guessed at on a conforming third-party feed, where the request
+    // would simply 404.
     [Fact]
-    public void GetIconFallsBackToTheEmbeddedIconEndpoint()
+    public void GetIconDoesNotGuessAnEmbeddedIconRouteOnANonNuGetOrgFeed()
     {
         using var feed = new FakeV3Feed();
         NuGetV3ServiceIndex.ClearCache();
@@ -1121,13 +1124,51 @@ public sealed class NuGetV3ClientTests
             .WithVersion("2.0.0")
             .Build();
 
-        var icon = manager.ExposedDetailsHelper.LoadIcon(package);
+        Assert.Null(manager.ExposedDetailsHelper.LoadIcon(package));
+    }
 
-        Assert.NotNull(icon);
+    [Theory]
+    [InlineData("https://api.nuget.org/v3-flatcontainer/", true)]
+    [InlineData("https://nuget.org/v3-flatcontainer/", true)]
+    [InlineData("https://packages.example.test/v3-flatcontainer/", false)]
+    [InlineData("https://nuget.org.example.test/flat/", false)]
+    [InlineData("https://pkgs.dev.azure.com/contoso/_packaging/feed/nuget/v3/flat2/", false)]
+    public void TheEmbeddedIconRouteIsOnlyUsedWhereItExists(string packageBase, bool expected)
+    {
         Assert.Equal(
-            $"{feed.BaseUri}flatcontainer/contoso.tool/2.0.0/icon",
-            icon.Value.Url.AbsoluteUri
+            expected,
+            NuGetV3Client.SupportsEmbeddedIconRoute(new Uri(packageBase))
         );
+    }
+
+    // Comment 16: this client implements NuGet semantics, whose pre-release labels are compared
+    // case-insensitively. Under strict SemVer's ASCII ordering "1.0.0-Z" would sort below
+    // "1.0.0-a", which would pick a different latest version than NuGet does.
+    [Fact]
+    public void VersionSelectionUsesNuGetsCaseInsensitiveLabelOrdering()
+    {
+        using var feed = new FakeV3Feed { Versions = ["1.0.0-a", "1.0.0-Z"] };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(["1.0.0-Z", "1.0.0-a"], NuGetV3Client.GetVersionsDescending(index, "Contoso.Tool"));
+        Assert.Equal("1.0.0-Z", NuGetV3Client.SelectHighestVersion(["1.0.0-a", "1.0.0-Z"], true));
+    }
+
+    [Fact]
+    public void TheClientAndTheManagerAgreeOnLabelOrdering()
+    {
+        using var feed = new FakeV3Feed();
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+
+        Assert.True(NuGetV3Client.TryParseNuGetVersion("1.0.0-Z", out var upper));
+        Assert.True(NuGetV3Client.TryParseNuGetVersion("1.0.0-a", out var lower));
+
+        Assert.Equal(
+            Math.Sign(upper.CompareTo(lower)),
+            Math.Sign(manager.CompareVersions("1.0.0-Z", "1.0.0-a")!.Value)
+        );
+        Assert.True(upper > lower);
     }
 
     [Fact]

--- a/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
@@ -772,6 +772,34 @@ public sealed class NuGetV3ClientTests
         Assert.Equal("2.0.0", result.Version);
     }
 
+    // A registration-only service index is accepted (search and details still work through it),
+    // but versions cannot be enumerated without a PackageBaseAddress. Converting that into an
+    // empty version list would report "no update available" on every check forever, so it is
+    // surfaced as a failure instead.
+    [Fact]
+    public void AFeedWithoutAPackageBaseAddressReportsAVersionEnumerationFailure()
+    {
+        using var feed = new FakeV3Feed { AdvertisePackageBaseAddress = false };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+        Assert.Null(index.PackageBaseAddress);
+        Assert.NotNull(index.RegistrationsBaseUrl);
+
+        Assert.Empty(NuGetV3Client.GetVersions(index, "Contoso.Tool", out bool failed));
+        Assert.True(failed);
+
+        Assert.Null(
+            NuGetV3Client.GetUpdateCandidate(
+                index,
+                "Contoso.Tool",
+                "1.0.0",
+                false,
+                out bool candidateFailed
+            )
+        );
+        Assert.True(candidateFailed);
+    }
+
     [Fact]
     public void GetVersionsDescendingOrdersBySemanticVersion()
     {
@@ -1360,6 +1388,8 @@ public sealed class NuGetV3ClientTests
 
         public bool AdvertiseRegistrations { get; init; } = true;
 
+        public bool AdvertisePackageBaseAddress { get; init; } = true;
+
         public bool UseArrayResourceTypes { get; init; }
 
         public bool InlineCatalogEntry { get; init; }
@@ -1428,19 +1458,17 @@ public sealed class NuGetV3ClientTests
 
         private string BuildServiceIndex()
         {
-            List<string> resources =
-            [
-                Resource($"{BaseUri}flatcontainer/", "PackageBaseAddress/3.0.0"),
-            ];
+            List<string> resources = [];
+
+            if (AdvertisePackageBaseAddress)
+                resources.Add(Resource($"{BaseUri}flatcontainer/", "PackageBaseAddress/3.0.0"));
 
             if (AdvertiseRegistrations)
             {
-                resources.Insert(
-                    0,
+                resources.Add(
                     Resource($"{BaseUri}registration-gz-semver2/", "RegistrationsBaseUrl/3.6.0")
                 );
-                resources.Insert(
-                    1,
+                resources.Add(
                     Resource($"{BaseUri}registration-legacy/", "RegistrationsBaseUrl")
                 );
             }

--- a/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetV3ClientTests.cs
@@ -1,0 +1,1304 @@
+using System.Net;
+using UniGetUI.Core.IconEngine;
+using UniGetUI.PackageEngine.Classes.Manager;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.ManagerClasses.Manager;
+using UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal;
+using UniGetUI.PackageEngine.Managers.PowerShellManager;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Builders;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Helpers;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class NuGetV3ClientTests
+{
+    private static readonly string[] DefaultVersions =
+    [
+        "1.0.0",
+        "1.2.0",
+        "2.0.0-beta.1",
+        "2.0.0",
+    ];
+
+    private const string SparseCatalogEntry = """
+    {"id":"Contoso.Tool","version":"2.0.0"}
+    """;
+
+    [Theory]
+    [InlineData("https://api.nuget.org/v3/index.json", true)]
+    [InlineData("https://pkgs.dev.azure.com/contoso/_packaging/feed/nuget/v3/index.json", true)]
+    [InlineData("https://nuget.pkg.github.com/contoso/INDEX.JSON", true)]
+    [InlineData("https://www.nuget.org/api/v2", false)]
+    [InlineData("https://www.powershellgallery.com/api/v2", false)]
+    [InlineData("https://community.chocolatey.org/api/v2/", false)]
+    [InlineData("https://packages.example.test/api/v3", true)]
+    [InlineData("https://packages.example.test/api/v3/", true)]
+    [InlineData("https://packages.example.test/nuget/V3", true)]
+    [InlineData("https://packages.example.test/feed", false)]
+    [InlineData("https://www.poshtestgallery.com/api/v2", false)]
+    public void IsV3SourceOnlyMatchesServiceIndexUrls(string url, bool expected)
+    {
+        var source = new SourceBuilder().WithUrl(url).Build();
+
+        Assert.Equal(expected, NuGetV3ServiceIndex.IsV3Source(source));
+    }
+
+    [Theory]
+    [InlineData("https://api.nuget.org/v3/index.json", "https://api.nuget.org/v3/index.json")]
+    [InlineData("https://example.test/api/v3", "https://example.test/api/v3/index.json")]
+    [InlineData("https://example.test/api/v3/", "https://example.test/api/v3/index.json")]
+    [InlineData("https://example.test/v3/index.json?x=1", "https://example.test/v3/index.json")]
+    public void ServiceIndexUrlIsDerivedFromTheSourceUrl(string url, string expected)
+    {
+        var source = new SourceBuilder().WithUrl(url).Build();
+
+        Assert.Equal(expected, NuGetV3ServiceIndex.GetServiceIndexUrl(source)?.AbsoluteUri);
+    }
+
+    [Fact]
+    public void ResolveSelectsThePreferredResourceForEachType()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+
+        Assert.NotNull(index);
+        Assert.Equal($"{feed.BaseUri}query", index.SearchQueryService?.AbsoluteUri);
+        Assert.Equal($"{feed.BaseUri}registration-gz-semver2/", index.RegistrationsBaseUrl?.AbsoluteUri);
+        Assert.Equal($"{feed.BaseUri}flatcontainer/", index.PackageBaseAddress?.AbsoluteUri);
+    }
+
+    [Fact]
+    public void ResolveReadsResourcesDeclaringTheirTypeAsAnArray()
+    {
+        using var feed = new FakeV3Feed { UseArrayResourceTypes = true };
+        var index = feed.Resolve();
+
+        Assert.NotNull(index);
+        Assert.Equal($"{feed.BaseUri}query", index.SearchQueryService?.AbsoluteUri);
+        Assert.Equal($"{feed.BaseUri}flatcontainer/", index.PackageBaseAddress?.AbsoluteUri);
+    }
+
+    [Fact]
+    public void ResolveIsCachedPerSource()
+    {
+        using var feed = new FakeV3Feed();
+
+        Assert.NotNull(feed.Resolve(clearCaches: true));
+        Assert.NotNull(feed.Resolve(clearCaches: false));
+
+        Assert.Single(feed.Server.RequestPaths, path => path.Contains("index.json"));
+    }
+
+    [Fact]
+    public void ResolveReturnsNullOnAMalformedServiceIndex()
+    {
+        using var feed = new FakeV3Feed { ServiceIndexBody = "{ not json" };
+
+        Assert.Null(feed.Resolve());
+    }
+
+    [Fact]
+    public void ResolveReturnsNullWhenNoUsableResourceIsAdvertised()
+    {
+        using var feed = new FakeV3Feed
+        {
+            ServiceIndexBody = """
+            {"version":"3.0.0","resources":[{"@id":"https://example.test/publish","@type":"PackagePublish/2.0.0"}]}
+            """,
+        };
+
+        Assert.Null(feed.Resolve());
+    }
+
+    [Fact]
+    public void SearchSendsV3ParametersAndReadsJsonResults()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var results = NuGetV3Client.Search(index, "contoso tool", false, "DotnetTool", 50);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Contoso.Tool", results[0].Id);
+        Assert.Equal("2.0.0", results[0].Version);
+        Assert.Equal("A tool", results[0].Description);
+        Assert.Equal($"{feed.BaseUri}icons/contoso.png", results[0].IconUrl);
+
+        string query = Assert.Single(feed.Server.RequestPaths, path => path.Contains("/query"));
+        Assert.Contains("q=contoso+tool", query);
+        Assert.Contains("take=50", query);
+        Assert.Contains("prerelease=false", query);
+        Assert.Contains("semVerLevel=2.0.0", query);
+        Assert.Contains("packageType=DotnetTool", query);
+    }
+
+    [Fact]
+    public void SearchOmitsThePackageTypeFilterWhenNoneIsRequested()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        NuGetV3Client.Search(index, "contoso", true, null, 20);
+
+        string query = Assert.Single(feed.Server.RequestPaths, path => path.Contains("/query"));
+        Assert.DoesNotContain("packageType", query);
+        Assert.Contains("prerelease=true", query);
+        Assert.Contains("take=20", query);
+    }
+
+    [Fact]
+    public void SearchFallsBackToAnExactIdLookupWhenTheFeedHasNoSearchService()
+    {
+        using var feed = new FakeV3Feed { AdvertiseSearchService = false };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var results = NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50);
+
+        var result = Assert.Single(results);
+        Assert.Equal("Contoso.Tool", result.Id);
+        Assert.Equal("2.0.0", result.Version);
+        Assert.DoesNotContain(feed.Server.RequestPaths, path => path.Contains("/query"));
+    }
+
+    [Fact]
+    public void SearchPagesUntilTheResultLimitIsReached()
+    {
+        using var feed = new FakeV3Feed { SearchPageSize = 2, SearchTotalPackages = 5 };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var results = NuGetV3Client.Search(index, "contoso", false, null, 5);
+
+        Assert.Equal(5, results.Count);
+        Assert.Equal(
+            ["Pkg.0", "Pkg.1", "Pkg.2", "Pkg.3", "Pkg.4"],
+            results.Select(result => result.Id)
+        );
+
+        var queries = feed.Server.RequestPaths.Where(path => path.Contains("/query")).ToList();
+        Assert.Equal(3, queries.Count);
+        Assert.Contains("skip=0", queries[0]);
+        Assert.Contains("skip=2", queries[1]);
+        Assert.Contains("skip=4", queries[2]);
+    }
+
+    [Fact]
+    public void SearchStopsPagingOnAShortPage()
+    {
+        using var feed = new FakeV3Feed { SearchPageSize = 10, SearchTotalPackages = 3 };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var results = NuGetV3Client.Search(index, "contoso", false, null, 50);
+
+        Assert.Equal(3, results.Count);
+        Assert.Single(feed.Server.RequestPaths, path => path.Contains("/query"));
+    }
+
+    [Fact]
+    public void SearchKeepsTheHighestVersionOfADuplicatedId()
+    {
+        using var feed = new FakeV3Feed { DuplicateIdVersions = ["1.0.0", "10.0.0", "2.0.0"] };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var results = NuGetV3Client.Search(index, "contoso", false, null, 50);
+
+        var result = Assert.Single(results);
+        Assert.Equal("Duplicated.Tool", result.Id);
+        Assert.Equal("10.0.0", result.Version);
+    }
+
+    [Fact]
+    public void SearchFallsBackToAnExactIdLookupWhenTheFeedReturnsNoResults()
+    {
+        using var feed = new FakeV3Feed { SearchTotalPackages = 0 };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var results = NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50);
+
+        var result = Assert.Single(results);
+        Assert.Equal("Contoso.Tool", result.Id);
+        Assert.Equal("2.0.0", result.Version);
+    }
+
+    [Fact]
+    public void GetCatalogEntryToleratesMetadataWithEveryOptionalFieldMissing()
+    {
+        using var feed = new FakeV3Feed { CatalogEntryBody = SparseCatalogEntry };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var entry = NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0");
+
+        Assert.NotNull(entry);
+        Assert.Null(entry.Description);
+        Assert.Null(entry.LicenseExpression);
+        Assert.Null(entry.PackageHash);
+        Assert.Equal(0, entry.PackageSize);
+        Assert.Null(entry.DependencyGroups);
+        Assert.Empty(NuGetV3Json.AsStringList(entry.Authors));
+        Assert.Empty(NuGetV3Json.AsStringList(entry.Tags));
+        Assert.Equal("2026-01-02T03:04:05Z", entry.Published);
+    }
+
+    [Fact]
+    public void GetDetailsToleratesMetadataWithEveryOptionalFieldMissing()
+    {
+        using var feed = new FakeV3Feed { CatalogEntryBody = SparseCatalogEntry };
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.V3Entries.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("2.0.0")
+            .Build();
+        var details = new PackageDetailsBuilder().Build(package);
+
+        manager.ExposedDetailsHelper.LoadDetails(details);
+
+        Assert.Null(details.Description);
+        Assert.Null(details.License);
+        Assert.Empty(details.Dependencies);
+        Assert.Empty(details.Tags);
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/2.0.0/contoso.tool.2.0.0.nupkg",
+            details.InstallerUrl?.AbsoluteUri
+        );
+        Assert.Contains(feed.Server.RequestMethods, method => method == "HEAD");
+    }
+
+    [Theory]
+    [InlineData("Contoso.Tool", "contoso.tool")]
+    [InlineData("CONTOSO_Tool-Extra", "contoso_tool-extra")]
+    [InlineData(" Contoso.Tool ", "contoso.tool")]
+    [InlineData("Contoso+Tool", "contoso%2Btool")]
+    [InlineData("Contoso Tool", "contoso%20tool")]
+    public void EscapeIdNormalizesAndEscapesPackageIds(string packageId, string expected)
+    {
+        Assert.Equal(expected, NuGetV3Client.EscapeId(packageId));
+    }
+
+    [Fact]
+    public void AV2SourceNeverReachesAV3Endpoint()
+    {
+        using var feed = new FakeV3Feed();
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.Manifests.Clear();
+        BaseNuGet.V3Entries.Clear();
+        BaseNuGet.V3IconUrls.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}api/v2");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("2.0.0")
+            .Build();
+
+        manager.ExposedDetailsHelper.LoadDetails(new PackageDetailsBuilder().Build(package));
+        manager.ExposedDetailsHelper.LoadVersions(package);
+
+        Assert.NotEmpty(feed.Server.RequestPaths);
+        Assert.All(
+            feed.Server.RequestPaths,
+            path =>
+            {
+                Assert.DoesNotContain("index.json", path);
+                Assert.DoesNotContain("/query", path);
+                Assert.DoesNotContain("registration", path);
+            }
+        );
+        Assert.Contains(feed.Server.RequestPaths, path => path.Contains("Packages(Id="));
+        Assert.Contains(feed.Server.RequestPaths, path => path.Contains("FindPackagesById"));
+    }
+
+    [Fact]
+    public void GetInstallableVersionsUsesTheFlatContainerForV3Sources()
+    {
+        using var feed = new FakeV3Feed { Versions = ["1.0.0", "10.0.0", "2.1.0"] };
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.0.0")
+            .Build();
+
+        Assert.Equal(
+            ["10.0.0", "2.1.0", "1.0.0"],
+            manager.ExposedDetailsHelper.LoadVersions(package)
+        );
+    }
+
+    [Fact]
+    public void GetNuPkgUrlUsesTheFlatContainerForV3SourcesAndV2PathsOtherwise()
+    {
+        using var feed = new FakeV3Feed();
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+
+        var v3Manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var v3Package = new PackageBuilder()
+            .WithManager(v3Manager)
+            .WithSource(v3Manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.0.0.0")
+            .Build();
+
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/1.0.0/contoso.tool.1.0.0.nupkg",
+            NuGetManifestLoader.GetNuPkgUrl(v3Package).AbsoluteUri
+        );
+
+        var v2Manager = new TestNuGetManager("https://packages.example.test/api/v2");
+        var v2Package = new PackageBuilder()
+            .WithManager(v2Manager)
+            .WithSource(v2Manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.0.0")
+            .Build();
+
+        Assert.Equal(
+            "https://packages.example.test/api/v2/package/Contoso.Tool/1.0.0",
+            NuGetManifestLoader.GetNuPkgUrl(v2Package).AbsoluteUri
+        );
+    }
+
+    [Fact]
+    public void SearchDegradesToTheExactIdLookupOnAMalformedSearchResponse()
+    {
+        using var feed = new FakeV3Feed { SearchBody = "{ \"data\": [ not json" };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var result = Assert.Single(NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50));
+        Assert.Equal("Contoso.Tool", result.Id);
+        Assert.Equal("2.0.0", result.Version);
+        Assert.Null(result.Description);
+    }
+
+    [Fact]
+    public void SearchReturnsNothingWhenBothTheSearchAndTheExactIdLookupFail()
+    {
+        using var feed = new FakeV3Feed
+        {
+            SearchBody = "{ \"data\": [ not json",
+            FlatContainerBody = "{ \"versions\": ",
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Empty(NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50));
+    }
+
+    [Fact]
+    public void SearchIgnoresResultsMissingAnIdOrVersion()
+    {
+        using var feed = new FakeV3Feed
+        {
+            SearchBody = """
+            {
+              "totalHits": 3,
+              "data": [
+                { "version": "1.0.0" },
+                { "id": "No.Version" },
+                { "id": "Good.Tool", "version": "1.0.0" }
+              ]
+            }
+            """,
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var result = Assert.Single(NuGetV3Client.Search(index, "contoso", false, null, 50));
+        Assert.Equal("Good.Tool", result.Id);
+    }
+
+    [Fact]
+    public void GetVersionsReturnsNothingOnAMalformedVersionIndex()
+    {
+        using var feed = new FakeV3Feed { FlatContainerBody = "{ \"versions\": " };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Empty(NuGetV3Client.GetVersions(index, "Contoso.Tool"));
+        Assert.Null(NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false));
+    }
+
+    [Fact]
+    public void GetCatalogEntryFallsBackToTheNuspecOnAMalformedRegistrationLeaf()
+    {
+        using var feed = new FakeV3Feed { RegistrationLeafBody = "{ oops" };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var entry = NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0");
+
+        Assert.NotNull(entry);
+        Assert.Equal("A tool from the nuspec", entry.Description);
+        Assert.Contains(feed.Server.RequestPaths, path => path.EndsWith(".nuspec"));
+    }
+
+    [Fact]
+    public void GetCatalogEntryReturnsNothingWhenBothMetadataSourcesAreMalformed()
+    {
+        using var feed = new FakeV3Feed
+        {
+            RegistrationLeafBody = "{ oops",
+            NuspecBody = "<package><metadata><id>Contoso",
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Null(NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0"));
+    }
+
+    [Fact]
+    public void IsListedTreatsAMalformedRegistrationLeafAsListed()
+    {
+        using var feed = new FakeV3Feed { RegistrationLeafBody = "{ oops" };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.True(NuGetV3Client.IsListed(index, "Contoso.Tool", "2.0.0"));
+    }
+
+    [Fact]
+    public void GetNuspecMetadataReturnsNothingOnMalformedXml()
+    {
+        using var feed = new FakeV3Feed
+        {
+            AdvertiseRegistrations = false,
+            NuspecBody = "<package><metadata><id>Contoso",
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Null(NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0"));
+    }
+
+    [Fact]
+    public void TheExactIdFallbackRejectsAPackageWithoutTheRequiredPackageType()
+    {
+        using var feed = new FakeV3Feed { SearchTotalPackages = 0 };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Empty(NuGetV3Client.Search(index, "Contoso.Tool", false, "DotnetTool", 50));
+        Assert.Contains(feed.Server.RequestPaths, path => path.EndsWith(".nuspec"));
+    }
+
+    [Fact]
+    public void TheExactIdFallbackAcceptsAPackageDeclaringTheRequiredPackageType()
+    {
+        using var feed = new FakeV3Feed
+        {
+            SearchTotalPackages = 0,
+            NuspecPackageType = "DotnetTool",
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var result = Assert.Single(
+            NuGetV3Client.Search(index, "Contoso.Tool", false, "DotnetTool", 50)
+        );
+        Assert.Equal("Contoso.Tool", result.Id);
+        Assert.True(result.IsExactIdFallback);
+    }
+
+    [Fact]
+    public void TheExactIdFallbackSkipsPackageTypeVerificationWhenNoneIsRequired()
+    {
+        using var feed = new FakeV3Feed { SearchTotalPackages = 0 };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Single(NuGetV3Client.Search(index, "Contoso.Tool", false, null, 50));
+        Assert.DoesNotContain(feed.Server.RequestPaths, path => path.EndsWith(".nuspec"));
+    }
+
+    [Fact]
+    public void ParseNuspecReadsPackageTypes()
+    {
+        var entry = NuGetV3Client.ParseNuspec(
+            """
+            <package><metadata><id>Contoso.Tool</id>
+              <packageTypes><packageType name="DotnetTool" /></packageTypes>
+            </metadata></package>
+            """,
+            "Contoso.Tool",
+            "1.0.0",
+            null
+        );
+
+        Assert.NotNull(entry);
+        Assert.True(entry.HasPackageType("dotnettool"));
+        Assert.False(entry.HasPackageType("Dependency"));
+    }
+
+    [Fact]
+    public void HasPackageTypeIsFalseWhenTheMetadataDeclaresNone()
+    {
+        var entry = NuGetV3Client.ParseNuspec(
+            """<package><metadata><id>Contoso.Tool</id></metadata></package>""",
+            "Contoso.Tool",
+            "1.0.0",
+            null
+        );
+
+        Assert.NotNull(entry);
+        Assert.Null(entry.PackageTypes);
+        Assert.False(entry.HasPackageType("DotnetTool"));
+    }
+
+    [Fact]
+    public void GetVersionsDescendingOrdersBySemanticVersion()
+    {
+        using var feed = new FakeV3Feed
+        {
+            Versions = ["1.0.0", "10.0.0", "2.1.0", "2.0.0-beta.1", "9.9.9"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var versions = NuGetV3Client.GetVersionsDescending(index, "Contoso.Tool");
+
+        Assert.Equal(["10.0.0", "9.9.9", "2.1.0", "2.0.0-beta.1", "1.0.0"], versions);
+    }
+
+    [Fact]
+    public void GetVersionsRequestsTheFlatContainerIndexOnlyOncePerPackage()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        NuGetV3Client.GetVersions(index, "Contoso.Tool");
+        NuGetV3Client.GetVersions(index, "Contoso.Tool");
+
+        Assert.Single(feed.Server.RequestPaths, path => path.Contains("/flatcontainer/"));
+    }
+
+    [Fact]
+    public void GetUpdateCandidateIgnoresPreReleasesUnlessTheyAreEnabled()
+    {
+        using var feed = new FakeV3Feed { Versions = ["1.0.0", "1.2.0", "2.0.0-beta.1"] };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal("1.2.0", NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false));
+        Assert.Equal(
+            "2.0.0-beta.1",
+            NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", true)
+        );
+    }
+
+    [Fact]
+    public void GetUpdateCandidateReturnsNullWhenTheInstalledVersionIsTheHighest()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Null(NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "2.0.0", false));
+        Assert.Null(NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "9.0.0", false));
+    }
+
+    [Fact]
+    public void GetUpdateCandidateSkipsUnlistedVersions()
+    {
+        using var feed = new FakeV3Feed
+        {
+            Versions = ["1.0.0", "1.2.0", "1.3.0"],
+            UnlistedVersions = ["1.3.0"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal("1.2.0", NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false));
+    }
+
+    [Fact]
+    public void GetUpdateCandidateReturnsNullWhenEveryNewerVersionIsUnlisted()
+    {
+        using var feed = new FakeV3Feed
+        {
+            Versions = ["1.0.0", "1.2.0"],
+            UnlistedVersions = ["1.2.0"],
+        };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Null(NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "1.0.0", false));
+    }
+
+    [Fact]
+    public void GetUpdateCandidateDoesNotProbeListingWhenNoNewerVersionExists()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        NuGetV3Client.GetUpdateCandidate(index, "Contoso.Tool", "2.0.0", false);
+
+        Assert.DoesNotContain(feed.Server.RequestPaths, path => path.Contains("registration"));
+    }
+
+    [Fact]
+    public void GetCatalogEntryFollowsACatalogEntryReference()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var entry = NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0");
+
+        Assert.NotNull(entry);
+        Assert.Equal("Contoso.Tool", entry.Id);
+        Assert.Equal("A tool", entry.Description);
+        Assert.Equal("Contoso, Fabrikam", NuGetV3Json.AsJoinedString(entry.Authors));
+        Assert.Equal("MIT", entry.LicenseExpression);
+        Assert.Equal(4096, entry.PackageSize);
+        Assert.Equal("hash-value", entry.PackageHash);
+        Assert.Equal("2026-01-02T03:04:05Z", entry.Published);
+        Assert.Equal(["cli", "tool"], NuGetV3Json.AsStringList(entry.Tags));
+
+        var dependency = Assert.Single(entry.DependencyGroups?[0].Dependencies ?? []);
+        Assert.Equal("Contoso.Core", dependency.Id);
+        Assert.Equal("[1.5.0, )", dependency.Range);
+    }
+
+    [Fact]
+    public void GetCatalogEntryReadsAnInlinedCatalogEntry()
+    {
+        using var feed = new FakeV3Feed { InlineCatalogEntry = true };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var entry = NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0");
+
+        Assert.NotNull(entry);
+        Assert.Equal("A tool", entry.Description);
+        Assert.DoesNotContain(feed.Server.RequestPaths, path => path.Contains("/catalog/"));
+    }
+
+    [Fact]
+    public void GetCatalogEntryFallsBackToTheNuspecWhenTheFeedHasNoRegistration()
+    {
+        using var feed = new FakeV3Feed { AdvertiseRegistrations = false };
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        var entry = NuGetV3Client.GetCatalogEntry(index, "Contoso.Tool", "2.0.0");
+
+        Assert.NotNull(entry);
+        Assert.Equal("Contoso.Tool", entry.Id);
+        Assert.Equal("A tool from the nuspec", entry.Description);
+        Assert.Equal("Contoso, Fabrikam", entry.GetAuthors());
+        Assert.Equal(["cli", "tool"], entry.GetTags());
+        Assert.Equal("MIT", entry.LicenseExpression);
+        Assert.Equal("https://licenses.test/MIT", entry.LicenseUrl);
+        Assert.Equal("https://contoso.test/", entry.ProjectUrl);
+        Assert.Equal("Notes", entry.ReleaseNotes);
+        Assert.Equal("icon.png", entry.IconFile);
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/2.0.0/contoso.tool.2.0.0.nupkg",
+            entry.PackageContent
+        );
+
+        var dependencies = entry.DependencyGroups?[0].Dependencies;
+        Assert.NotNull(dependencies);
+        Assert.Equal(2, dependencies.Count);
+        Assert.Equal("Contoso.Core", dependencies[0].Id);
+        Assert.Equal("[1.5.0, )", dependencies[0].Range);
+        Assert.Equal("Fabrikam.Core", dependencies[1].Id);
+
+        Assert.Contains(feed.Server.RequestPaths, path => path.EndsWith(".nuspec"));
+    }
+
+    [Fact]
+    public void GetDetailsFallsBackToTheNuspecWhenTheFeedHasNoRegistration()
+    {
+        using var feed = new FakeV3Feed { AdvertiseRegistrations = false };
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.V3Entries.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("2.0.0")
+            .Build();
+        var details = new PackageDetailsBuilder().Build(package);
+
+        manager.ExposedDetailsHelper.LoadDetails(details);
+
+        Assert.Equal("A tool from the nuspec", details.Description);
+        Assert.Equal("Contoso, Fabrikam", details.Author);
+        Assert.Equal("MIT", details.License);
+        Assert.Equal(["cli", "tool"], details.Tags);
+        Assert.Equal(2, details.Dependencies.Count);
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/2.0.0/contoso.tool.nuspec",
+            details.ManifestUrl?.AbsoluteUri
+        );
+    }
+
+    [Fact]
+    public void ParseNuspecToleratesADocumentWithOnlyAnId()
+    {
+        var entry = NuGetV3Client.ParseNuspec(
+            """<?xml version="1.0"?><package><metadata><id>Contoso.Tool</id></metadata></package>""",
+            "Fallback.Id",
+            "1.0.0",
+            null
+        );
+
+        Assert.NotNull(entry);
+        Assert.Equal("Contoso.Tool", entry.Id);
+        Assert.Equal("1.0.0", entry.Version);
+        Assert.Null(entry.Description);
+        Assert.Null(entry.DependencyGroups);
+        Assert.Empty(entry.GetTags());
+        Assert.Null(entry.GetAuthors());
+    }
+
+    [Fact]
+    public void ParseNuspecReturnsNullWhenThereIsNoMetadataElement()
+    {
+        Assert.Null(
+            NuGetV3Client.ParseNuspec("<package></package>", "Contoso.Tool", "1.0.0", null)
+        );
+    }
+
+    [Fact]
+    public void GetNuspecUrlUsesNormalizedLowercasedSegments()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/1.0.0/contoso.tool.nuspec",
+            NuGetV3Client.GetNuspecUrl(index, "Contoso.Tool", "1.0.0.0")?.AbsoluteUri
+        );
+    }
+
+    [Fact]
+    public void GetPackageContentUrlUsesNormalizedLowercasedSegments()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/1.0.0/contoso.tool.1.0.0.nupkg",
+            NuGetV3Client.GetPackageContentUrl(index, "Contoso.Tool", "1.0.0.0")?.AbsoluteUri
+        );
+    }
+
+    [Fact]
+    public void GetRegistrationLeafUrlUsesNormalizedLowercasedSegments()
+    {
+        using var feed = new FakeV3Feed();
+        var index = feed.Resolve();
+        Assert.NotNull(index);
+
+        Assert.Equal(
+            $"{feed.BaseUri}registration-gz-semver2/contoso.tool/2.0.0-beta.1.json",
+            NuGetV3Client.GetRegistrationLeafUrl(index, "Contoso.Tool", "2.0.0-Beta.1")?.AbsoluteUri
+        );
+    }
+
+    [Theory]
+    [InlineData("1.0", "1.0.0")]
+    [InlineData("1.0.0.0", "1.0.0")]
+    [InlineData("1.0.0.4", "1.0.0.4")]
+    [InlineData("1.02.3", "1.2.3")]
+    [InlineData("1.0.0+build.9", "1.0.0")]
+    [InlineData("2.0.0-Beta.1", "2.0.0-beta.1")]
+    [InlineData("2.0.0-Beta.1+meta", "2.0.0-beta.1")]
+    [InlineData("not-a-version", "not-a-version")]
+    public void NormalizeVersionFollowsNuGetRules(string version, string expected)
+    {
+        Assert.Equal(expected, NuGetV3Client.NormalizeVersion(version));
+    }
+
+    [Theory]
+    [InlineData("[1.5.0, )", "1.5.0")]
+    [InlineData("[1.5.0]", "1.5.0")]
+    [InlineData("1.5.0", "1.5.0")]
+    [InlineData("(, 2.0.0]", "(, 2.0.0]")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void FormatDependencyRangeShowsTheLowerBound(string? range, string expected)
+    {
+        Assert.Equal(expected, BaseNuGetDetailsHelper.FormatDependencyRange(range));
+    }
+
+    [Fact]
+    public void GetDetailsMapsEveryV3MetadataFieldOntoPackageDetails()
+    {
+        using var feed = new FakeV3Feed();
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.V3Entries.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("2.0.0")
+            .Build();
+        var details = new PackageDetailsBuilder().Build(package);
+
+        manager.ExposedDetailsHelper.LoadDetails(details);
+
+        Assert.Equal("A tool", details.Description);
+        Assert.Equal("Contoso, Fabrikam", details.Author);
+        Assert.Equal("Contoso, Fabrikam", details.Publisher);
+        Assert.Equal("MIT", details.License);
+        Assert.Equal("https://licenses.test/MIT", details.LicenseUrl?.AbsoluteUri);
+        Assert.Equal("https://contoso.test/", details.HomepageUrl?.AbsoluteUri);
+        Assert.Equal("Notes", details.ReleaseNotes);
+        Assert.Equal("2026-01-02T03:04:05Z", details.UpdateDate);
+        Assert.Equal("hash-value", details.InstallerHash);
+        Assert.Equal(4096, details.InstallerSize);
+        Assert.Equal(["cli", "tool"], details.Tags);
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/2.0.0/contoso.tool.2.0.0.nupkg",
+            details.InstallerUrl?.AbsoluteUri
+        );
+        Assert.Equal(
+            $"{feed.BaseUri}registration-gz-semver2/contoso.tool/2.0.0.json",
+            details.ManifestUrl?.AbsoluteUri
+        );
+
+        var dependency = Assert.Single(details.Dependencies);
+        Assert.Equal("Contoso.Core", dependency.Name);
+        Assert.Equal("1.5.0", dependency.Version);
+        Assert.True(dependency.Mandatory);
+    }
+
+    [Fact]
+    public void GetDetailsDoesNotTouchTheNetworkTwiceForDetailsAndIcon()
+    {
+        using var feed = new FakeV3Feed();
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.V3Entries.Clear();
+        BaseNuGet.V3IconUrls.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("2.0.0")
+            .Build();
+
+        manager.ExposedDetailsHelper.LoadDetails(new PackageDetailsBuilder().Build(package));
+        int requestsAfterDetails = feed.Server.RequestPaths.Count;
+
+        manager.ExposedDetailsHelper.LoadIcon(package);
+
+        Assert.Equal(requestsAfterDetails, feed.Server.RequestPaths.Count);
+    }
+
+    [Fact]
+    public void GetIconFallsBackToTheEmbeddedIconEndpoint()
+    {
+        using var feed = new FakeV3Feed();
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.V3Entries.Clear();
+        BaseNuGet.V3IconUrls.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("2.0.0")
+            .Build();
+
+        var icon = manager.ExposedDetailsHelper.LoadIcon(package);
+
+        Assert.NotNull(icon);
+        Assert.Equal(
+            $"{feed.BaseUri}flatcontainer/contoso.tool/2.0.0/icon",
+            icon.Value.Url.AbsoluteUri
+        );
+    }
+
+    [Fact]
+    public void GetIconReturnsNothingWhenSearchAlreadyReportedNoIcon()
+    {
+        using var feed = new FakeV3Feed();
+        NuGetV3ServiceIndex.ClearCache();
+        NuGetV3Client.ClearCaches();
+        BaseNuGet.V3Entries.Clear();
+        BaseNuGet.V3IconUrls.Clear();
+
+        var manager = new TestNuGetManager($"{feed.BaseUri}v3/index.json");
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithSource(manager.Properties.DefaultSource)
+            .WithId("Contoso.Tool")
+            .WithVersion("2.0.0")
+            .Build();
+        BaseNuGet.V3IconUrls[package.GetHash()] = string.Empty;
+
+        Assert.Null(manager.ExposedDetailsHelper.LoadIcon(package));
+        Assert.Empty(feed.Server.RequestPaths);
+    }
+
+    private sealed class TestNuGetManager : BaseNuGet
+    {
+        public TestNuGetManager(string sourceUrl)
+        {
+            Capabilities = new ManagerCapabilities
+            {
+                SupportsCustomVersions = true,
+                SupportsCustomPackageIcons = true,
+                CanListDependencies = true,
+            };
+
+            Properties = new ManagerProperties
+            {
+                Id = "test-nuget",
+                Name = "TestNuGet",
+                DefaultSource = new ManagerSource(this, "test", new Uri(sourceUrl)),
+            };
+
+            ExposedDetailsHelper = new TestNuGetDetailsHelper(this);
+            DetailsHelper = ExposedDetailsHelper;
+        }
+
+        public TestNuGetDetailsHelper ExposedDetailsHelper { get; }
+
+        protected override IReadOnlyList<Package> _getInstalledPackages_UnSafe() => [];
+
+        public override IReadOnlyList<string> FindCandidateExecutableFiles() => [];
+
+        protected override void _loadManagerExecutableFile(
+            out bool found,
+            out string executablePath,
+            out string callArgs
+        )
+        {
+            found = false;
+            executablePath = string.Empty;
+            callArgs = string.Empty;
+        }
+
+        protected override void _loadManagerVersion(out string version) => version = "0.0.0";
+    }
+
+    private sealed class TestNuGetDetailsHelper : BaseNuGetDetailsHelper
+    {
+        public TestNuGetDetailsHelper(BaseNuGet manager)
+            : base(manager) { }
+
+        protected override string? GetInstallLocation_UnSafe(IPackage package) => null;
+
+        public void LoadDetails(IPackageDetails details) => GetDetails_UnSafe(details);
+
+        public CacheableIcon? LoadIcon(IPackage package) => GetIcon_UnSafe(package);
+
+        public IReadOnlyList<string> LoadVersions(IPackage package) =>
+            GetInstallableVersions_UnSafe(package);
+    }
+
+    private sealed class FakeV3Feed : IDisposable
+    {
+        public FakeV3Feed()
+        {
+            Server = new TestHttpServer(Handle);
+        }
+
+        public TestHttpServer Server { get; }
+
+        public string BaseUri => Server.BaseUri.AbsoluteUri;
+
+        public IReadOnlyList<string> Versions { get; init; } = DefaultVersions;
+
+        public IReadOnlyList<string> UnlistedVersions { get; init; } = [];
+
+        public int? SearchPageSize { get; init; }
+
+        public int? SearchTotalPackages { get; init; }
+
+        public IReadOnlyList<string>? DuplicateIdVersions { get; init; }
+
+        public string? CatalogEntryBody { get; init; }
+
+        public string? SearchBody { get; init; }
+
+        public string? FlatContainerBody { get; init; }
+
+        public string? RegistrationLeafBody { get; init; }
+
+        public string? NuspecBody { get; init; }
+
+        public string? NuspecPackageType { get; init; }
+
+        public bool AdvertiseSearchService { get; init; } = true;
+
+        public bool AdvertiseRegistrations { get; init; } = true;
+
+        public bool UseArrayResourceTypes { get; init; }
+
+        public bool InlineCatalogEntry { get; init; }
+
+        public string? ServiceIndexBody { get; init; }
+
+        public NuGetV3ServiceIndex? Resolve(bool clearCaches = true)
+        {
+            if (clearCaches)
+            {
+                NuGetV3ServiceIndex.ClearCache();
+                NuGetV3Client.ClearCaches();
+            }
+
+            var source = new SourceBuilder().WithUrl($"{BaseUri}v3/index.json").Build();
+            return NuGetV3ServiceIndex.Resolve(source);
+        }
+
+        public void Dispose() => Server.Dispose();
+
+        private (int StatusCode, string Content, string ContentType) Handle(
+            HttpListenerRequest request
+        )
+        {
+            string path = request.Url?.AbsolutePath ?? string.Empty;
+
+            if (string.Equals(request.HttpMethod, "HEAD", StringComparison.OrdinalIgnoreCase))
+                return (200, string.Empty, "application/octet-stream");
+
+            if (path.EndsWith("/v3/index.json", StringComparison.OrdinalIgnoreCase))
+                return Json(ServiceIndexBody ?? BuildServiceIndex());
+
+            if (path.EndsWith("/query", StringComparison.OrdinalIgnoreCase))
+                return Json(SearchBody ?? BuildSearchResponse(request));
+
+            if (path.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
+                return (200, NuspecBody ?? RenderedNuspec, "text/xml");
+
+            if (path.Contains("/flatcontainer/", StringComparison.OrdinalIgnoreCase))
+                return Json(FlatContainerBody ?? BuildFlatContainerIndex());
+
+            if (path.Contains("/registration-gz-semver2/", StringComparison.OrdinalIgnoreCase))
+                return Json(RegistrationLeafBody ?? BuildRegistrationLeaf(path));
+
+            if (path.Contains("/catalog/", StringComparison.OrdinalIgnoreCase))
+                return Json(CatalogEntry);
+
+            if (path.Contains("/api/v2", StringComparison.OrdinalIgnoreCase))
+                return (200, "<entry><d:Id>Contoso.Tool</d:Id></entry>", "application/xml");
+
+            return (404, string.Empty, "application/json");
+        }
+
+        private static (int StatusCode, string Content, string ContentType) Json(string content) =>
+            (200, content, "application/json");
+
+        private string BuildServiceIndex()
+        {
+            List<string> resources =
+            [
+                Resource($"{BaseUri}flatcontainer/", "PackageBaseAddress/3.0.0"),
+            ];
+
+            if (AdvertiseRegistrations)
+            {
+                resources.Insert(
+                    0,
+                    Resource($"{BaseUri}registration-gz-semver2/", "RegistrationsBaseUrl/3.6.0")
+                );
+                resources.Insert(
+                    1,
+                    Resource($"{BaseUri}registration-legacy/", "RegistrationsBaseUrl")
+                );
+            }
+
+            if (AdvertiseSearchService)
+            {
+                resources.Insert(0, Resource($"{BaseUri}query", "SearchQueryService/3.5.0"));
+                resources.Insert(
+                    1,
+                    Resource($"{BaseUri}legacy-query", "SearchQueryService/3.0.0-beta")
+                );
+            }
+
+            return $"{{\"version\":\"3.0.0\",\"resources\":[{string.Join(",", resources)}]}}";
+        }
+
+        private string Resource(string id, string type)
+        {
+            string typeValue = UseArrayResourceTypes ? $"[\"{type}\"]" : $"\"{type}\"";
+            return $"{{\"@id\":\"{id}\",\"@type\":{typeValue}}}";
+        }
+
+        private string BuildSearchResponse(HttpListenerRequest request)
+        {
+            if (DuplicateIdVersions is { Count: > 0 })
+            {
+                IEnumerable<string> duplicates = DuplicateIdVersions.Select(version =>
+                    $$"""{"id":"Duplicated.Tool","version":"{{version}}","description":"A tool"}"""
+                );
+                return $$"""{"totalHits":{{DuplicateIdVersions.Count}},"data":[{{string.Join(",", duplicates)}}]}""";
+            }
+
+            if (SearchPageSize is { } pageSize || SearchTotalPackages is not null)
+            {
+                int total = SearchTotalPackages ?? 0;
+                int size = SearchPageSize ?? total;
+                int skip = int.TryParse(request.QueryString["skip"], out int parsedSkip)
+                    ? parsedSkip
+                    : 0;
+                int take = int.TryParse(request.QueryString["take"], out int parsedTake)
+                    ? parsedTake
+                    : size;
+
+                List<string> entries = [];
+                for (int i = skip; i < Math.Min(total, skip + Math.Min(size, take)); i++)
+                    entries.Add($$"""{"id":"Pkg.{{i}}","version":"1.0.0","description":"A tool"}""");
+
+                return $$"""{"totalHits":{{total}},"data":[{{string.Join(",", entries)}}]}""";
+            }
+
+            return $$"""
+            {
+              "totalHits": 2,
+              "data": [
+                {
+                  "id": "Contoso.Tool",
+                  "version": "2.0.0",
+                  "description": "A tool",
+                  "authors": ["Contoso"],
+                  "tags": ["cli", "tool"],
+                  "iconUrl": "{{BaseUri}}icons/contoso.png",
+                  "licenseUrl": "{{BaseUri}}licenses/contoso",
+                  "projectUrl": "https://contoso.test/"
+                },
+                {
+                  "id": "Fabrikam.Tool",
+                  "version": "1.0.0",
+                  "description": "Another tool",
+                  "authors": "Fabrikam"
+                }
+              ]
+            }
+            """;
+        }
+
+        private string BuildFlatContainerIndex() =>
+            $"{{\"versions\":[{string.Join(",", Versions.Select(version => $"\"{version}\""))}]}}";
+
+        private string BuildRegistrationLeaf(string path)
+        {
+            string version = Path.GetFileNameWithoutExtension(path);
+            bool listed = !UnlistedVersions.Any(unlisted =>
+                NuGetV3Client.NormalizeVersion(unlisted).Equals(
+                    version,
+                    StringComparison.OrdinalIgnoreCase
+                )
+            );
+
+            string catalogEntry = InlineCatalogEntry
+                ? CatalogEntry
+                : $"\"{BaseUri}catalog/contoso.tool.{version}.json\"";
+
+            return $$"""
+            {
+              "catalogEntry": {{catalogEntry}},
+              "packageContent": "{{BaseUri}}flatcontainer/contoso.tool/{{version}}/contoso.tool.{{version}}.nupkg",
+              "published": "2026-01-02T03:04:05Z",
+              "listed": {{(listed ? "true" : "false")}}
+            }
+            """;
+        }
+
+        private string CatalogEntry => CatalogEntryBody ?? DefaultCatalogEntry;
+
+        private string RenderedNuspec =>
+            Nuspec.Replace(
+                "{{PACKAGE_TYPES}}",
+                NuspecPackageType is null
+                    ? string.Empty
+                    : $"<packageTypes><packageType name=\"{NuspecPackageType}\" /></packageTypes>"
+            );
+
+        private const string Nuspec =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+              <metadata>
+                <id>Contoso.Tool</id>
+                <version>2.0.0</version>
+                <authors>Contoso, Fabrikam</authors>
+                <license type="expression">MIT</license>
+                <licenseUrl>https://licenses.test/MIT</licenseUrl>
+                <icon>icon.png</icon>
+                <projectUrl>https://contoso.test/</projectUrl>
+                <description>A tool from the nuspec</description>
+                <releaseNotes>Notes</releaseNotes>
+                <tags>cli tool</tags>
+                {{PACKAGE_TYPES}}
+                <dependencies>
+                  <group targetFramework="net10.0">
+                    <dependency id="Contoso.Core" version="[1.5.0, )" />
+                  </group>
+                  <group targetFramework="net9.0">
+                    <dependency id="Fabrikam.Core" version="[2.0.0, )" />
+                  </group>
+                </dependencies>
+              </metadata>
+            </package>
+            """;
+
+        private const string DefaultCatalogEntry =
+            """
+            {
+              "id": "Contoso.Tool",
+              "version": "2.0.0",
+              "description": "A tool",
+              "authors": "Contoso, Fabrikam",
+              "iconFile": "icon.png",
+              "tags": ["cli", "tool"],
+              "licenseExpression": "MIT",
+              "licenseUrl": "https://licenses.test/MIT",
+              "projectUrl": "https://contoso.test/",
+              "releaseNotes": "Notes",
+              "packageHash": "hash-value",
+              "packageHashAlgorithm": "SHA512",
+              "packageSize": 4096,
+              "listed": true,
+              "dependencyGroups": [
+                {
+                  "targetFramework": "net10.0",
+                  "dependencies": [{ "id": "Contoso.Core", "range": "[1.5.0, )" }]
+                }
+              ]
+            }
+            """;
+    }
+}

--- a/src/UniGetUI.PackageEngine.Tests/NuGetV3ManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetV3ManagerTests.cs
@@ -1,0 +1,529 @@
+using System.Net;
+using UniGetUI.PackageEngine.Classes.Manager;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.ManagerClasses.Classes;
+using UniGetUI.PackageEngine.ManagerClasses.Manager;
+using UniGetUI.PackageEngine.Managers.Generic.NuGet.Internal;
+using UniGetUI.PackageEngine.Managers.PowerShellManager;
+using UniGetUI.PackageEngine.PackageClasses;
+using UniGetUI.PackageEngine.Structs;
+using UniGetUI.PackageEngine.Tests.Infrastructure.Helpers;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class NuGetV3ManagerTests
+{
+    [Fact]
+    public void FindPackagesV3AssociatesTheSourceAndSeedsTheIconCache()
+    {
+        using var feed = new UpdateFeed();
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+
+        var packages = manager.FindPackagesV3(source, "contoso", false, feed.Logger(manager));
+
+        Assert.Equal(2, packages.Count);
+        Assert.All(packages, package => Assert.Same(source, package.Source));
+        Assert.All(packages, package => Assert.Same(manager, package.Manager));
+
+        Assert.Equal("Contoso.Tool", packages[0].Id);
+        Assert.Equal("2.0.0", packages[0].VersionString);
+        Assert.Equal(
+            $"{feed.BaseUri}icons/contoso.png",
+            BaseNuGet.V3IconUrls[packages[0].GetHash()]
+        );
+
+        Assert.Equal("Fabrikam.Tool", packages[1].Id);
+        Assert.Equal(string.Empty, BaseNuGet.V3IconUrls[packages[1].GetHash()]);
+    }
+
+    [Fact]
+    public void FindPackagesV3ReportsAnUnresolvableServiceIndex()
+    {
+        using var feed = new UpdateFeed { ServiceIndexStatusCode = 500 };
+        var manager = feed.CreateManager();
+
+        var packages = manager.FindPackagesV3(
+            manager.Properties.DefaultSource,
+            "contoso",
+            false,
+            feed.Logger(manager)
+        );
+
+        Assert.Empty(packages);
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesV3CarriesTheInstalledScopeOntoTheUpdate()
+    {
+        using var feed = new UpdateFeed { Versions = ["2025.1.0", "2025.2.0"] };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+
+        var installed = new PackageBuilderFor(manager, source)
+            .Build("Devolutions.PowerShell", "2025.1.0", PackageScope.Machine);
+
+        var update = Assert.Single(
+            manager.GetAvailableUpdatesV3(source, [installed], false, feed.Logger(manager))!
+        );
+
+        Assert.Equal("Devolutions.PowerShell", update.Id);
+        Assert.Equal("2025.1.0", update.VersionString);
+        Assert.Equal("2025.2.0", update.NewVersionString);
+        Assert.Equal(PackageScope.Machine, update.OverridenOptions.Scope);
+        Assert.Same(source, update.Source);
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesV3KeepsACurrentUserModuleOnCurrentUser()
+    {
+        using var feed = new UpdateFeed { Versions = ["2025.1.0", "2025.2.0"] };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+
+        var installed = new PackageBuilderFor(manager, source)
+            .Build("Devolutions.PowerShell", "2025.1.0", PackageScope.User);
+
+        var update = Assert.Single(
+            manager.GetAvailableUpdatesV3(source, [installed], false, feed.Logger(manager))!
+        );
+
+        Assert.Equal(PackageScope.User, update.OverridenOptions.Scope);
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesV3ResolvesAModuleInstalledTwiceToTheLastEnumeratedScope()
+    {
+        using var feed = new UpdateFeed { Versions = ["2025.1.0", "2025.2.0", "2025.3.0"] };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        var update = Assert.Single(
+            manager.GetAvailableUpdatesV3(
+                source,
+                [
+                    builder.Build("Devolutions.PowerShell", "2025.1.0", PackageScope.Machine),
+                    builder.Build("Devolutions.PowerShell", "2025.2.0", PackageScope.User),
+                ],
+                false,
+                feed.Logger(manager)
+            )!
+        );
+
+        Assert.Equal("2025.2.0", update.VersionString);
+        Assert.Equal("2025.3.0", update.NewVersionString);
+        Assert.Equal(PackageScope.User, update.OverridenOptions.Scope);
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesV3ReturnsNothingWhenEveryPackageIsCurrent()
+    {
+        using var feed = new UpdateFeed { Versions = ["1.0.0", "2.0.0"] };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        var updates = manager.GetAvailableUpdatesV3(
+            source,
+            [builder.Build("Contoso.Tool", "2.0.0"), builder.Build("Fabrikam.Tool", "2.0.0")],
+            false,
+            feed.Logger(manager)
+        );
+
+        Assert.NotNull(updates);
+        Assert.Empty(updates);
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesV3ReturnsNullWhenTheServiceIndexCannotBeResolved()
+    {
+        using var feed = new UpdateFeed { ServiceIndexStatusCode = 500 };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+
+        Assert.Null(
+            manager.GetAvailableUpdatesV3(
+                source,
+                [new PackageBuilderFor(manager, source).Build("Contoso.Tool", "1.0.0")],
+                false,
+                feed.Logger(manager)
+            )
+        );
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesV3KeepsOtherPackagesWhenOneFeedLookupFails()
+    {
+        using var feed = new UpdateFeed
+        {
+            Versions = ["1.0.0", "2.0.0"],
+            UnservedPackageIds = ["Broken.Tool"],
+        };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        var updates = manager.GetAvailableUpdatesV3(
+            source,
+            [builder.Build("Broken.Tool", "1.0.0"), builder.Build("Contoso.Tool", "1.0.0")],
+            false,
+            feed.Logger(manager)
+        );
+
+        Assert.NotNull(updates);
+        var update = Assert.Single(updates);
+        Assert.Equal("Contoso.Tool", update.Id);
+        Assert.Equal("2.0.0", update.NewVersionString);
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesV3HonoursThePreReleasePreference()
+    {
+        using var feed = new UpdateFeed { Versions = ["1.0.0", "2.0.0-beta.1"] };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var installed = new PackageBuilderFor(manager, source).Build("Contoso.Tool", "1.0.0");
+
+        Assert.Empty(
+            manager.GetAvailableUpdatesV3(source, [installed], false, feed.Logger(manager))!
+        );
+
+        NuGetV3Client.ClearCaches();
+        var update = Assert.Single(
+            manager.GetAvailableUpdatesV3(source, [installed], true, feed.Logger(manager))!
+        );
+        Assert.Equal("2.0.0-beta.1", update.NewVersionString);
+    }
+
+    // The upper bound is the regression guard: without MaxDegreeOfParallelism a user with many
+    // installed tools would fan out unbounded against the feed. The lower bound proves the test
+    // is not vacuous, and is reached through a handshake rather than a sleep - the fixture holds
+    // each request until two are genuinely in flight - so the assertion does not depend on
+    // timing under load.
+    [Fact]
+    public void GetAvailableUpdatesV3BoundsConcurrentFeedRequests()
+    {
+        using var feed = new UpdateFeed
+        {
+            Versions = ["1.0.0", "2.0.0"],
+            HandleConcurrently = true,
+            HandshakeTarget = 2,
+        };
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        List<IPackage> installed = [];
+        for (int i = 0; i < NuGetV3Client.MaxConcurrentRequests * 4; i++)
+            installed.Add(builder.Build($"Contoso.Tool.{i}", "1.0.0"));
+
+        var updates = manager.GetAvailableUpdatesV3(
+            source,
+            installed,
+            false,
+            feed.Logger(manager)
+        );
+
+        Assert.NotNull(updates);
+        Assert.Equal(installed.Count, updates.Count);
+        Assert.InRange(
+            feed.Server.PeakConcurrentRequests,
+            feed.HandshakeTarget,
+            NuGetV3Client.MaxConcurrentRequests
+        );
+    }
+
+    // Issue #5331: the max-installed filter read the map with the original-cased id but wrote
+    // it lowercased, so the lookup always missed and the map degraded to last-wins instead of
+    // max-wins. Any id that is not already lowercase - i.e. most NuGet and PowerShell ids -
+    // could therefore be offered an update already satisfied by a copy in another scope.
+    [Fact]
+    public void KeepUpdatesNewerThanInstalledUsesTheHighestInstalledCopyForAMixedCaseId()
+    {
+        using var feed = new UpdateFeed();
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        IReadOnlyList<IPackage> installed =
+        [
+            builder.Build("Devolutions.PowerShell", "2025.2.0", PackageScope.Machine),
+            builder.Build("Devolutions.PowerShell", "2025.1.0", PackageScope.User),
+        ];
+
+        var alreadySatisfied = builder.BuildUpdate(
+            "Devolutions.PowerShell",
+            "2025.1.0",
+            "2025.1.5"
+        );
+        Assert.Empty(manager.KeepUpdatesNewerThanInstalled([alreadySatisfied], installed));
+
+        var genuine = builder.BuildUpdate("Devolutions.PowerShell", "2025.1.0", "2025.3.0");
+        Assert.Single(manager.KeepUpdatesNewerThanInstalled([genuine], installed));
+    }
+
+    [Fact]
+    public void KeepUpdatesNewerThanInstalledStillWorksForALowercaseId()
+    {
+        using var feed = new UpdateFeed();
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        IReadOnlyList<IPackage> installed =
+        [
+            builder.Build("dotnet-ef", "10.0.0"),
+            builder.Build("dotnet-ef", "8.0.0"),
+        ];
+
+        Assert.Empty(
+            manager.KeepUpdatesNewerThanInstalled(
+                [builder.BuildUpdate("dotnet-ef", "8.0.0", "9.0.0")],
+                installed
+            )
+        );
+        Assert.Single(
+            manager.KeepUpdatesNewerThanInstalled(
+                [builder.BuildUpdate("dotnet-ef", "8.0.0", "11.0.0")],
+                installed
+            )
+        );
+    }
+
+    [Fact]
+    public void KeepUpdatesNewerThanInstalledOffersTheStableReleaseOverAnInstalledPreRelease()
+    {
+        using var feed = new UpdateFeed();
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        IReadOnlyList<IPackage> installed = [builder.Build("Contoso.Tool", "2.0.0-rc1")];
+
+        Assert.Single(
+            manager.KeepUpdatesNewerThanInstalled(
+                [builder.BuildUpdate("Contoso.Tool", "2.0.0-rc1", "2.0.0")],
+                installed
+            )
+        );
+        Assert.Empty(
+            manager.KeepUpdatesNewerThanInstalled(
+                [builder.BuildUpdate("Contoso.Tool", "2.0.0-rc1", "2.0.0-beta.9")],
+                installed
+            )
+        );
+    }
+
+    [Fact]
+    public void KeepUpdatesNewerThanInstalledKeepsUpdatesForUnknownIds()
+    {
+        using var feed = new UpdateFeed();
+        var manager = feed.CreateManager();
+        var source = manager.Properties.DefaultSource;
+        var builder = new PackageBuilderFor(manager, source);
+
+        Assert.Single(
+            manager.KeepUpdatesNewerThanInstalled(
+                [builder.BuildUpdate("Not.Installed", "1.0.0", "2.0.0")],
+                []
+            )
+        );
+    }
+
+    private sealed class PackageBuilderFor(BaseNuGet manager, IManagerSource source)
+    {
+        public Package Build(string id, string version, string? scope = null)
+        {
+            return new Package(
+                id,
+                id,
+                version,
+                source,
+                manager,
+                scope is null ? null : new OverridenInstallationOptions(scope)
+            );
+        }
+
+        public Package BuildUpdate(string id, string installedVersion, string newVersion)
+        {
+            return new Package(id, id, installedVersion, newVersion, source, manager);
+        }
+    }
+
+    private sealed class UpdateFeed : IDisposable
+    {
+        private TestHttpServer? _server;
+
+        public TestHttpServer Server => _server ??= new TestHttpServer(Handle, HandleConcurrently);
+
+        public string BaseUri => Server.BaseUri.AbsoluteUri;
+
+        public IReadOnlyList<string> Versions { get; init; } = ["1.0.0", "2.0.0"];
+
+        public IReadOnlyList<string> UnservedPackageIds { get; init; } = [];
+
+        public int ServiceIndexStatusCode { get; init; } = 200;
+
+        public bool HandleConcurrently { get; init; }
+
+        public int HandshakeTarget { get; init; }
+
+        private readonly ManualResetEventSlim _handshakeRelease = new(false);
+        private int _handshakeInFlight;
+
+        public TestNuGetManager CreateManager()
+        {
+            NuGetV3ServiceIndex.ClearCache();
+            NuGetV3Client.ClearCaches();
+            BaseNuGet.V3Entries.Clear();
+            BaseNuGet.V3IconUrls.Clear();
+            return new TestNuGetManager($"{BaseUri}v3/index.json");
+        }
+
+        public INativeTaskLogger Logger(BaseNuGet manager) =>
+            manager.TaskLogger.CreateNew(LoggableTaskType.ListUpdates);
+
+        public void Dispose()
+        {
+            _server?.Dispose();
+            _handshakeRelease.Dispose();
+        }
+
+        // Blocks until HandshakeTarget requests are simultaneously in flight, so overlap is
+        // established by agreement instead of by racing a timer. The timeout releases everyone
+        // if the client turns out to be serialised, keeping a failing run fast.
+        private void AwaitHandshake()
+        {
+            if (HandshakeTarget <= 0)
+                return;
+
+            if (Interlocked.Increment(ref _handshakeInFlight) >= HandshakeTarget)
+                _handshakeRelease.Set();
+
+            if (!_handshakeRelease.Wait(TimeSpan.FromSeconds(10)))
+                _handshakeRelease.Set();
+
+            Interlocked.Decrement(ref _handshakeInFlight);
+        }
+
+        private (int StatusCode, string Content, string ContentType) Handle(
+            HttpListenerRequest request
+        )
+        {
+            string path = request.Url?.AbsolutePath ?? string.Empty;
+
+            if (path.EndsWith("/v3/index.json", StringComparison.OrdinalIgnoreCase))
+            {
+                return ServiceIndexStatusCode is 200
+                    ? (200, ServiceIndex, "application/json")
+                    : (ServiceIndexStatusCode, string.Empty, "application/json");
+            }
+
+            if (path.EndsWith("/query", StringComparison.OrdinalIgnoreCase))
+                return (200, SearchResponse, "application/json");
+
+            if (path.Contains("/flatcontainer/", StringComparison.OrdinalIgnoreCase))
+            {
+                AwaitHandshake();
+
+                if (
+                    UnservedPackageIds.Any(id =>
+                        path.Contains(
+                            $"/{id.ToLowerInvariant()}/",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                )
+                    return (500, string.Empty, "application/json");
+
+                return (200, FlatContainerIndex, "application/json");
+            }
+
+            if (path.Contains("/registration/", StringComparison.OrdinalIgnoreCase))
+                return (200, RegistrationLeaf, "application/json");
+
+            return (404, string.Empty, "application/json");
+        }
+
+        private string ServiceIndex =>
+            $$"""
+            {
+              "version": "3.0.0",
+              "resources": [
+                { "@id": "{{BaseUri}}query", "@type": "SearchQueryService/3.5.0" },
+                { "@id": "{{BaseUri}}registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                { "@id": "{{BaseUri}}flatcontainer/", "@type": "PackageBaseAddress/3.0.0" }
+              ]
+            }
+            """;
+
+        private string SearchResponse =>
+            $$"""
+            {
+              "totalHits": 2,
+              "data": [
+                {
+                  "id": "Contoso.Tool",
+                  "version": "2.0.0",
+                  "iconUrl": "{{BaseUri}}icons/contoso.png"
+                },
+                { "id": "Fabrikam.Tool", "version": "1.0.0" }
+              ]
+            }
+            """;
+
+        private string FlatContainerIndex =>
+            $"{{\"versions\":[{string.Join(",", Versions.Select(version => $"\"{version}\""))}]}}";
+
+        private const string RegistrationLeaf =
+            """
+            {"listed":true,"published":"2026-01-02T03:04:05Z"}
+            """;
+    }
+
+    private sealed class TestNuGetManager : BaseNuGet
+    {
+        public TestNuGetManager(string sourceUrl)
+        {
+            Capabilities = new ManagerCapabilities
+            {
+                SupportsCustomVersions = true,
+                SupportsCustomPackageIcons = true,
+                CanListDependencies = true,
+            };
+
+            Properties = new ManagerProperties
+            {
+                Id = "test-nuget",
+                Name = "TestNuGet",
+                DefaultSource = new ManagerSource(this, "test", new Uri(sourceUrl)),
+            };
+
+            DetailsHelper = new Helper(this);
+        }
+
+        protected override IReadOnlyList<Package> _getInstalledPackages_UnSafe() => [];
+
+        public override IReadOnlyList<string> FindCandidateExecutableFiles() => [];
+
+        protected override void _loadManagerExecutableFile(
+            out bool found,
+            out string executablePath,
+            out string callArgs
+        )
+        {
+            found = false;
+            executablePath = string.Empty;
+            callArgs = string.Empty;
+        }
+
+        protected override void _loadManagerVersion(out string version) => version = "0.0.0";
+
+        private sealed class Helper(BaseNuGet manager) : BaseNuGetDetailsHelper(manager)
+        {
+            protected override string? GetInstallLocation_UnSafe(IPackage package) => null;
+        }
+    }
+}

--- a/src/UniGetUI.PackageEngine.Tests/NuGetV3ManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/NuGetV3ManagerTests.cs
@@ -31,11 +31,11 @@ public sealed class NuGetV3ManagerTests
         Assert.Equal("2.0.0", packages[0].VersionString);
         Assert.Equal(
             $"{feed.BaseUri}icons/contoso.png",
-            BaseNuGet.V3IconUrls[packages[0].GetHash()]
+            BaseNuGet.V3IconUrls[packages[0].GetVersionedHash()]
         );
 
         Assert.Equal("Fabrikam.Tool", packages[1].Id);
-        Assert.Equal(string.Empty, BaseNuGet.V3IconUrls[packages[1].GetHash()]);
+        Assert.Equal(string.Empty, BaseNuGet.V3IconUrls[packages[1].GetVersionedHash()]);
     }
 
     [Fact]

--- a/src/UniGetUI.PackageEngine.Tests/OperationHistoryTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/OperationHistoryTests.cs
@@ -223,6 +223,81 @@ public sealed class OperationHistoryTests : IDisposable
         Assert.Equal(OperationHistoryRecord.StatusSucceeded, record.Status);
     }
 
+    // The package a Discover install starts from carries the feed's LATEST version, while the
+    // user may have pinned an older one in the install options. Recording the package version
+    // then claims a version that was never installed - and the retry-from-history flow rebuilds
+    // the package from these fields.
+    [Fact]
+    public void FromOperation_Install_RecordsThePinnedVersionRatherThanTheLatest()
+    {
+        var manager = new PackageManagerBuilder().WithName("Scoop").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion("3.0.3")
+            .Build();
+
+        using var op = new InstallPackageOperation(
+            package,
+            new InstallOptions { Version = "2.1.7" },
+            IgnoreParallelInstalls: true
+        );
+        var record = OperationHistoryRecord.FromOperation(
+            op,
+            OperationHistoryRecord.StatusSucceeded
+        );
+
+        Assert.Equal("", record.VersionBefore);
+        Assert.Equal("2.1.7", record.VersionAfter);
+    }
+
+    [Fact]
+    public void FromOperation_Update_RecordsThePinnedVersionRatherThanTheNewVersion()
+    {
+        var manager = new PackageManagerBuilder().WithName("Scoop").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.0.0")
+            .WithNewVersion("3.0.0")
+            .Build();
+
+        using var op = new UpdatePackageOperation(
+            package,
+            new InstallOptions { Version = "2.0.0" }
+        );
+        var record = OperationHistoryRecord.FromOperation(
+            op,
+            OperationHistoryRecord.StatusSucceeded
+        );
+
+        Assert.Equal("1.0.0", record.VersionBefore);
+        Assert.Equal("2.0.0", record.VersionAfter);
+    }
+
+    [Fact]
+    public void FromOperation_Uninstall_RecordsNoVersionAfterEvenWhenPinned()
+    {
+        var manager = new PackageManagerBuilder().WithName("Scoop").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.0.0")
+            .Build();
+
+        using var op = new UninstallPackageOperation(
+            package,
+            new InstallOptions { Version = "2.0.0" }
+        );
+        var record = OperationHistoryRecord.FromOperation(
+            op,
+            OperationHistoryRecord.StatusSucceeded
+        );
+
+        Assert.Equal("1.0.0", record.VersionBefore);
+        Assert.Equal("", record.VersionAfter);
+    }
+
     [Fact]
     public void FromOperation_Update_CapturesVersionTransition()
     {

--- a/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageOperationsTests.cs
@@ -10,6 +10,8 @@ using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Managers.NpmManager;
+using UniGetUI.PackageEngine.Managers.PipManager;
 using UniGetUI.PackageEngine.Operations;
 using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.PackageLoader;
@@ -197,6 +199,102 @@ public sealed class PackageOperationsTests
             }
         );
         Assert.Contains("1.0.0 -> 3.0.0", operation.Metadata.OperationInformation);
+    }
+
+    // UninstallPreviousVersionsOnUpdate is the one destructive consumer of the per-manager
+    // version comparison: it queues every installed copy it considers superseded for removal.
+    // On a SemVer registry the pre-release IS superseded by its stable release and must be
+    // cleaned up, which the shared numeric comparison could never see.
+    [Fact]
+    public async Task UpdateOperationQueuesASupersededPreReleaseForUninstallOnSemVerManagers()
+    {
+        var manager = new Npm();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("contoso-tool")
+            .WithVersion("2.0.0-rc1")
+            .WithNewVersion("2.0.0")
+            .Build();
+        InitializeLoaders();
+        await InstalledPackagesLoader.Instance.AddForeign(
+            new PackageBuilder()
+                .WithManager(manager)
+                .WithId("contoso-tool")
+                .WithVersion("2.0.0-rc1")
+                .Build()
+        );
+
+        using var operation = new UpdatePackageOperation(
+            package,
+            new InstallOptions { UninstallPreviousVersionsOnUpdate = true }
+        );
+
+        var inner = Assert.Single(GetInnerOperations(operation, "PostOperations"));
+        var uninstall = Assert.IsType<UninstallPackageOperation>(inner.Operation);
+        Assert.Equal("2.0.0-rc1", uninstall.Package.VersionString);
+    }
+
+    // The mirror image, and the reason this had to be per-manager: on PyPI a bare trailing
+    // dash-number is an implicit POST-release, so "1.0.0-1" is NEWER than "1.0.0" and must
+    // never be queued for removal when updating onto it.
+    [Fact]
+    public async Task UpdateOperationLeavesANewerPostReleaseInstalledOnPip()
+    {
+        var manager = new Pip();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("contoso-tool")
+            .WithVersion("0.9.0")
+            .WithNewVersion("1.0.0")
+            .Build();
+        InitializeLoaders();
+        await InstalledPackagesLoader.Instance.AddForeign(
+            new PackageBuilder()
+                .WithManager(manager)
+                .WithId("contoso-tool")
+                .WithVersion("1.0.0-1")
+                .Build()
+        );
+
+        using var operation = new UpdatePackageOperation(
+            package,
+            new InstallOptions { UninstallPreviousVersionsOnUpdate = true }
+        );
+
+        Assert.Empty(GetInnerOperations(operation, "PostOperations"));
+    }
+
+    // Pins pre-existing behaviour rather than endorsing it: when an installed version cannot be
+    // parsed at all, it is still treated as superseded and queued for removal. Left as-is
+    // deliberately - changing what a destructive operation does to unparseable input belongs in
+    // its own change, not in a version-comparison fix.
+    [Fact]
+    public async Task UpdateOperationStillQueuesAnUnparseableInstalledVersionForUninstall()
+    {
+        var manager = CreateManager();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.0.0")
+            .WithNewVersion("3.0.0")
+            .Build();
+        InitializeLoaders();
+        await InstalledPackagesLoader.Instance.AddForeign(
+            new PackageBuilder()
+                .WithManager(manager)
+                .WithId("Contoso.Tool")
+                .WithVersion("10c8e557")
+                .Build()
+        );
+
+        using var operation = new UpdatePackageOperation(
+            package,
+            new InstallOptions { UninstallPreviousVersionsOnUpdate = true }
+        );
+
+        var inner = Assert.Single(GetInnerOperations(operation, "PostOperations"));
+        var uninstall = Assert.IsType<UninstallPackageOperation>(inner.Operation);
+        Assert.Equal("10c8e557", uninstall.Package.VersionString);
     }
 
     [Fact]

--- a/src/UniGetUI.PackageEngine.Tests/PackageTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageTests.cs
@@ -1,6 +1,16 @@
 using UniGetUI.Core.Data;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.SettingsEngine.SecureSettings;
+using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Managers.BunManager;
+using UniGetUI.PackageEngine.Managers.CargoManager;
+using UniGetUI.PackageEngine.Managers.DotNetManager;
+using UniGetUI.PackageEngine.Managers.FlatpakManager;
+using UniGetUI.PackageEngine.Managers.HomebrewManager;
+using UniGetUI.PackageEngine.Managers.NpmManager;
+using UniGetUI.PackageEngine.Managers.PipManager;
+using UniGetUI.PackageEngine.Managers.SnapManager;
+
 using UniGetUI.PackageEngine.PackageLoader;
 using UniGetUI.PackageEngine.Tests.Infrastructure.Builders;
 
@@ -70,6 +80,285 @@ public sealed class NewerVersionIsInstalledTests : IDisposable
             .WithManager(manager).WithId("Contoso.Tool").WithVersion("1.0.0").WithNewVersion(newVersion).Build();
 
         Assert.Equal(expected, update.NewerVersionIsInstalled());
+    }
+
+    // Issue #5331: on a NuGet feed a dash introduces a SemVer 2.0 pre-release, so the stable
+    // release supersedes it. The shared numeric parser read "2.0.0-rc1" as 2.0.0.1 and so
+    // considered it newer than 2.0.0, permanently hiding the upgrade off a pre-release. The
+    // underscore spelling of the same thing was already guarded above.
+    [Theory]
+    [InlineData("2.0.0-rc1", "2.0.0", false)]
+    [InlineData("2.0.0-beta.1", "2.0.0", false)]
+    [InlineData("2.0.0-preview.7.26381.103", "2.0.0", false)]
+    [InlineData("2.0.0-rc1", "2.0.0-rc2", false)]
+    [InlineData("1.9.0", "1.10.0", false)]
+    [InlineData("2.0.0", "2.0.0-rc1", true)]
+    [InlineData("2.0.0-rc2", "2.0.0-rc1", true)]
+    [InlineData("2.0.0", "2.0.0", true)]
+    [InlineData("1.0.0.4", "1.0.0.3", true)]
+    public async Task NewerVersionIsInstalled_UsesNuGetSemanticsOnNuGetManagers(
+        string installedVersion,
+        string newVersion,
+        bool expected
+    )
+    {
+        var manager = new DotNet();
+        InitializeLoaders();
+
+        await InstalledPackagesLoader.Instance.AddForeign(
+            new PackageBuilder()
+                .WithManager(manager)
+                .WithId("Contoso.Tool")
+                .WithVersion(installedVersion)
+                .Build()
+        );
+
+        var update = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion(installedVersion)
+            .WithNewVersion(newVersion)
+            .Build();
+
+        Assert.Equal(expected, update.NewerVersionIsInstalled());
+    }
+
+    // Regression guard for the fix above: outside NuGet a trailing dash or underscore is a
+    // build revision that is NEWER than its base version (Debian, Scoop, Homebrew), so the
+    // shared numeric comparison must keep applying there.
+    [Theory]
+    [InlineData("1.2.3-4", "1.2.3", true)]
+    [InlineData("1.2.3", "1.2.3-4", false)]
+    [InlineData("1.2.3-1", "1.2.3-2", false)]
+    [InlineData("1.2.3-2", "1.2.3-1", true)]
+    [InlineData("18.4_1", "18.4", true)]
+    public async Task NewerVersionIsInstalled_KeepsRevisionSemanticsOffNuGetManagers(
+        string installedVersion,
+        string newVersion,
+        bool expected
+    )
+    {
+        var manager = new PackageManagerBuilder().Build();
+        InitializeLoaders();
+
+        await InstalledPackagesLoader.Instance.AddForeign(
+            new PackageBuilder()
+                .WithManager(manager)
+                .WithId("Contoso.Tool")
+                .WithVersion(installedVersion)
+                .Build()
+        );
+
+        var update = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion(installedVersion)
+            .WithNewVersion(newVersion)
+            .Build();
+
+        Assert.Equal(expected, update.NewerVersionIsInstalled());
+    }
+
+    [Theory]
+    [InlineData("2.0.0-rc1", "2.0.0", -1)]
+    [InlineData("2.0.0", "2.0.0-rc1", 1)]
+    [InlineData("1.10.0", "1.9.0", 1)]
+    [InlineData("1.0.0", "1.0.0.0", 0)]
+    public void CompareVersions_UsesSemVerOnNuGetManagers(string a, string b, int expected)
+    {
+        var comparison = new DotNet().CompareVersions(a, b);
+
+        Assert.NotNull(comparison);
+        Assert.Equal(expected, Math.Sign(comparison.Value));
+    }
+
+    [Theory]
+    [InlineData("1.2.3-4", "1.2.3", 1)]
+    [InlineData("18.4_1", "18.4", 1)]
+    [InlineData("1.10.0", "1.9.0", 1)]
+    public void CompareVersions_KeepsNumericSemanticsElsewhere(string a, string b, int expected)
+    {
+        var comparison = new PackageManagerBuilder().Build().CompareVersions(a, b);
+
+        Assert.NotNull(comparison);
+        Assert.Equal(expected, Math.Sign(comparison.Value));
+    }
+
+    [Theory]
+    [InlineData("10c8e557", "2.0.0")]
+    [InlineData("2.0.0", "8b640eef")]
+    [InlineData("10c8e557", "8b640eef")]
+    public void CompareVersions_ReturnsNullWhenAVersionCannotBeParsed(string a, string b)
+    {
+        Assert.Null(new PackageManagerBuilder().Build().CompareVersions(a, b));
+        Assert.Null(new DotNet().CompareVersions(a, b));
+    }
+
+    // npm, Bun and crates.io are strict SemVer registries: a dash always introduces a
+    // pre-release, which is OLDER than the release it precedes. All three pass the registry's
+    // raw version strings straight through (npm outdated's current/latest, bun outdated's
+    // table, cargo install-update --list), so the shared numeric parser reading
+    // "1.0.0-beta.1" as 1.0.0.1 hid every upgrade off a pre-release onto its stable release.
+    [Theory]
+    [InlineData("npm", "1.0.0-beta.1", "1.0.0", false)]
+    [InlineData("npm", "5.0.0-rc.1", "5.0.0", false)]
+    [InlineData("npm", "1.0.0", "1.0.0-beta.1", true)]
+    [InlineData("bun", "1.0.0-beta.1", "1.0.0", false)]
+    [InlineData("bun", "2.0.0-alpha.3", "2.0.0-alpha.4", false)]
+    [InlineData("cargo", "1.0.0-alpha.1", "1.0.0", false)]
+    [InlineData("cargo", "0.9.0", "0.10.0", false)]
+    [InlineData("cargo", "1.0.0", "1.0.0-alpha.1", true)]
+    public async Task NewerVersionIsInstalled_UsesSemVerOnSemVerRegistries(
+        string managerName,
+        string installedVersion,
+        string newVersion,
+        bool expected
+    )
+    {
+        IPackageManager manager = managerName switch
+        {
+            "npm" => new Npm(),
+            "bun" => new Bun(),
+            "cargo" => new Cargo(),
+            _ => throw new ArgumentOutOfRangeException(nameof(managerName)),
+        };
+        InitializeLoaders();
+
+        await InstalledPackagesLoader.Instance.AddForeign(
+            new PackageBuilder()
+                .WithManager(manager)
+                .WithId("contoso-tool")
+                .WithVersion(installedVersion)
+                .Build()
+        );
+
+        var update = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("contoso-tool")
+            .WithVersion(installedVersion)
+            .WithNewVersion(newVersion)
+            .Build();
+
+        Assert.Equal(expected, update.NewerVersionIsInstalled());
+    }
+
+    // The counterpart guard: managers whose trailing dash, underscore or hash is a build or
+    // port revision - and therefore NEWER than the base version - must keep the shared
+    // numeric comparison. Getting this wrong would hide real updates on these ecosystems.
+    [Theory]
+    [InlineData("homebrew", "18.4_1", "18.4", 1)]
+    [InlineData("homebrew", "18.4", "18.4_1", -1)]
+    [InlineData("homebrew", "1.2.3-4", "1.2.3", 1)]
+    [InlineData("flatpak", "1.2.3-4", "1.2.3", 1)]
+    [InlineData("snap", "1.2.3-4", "1.2.3", 1)]
+    public void CompareVersions_KeepsRevisionSemanticsOnRevisionEcosystems(
+        string managerName,
+        string a,
+        string b,
+        int expected
+    )
+    {
+        IPackageManager manager = managerName switch
+        {
+            "homebrew" => new Homebrew(),
+            "flatpak" => new Flatpak(),
+            "snap" => new Snap(),
+            _ => throw new ArgumentOutOfRangeException(nameof(managerName)),
+        };
+
+        var comparison = manager.CompareVersions(a, b);
+
+        Assert.NotNull(comparison);
+        Assert.Equal(expected, Math.Sign(comparison.Value));
+    }
+
+    [Theory]
+    [InlineData("1.0.0-beta.1", "1.0.0", -1)]
+    [InlineData("1.0.0", "1.0.0-beta.1", 1)]
+    [InlineData("0.9.0", "0.10.0", -1)]
+    [InlineData("1.0.0+build.5", "1.0.0", 0)]
+    public void CompareVersions_UsesSemVerOnNpmBunAndCargo(string a, string b, int expected)
+    {
+        foreach (IPackageManager manager in new IPackageManager[] { new Npm(), new Bun(), new Cargo() })
+        {
+            var comparison = manager.CompareVersions(a, b);
+            Assert.NotNull(comparison);
+            Assert.Equal(expected, Math.Sign(comparison.Value));
+        }
+    }
+
+    // PyPI follows PEP 440, where a pre-release carries no dash ("1.0.0rc1") and is OLDER than
+    // its release, while a bare trailing dash-number ("1.0.0-1") is an implicit post-release and
+    // so is NEWER. The shared numeric parser dropped the letters and glued the trailing digit
+    // onto the previous segment, reading "1.0.0rc1" as 1.0.1 - which both outranked 1.0.0 and
+    // hid the upgrade onto it. Pip reads the columns of `pip list --outdated` verbatim, so the
+    // registry's own spelling reaches this comparison unchanged.
+    [Theory]
+    [InlineData("1.0.0rc1", "1.0.0", false)]
+    [InlineData("1.0.0b1", "1.0.0", false)]
+    [InlineData("1.0.0a1", "1.0.0", false)]
+    [InlineData("1.0.0.dev1", "1.0.0", false)]
+    [InlineData("1.0.0rc1", "1.0.0rc2", false)]
+    [InlineData("1.0.0", "1.0.0rc1", true)]
+    [InlineData("1.0.0.post1", "1.0.0", true)]
+    [InlineData("1.0.0-1", "1.0.0", true)]
+    [InlineData("1.0", "1.0.0", true)]
+    [InlineData("1!1.0", "2.0", true)]
+    public async Task NewerVersionIsInstalled_UsesPep440OnPip(
+        string installedVersion,
+        string newVersion,
+        bool expected
+    )
+    {
+        var manager = new Pip();
+        InitializeLoaders();
+
+        await InstalledPackagesLoader.Instance.AddForeign(
+            new PackageBuilder()
+                .WithManager(manager)
+                .WithId("contoso-tool")
+                .WithVersion(installedVersion)
+                .Build()
+        );
+
+        var update = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("contoso-tool")
+            .WithVersion(installedVersion)
+            .WithNewVersion(newVersion)
+            .Build();
+
+        Assert.Equal(expected, update.NewerVersionIsInstalled());
+    }
+
+    [Theory]
+    [InlineData("1.0.0rc1", "1.0.0", -1)]
+    [InlineData("1.0.0-1", "1.0.0", 1)]
+    [InlineData("1.0.0.post1", "1.0.0", 1)]
+    [InlineData("1.0.0.dev1", "1.0.0rc1", -1)]
+    [InlineData("1.0", "1.0.0", 0)]
+    public void CompareVersions_UsesPep440OnPip(string a, string b, int expected)
+    {
+        var comparison = new Pip().CompareVersions(a, b);
+
+        Assert.NotNull(comparison);
+        Assert.Equal(expected, Math.Sign(comparison.Value));
+    }
+
+    // The three comparators must stay wired to the right managers: the same string can order
+    // differently in each ecosystem, and "1.0.0-1" is the case that separates all three.
+    [Fact]
+    public void EachEcosystemOrdersATrailingDashNumberByItsOwnRules()
+    {
+        // SemVer: a dash always starts a pre-release, so -1 is OLDER than the release
+        Assert.Equal(-1, Math.Sign(new Npm().CompareVersions("1.0.0-1", "1.0.0")!.Value));
+        Assert.Equal(-1, Math.Sign(new Cargo().CompareVersions("1.0.0-1", "1.0.0")!.Value));
+
+        // PEP 440: a bare -N is an implicit post-release, so it is NEWER
+        Assert.Equal(1, Math.Sign(new Pip().CompareVersions("1.0.0-1", "1.0.0")!.Value));
+
+        // Revision ecosystems keep the shared numeric reading, where -1 is also NEWER
+        Assert.Equal(1, Math.Sign(new Homebrew().CompareVersions("1.0.0-1", "1.0.0")!.Value));
     }
 
     private static void InitializeLoaders()

--- a/src/UniGetUI.PackageEngine.Tests/PythonVersionTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PythonVersionTests.cs
@@ -1,0 +1,115 @@
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class PythonVersionTests
+{
+    // Every expectation below was generated from Python's packaging library, which is the
+    // reference implementation of PEP 440, rather than written by hand.
+    [Theory]
+    [InlineData("1.0.0rc1", "1.0.0", -1)]
+    [InlineData("1.0.0b1", "1.0.0", -1)]
+    [InlineData("1.0.0a1", "1.0.0", -1)]
+    [InlineData("1.0.0rc1", "1.0.0rc2", -1)]
+    [InlineData("1.0.0a2", "1.0.0b1", -1)]
+    [InlineData("1.0.0b2", "1.0.0rc1", -1)]
+    [InlineData("1.0.0alpha1", "1.0.0a1", 0)]
+    [InlineData("1.0.0beta1", "1.0.0b1", 0)]
+    [InlineData("1.0.0c1", "1.0.0rc1", 0)]
+    [InlineData("1.0.0pre1", "1.0.0rc1", 0)]
+    [InlineData("1.0.0preview1", "1.0.0rc1", 0)]
+    [InlineData("1.0.0-rc1", "1.0.0rc1", 0)]
+    [InlineData("1.0.0_rc1", "1.0.0rc1", 0)]
+    [InlineData("1.0.0.rc1", "1.0.0rc1", 0)]
+    [InlineData("1.0.0rc", "1.0.0rc0", 0)]
+    [InlineData("1.0.0.post1", "1.0.0", 1)]
+    [InlineData("1.0.0-post1", "1.0.0.post1", 0)]
+    [InlineData("1.0.0.rev1", "1.0.0.post1", 0)]
+    [InlineData("1.0.0.r1", "1.0.0.post1", 0)]
+    [InlineData("1.0.0-1", "1.0.0", 1)]
+    [InlineData("1.0.0-1", "1.0.0.post1", 0)]
+    [InlineData("1.0.0-2", "1.0.0-1", 1)]
+    [InlineData("1.0.0.dev1", "1.0.0", -1)]
+    [InlineData("1.0.0.dev1", "1.0.0a1", -1)]
+    [InlineData("1.0.0a1.dev1", "1.0.0a1", -1)]
+    [InlineData("1.0.0.post1.dev1", "1.0.0.post1", -1)]
+    [InlineData("1.0.0.post1.dev1", "1.0.0", 1)]
+    [InlineData("1.0.0.dev2", "1.0.0.dev1", 1)]
+    [InlineData("1.0", "1.0.0", 0)]
+    [InlineData("1.0.0.0", "1.0", 0)]
+    [InlineData("1.2.3.4.5", "1.2.3.4", 1)]
+    [InlineData("1.10", "1.9", 1)]
+    [InlineData("1!1.0", "2.0", 1)]
+    [InlineData("1!1.0", "1.0", 1)]
+    [InlineData("2!1.0", "1!9.9", 1)]
+    [InlineData("1.0+local", "1.0", 1)]
+    [InlineData("1.0+local.2", "1.0+local.1", 1)]
+    [InlineData("v1.0.0", "1.0.0", 0)]
+    [InlineData("1.0.0RC1", "1.0.0rc1", 0)]
+    [InlineData("  1.0.0  ", "1.0.0", 0)]
+    public void OrderingMatchesThePep440ReferenceImplementation(string a, string b, int expected)
+    {
+        Assert.True(PythonVersion.TryParse(a, out var parsedA), $"could not parse {a}");
+        Assert.True(PythonVersion.TryParse(b, out var parsedB), $"could not parse {b}");
+
+        Assert.Equal(expected, Math.Sign(parsedA.CompareTo(parsedB)));
+        Assert.Equal(-expected, Math.Sign(parsedB.CompareTo(parsedA)));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-version")]
+    [InlineData("1.0.0-abc")]
+    [InlineData("1.0.0..0")]
+    [InlineData("1..0")]
+    [InlineData("1.0.0+")]
+    [InlineData("hello")]
+    [InlineData("8b640eef")]
+    public void UnparseableVersionsAreRejected(string version)
+    {
+        Assert.False(PythonVersion.TryParse(version, out var parsed));
+        Assert.False(parsed.IsValid);
+    }
+
+    [Theory]
+    [InlineData("1.0.0rc1", true)]
+    [InlineData("1.0.0a1", true)]
+    [InlineData("1.0.0.dev1", true)]
+    [InlineData("1.0.0a1.dev1", true)]
+    [InlineData("1.0.0", false)]
+    [InlineData("1.0.0.post1", false)]
+    [InlineData("1.0.0+local", false)]
+    public void PreReleaseIsDetected(string version, bool expected)
+    {
+        Assert.True(PythonVersion.TryParse(version, out var parsed));
+        Assert.Equal(expected, parsed.IsPreRelease);
+    }
+
+    [Fact]
+    public void ALocalSegmentNamedDevIsNotADevRelease()
+    {
+        Assert.True(PythonVersion.TryParse("1.0.0+devbuild", out var local));
+        Assert.True(PythonVersion.TryParse("1.0.0", out var release));
+
+        Assert.False(local.IsPreRelease);
+        Assert.True(local > release);
+    }
+
+    [Fact]
+    public void InvalidVersionsOrderBelowValidOnes()
+    {
+        Assert.True(PythonVersion.TryParse("0.0.1", out var valid));
+        PythonVersion invalid = default;
+
+        Assert.True(valid > invalid);
+        Assert.Equal(string.Empty, invalid.ToString());
+    }
+
+    [Fact]
+    public void OriginalStringIsPreserved()
+    {
+        Assert.True(PythonVersion.TryParse("1.0.0RC1", out var parsed));
+        Assert.Equal("1.0.0RC1", parsed.Original);
+    }
+}

--- a/src/UniGetUI.PackageEngine.Tests/SemanticVersionTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/SemanticVersionTests.cs
@@ -1,0 +1,80 @@
+using UniGetUI.Core.Tools;
+
+namespace UniGetUI.PackageEngine.Tests;
+
+public sealed class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("1.10.0", "1.9.0")]
+    [InlineData("2.0.0", "2.0.0-beta")]
+    [InlineData("2.0.0-beta.2", "2.0.0-beta.1")]
+    [InlineData("2.0.0-beta", "2.0.0-alpha")]
+    [InlineData("2.0.0-rc.10", "2.0.0-rc.2")]
+    [InlineData("1.0.0.1", "1.0.0")]
+    [InlineData("10.0.11", "2.1.0")]
+    [InlineData("11.0.0-preview.7", "11.0.0-preview.6")]
+    [InlineData("1.0.0-beta", "1.0.0-alpha.9")]
+    public void HigherVersionsCompareGreater(string higher, string lower)
+    {
+        Assert.True(SemanticVersion.TryParse(higher, out var parsedHigher));
+        Assert.True(SemanticVersion.TryParse(lower, out var parsedLower));
+
+        Assert.True(parsedHigher > parsedLower);
+        Assert.True(parsedLower < parsedHigher);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "1.0.0.0")]
+    [InlineData("1.0.0+build.5", "1.0.0")]
+    [InlineData("1.2", "1.2.0")]
+    [InlineData("1.0.0-BETA", "1.0.0-beta")]
+    [InlineData("v1.0.0", "1.0.0")]
+    public void EquivalentVersionsCompareEqual(string left, string right)
+    {
+        Assert.True(SemanticVersion.TryParse(left, out var parsedLeft));
+        Assert.True(SemanticVersion.TryParse(right, out var parsedRight));
+
+        Assert.Equal(0, parsedLeft.CompareTo(parsedRight));
+        Assert.True(parsedLeft == parsedRight);
+    }
+
+    [Theory]
+    [InlineData("1.0.0-beta", true)]
+    [InlineData("1.0.0-preview.7.26381.103", true)]
+    [InlineData("1.0.0", false)]
+    [InlineData("1.0.0+build", false)]
+    public void PreReleaseIsDetected(string version, bool expected)
+    {
+        Assert.True(SemanticVersion.TryParse(version, out var parsed));
+        Assert.Equal(expected, parsed.IsPreRelease);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-version")]
+    [InlineData("1.2.3.4.5")]
+    [InlineData("1.x.3")]
+    public void UnparseableVersionsAreRejected(string version)
+    {
+        Assert.False(SemanticVersion.TryParse(version, out var parsed));
+        Assert.False(parsed.IsValid);
+    }
+
+    [Fact]
+    public void InvalidVersionsOrderBelowValidOnes()
+    {
+        Assert.True(SemanticVersion.TryParse("0.0.1", out var valid));
+        var invalid = SemanticVersion.Invalid("garbage");
+
+        Assert.True(valid > invalid);
+    }
+
+    [Fact]
+    public void OriginalStringIsPreserved()
+    {
+        Assert.True(SemanticVersion.TryParse("1.0.0.0-Beta+meta", out var parsed));
+        Assert.Equal("1.0.0.0-Beta+meta", parsed.Original);
+        Assert.Equal("1.0.0.0-Beta+meta", parsed.ToString());
+    }
+}

--- a/src/UniGetUI.PackageEngine.Tests/SemanticVersionTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/SemanticVersionTests.cs
@@ -27,7 +27,6 @@ public sealed class SemanticVersionTests
     [InlineData("1.0.0", "1.0.0.0")]
     [InlineData("1.0.0+build.5", "1.0.0")]
     [InlineData("1.2", "1.2.0")]
-    [InlineData("1.0.0-BETA", "1.0.0-beta")]
     [InlineData("v1.0.0", "1.0.0")]
     public void EquivalentVersionsCompareEqual(string left, string right)
     {
@@ -68,6 +67,32 @@ public sealed class SemanticVersionTests
         var invalid = SemanticVersion.Invalid("garbage");
 
         Assert.True(valid > invalid);
+    }
+
+    // SemVer 2.0 compares pre-release identifiers in ASCII order, so case matters and
+    // "1.0.0-RC" precedes "1.0.0-rc". NuGet's own comparer is case-insensitive, and this type is
+    // shared by both, so the mode has to be explicit.
+    [Fact]
+    public void PreReleaseLabelsAreCaseSensitiveByDefault()
+    {
+        Assert.True(SemanticVersion.TryParse("1.0.0-RC", out var upper));
+        Assert.True(SemanticVersion.TryParse("1.0.0-rc", out var lower));
+
+        Assert.True(upper < lower);
+        Assert.NotEqual(0, upper.CompareTo(lower));
+    }
+
+    [Fact]
+    public void PreReleaseLabelsCompareCaseInsensitivelyForNuGetFeeds()
+    {
+        Assert.True(
+            SemanticVersion.TryParse("1.0.0-RC", SemVerLabels.CaseInsensitive, out var upper)
+        );
+        Assert.True(
+            SemanticVersion.TryParse("1.0.0-rc", SemVerLabels.CaseInsensitive, out var lower)
+        );
+
+        Assert.Equal(0, upper.CompareTo(lower));
     }
 
     [Fact]


### PR DESCRIPTION
 ## Summary                                                                                                                                    
                                                                                                                                                   
Engineering Manager for NuGet.org reported that UniGetUI's V2/OData traffic consumes a large share of nuget.org's database DTU. This moves the NuGet-backed managers onto the V3 API for feeds that support it, while leaving V2 fully intact for feeds that don't.

## What is *not* migrated, and why                                                                                                            
                                                                                                                                                   
**The PowerShell Gallery has no usable V3 service index.** Every path under `powershellgallery.com/api/v3/` returns `403 — blocked by a Web Application Firewall rule` (while `/api/v2/` returns 200, and a nonexistent `/v3/` returns 404, so the prefix exists and is deliberately blocked). Microsoft's own PSResourceGet docs still register PSGallery as `.../api/v2`. Step 7 of the issue isn't actionable for it, so both PowerShell managers stay on V2.                                            
                                                                                                                                           
**Chocolatey** stays on V2 too — `community.chocolatey.org/api/v3/index.json` is a 404. Worth flagging one correction to the issue's framing: Chocolatey is *not* purely CLI-driven. It derives from `BaseNuGet` and `FindPackages_UnSafe` is `sealed`, so its **search, details and icons** run through the shared HTTP path; only updates and version listing are `choco`. V2 is therefore a permanently maintained path, not a fallback to delete later.                                                                                  
                                                                                                                                           
A V3-capable *custom* PowerShell repository (Azure Artifacts, GitHub Packages, JFrog, MyGet) is picked up automatically with no per-manager work.

 ## Risk                                                                                                                                       
                                                                                                                                                   
Highest-risk area is `CompareVersions`, because it touches every manager's update decision, not just NuGet. Mitigations: the default preserves current semantics exactly, and there are explicit tests asserting that revision ecosystems still read a trailing suffix as **newer** — so a future "simplification" that makes the shared parser SemVer-aware will fail CI.                                                                      
                                                                                                                                             
Second: users sitting on a pre-release across eight managers will now be offered the stable release they were previously denied. That's the fix working, but it will look like a surge of new updates.                                            
                                                                                                                                                   
## Behaviour changes users will notice (intended)                                                                                             
                                                                                                                                                   
- `.NET Tool` search returns **fewer** results — libraries that can't be installed as tools are filtered out                                  
- Version dropdowns are **newest-first**, not alphabetical (and no longer truncated: `dotnet-ef` went from 100 to all 266 versions)           
- Details → Manifest URL is now an `api.nuget.org/v3/registration5-…json` URL                                                                 
- `.NET Tool` installs now default to **global**                                                                                              
- A package on a pre-release may suddenly show an update