### PR TITLE
Reset test settings before clearing the data-directory override

### DIFF
--- a/src/UniGetUI.PackageEngine.Tests/OperationCallArgsWiringTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/OperationCallArgsWiringTests.cs
@@ -40,9 +40,9 @@ public sealed class OperationCallArgsWiringTests : IDisposable
 
     public void Dispose()
     {
+        Settings.ResetSettings();
         CoreData.TEST_DataDirectoryOverride = null;
         SecureSettings.TEST_SecureSettingsRootOverride = null;
-        Settings.ResetSettings();
         try
         {
             if (Directory.Exists(_testRoot))

--- a/src/UniGetUI.PackageEngine.Tests/ShimStandardInputTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/ShimStandardInputTests.cs
@@ -53,9 +53,9 @@ public sealed class ShimStandardInputTests : IDisposable
 
     public void Dispose()
     {
+        Settings.ResetSettings();
         CoreData.TEST_DataDirectoryOverride = null;
         SecureSettings.TEST_SecureSettingsRootOverride = null;
-        Settings.ResetSettings();
         try
         {
             if (Directory.Exists(_testRoot))


### PR DESCRIPTION
This pull request makes a minor refactor to the test cleanup logic in the `Dispose` methods of two test classes. The main change is reordering the call to `Settings.ResetSettings()` to ensure it occurs before resetting other test overrides, which may improve test isolation and reliability.

Test cleanup improvements:

* [`src/UniGetUI.PackageEngine.Tests/OperationCallArgsWiringTests.cs`](diffhunk://#diff-7734d0a7f78466a9508bf16615aec2e454cb61e20aa8c471daf5aa02b8da3641R43-L45): Moved the call to `Settings.ResetSettings()` to the start of the `Dispose` method for more predictable test state reset.
* [`src/UniGetUI.PackageEngine.Tests/ShimStandardInputTests.cs`](diffhunk://#diff-f3ff9a9a0e878a911817f837b2b962d596af5fa162d189e15776eb95b1ec3625R56-L58): Likewise, reordered `Settings.ResetSettings()` to be the first statement in the `Dispose` method.