### PR TITLE
Prevent window from pulling forward before UAC prompts

### DIFF
--- a/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/MainWindow.axaml.cs
@@ -19,7 +19,6 @@ using UniGetUI.Avalonia.ViewModels;
 using UniGetUI.Avalonia.Views.Controls;
 using UniGetUI.Avalonia.Views.DialogPages;
 using UniGetUI.Avalonia.Views.Pages;
-using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -190,12 +189,6 @@ public partial class MainWindow : Window
 
         _trayService = new TrayService(this);
         _trayService.UpdateStatus();
-
-        // Let the elevation code activate us right before a UAC prompt, so we own the foreground
-        // and can delegate it to the consent UI (#5146). Only activate when we're already on screen;
-        // don't yank a tray-hidden window forward during silent/background elevation.
-        CoreData.BringMainWindowToForegroundAsync = () =>
-            Dispatcher.UIThread.InvokeAsync(() => { if (IsVisible) ShowFromTray(); }).GetTask();
     }
 
     protected override void OnOpened(EventArgs e)

--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -389,14 +389,6 @@ namespace UniGetUI.Core.Data
         public static string ElevatorArgs = "";
 
         /// <summary>
-        /// Set by the UI layer to bring the main window to the foreground and wait until it is.
-        /// Called right before a UAC prompt is triggered so the app owns the foreground and can
-        /// delegate it to the consent UI (fixes prompts hiding behind the window with secure desktop off).
-        /// Null in headless mode, where no window exists to activate.
-        /// </summary>
-        public static Func<Task>? BringMainWindowToForegroundAsync;
-
-        /// <summary>
         /// This method will return the most appropriate data directory.
         /// If the new directory exists, it will be used.
         /// If the new directory does not exist, but the old directory does, it will be moved to the new location, and the new location will be used.

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -752,19 +752,17 @@ namespace UniGetUI.Core.Tools
         private static extern bool AllowSetForegroundWindow(int dwProcessId);
 
         /// <summary>
-        /// Windows: bring UniGetUI to the foreground and grant foreground rights so an imminent
-        /// UAC consent prompt surfaces in front instead of only flashing the taskbar (#5146).
-        /// No-op elsewhere, and when the app owns no visible foreground window to delegate.
+        /// Windows: hand our foreground rights to the imminent UAC consent prompt so it surfaces
+        /// in front instead of only flashing the taskbar (#5146). Succeeds only while UniGetUI
+        /// already owns the foreground; it deliberately never activates the window, which would
+        /// interrupt a user who had minimized it (#5102). No-op elsewhere.
         /// Must be called immediately before launching the elevator.
         /// </summary>
-        public static async Task PrepareForegroundForElevationAsync()
+        public static void PrepareForegroundForElevation()
         {
             if (!OperatingSystem.IsWindows())
                 return;
 
-            var bringToFront = CoreData.BringMainWindowToForegroundAsync;
-            if (bringToFront is not null)
-                await bringToFront();
             AllowSetForegroundWindow(ASFW_ANY);
         }
 
@@ -824,7 +822,7 @@ namespace UniGetUI.Core.Tools
 
                 // When admin-rights caching is enabled, the UAC consent prompt is raised here.
                 // Surface it in front instead of letting it flash unnoticed in the taskbar (#5146).
-                await PrepareForegroundForElevationAsync();
+                PrepareForegroundForElevation();
 
                 p.Start();
                 await p.WaitForExitAsync();

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -753,9 +753,10 @@ namespace UniGetUI.Core.Tools
 
         /// <summary>
         /// Windows: hand our foreground rights to the imminent UAC consent prompt so it surfaces
-        /// in front instead of only flashing the taskbar (#5146). Succeeds only while UniGetUI
-        /// already owns the foreground; it deliberately never activates the window, which would
-        /// interrupt a user who had minimized it (#5102). No-op elsewhere.
+        /// in front instead of only flashing the taskbar (#5146). Windows decides whether we
+        /// still hold that privilege and grants nothing once another app owns the foreground.
+        /// Either way this only ever lets the consent UI come forward; it never activates our
+        /// own window, so a minimized UniGetUI stays minimized (#5102). No-op elsewhere.
         /// Must be called immediately before launching the elevator.
         /// </summary>
         public static void PrepareForegroundForElevation()

--- a/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractProcessOperation.cs
@@ -140,10 +140,10 @@ public abstract class AbstractProcessOperation : AbstractOperation
         CancellationToken.ThrowIfCancellationRequested();
 
         // When admin-rights caching is disabled (or a cache miss), the elevator is launched
-        // directly here and the UAC prompt is raised at this Start() — bring it to the
-        // foreground too, not just on the cached path (#5146).
+        // directly here and the UAC prompt is raised at this Start() — delegate foreground
+        // rights here too, not just on the cached path (#5146).
         if (process.StartInfo.FileName == CoreData.ElevatorPath)
-            await CoreTools.PrepareForegroundForElevationAsync();
+            CoreTools.PrepareForegroundForElevation();
 
         process.Start();
         if (CancellationToken.IsCancellationRequested)


### PR DESCRIPTION
This pull request refactors how UniGetUI handles foreground window rights before showing a UAC consent prompt. The main change is to simplify and centralize foreground delegation logic, ensuring the app never unintentionally activates or brings forward the main window, which could disrupt the user. The previous mechanism using a delegate from the UI layer is removed in favor of a direct call that only delegates foreground rights if the app already owns the foreground.

**Foreground rights delegation refactor:**

* Removed the `CoreData.BringMainWindowToForegroundAsync` delegate and all related UI-layer logic, eliminating the ability for the UI to forcibly bring the main window to the foreground before elevation. [[1]](diffhunk://#diff-133754dff4c1cb9804c5fabcde40f72eb6a6c36bc32e2e3bcd175e50f5f3a963L22) [[2]](diffhunk://#diff-133754dff4c1cb9804c5fabcde40f72eb6a6c36bc32e2e3bcd175e50f5f3a963L193-L198) [[3]](diffhunk://#diff-df264a55a2539d30dd3b1a3b2ba468333e613d2a4a04bf0887a591035f3d0e1eL391-L398)
* Refactored `CoreTools.PrepareForegroundForElevationAsync()` to a synchronous `PrepareForegroundForElevation()` method that only delegates foreground rights without activating the window, and updated all call sites accordingly. [[1]](diffhunk://#diff-619abd46a81953ef9167a62636f794b01cdbe6a3373adfc7931ff476eeee3268L755-L767) [[2]](diffhunk://#diff-619abd46a81953ef9167a62636f794b01cdbe6a3373adfc7931ff476eeee3268L827-R825) [[3]](diffhunk://#diff-8fcec10b51267023bb21e605bdd8c9802f52561f686cb905f216d02a26469b36L143-R146)

**Documentation improvements:**

* Updated comments and method summaries to clarify the new behavior: the app now only delegates foreground rights and never brings the window forward, preventing unwanted interruptions when the window is minimized or in the tray. [[1]](diffhunk://#diff-619abd46a81953ef9167a62636f794b01cdbe6a3373adfc7931ff476eeee3268L755-L767) [[2]](diffhunk://#diff-8fcec10b51267023bb21e605bdd8c9802f52561f686cb905f216d02a26469b36L143-R146)