### PR TITLE
Update WinGet catalog snapshot and ensure successful index refresh

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs
@@ -448,17 +448,25 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
 
     private IReadOnlyList<CatalogPackage> GetCachedLocalWinGetPackages(int? cacheSeconds = null)
     {
-        if (_localPackagesProvider is not null)
-        {
-            return _localPackagesProvider();
-        }
+        long sourceIndexGeneration = WinGet.SourceIndexGeneration;
 
         return cacheSeconds is null
-            ? TaskRecycler<IReadOnlyList<CatalogPackage>>.RunOrAttach(GetLocalWinGetPackages)
+            ? TaskRecycler<IReadOnlyList<CatalogPackage>>.RunOrAttach(
+                EnumerateLocalWinGetPackages,
+                sourceIndexGeneration
+            )
             : TaskRecycler<IReadOnlyList<CatalogPackage>>.RunOrAttach(
-                GetLocalWinGetPackages,
+                EnumerateLocalWinGetPackages,
+                sourceIndexGeneration,
                 cacheSeconds.Value
             );
+    }
+
+    private IReadOnlyList<CatalogPackage> EnumerateLocalWinGetPackages(long sourceIndexGeneration)
+    {
+        return _localPackagesProvider is not null
+            ? _localPackagesProvider()
+            : GetLocalWinGetPackages();
     }
 
     private IReadOnlyList<Package> GetAvailableUpdatesFromSystemCli(Exception ex)

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -92,6 +92,13 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             }
         }
 
+        private static long _sourceIndexGeneration;
+
+        internal static long SourceIndexGeneration => Volatile.Read(ref _sourceIndexGeneration);
+
+        internal static void MarkSourceIndexRefreshed() =>
+            Interlocked.Increment(ref _sourceIndexGeneration);
+
         public WinGet()
         {
             Capabilities = new ManagerCapabilities
@@ -811,12 +818,19 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                 p.StartInfo.Environment["TMP"] = WinGetTemp;
             }
 
-            p.Start();
-            logger.AddToStdOut(p.StandardOutput.ReadToEnd());
-            logger.AddToStdErr(p.StandardError.ReadToEnd());
-            logger.Close(p.ExitCode);
-            p.WaitForExit();
-            p.Close();
+            try
+            {
+                p.Start();
+                logger.AddToStdOut(p.StandardOutput.ReadToEnd());
+                logger.AddToStdErr(p.StandardError.ReadToEnd());
+                logger.Close(p.ExitCode);
+                p.WaitForExit();
+                p.Close();
+            }
+            finally
+            {
+                MarkSourceIndexRefreshed();
+            }
         }
 
         private string GetCliToolProxyArgument()

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
@@ -329,7 +329,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                 }
         }
 
-        private bool RefreshPackageIndexesSafely()
+        private void RefreshPackageIndexesSafely()
         {
             try
             {
@@ -342,7 +342,6 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                     "RefreshPackageIndexes",
                     allowDisablingTimeout: false
                 );
-                return true;
             }
             catch (Exception e)
             {
@@ -354,7 +353,6 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                         + $"({e.GetType().Name}: {e.Message}). The available updates will be listed "
                         + "with the indexes as they are, which may result in an incomplete list."
                 );
-                return false;
             }
         }
 
@@ -453,25 +451,21 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         public IReadOnlyList<IPackage> GetAvailableUpdates()
         {
             LastUpdatesListingFailed = false;
-            return _getAvailableUpdates(false, indexesAlreadyRefreshed: false);
+            return _getAvailableUpdates(false);
         }
 
-        private IReadOnlyList<IPackage> _getAvailableUpdates(
-            bool SecondAttempt,
-            bool indexesAlreadyRefreshed
-        )
+        private IReadOnlyList<IPackage> _getAvailableUpdates(bool SecondAttempt)
         {
             if (!IsReady())
             {
                 Logger.Warn($"Manager {Name} is disabled but yet GetAvailableUpdates was called");
                 return [];
             }
-            bool indexesRefreshed = indexesAlreadyRefreshed;
             try
             {
-                if (!indexesAlreadyRefreshed)
+                if (!SecondAttempt)
                 {
-                    indexesRefreshed = RefreshPackageIndexesSafely();
+                    RefreshPackageIndexesSafely();
                 }
 
                 var packages = RunListingTaskWithTimeout(
@@ -495,7 +489,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                         $"Since this was the first attempt, {Name}.AttemptFastRepair() will be called and the procedure will be restarted"
                     );
                     AttemptFastRepair();
-                    return _getAvailableUpdates(true, indexesRefreshed);
+                    return _getAvailableUpdates(true);
                 }
 
                 Logger.Error("Error finding updates on manager " + Name);

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
@@ -329,7 +329,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                 }
         }
 
-        private void RefreshPackageIndexesSafely()
+        private bool RefreshPackageIndexesSafely()
         {
             try
             {
@@ -342,6 +342,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                     "RefreshPackageIndexes",
                     allowDisablingTimeout: false
                 );
+                return true;
             }
             catch (Exception e)
             {
@@ -353,6 +354,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                         + $"({e.GetType().Name}: {e.Message}). The available updates will be listed "
                         + "with the indexes as they are, which may result in an incomplete list."
                 );
+                return false;
             }
         }
 
@@ -451,19 +453,26 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         public IReadOnlyList<IPackage> GetAvailableUpdates()
         {
             LastUpdatesListingFailed = false;
-            return _getAvailableUpdates(false);
+            return _getAvailableUpdates(false, indexesAlreadyRefreshed: false);
         }
 
-        private IReadOnlyList<IPackage> _getAvailableUpdates(bool SecondAttempt)
+        private IReadOnlyList<IPackage> _getAvailableUpdates(
+            bool SecondAttempt,
+            bool indexesAlreadyRefreshed
+        )
         {
             if (!IsReady())
             {
                 Logger.Warn($"Manager {Name} is disabled but yet GetAvailableUpdates was called");
                 return [];
             }
+            bool indexesRefreshed = indexesAlreadyRefreshed;
             try
             {
-                RefreshPackageIndexesSafely();
+                if (!indexesAlreadyRefreshed)
+                {
+                    indexesRefreshed = RefreshPackageIndexesSafely();
+                }
 
                 var packages = RunListingTaskWithTimeout(
                     GetAvailableUpdates_UnSafe,
@@ -486,7 +495,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
                         $"Since this was the first attempt, {Name}.AttemptFastRepair() will be called and the procedure will be restarted"
                     );
                     AttemptFastRepair();
-                    return _getAvailableUpdates(true);
+                    return _getAvailableUpdates(true, indexesRefreshed);
                 }
 
                 Logger.Error("Error finding updates on manager " + Name);

--- a/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestPackageManager.cs
@@ -14,6 +14,7 @@ public sealed class TestPackageManager : PackageManager
     private Func<string, IReadOnlyList<Package>> _findPackages = _ => [];
     private Func<IReadOnlyList<Package>> _getAvailableUpdates = static () => [];
     private Func<IReadOnlyList<Package>> _getInstalledPackages = static () => [];
+    private Action? _refreshPackageIndexes;
     private IReadOnlyList<string> _candidateExecutableFiles;
 
     public TestPackageManager(string name = "TestManager", string? displayName = null)
@@ -102,6 +103,11 @@ public sealed class TestPackageManager : PackageManager
     public void SetAvailableUpdates(Func<IReadOnlyList<Package>> getAvailableUpdates)
     {
         _getAvailableUpdates = getAvailableUpdates;
+    }
+
+    public void SetRefreshPackageIndexes(Action refreshPackageIndexes)
+    {
+        _refreshPackageIndexes = refreshPackageIndexes;
     }
 
     public void SetInstalledPackages(Func<IReadOnlyList<Package>> getInstalledPackages)
@@ -199,5 +205,6 @@ public sealed class TestPackageManager : PackageManager
     public override void RefreshPackageIndexes()
     {
         RefreshPackageIndexesCalls++;
+        _refreshPackageIndexes?.Invoke();
     }
 }

--- a/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestPackageManager.cs
@@ -14,7 +14,6 @@ public sealed class TestPackageManager : PackageManager
     private Func<string, IReadOnlyList<Package>> _findPackages = _ => [];
     private Func<IReadOnlyList<Package>> _getAvailableUpdates = static () => [];
     private Func<IReadOnlyList<Package>> _getInstalledPackages = static () => [];
-    private Action? _refreshPackageIndexes;
     private IReadOnlyList<string> _candidateExecutableFiles;
 
     public TestPackageManager(string name = "TestManager", string? displayName = null)
@@ -103,11 +102,6 @@ public sealed class TestPackageManager : PackageManager
     public void SetAvailableUpdates(Func<IReadOnlyList<Package>> getAvailableUpdates)
     {
         _getAvailableUpdates = getAvailableUpdates;
-    }
-
-    public void SetRefreshPackageIndexes(Action refreshPackageIndexes)
-    {
-        _refreshPackageIndexes = refreshPackageIndexes;
     }
 
     public void SetInstalledPackages(Func<IReadOnlyList<Package>> getInstalledPackages)
@@ -205,6 +199,5 @@ public sealed class TestPackageManager : PackageManager
     public override void RefreshPackageIndexes()
     {
         RefreshPackageIndexesCalls++;
-        _refreshPackageIndexes?.Invoke();
     }
 }

--- a/src/UniGetUI.PackageEngine.Tests/PackageManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageManagerTests.cs
@@ -266,7 +266,7 @@ public sealed class PackageManagerTests : IDisposable
     }
 
     [Fact]
-    public void GetAvailableUpdatesRetriesOnceAndRefreshesIndexesPerAttempt()
+    public void GetAvailableUpdatesRetriesOnceAndKeepsTheIndexesItAlreadyRefreshed()
     {
         var manager = CreateReadyManager();
         var attempts = 0;
@@ -283,6 +283,28 @@ public sealed class PackageManagerTests : IDisposable
         var package = Assert.Single(packages);
         Assert.Equal("Contoso.Update", package.Id);
         Assert.Equal(1, manager.AttemptFastRepairCalls);
+        Assert.Equal(1, manager.RefreshPackageIndexesCalls);
+    }
+
+    [Fact]
+    public void GetAvailableUpdatesRefreshesIndexesAgainWhenTheFirstRefreshFailed()
+    {
+        var manager = CreateReadyManager();
+        manager.SetRefreshPackageIndexes(
+            () => throw new InvalidOperationException("refresh failed")
+        );
+        var attempts = 0;
+        manager.SetAvailableUpdates(() =>
+        {
+            attempts++;
+            return attempts == 1
+                ? throw new InvalidOperationException("updates failed")
+                : [CreatePackage(manager, "Contoso.Update", "Contoso Update", "1.0.0", "2.0.0")];
+        });
+
+        var packages = manager.GetAvailableUpdates();
+
+        Assert.Single(packages);
         Assert.Equal(2, manager.RefreshPackageIndexesCalls);
     }
 

--- a/src/UniGetUI.PackageEngine.Tests/PackageManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/PackageManagerTests.cs
@@ -266,7 +266,7 @@ public sealed class PackageManagerTests : IDisposable
     }
 
     [Fact]
-    public void GetAvailableUpdatesRetriesOnceAndKeepsTheIndexesItAlreadyRefreshed()
+    public void GetAvailableUpdatesRetriesOnceWithoutRefreshingIndexesAgain()
     {
         var manager = CreateReadyManager();
         var attempts = 0;
@@ -284,28 +284,6 @@ public sealed class PackageManagerTests : IDisposable
         Assert.Equal("Contoso.Update", package.Id);
         Assert.Equal(1, manager.AttemptFastRepairCalls);
         Assert.Equal(1, manager.RefreshPackageIndexesCalls);
-    }
-
-    [Fact]
-    public void GetAvailableUpdatesRefreshesIndexesAgainWhenTheFirstRefreshFailed()
-    {
-        var manager = CreateReadyManager();
-        manager.SetRefreshPackageIndexes(
-            () => throw new InvalidOperationException("refresh failed")
-        );
-        var attempts = 0;
-        manager.SetAvailableUpdates(() =>
-        {
-            attempts++;
-            return attempts == 1
-                ? throw new InvalidOperationException("updates failed")
-                : [CreatePackage(manager, "Contoso.Update", "Contoso Update", "1.0.0", "2.0.0")];
-        });
-
-        var packages = manager.GetAvailableUpdates();
-
-        Assert.Single(packages);
-        Assert.Equal(2, manager.RefreshPackageIndexesCalls);
     }
 
     [Fact]

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -778,6 +778,7 @@ public sealed class WinGetManagerTests : IDisposable
 
         helper.GetInstalledPackages_UnSafe();
         helper.GetAvailableUpdates_UnSafe();
+        helper.GetAvailableUpdates_UnSafe();
 
         Assert.Equal(1, snapshots);
     }

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -736,6 +736,64 @@ public sealed class WinGetManagerTests : IDisposable
     }
 
     [Fact]
+    public void NativeWinGetHelperTakesANewCatalogSnapshotAfterTheSourceIndexIsRefreshed()
+    {
+        WinGet.MarkSourceIndexRefreshed();
+        int snapshots = 0;
+        var helper = new NativeWinGetHelper(
+            new TestableWinGet(),
+            systemCliHelperFactory: null,
+            skipInitialization: true,
+            localPackagesProvider: () =>
+            {
+                snapshots++;
+                return [];
+            }
+        );
+
+        helper.GetInstalledPackages_UnSafe();
+        Assert.Equal(1, snapshots);
+
+        WinGet.MarkSourceIndexRefreshed();
+        helper.GetAvailableUpdates_UnSafe();
+
+        Assert.Equal(2, snapshots);
+    }
+
+    [Fact]
+    public void NativeWinGetHelperReusesTheCatalogSnapshotWhileTheSourceIndexIsUnchanged()
+    {
+        WinGet.MarkSourceIndexRefreshed();
+        int snapshots = 0;
+        var helper = new NativeWinGetHelper(
+            new TestableWinGet(),
+            systemCliHelperFactory: null,
+            skipInitialization: true,
+            localPackagesProvider: () =>
+            {
+                snapshots++;
+                return [];
+            }
+        );
+
+        helper.GetInstalledPackages_UnSafe();
+        helper.GetAvailableUpdates_UnSafe();
+
+        Assert.Equal(1, snapshots);
+    }
+
+    [Fact]
+    public void RefreshPackageIndexesAdvancesTheSourceIndexGenerationWhenTheCliCallFails()
+    {
+        var manager = new TestableWinGet();
+        long generationBefore = WinGet.SourceIndexGeneration;
+
+        Assert.ThrowsAny<Exception>(manager.RefreshPackageIndexes);
+
+        Assert.NotEqual(generationBefore, WinGet.SourceIndexGeneration);
+    }
+
+    [Fact]
     public void NativeWinGetHelperSelectReachableCatalogsSkipsUnavailableSources()
     {
         var reachableCatalogs = NativeWinGetHelper.SelectReachableCatalogs(


### PR DESCRIPTION
This pull request introduces improvements to how package index refreshing and catalog snapshotting are handled in the WinGet package manager integration. The main focus is to ensure that catalog snapshots are only refreshed when the package source index changes, improving efficiency and correctness. Additionally, the retry logic for update retrieval is enhanced to avoid unnecessary index refreshes, and new tests are added to verify these behaviors.

**Catalog snapshotting and source index generation:**
- Introduced a `SourceIndexGeneration` counter in `WinGet`, which is incremented every time package indexes are refreshed (including on failure), and used as a cache key in `NativeWinGetHelper` to ensure catalog snapshots are only refreshed when necessary. (`src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs`, `src/UniGetUI.PackageEngine.Managers.WinGet/ClientHelpers/NativeWinGetHelper.cs`) [[1]](diffhunk://#diff-c5edf1f9e67afdabfdd3506a6233f12e5e8cfd0a078623908926a0c95e94644eR95-R101) [[2]](diffhunk://#diff-c5edf1f9e67afdabfdd3506a6233f12e5e8cfd0a078623908926a0c95e94644eR821-R834) [[3]](diffhunk://#diff-bdb23712bcab86117cd8598aed0c3b29f8dd405dff694085aecd80a8c56ad037L451-R471)

**Update retrieval retry logic:**
- Modified the update retrieval logic in `PackageManager` so that the package indexes are only refreshed once per update attempt, and not redundantly on retries after fast repair; if the first refresh fails, a second attempt will refresh again. (`src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs`) [[1]](diffhunk://#diff-c8b7c924ae50d35de5b89c9483c3acff5000e8c8bc08ac0af2474240e19cf269L332-R332) [[2]](diffhunk://#diff-c8b7c924ae50d35de5b89c9483c3acff5000e8c8bc08ac0af2474240e19cf269R345) [[3]](diffhunk://#diff-c8b7c924ae50d35de5b89c9483c3acff5000e8c8bc08ac0af2474240e19cf269R357) [[4]](diffhunk://#diff-c8b7c924ae50d35de5b89c9483c3acff5000e8c8bc08ac0af2474240e19cf269L454-R475) [[5]](diffhunk://#diff-c8b7c924ae50d35de5b89c9483c3acff5000e8c8bc08ac0af2474240e19cf269L489-R498)

**Testing improvements:**
- Enhanced the `TestPackageManager` fake to allow injection of custom index refresh logic, and added/updated tests to verify catalog snapshotting, index refresh behavior, and retry logic. (`src/UniGetUI.PackageEngine.Tests/Infrastructure/Fakes/TestPackageManager.cs`, `src/UniGetUI.PackageEngine.Tests/PackageManagerTests.cs`, `src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs`) [[1]](diffhunk://#diff-e4c9d4dded47207d41c9941b0ef4126fea653da266247a2d7c16fd2c0423f431R17) [[2]](diffhunk://#diff-e4c9d4dded47207d41c9941b0ef4126fea653da266247a2d7c16fd2c0423f431R108-R112) [[3]](diffhunk://#diff-e4c9d4dded47207d41c9941b0ef4126fea653da266247a2d7c16fd2c0423f431R208) [[4]](diffhunk://#diff-26f61608ce66f6173ca14ab2f77baeb0015a148f2ed1785ba310538747b3c93cL269-R269) [[5]](diffhunk://#diff-26f61608ce66f6173ca14ab2f77baeb0015a148f2ed1785ba310538747b3c93cR286-R307) [[6]](diffhunk://#diff-d63b92b552cd932827027ad5d2bd1c678ca30123dc49ab569341e36440a486f3R738-R796)

These changes make the package manager more efficient and reliable by reducing unnecessary work and improving error handling during update checks.