### PR TITLE
Update Pinget to version 0.12.0

### DIFF
--- a/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
+++ b/src/UniGetUI.Avalonia/UniGetUI.Avalonia.csproj
@@ -198,7 +198,7 @@
         <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
         <PackageReference Include="Devolutions.UniGetUI.Elevator" Version="2.6.1.3" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
-        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.11.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
+        <PackageReference Include="Devolutions.Pinget.Cli.Rust" Version="0.12.0" GeneratePathProperty="true" ExcludeAssets="build;buildTransitive;native" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/UniGetUI.PackageEngine.Managers.WinGet.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Devolutions.Pinget.Core" Version="0.11.0" />
+        <PackageReference Include="Devolutions.Pinget.Core" Version="0.12.0" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### What was broken

On machines where `winget.exe` isn't resolvable by name, the WinGet section came up empty. Pinget shells out to the system WinGet for source operations, and `list` propagated a failed source refresh:

Manager WinGet failed to list installed packages with exception InvalidOperationException: Pinget exited with code 1:
error: failed to run winget source command: program not found

Sources still listed fine (they answer from the store loaded at open), which is why the report shows WinGet "ready" with zero packages.

### Why this PR is two lines

The fix belongs in Pinget, and it shipped there in 0.12.0
(Devolutions/pinget#44):

- WinGet is resolved past the PATH — `PINGET_WINGET_PATH`, the running executable's directory and the PATH exactly as before, then the App Execution Alias directory and the newest registered App Installer package. Only the last two are new, so a machine that already worked resolves the very same executable.
- A query that cannot re-mirror the sources keeps the mirror it cached earlier and reports a warning instead of failing. Commands that *change* sources still fail loudly, since they have to see the real source list.
- `list`/`upgrade` re-export at most every 15 minutes instead of spawning WinGet on every enumeration.