### PR TITLE
Mark truncated text with an ellipsis app-wide

### DIFF
--- a/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
+++ b/src/UniGetUI.Avalonia/Assets/Styles/Styles.Common.axaml
@@ -288,6 +288,10 @@
 
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
 
+    <Style Selector="TextBlock">
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+    </Style>
+
     <!-- Avalonia's Fluent controls still consume UWP-era accent resources, whose dark-theme
          defaults use the base accent and white foreground. Bind every filled accent control to
          the WinUI v2 tokens above so dark mode consistently uses a lighter fill and dark glyphs. -->

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageAutoUpdatesWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageAutoUpdatesWindow.axaml
@@ -45,15 +45,15 @@
                 CornerRadius="6"
                 Padding="12,8"
                 Background="{DynamicResource SubtleFillColorSecondaryBrush}">
-            <StackPanel Orientation="Horizontal" Spacing="8">
-                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/warning_round.svg"
+            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/warning_round.svg"
                                   Width="16" Height="16"
                                   VerticalAlignment="Center"
                                   automation:AutomationProperties.AccessibilityView="Raw"/>
-                <TextBlock Text="{Binding ScopeWarning}"
+                <TextBlock Grid.Column="1" Text="{Binding ScopeWarning}"
                            TextWrapping="Wrap"
                            VerticalAlignment="Center"/>
-            </StackPanel>
+            </Grid>
         </Border>
 
         <Grid Grid.Row="2" ColumnDefinitions="*,Auto" ColumnSpacing="8">

--- a/src/UniGetUI.Avalonia/Views/DialogPages/ManageShortcutsWindow.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/ManageShortcutsWindow.axaml
@@ -130,14 +130,14 @@
                                 <DataGridTemplateColumn Width="2*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="vm:ShortcutEntryViewModel">
-                                            <StackPanel Orientation="Horizontal" Spacing="6"
-                                                        VerticalAlignment="Center" Margin="0,0,4,0">
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/id.svg"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6"
+                                                  VerticalAlignment="Center" Margin="0,0,4,0">
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/id.svg"
                                                                   Width="16" Height="16" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding Name}" VerticalAlignment="Center"
+                                                <TextBlock Grid.Column="1" Text="{Binding Name}" VerticalAlignment="Center"
                                                            TextTrimming="CharacterEllipsis"
                                                            ToolTip.Tip="{Binding Name}"/>
-                                            </StackPanel>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -146,14 +146,14 @@
                                 <DataGridTemplateColumn Width="3*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="vm:ShortcutEntryViewModel">
-                                            <StackPanel Orientation="Horizontal" Spacing="6"
-                                                        VerticalAlignment="Center" Margin="0,0,4,0">
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/open_folder.svg"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6"
+                                                  VerticalAlignment="Center" Margin="0,0,4,0">
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/open_folder.svg"
                                                                   Width="16" Height="16" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding Path}" VerticalAlignment="Center"
+                                                <TextBlock Grid.Column="1" Text="{Binding Path}" VerticalAlignment="Center"
                                                            TextTrimming="CharacterEllipsis"
                                                            ToolTip.Tip="{Binding Path}"/>
-                                            </StackPanel>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -365,15 +365,15 @@
                                                                           automation:AutomationProperties.Name="{Binding DeleteAutomationName}"
                                                                           ToolTip.Tip="{t:Translate Text='Delete this shortcut, now and whenever an upgrade creates it again'}"/>
 
-                                                                <StackPanel Grid.Column="2"
-                                                                            Orientation="Horizontal"
-                                                                            Spacing="6"
-                                                                            VerticalAlignment="Center">
-                                                                    <TextBlock Text="{Binding Name}"
+                                                                <Grid Grid.Column="2"
+                                                                      ColumnDefinitions="*,Auto"
+                                                                      ColumnSpacing="6"
+                                                                      VerticalAlignment="Center">
+                                                                    <TextBlock Grid.Column="0" Text="{Binding Name}"
                                                                                VerticalAlignment="Center"
                                                                                TextTrimming="CharacterEllipsis"
                                                                                ToolTip.Tip="{Binding Path}"/>
-                                                                    <Border Background="{DynamicResource SystemAccentColor}"
+                                                                    <Border Grid.Column="1" Background="{DynamicResource SystemAccentColor}"
                                                                             CornerRadius="4"
                                                                             Padding="4,0"
                                                                             VerticalAlignment="Center"
@@ -382,7 +382,7 @@
                                                                                    FontSize="10"
                                                                                    Foreground="White"/>
                                                                     </Border>
-                                                                </StackPanel>
+                                                                </Grid>
 
                                                                 <TextBlock Grid.Column="3"
                                                                            Text="{Binding Location}"
@@ -504,14 +504,14 @@
                                     <DataGridTemplateColumn Width="2*">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate x:DataType="vm:StartMenuShortcutEntryViewModel">
-                                                <StackPanel Orientation="Horizontal" Spacing="6"
-                                                            VerticalAlignment="Center" Margin="0,0,4,0">
-                                                    <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/id.svg"
+                                                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6"
+                                                      VerticalAlignment="Center" Margin="0,0,4,0">
+                                                    <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/id.svg"
                                                                       Width="16" Height="16" VerticalAlignment="Center"/>
-                                                    <TextBlock Text="{Binding Name}" VerticalAlignment="Center"
+                                                    <TextBlock Grid.Column="1" Text="{Binding Name}" VerticalAlignment="Center"
                                                                TextTrimming="CharacterEllipsis"
                                                                ToolTip.Tip="{Binding Name}"/>
-                                                </StackPanel>
+                                                </Grid>
                                             </DataTemplate>
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
@@ -520,14 +520,14 @@
                                     <DataGridTemplateColumn Width="3*">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate x:DataType="vm:StartMenuShortcutEntryViewModel">
-                                                <StackPanel Orientation="Horizontal" Spacing="6"
-                                                            VerticalAlignment="Center" Margin="0,0,4,0">
-                                                    <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/open_folder.svg"
+                                                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6"
+                                                      VerticalAlignment="Center" Margin="0,0,4,0">
+                                                    <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/open_folder.svg"
                                                                       Width="16" Height="16" VerticalAlignment="Center"/>
-                                                    <TextBlock Text="{Binding Location}" VerticalAlignment="Center"
+                                                    <TextBlock Grid.Column="1" Text="{Binding Location}" VerticalAlignment="Center"
                                                                TextTrimming="CharacterEllipsis"
                                                                ToolTip.Tip="{Binding Path}"/>
-                                                </StackPanel>
+                                                </Grid>
                                             </DataTemplate>
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>

--- a/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/LogPages/OperationHistoryPage.axaml
@@ -113,10 +113,10 @@
                             <DataGridTemplateColumn Header="{t:Translate Operation}" Width="1*" MinWidth="120" Tag="kind">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate x:DataType="vm:OperationHistoryRowViewModel">
-                                        <StackPanel Orientation="Horizontal" Spacing="6" Margin="12,0,4,0" VerticalAlignment="Center">
-                                            <controls:SvgIcon Path="{Binding KindIconPath}" Width="24" Height="24" VerticalAlignment="Center"/>
-                                            <TextBlock Text="{Binding KindLabel}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
-                                        </StackPanel>
+                                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6" Margin="12,0,4,0" VerticalAlignment="Center">
+                                            <controls:SvgIcon Grid.Column="0" Path="{Binding KindIconPath}" Width="24" Height="24" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding KindLabel}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                        </Grid>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/SettingsBasePage.axaml
@@ -44,17 +44,17 @@
                 Margin="16,0,16,8"
                 Padding="4"
                 IsVisible="{Binding IsRestartBannerVisible}">
-            <StackPanel Orientation="Horizontal"
-                        Margin="8,6">
-                <TextBlock Text="{Binding RestartBannerText}"
+            <Grid ColumnDefinitions="*,Auto"
+                  Margin="8,6">
+                <TextBlock Grid.Column="0" Text="{Binding RestartBannerText}"
                            FontSize="14"
                            VerticalAlignment="Center"
                            Margin="0,0,16,0"/>
-                <Button Content="{Binding RestartButtonText}"
+                <Button Grid.Column="1" Content="{Binding RestartButtonText}"
                         automation:AutomationProperties.Name="{Binding RestartButtonText}"
                         Command="{Binding RestartAppCommand}"
                         HorizontalAlignment="Right"/>
-            </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Row 2: Content frame — sub-pages slide in horizontally (WinUI SlideNavigationTransition) -->

--- a/src/UniGetUI.Avalonia/Views/SidebarView.axaml
+++ b/src/UniGetUI.Avalonia/Views/SidebarView.axaml
@@ -32,14 +32,14 @@
                          automation:AutomationProperties.AcceleratorKey="Ctrl+1"
                          ToolTip.Tip="{t:Translate Discover Packages}">
                 <Panel>
-                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,8">
-                        <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/DiscoverPackage.svg" Width="24" Height="24" VerticalAlignment="Center" />
-                        <TextBlock Text="{t:Translate Discover Packages}"
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="8,8">
+                        <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/DiscoverPackage.svg" Width="24" Height="24" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="1" Text="{t:Translate Discover Packages}"
                                    FontSize="14"
                                    FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                    </StackPanel>
+                    </Grid>
                     <ProgressBar IsIndeterminate="{Binding DiscoverIsLoading}"
                                  IsVisible="{Binding DiscoverIsLoading}"
                                  Height="2"
@@ -57,14 +57,14 @@
                          automation:AutomationProperties.AcceleratorKey="Ctrl+2"
                          ToolTip.Tip="{t:Translate Software Updates}">
                 <Panel>
-                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,8">
-                        <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/update.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                        <TextBlock Text="{t:Translate Software Updates}"
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="8,8">
+                        <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/update.svg" Width="24" Height="24" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="1" Text="{t:Translate Software Updates}"
                                    FontSize="14"
                                    FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                    </StackPanel>
+                    </Grid>
                     <!-- Update count bubble (InfoBadge-style), anchored to the icon's top-right in both rail and flyout -->
                     <Border Background="{DynamicResource AccentFillColorDefaultBrush}"
                             CornerRadius="8"
@@ -99,14 +99,14 @@
                          automation:AutomationProperties.AcceleratorKey="Ctrl+3"
                          ToolTip.Tip="{t:Translate Installed Packages}">
                 <Panel>
-                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,8">
-                        <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/InstalledPackages.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                        <TextBlock Text="{t:Translate Installed Packages}"
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="8,8">
+                        <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/InstalledPackages.svg" Width="24" Height="24" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="1" Text="{t:Translate Installed Packages}"
                                    FontSize="14"
                                    FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                    </StackPanel>
+                    </Grid>
                     <ProgressBar IsIndeterminate="{Binding InstalledIsLoading}"
                                  IsVisible="{Binding InstalledIsLoading}"
                                  Height="2"
@@ -124,14 +124,14 @@
                          automation:AutomationProperties.AcceleratorKey="Ctrl+4"
                          ToolTip.Tip="{t:Translate Package Bundles}">
                 <Panel>
-                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,8">
-                        <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/PackagesBundle.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                        <TextBlock Text="{t:Translate Package Bundles}"
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="8,8">
+                        <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/PackagesBundle.svg" Width="24" Height="24" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="1" Text="{t:Translate Package Bundles}"
                                    FontSize="14"
                                    FontWeight="Normal"
                                    VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                    </StackPanel>
+                    </Grid>
                     <!-- Unsaved changes dot, anchored to the icon's top-right in both rail and flyout -->
                     <Border Background="{DynamicResource SystemFillColorCautionBrush}"
                             CornerRadius="5"
@@ -165,11 +165,11 @@
                              automation:AutomationProperties.Name="{t:Translate Settings}"
                              automation:AutomationProperties.AcceleratorKey="Ctrl+5"
                              ToolTip.Tip="{t:Translate Settings}">
-                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,8">
-                        <controls:SvgIcon x:Name="SettingsIcon" Path="avares://UniGetUI/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center" RenderTransformOrigin="50%,50%"/>
-                        <TextBlock Text="{t:Translate Settings}" FontSize="14" VerticalAlignment="Center"
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="8,8">
+                        <controls:SvgIcon Grid.Column="0" x:Name="SettingsIcon" Path="avares://UniGetUI/Assets/Symbols/settings.svg" Width="24" Height="24" VerticalAlignment="Center" RenderTransformOrigin="50%,50%"/>
+                        <TextBlock Grid.Column="1" Text="{t:Translate Settings}" FontSize="14" VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                    </StackPanel>
+                    </Grid>
                 </ListBoxItem>
 
                 <!-- Package Managers -->
@@ -177,23 +177,23 @@
                              automation:AutomationProperties.Name="{t:Translate Package Managers}"
                              automation:AutomationProperties.AcceleratorKey="Ctrl+6"
                              ToolTip.Tip="{t:Translate Package Managers}">
-                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,8">
-                        <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/package_managers.svg" Width="24" Height="24" VerticalAlignment="Center"/>
-                        <TextBlock Text="{t:Translate Package Managers}" FontSize="14" VerticalAlignment="Center"
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="8,8">
+                        <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/package_managers.svg" Width="24" Height="24" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="1" Text="{t:Translate Package Managers}" FontSize="14" VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                    </StackPanel>
+                    </Grid>
                 </ListBoxItem>
 
                 <!-- More is kept selected while its flyout is open so its navigation pill remains visible. -->
                 <ListBoxItem x:Name="MoreNavBtn" Tag="More" Classes="nav-item" Padding="4,2" CornerRadius="6"
                              automation:AutomationProperties.Name="{t:Translate More}"
                              ToolTip.Tip="{t:Translate More}">
-                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="8,8">
-                        <TextBlock Text="···" FontSize="20" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center"
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="8,8">
+                        <TextBlock Grid.Column="0" Text="···" FontSize="20" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center"
                                    automation:AutomationProperties.AccessibilityView="Raw"/>
-                        <TextBlock Text="{t:Translate More}" FontSize="14" VerticalAlignment="Center"
+                        <TextBlock Grid.Column="1" Text="{t:Translate More}" FontSize="14" VerticalAlignment="Center"
                                    IsVisible="{Binding $parent[local:SidebarView].ShowLabels}"/>
-                    </StackPanel>
+                    </Grid>
                     <FlyoutBase.AttachedFlyout>
                         <MenuFlyout Placement="RightEdgeAlignedTop">
                         <MenuItem Header="{t:Translate UniGetUI Log}" Command="{Binding RequestNavigationCommand}" CommandParameter="OwnLog">

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -308,8 +308,8 @@
                                                     <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
                                                               VerticalAlignment="Center">
                                                         <CheckBox.Content>
-                                                            <StackPanel Orientation="Horizontal" Spacing="4">
-                                                        <ToggleButton IsChecked="{Binding IsExpanded, Mode=TwoWay}"
+                                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="4">
+                                                        <ToggleButton Grid.Column="0" IsChecked="{Binding IsExpanded, Mode=TwoWay}"
                                                                       IsVisible="{Binding HasChildren}"
                                                                       Classes="tree-chevron"
                                                                       BorderThickness="0"
@@ -337,8 +337,8 @@
                                                                       IsVisible="{Binding IsExpanded}"/>
                                                             </Grid>
                                                         </ToggleButton>
-                                                                <TextBlock Text="{Binding PackageName}" VerticalAlignment="Center"/>
-                                                            </StackPanel>
+                                                                <TextBlock Grid.Column="1" Text="{Binding PackageName}" VerticalAlignment="Center"/>
+                                                            </Grid>
                                                         </CheckBox.Content>
                                                     </CheckBox>
                                                     <!-- Child sources, indented, only shown when parent is expanded -->
@@ -562,10 +562,10 @@
                                                         Width="*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
-                                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0"
-                                                        automation:AutomationProperties.Name="{Binding Package.AutomationName}"
-                                                        automation:AutomationProperties.ItemType="{t:Translate Package}">
-                                                <Panel Width="24" Height="24" VerticalAlignment="Center"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6" VerticalAlignment="Center" Margin="4,0"
+                                                  automation:AutomationProperties.Name="{Binding Package.AutomationName}"
+                                                  automation:AutomationProperties.ItemType="{t:Translate Package}">
+                                                <Panel Grid.Column="0" Width="24" Height="24" VerticalAlignment="Center"
                                                        controls:PackageIconLoader.Track="True">
                                                     <Image Source="{Binding IconBitmap}" Width="24" Height="24"
                                                            Stretch="Uniform" IsVisible="{Binding HasCustomIcon}"/>
@@ -586,8 +586,9 @@
                                                                       HorizontalAlignment="Right"
                                                                       VerticalAlignment="Bottom"/>
                                                 </Panel>
-                                                <TextBlock Text="{Binding Package.Name}" VerticalAlignment="Center"/>
-                                            </StackPanel>
+                                                <TextBlock Grid.Column="1" Text="{Binding Package.Name}" VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -596,11 +597,12 @@
                                                         Width="*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
-                                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0">
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/id.svg"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6" VerticalAlignment="Center" Margin="4,0">
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/id.svg"
                                                                   Width="24" Height="24" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding Package.Id}" VerticalAlignment="Center"/>
-                                            </StackPanel>
+                                                <TextBlock Grid.Column="1" Text="{Binding Package.Id}" VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -609,11 +611,12 @@
                                                         Width="*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
-                                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0">
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/version.svg"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6" VerticalAlignment="Center" Margin="4,0">
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/version.svg"
                                                                   Width="24" Height="24" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding VersionComboString}" VerticalAlignment="Center"/>
-                                            </StackPanel>
+                                                <TextBlock Grid.Column="1" Text="{Binding VersionComboString}" VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -623,17 +626,18 @@
                                                         IsVisible="{Binding $parent[UserControl].((vm:PackagesPageViewModel)DataContext).NewVersionHeaderVisible}">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
-                                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0">
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/download.svg"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6" VerticalAlignment="Center" Margin="4,0">
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/download.svg"
                                                                   Width="24" Height="24" VerticalAlignment="Center"
                                                                   IsVisible="{Binding !InstallerHostChanged}"/>
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/warning_filled.svg"
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/warning_filled.svg"
                                                                   Width="22" Height="22" VerticalAlignment="Center"
                                                                   Foreground="#F59E0B"
                                                                   IsVisible="{Binding InstallerHostChanged}"
                                                                   ToolTip.Tip="{Binding InstallerHostChangeTooltip}"/>
-                                                <TextBlock Text="{Binding Package.NewVersionString}" VerticalAlignment="Center"/>
-                                            </StackPanel>
+                                                <TextBlock Grid.Column="1" Text="{Binding Package.NewVersionString}" VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -642,11 +646,12 @@
                                                         Width="*">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
-                                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0">
-                                                <controls:SvgIcon Path="{Binding SourceIconPath}"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6" VerticalAlignment="Center" Margin="4,0">
+                                                <controls:SvgIcon Grid.Column="0" Path="{Binding SourceIconPath}"
                                                                   Width="24" Height="24" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding Package.Source.AsString_DisplayName}" VerticalAlignment="Center"/>
-                                            </StackPanel>
+                                                <TextBlock Grid.Column="1" Text="{Binding Package.Source.AsString_DisplayName}" VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -656,20 +661,20 @@
                                                         IsVisible="{Binding $parent[UserControl].((vm:PackagesPageViewModel)DataContext).InstallerHostColumnVisible}">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate x:DataType="pkg:PackageWrapper">
-                                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="4,0"
-                                                        controls:PackageInstallerHostLoader.Track="True">
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/launch.svg"
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6" VerticalAlignment="Center" Margin="4,0"
+                                                  controls:PackageInstallerHostLoader.Track="True">
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/launch.svg"
                                                                   Width="24" Height="24" VerticalAlignment="Center"
                                                                   IsVisible="{Binding !InstallerHostChanged}"/>
-                                                <controls:SvgIcon Path="avares://UniGetUI/Assets/Symbols/warning_filled.svg"
+                                                <controls:SvgIcon Grid.Column="0" Path="avares://UniGetUI/Assets/Symbols/warning_filled.svg"
                                                                   Width="22" Height="22" VerticalAlignment="Center"
                                                                   Foreground="#F59E0B"
                                                                   IsVisible="{Binding InstallerHostChanged}"
                                                                   ToolTip.Tip="{Binding InstallerHostChangeTooltip}"/>
-                                                <TextBlock Text="{Binding InstallerHostText}" VerticalAlignment="Center"
+                                                <TextBlock Grid.Column="1" Text="{Binding InstallerHostText}" VerticalAlignment="Center"
                                                            TextTrimming="CharacterEllipsis"
                                                            ToolTip.Tip="{Binding InstallerHostTooltip}"/>
-                                            </StackPanel>
+                                            </Grid>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>


### PR DESCRIPTION
This pull request refactors several UI components to improve layout consistency and text handling across the application. The main changes involve replacing `StackPanel` layouts with `Grid` layouts for better alignment of icons and text, and setting a global text trimming style to ensure long text is properly ellipsized. These updates enhance the visual appearance and usability, especially when dealing with variable-length text.

**UI Layout Refactoring:**

* Replaced multiple instances of `StackPanel` with `Grid` layouts in files such as `ManageShortcutsWindow.axaml`, `ManageAutoUpdatesWindow.axaml`, `OperationHistoryPage.axaml`, `SettingsBasePage.axaml`, and `SidebarView.axaml`. This change ensures better alignment and spacing between icons and text, especially for items with variable-length content. 

**Text Handling Improvements:**

* Added a global style for `TextBlock` in `Styles.Common.axaml` to set `TextTrimming` to `CharacterEllipsis`, ensuring that overflowing text is consistently truncated with an ellipsis throughout the application.

These changes collectively improve the app's look and feel, making UI elements more robust and visually consistent.
