### PR TITLE
Move package-list action bar items to overflow flyout

### DIFF
--- a/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/SoftwarePages/PackagesPageViewModel.cs
@@ -27,6 +27,8 @@ using UniGetUI.PackageEngine.PackageLoader;
 
 namespace UniGetUI.Avalonia.ViewModels.Pages;
 
+public sealed record ToolbarEntry(Control Control, string IconName, string Label, Action? Invoke);
+
 public enum SearchMode { Both, Name, Id, Exact, Similar }
 
 public enum PackageViewMode { List = 0, Grid = 1, Icons = 2 }
@@ -195,7 +197,7 @@ public partial class PackagesPageViewModel : ViewModelBase
     // ─── Collections ──────────────────────────────────────────────────────────
     public ObservablePackageCollection FilteredPackages { get; } = new();
     public AvaloniaList<SourceTreeNode> SourceNodes { get; } = new();
-    public AvaloniaList<object> ToolBarItems { get; } = new();
+    public List<ToolbarEntry> ToolbarEntries { get; } = new();
 
     // Labels of toolbar buttons that can be hidden to collapse the menu bar to icon-only
     // on narrow windows (buttons created with showLabel: false are never tracked here).
@@ -345,7 +347,7 @@ public partial class PackagesPageViewModel : ViewModelBase
         ToolTip.SetTip(btn, label);
         AutomationProperties.SetName(btn, label);
         btn.Click += (_, _) => onClick();
-        ToolBarItems.Add(btn);
+        ToolbarEntries.Add(new ToolbarEntry(btn, svgName, label, onClick));
         return btn;
     }
 
@@ -379,7 +381,7 @@ public partial class PackagesPageViewModel : ViewModelBase
                          ?? new SolidColorBrush(Color.FromArgb(80, 128, 128, 128)),
         };
         AutomationProperties.SetAccessibilityView(sep, AccessibilityView.Raw);
-        ToolBarItems.Add(sep);
+        ToolbarEntries.Add(new ToolbarEntry(sep, "", "", null));
     }
 
     public async Task ShowInfoDialog(Window owner, string title, string message)

--- a/src/UniGetUI.Avalonia/Views/Controls/ToolbarOverflowPanel.cs
+++ b/src/UniGetUI.Avalonia/Views/Controls/ToolbarOverflowPanel.cs
@@ -1,0 +1,227 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.VisualTree;
+
+namespace UniGetUI.Avalonia.Views.Controls;
+
+public sealed class ToolbarOverflowPanel : Panel
+{
+    public static readonly StyledProperty<double> SpacingProperty =
+        AvaloniaProperty.Register<ToolbarOverflowPanel, double>(nameof(Spacing), 4.0);
+
+    static ToolbarOverflowPanel()
+    {
+        AffectsMeasure<ToolbarOverflowPanel>(SpacingProperty);
+    }
+
+    private readonly List<Control> _items = new();
+    private readonly List<Control> _overflowedItems = new();
+    private readonly Dictionary<Control, double> _naturalWidths = new();
+    private double _expandedRowWidth = double.NaN;
+    private bool _labelsCollapsed;
+
+    public double Spacing
+    {
+        get => GetValue(SpacingProperty);
+        set => SetValue(SpacingProperty, value);
+    }
+
+    public Control? OverflowControl { get; set; }
+
+    public Action<bool>? LabelCollapseRequested { get; set; }
+
+    public IReadOnlyList<Control> OverflowedItems => _overflowedItems;
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        CollectItems();
+
+        double height = MeasureChildren(availableSize.Height);
+
+        if (UpdateLabelState(availableSize.Width))
+            height = Math.Max(height, MeasureChildren(availableSize.Height));
+
+        ApplyOverflow(availableSize.Width);
+        height = Math.Max(height, MeasureChildren(availableSize.Height));
+
+        double used = UsedWidth();
+        return new Size(double.IsInfinity(availableSize.Width) ? used : Math.Min(used, availableSize.Width), height);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        CollectItems();
+
+        double x = 0;
+        foreach (var item in _items)
+        {
+            if (!item.IsVisible)
+            {
+                item.Arrange(new Rect(x, 0, 0, 0));
+                continue;
+            }
+
+            double itemWidth = NaturalWidthOf(item);
+            item.Arrange(new Rect(x, 0, itemWidth, finalSize.Height));
+            x += itemWidth + Spacing;
+        }
+
+        if (OverflowControl is { } overflow)
+        {
+            double overflowWidth = overflow.IsVisible ? NaturalWidthOf(overflow) : 0;
+            overflow.Arrange(new Rect(x, 0, overflowWidth, overflowWidth > 0 ? finalSize.Height : 0));
+        }
+
+        return finalSize;
+    }
+
+    private void CollectItems()
+    {
+        _items.Clear();
+        foreach (var child in Children)
+        {
+            if (ReferenceEquals(child, OverflowControl)) continue;
+            _items.Add(child);
+        }
+    }
+
+    private double MeasureChildren(double availableHeight)
+    {
+        double height = 0;
+
+        foreach (var item in _items)
+        {
+            MeasureNaturalWidth(item, availableHeight);
+            height = Math.Max(height, item.DesiredSize.Height);
+        }
+
+        if (OverflowControl is { } overflow)
+        {
+            MeasureNaturalWidth(overflow, availableHeight);
+            height = Math.Max(height, overflow.DesiredSize.Height);
+        }
+
+        return height;
+    }
+
+    private void MeasureNaturalWidth(Control control, double availableHeight)
+    {
+        if (!control.IsVisible) return;
+
+        control.Measure(new Size(double.PositiveInfinity, availableHeight));
+        _naturalWidths[control] = control.DesiredSize.Width;
+    }
+
+    private double NaturalWidthOf(Control control)
+        => _naturalWidths.GetValueOrDefault(control);
+
+    private double RowWidth()
+    {
+        double total = 0;
+        for (int i = 0; i < _items.Count; i++)
+        {
+            if (i > 0) total += Spacing;
+            total += NaturalWidthOf(_items[i]);
+        }
+        return total;
+    }
+
+    private double UsedWidth()
+    {
+        double total = 0;
+        foreach (var item in _items)
+        {
+            if (!item.IsVisible) continue;
+            if (total > 0) total += Spacing;
+            total += NaturalWidthOf(item);
+        }
+
+        if (OverflowControl is { IsVisible: true } overflow)
+        {
+            if (total > 0) total += Spacing;
+            total += NaturalWidthOf(overflow);
+        }
+
+        return total;
+    }
+
+    private bool UpdateLabelState(double availableWidth)
+    {
+        if (double.IsInfinity(availableWidth) || availableWidth <= 1 || LabelCollapseRequested is null) return false;
+
+        double rowWidth = RowWidth();
+
+        if (!_labelsCollapsed)
+        {
+            _expandedRowWidth = rowWidth;
+            if (rowWidth <= availableWidth + 0.5) return false;
+            ApplyLabelState(true);
+            return true;
+        }
+
+        if (double.IsNaN(_expandedRowWidth) || _expandedRowWidth > availableWidth - 0.5) return false;
+        ApplyLabelState(false);
+        return true;
+    }
+
+    private void ApplyLabelState(bool collapsed)
+    {
+        _labelsCollapsed = collapsed;
+        LabelCollapseRequested?.Invoke(collapsed);
+
+        _overflowedItems.Clear();
+        foreach (var item in _items)
+        {
+            item.IsVisible = true;
+            _naturalWidths.Remove(item);
+            InvalidateMeasureTree(item);
+        }
+    }
+
+    private static void InvalidateMeasureTree(Control control)
+    {
+        control.InvalidateMeasure();
+        foreach (var descendant in control.GetVisualDescendants())
+        {
+            if (descendant is Layoutable layoutable) layoutable.InvalidateMeasure();
+        }
+    }
+
+    private void ApplyOverflow(double availableWidth)
+    {
+        _overflowedItems.Clear();
+        int shownCount = CountFittingItems(availableWidth);
+
+        for (int i = 0; i < _items.Count; i++)
+        {
+            bool shown = i < shownCount;
+            _items[i].IsVisible = shown;
+            if (!shown) _overflowedItems.Add(_items[i]);
+        }
+
+        if (OverflowControl is { } overflow)
+            overflow.IsVisible = _overflowedItems.Exists(item => item is not Separator);
+    }
+
+    private int CountFittingItems(double availableWidth)
+    {
+        if (double.IsInfinity(availableWidth) || RowWidth() <= availableWidth + 0.5) return _items.Count;
+
+        double budget = availableWidth
+                        - (OverflowControl is { } overflow ? NaturalWidthOf(overflow) + Spacing : 0);
+        double used = 0;
+        int count = 0;
+
+        foreach (var item in _items)
+        {
+            double itemWidth = NaturalWidthOf(item) + (count > 0 ? Spacing : 0);
+            if (used + itemWidth > budget) break;
+            used += itemWidth;
+            count++;
+        }
+
+        while (count > 0 && _items[count - 1] is Separator) count--;
+        return count;
+    }
+}

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml
@@ -209,16 +209,20 @@
             </StackPanel>
 
             <!-- Toolbar (AppBarButtons added by subclass) -->
-            <ItemsControl x:Name="ToolBar"
-                          Grid.Column="2"
-                          HorizontalAlignment="Left"
-                          ItemsSource="{Binding ToolBarItems}">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <StackPanel Orientation="Horizontal" Spacing="4"/>
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-            </ItemsControl>
+            <controls:ToolbarOverflowPanel x:Name="ToolBar"
+                                           Grid.Column="2"
+                                           Spacing="4"
+                                           ClipToBounds="True">
+                <Button x:Name="ToolbarOverflowButton"
+                        Width="40" Height="40"
+                        Padding="0"
+                        CornerRadius="4"
+                        automation:AutomationProperties.Name="{t:Translate More options}">
+                    <TextBlock Text="···" FontSize="20"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Margin="0,-4,0,0"/>
+                </Button>
+            </controls:ToolbarOverflowPanel>
 
         </Grid>
 

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/AbstractPackagesPage.axaml.cs
@@ -41,6 +41,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
     private double? _overlayRestingOffsetX;
     private static readonly SplineEasing FluentEntranceEasing = new(0.1, 0.9, 0.2, 1.0);
     private static readonly TimeSpan FilterAnimationDuration = TimeSpan.FromMilliseconds(300);
+    private readonly MenuFlyout _toolbarOverflowFlyout = new();
 
     protected AbstractPackagesPage(PackagesPageData data)
     {
@@ -96,6 +97,7 @@ public abstract partial class AbstractPackagesPage : UserControl,
 
         // Build the toolbar now that both AXAML controls and the ViewModel are ready
         GenerateToolBar(ViewModel);
+        InitializeToolbarOverflow();
 
         // Double-click a list row → show details
         PackageList.DoubleTapped += (_, e) =>
@@ -161,14 +163,6 @@ public abstract partial class AbstractPackagesPage : UserControl,
         // Responsive: switch between inline and overlay modes based on content width.
         FilteringPanel.GetObservable(BoundsProperty)
             .SubscribeValue(bounds => OnFilteringPanelWidthChanged(bounds.Width));
-
-        // Responsive: collapse the menu bar to icon-only on narrow windows so the
-        // toolbar buttons stay reachable instead of overflowing (mirrors WinUI).
-        this.GetObservable(BoundsProperty)
-            .SubscribeValue(bounds => UpdateToolbarLayout(bounds.Width));
-        Loaded += (_, _) => Dispatcher.UIThread.Post(
-            () => UpdateToolbarLayout(Bounds.Width),
-            DispatcherPriority.Loaded);
 
         // Grid/icons views: stretch cards to fill each row then reflow (mirrors WinUI's
         // UniformGridLayout) instead of leaving wasted space to the right.
@@ -238,10 +232,43 @@ public abstract partial class AbstractPackagesPage : UserControl,
         ViewModel.IconCardWidth = Math.Floor(availableWidth / columns);
     }
 
-    private void UpdateToolbarLayout(double availableWidth)
+    private void InitializeToolbarOverflow()
     {
-        if (availableWidth <= 0) return;
-        ViewModel.SetToolbarLabelsCollapsed(availableWidth < 900);
+        ToolBar.OverflowControl = ToolbarOverflowButton;
+        ToolBar.LabelCollapseRequested = ViewModel.SetToolbarLabelsCollapsed;
+
+        ToolBar.Children.Remove(ToolbarOverflowButton);
+        foreach (var entry in ViewModel.ToolbarEntries)
+            ToolBar.Children.Add(entry.Control);
+        ToolBar.Children.Add(ToolbarOverflowButton);
+
+        _toolbarOverflowFlyout.Opening += (_, _) => PopulateToolbarOverflowFlyout();
+        ToolbarOverflowButton.Flyout = _toolbarOverflowFlyout;
+    }
+
+    private void PopulateToolbarOverflowFlyout()
+    {
+        var items = new List<object>();
+        foreach (var control in ToolBar.OverflowedItems)
+        {
+            var entry = ViewModel.ToolbarEntries.FirstOrDefault(e => ReferenceEquals(e.Control, control));
+            if (entry is null) continue;
+
+            if (entry.Invoke is not { } invoke)
+            {
+                if (items.Count > 0 && items[^1] is not Separator) items.Add(new Separator());
+                continue;
+            }
+
+            var item = new MenuItem { Header = entry.Label, Icon = LoadMenuIcon(entry.IconName) };
+            item.Click += (_, _) => invoke();
+            items.Add(item);
+        }
+
+        while (items.Count > 0 && items[^1] is Separator) items.RemoveAt(items.Count - 1);
+
+        _toolbarOverflowFlyout.Items.Clear();
+        foreach (var item in items) _toolbarOverflowFlyout.Items.Add(item);
     }
 
     // ─── UI-only: focus the package list ─────────────────────────────────────

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/SoftwareUpdatesPage.cs
@@ -109,11 +109,6 @@ public class SoftwareUpdatesPage : AbstractPackagesPage
         ViewModel.AddToolbarButton("clipboard_list", CoreTools.Translate("Manage ignored updates"),
             () => vm.RequestManageIgnoredCommand.Execute(null));
         ViewModel.AddToolbarSeparator();
-        ViewModel.AddToolbarButton("sandclock", CoreTools.Translate("Automatically update selected packages"),
-            () => MarkForAutoUpdates(vm.FilteredPackages.GetCheckedPackages()));
-        ViewModel.AddToolbarButton("clipboard_list", CoreTools.Translate("Manage automatic updates"),
-            () => vm.RequestManageAutoUpdatesCommand.Execute(null));
-        ViewModel.AddToolbarSeparator();
         ViewModel.AddToolbarButton("save_as", CoreTools.Translate("Export to CSV"),
             () => _ = ExportPackagesToCsvAsync());
     }


### PR DESCRIPTION
This pull request introduces a responsive, overflow-aware toolbar for the packages page, replacing the previous static horizontal toolbar. The new implementation ensures toolbar buttons remain accessible on narrow windows by collapsing labels and moving excess buttons into an overflow menu. Major changes involve both the ViewModel and View, including a new `ToolbarOverflowPanel` control, a new `ToolbarEntry` abstraction, and logic to manage overflowed items.

**Toolbar Responsiveness and Overflow Handling:**

* Added a new `ToolbarOverflowPanel` control (`ToolbarOverflowPanel.cs`) that dynamically arranges toolbar items, collapses labels when space is limited, and moves items into an overflow menu as needed.
* Updated the toolbar in the view (`AbstractPackagesPage.axaml` and `.axaml.cs`) to use `ToolbarOverflowPanel`, added an overflow button, and implemented logic to populate the overflow menu with hidden toolbar items.

**ViewModel Adjustments:**

* Introduced a new `ToolbarEntry` record to represent toolbar items, replacing the previous use of `ToolBarItems` with a strongly-typed `ToolbarEntries` list. 
* Updated toolbar button and separator creation methods to use `ToolbarEntry` and the new list. 

**Code Cleanup and Refactoring:**

* Removed old responsive toolbar code that collapsed labels based on window width, now handled by the new panel and its callbacks.
* Cleaned up toolbar button definitions in `SoftwareUpdatesPage.cs` for consistency with the new system.