### PR TITLE
Clarify WinGet installer hash mismatches

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -1072,5 +1072,8 @@
   "UniGetUI is running in portable mode and started with empty settings. Settings from a previous installation were found at {0}.": "UniGetUI is running in portable mode and started with empty settings. Settings from a previous installation were found at {0}.",
   "Settings imported": "Settings imported",
   "{0} file(s) were copied. Restart UniGetUI to apply them.": "{0} file(s) were copied. Restart UniGetUI to apply them.",
-  "Could not import settings": "Could not import settings"
+  "Could not import settings": "Could not import settings",
+  "The installer for {package} does not match the hash published in its manifest, and WinGet refuses to skip that check while running as administrator": "The installer for {package} does not match the hash published in its manifest, and WinGet refuses to skip that check while running as administrator",
+  "The installer for {package} does not match the hash published in its manifest; WinGet only skips that check once its InstallerHashOverride administrator setting is enabled": "The installer for {package} does not match the hash published in its manifest; WinGet only skips that check once its InstallerHashOverride administrator setting is enabled",
+  "The installer for {package} does not match the hash published in its manifest, so it was not run": "The installer for {package} does not match the hash published in its manifest, so it was not run"
 }

--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -1073,7 +1073,7 @@
   "Settings imported": "Settings imported",
   "{0} file(s) were copied. Restart UniGetUI to apply them.": "{0} file(s) were copied. Restart UniGetUI to apply them.",
   "Could not import settings": "Could not import settings",
-  "The installer for {package} does not match the hash published in its manifest, and WinGet refuses to skip that check while running as administrator": "The installer for {package} does not match the hash published in its manifest, and WinGet refuses to skip that check while running as administrator",
-  "The installer for {package} does not match the hash published in its manifest; WinGet only skips that check once its InstallerHashOverride administrator setting is enabled": "The installer for {package} does not match the hash published in its manifest; WinGet only skips that check once its InstallerHashOverride administrator setting is enabled",
-  "The installer for {package} does not match the hash published in its manifest, so it was not run": "The installer for {package} does not match the hash published in its manifest, so it was not run"
+  "The installer for {package} does not match the hash in its manifest": "The installer for {package} does not match the hash in its manifest",
+  "The package manifest is likely out of date. WinGet cannot skip this check while running as administrator.": "The package manifest is likely out of date. WinGet cannot skip this check while running as administrator.",
+  "The package manifest is likely out of date. Skipping this check requires WinGet's InstallerHashOverride administrator setting.": "The package manifest is likely out of date. Skipping this check requires WinGet's InstallerHashOverride administrator setting."
 }

--- a/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryActionService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryActionService.cs
@@ -55,8 +55,9 @@ internal static class OperationHistoryActionService
         var options = LoadOptions(record);
         bool asAdmin = manager.Capabilities.CanRunAsAdmin && !options.RunAsAdministrator;
         bool interactive = manager.Capabilities.CanRunInteractively && !options.InteractiveInstallation;
-        bool skipHash = manager.Capabilities.CanSkipIntegrityChecks && !options.SkipHashCheck
-                        && record.Role != (int)OperationType.Uninstall;
+        bool skipHash = PackageOperation.CanRetrySkippingIntegrityChecks(
+            manager, options, (OperationType)record.Role,
+            CoreTools.IsAdministrator() || options.RunAsAdministrator);
         return (asAdmin, interactive, skipHash);
     }
 

--- a/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryActionService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryActionService.cs
@@ -56,8 +56,8 @@ internal static class OperationHistoryActionService
         bool asAdmin = manager.Capabilities.CanRunAsAdmin && !options.RunAsAdministrator;
         bool interactive = manager.Capabilities.CanRunInteractively && !options.InteractiveInstallation;
         bool skipHash = PackageOperation.CanRetrySkippingIntegrityChecks(
-            manager, options, (OperationType)record.Role,
-            CoreTools.IsAdministrator() || options.RunAsAdministrator);
+                            manager, options, CoreTools.IsAdministrator() || options.RunAsAdministrator)
+                        && record.Role != (int)OperationType.Uninstall;
         return (asAdmin, interactive, skipHash);
     }
 

--- a/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryActionService.cs
+++ b/src/UniGetUI.Avalonia/Infrastructure/OperationHistoryActionService.cs
@@ -56,7 +56,8 @@ internal static class OperationHistoryActionService
         bool asAdmin = manager.Capabilities.CanRunAsAdmin && !options.RunAsAdministrator;
         bool interactive = manager.Capabilities.CanRunInteractively && !options.InteractiveInstallation;
         bool skipHash = PackageOperation.CanRetrySkippingIntegrityChecks(
-                            manager, options, CoreTools.IsAdministrator() || options.RunAsAdministrator)
+                            manager, options, (OperationType)record.Role,
+                            record.RanElevated ?? (CoreTools.IsAdministrator() || options.RunAsAdministrator))
                         && record.Role != (int)OperationType.Uninstall;
         return (asAdmin, interactive, skipHash);
     }

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
@@ -267,7 +267,7 @@ public sealed partial class OperationViewModel : ViewModelBase
                         () => Operation.Retry(AbstractOperation.RetryMode.Retry_Interactive)));
 
                 if (PackageOperation.CanRetrySkippingIntegrityChecks(
-                        pkgOp.Package.Manager, pkgOp.Options, pkgOp.WillRunElevated))
+                        pkgOp.Package.Manager, pkgOp.Options, pkgOp.Role, pkgOp.WillRunElevated))
                     OpMenu.Items.Add(Item("Retry skipping integrity checks", "checksum.svg", true,
                         () => Operation.Retry(AbstractOperation.RetryMode.Retry_SkipIntegrity)));
             }

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
@@ -266,7 +266,8 @@ public sealed partial class OperationViewModel : ViewModelBase
                     OpMenu.Items.Add(Item("Retry interactively", "interactive.svg", true,
                         () => Operation.Retry(AbstractOperation.RetryMode.Retry_Interactive)));
 
-                if (!pkgOp.Options.SkipHashCheck && caps.CanSkipIntegrityChecks)
+                if (PackageOperation.CanRetrySkippingIntegrityChecks(
+                        pkgOp.Package.Manager, pkgOp.Options, pkgOp.Role, pkgOp.WillRunElevated))
                     OpMenu.Items.Add(Item("Retry skipping integrity checks", "checksum.svg", true,
                         () => Operation.Retry(AbstractOperation.RetryMode.Retry_SkipIntegrity)));
             }

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
@@ -267,7 +267,7 @@ public sealed partial class OperationViewModel : ViewModelBase
                         () => Operation.Retry(AbstractOperation.RetryMode.Retry_Interactive)));
 
                 if (PackageOperation.CanRetrySkippingIntegrityChecks(
-                        pkgOp.Package.Manager, pkgOp.Options, pkgOp.Role, pkgOp.WillRunElevated))
+                        pkgOp.Package.Manager, pkgOp.Options, pkgOp.WillRunElevated))
                     OpMenu.Items.Add(Item("Retry skipping integrity checks", "checksum.svg", true,
                         () => Operation.Retry(AbstractOperation.RetryMode.Retry_SkipIntegrity)));
             }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -101,7 +101,7 @@ public partial class OperationFailedDialog : UniGetUI.Avalonia.Views.DialogPages
                     () => { operation.Retry(AbstractOperation.RetryMode.Retry_Interactive); Close(); }));
 
             if (PackageOperation.CanRetrySkippingIntegrityChecks(
-                    pkgOp.Package.Manager, pkgOp.Options, pkgOp.Role, pkgOp.WillRunElevated))
+                    pkgOp.Package.Manager, pkgOp.Options, pkgOp.WillRunElevated))
                 retryOptions.Add(MenuItem(CoreTools.Translate("Retry skipping integrity checks"),
                     () => { operation.Retry(AbstractOperation.RetryMode.Retry_SkipIntegrity); Close(); }));
         }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -101,7 +101,7 @@ public partial class OperationFailedDialog : UniGetUI.Avalonia.Views.DialogPages
                     () => { operation.Retry(AbstractOperation.RetryMode.Retry_Interactive); Close(); }));
 
             if (PackageOperation.CanRetrySkippingIntegrityChecks(
-                    pkgOp.Package.Manager, pkgOp.Options, pkgOp.WillRunElevated))
+                    pkgOp.Package.Manager, pkgOp.Options, pkgOp.Role, pkgOp.WillRunElevated))
                 retryOptions.Add(MenuItem(CoreTools.Translate("Retry skipping integrity checks"),
                     () => { operation.Retry(AbstractOperation.RetryMode.Retry_SkipIntegrity); Close(); }));
         }

--- a/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/OperationFailedDialog.axaml.cs
@@ -100,7 +100,8 @@ public partial class OperationFailedDialog : UniGetUI.Avalonia.Views.DialogPages
                 retryOptions.Add(MenuItem(CoreTools.Translate("Retry interactively"),
                     () => { operation.Retry(AbstractOperation.RetryMode.Retry_Interactive); Close(); }));
 
-            if (!pkgOp.Options.SkipHashCheck && caps.CanSkipIntegrityChecks)
+            if (PackageOperation.CanRetrySkippingIntegrityChecks(
+                    pkgOp.Package.Manager, pkgOp.Options, pkgOp.Role, pkgOp.WillRunElevated))
                 retryOptions.Add(MenuItem(CoreTools.Translate("Retry skipping integrity checks"),
                     () => { operation.Retry(AbstractOperation.RetryMode.Retry_SkipIntegrity); Close(); }));
         }

--- a/src/UniGetUI.Interface.IpcApi/IpcOperationApi.cs
+++ b/src/UniGetUI.Interface.IpcApi/IpcOperationApi.cs
@@ -407,6 +407,7 @@ public static class IpcOperationApi
                     PackageOperation.CanRetrySkippingIntegrityChecks(
                         packageOperation.Package.Manager,
                         packageOperation.Options,
+                        packageOperation.Role,
                         packageOperation.WillRunElevated
                     )
                 )

--- a/src/UniGetUI.Interface.IpcApi/IpcOperationApi.cs
+++ b/src/UniGetUI.Interface.IpcApi/IpcOperationApi.cs
@@ -404,8 +404,12 @@ public static class IpcOperationApi
                 }
 
                 if (
-                    !packageOperation.Options.SkipHashCheck
-                    && packageOperation.Package.Manager.Capabilities.CanSkipIntegrityChecks
+                    PackageOperation.CanRetrySkippingIntegrityChecks(
+                        packageOperation.Package.Manager,
+                        packageOperation.Options,
+                        packageOperation.Role,
+                        packageOperation.WillRunElevated
+                    )
                 )
                 {
                     retryModes.Add("retry-no-hash-check");

--- a/src/UniGetUI.Interface.IpcApi/IpcOperationApi.cs
+++ b/src/UniGetUI.Interface.IpcApi/IpcOperationApi.cs
@@ -407,7 +407,6 @@ public static class IpcOperationApi
                     PackageOperation.CanRetrySkippingIntegrityChecks(
                         packageOperation.Package.Manager,
                         packageOperation.Options,
-                        packageOperation.Role,
                         packageOperation.WillRunElevated
                     )
                 )

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Helpers/WinGetPkgOperationHelper.cs
@@ -292,8 +292,8 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             return OperationVeredict.AutoRetry;
         }
 
-        if (uintCode is 0x8A150011)
-        { // TODO: Integrity failed
+        if (ReportedInstallerHashMismatch(returnCode))
+        {
             return OperationVeredict.Failure;
         }
 
@@ -429,6 +429,9 @@ internal sealed class WinGetPkgOperationHelper : BasePkgOperationHelper
             $"{count}{AttemptSeparator}{version}"
         );
     }
+
+    internal static bool ReportedInstallerHashMismatch(int returnCode) =>
+        (uint)returnCode is 0x8A150011;
 
     internal bool ReportedUpdateNotApplicable(
         IReadOnlyList<string> processOutput,

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -253,6 +253,12 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                 && helper.ReportedUpdateNotApplicable(processOutput, returnCode);
         }
 
+        public bool ReportedInstallerHashMismatch(int returnCode) =>
+            WinGetPkgOperationHelper.ReportedInstallerHashMismatch(returnCode);
+
+        public bool HonorsIntegrityCheckSkipWhenElevated =>
+            SelectedCliToolKind is WinGetCliToolKind.BundledPinget;
+
         protected override IReadOnlyList<Package> FindPackages_UnSafe(string query)
         {
             return WinGetHelper.Instance.FindPackages_UnSafe(query);

--- a/src/UniGetUI.PackageEngine.Operations/History/OperationHistoryRecord.cs
+++ b/src/UniGetUI.PackageEngine.Operations/History/OperationHistoryRecord.cs
@@ -38,6 +38,11 @@ public sealed class OperationHistoryRecord
     public string OptionsJson { get; set; } = "";
     /// <summary>Process exit code, when the operation ran a process (null otherwise).</summary>
     public int? ExitCode { get; set; }
+    /// <summary>
+    /// Whether the operation actually ran elevated, for package operations. Null on records
+    /// written before this was tracked, and for operations that never ran a process.
+    /// </summary>
+    public bool? RanElevated { get; set; }
     /// <summary>Short human-readable reason, derived from the last error line (mainly for failures).</summary>
     public string FailureSummary { get; set; } = "";
     public List<OperationHistoryOutputLine> Output { get; set; } = [];
@@ -93,6 +98,7 @@ public sealed class OperationHistoryRecord
                         _ => pop.Package.VersionString,
                     };
                     record.OptionsJson = pop.Options.AsJsonString();
+                    record.RanElevated = pop.WillRunElevated;
                     break;
                 case DownloadOperation dop:
                     record.PackageId = dop.Package.Id;

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -148,20 +148,23 @@ namespace UniGetUI.PackageEngine.Operations
             !Settings.Get(Settings.K.ProhibitElevation)
             && (Package.OverridenOptions.RunAsAdministrator is true || Options.RunAsAdministrator);
 
+        private volatile int _ranElevated = -1;
+
         public virtual bool WillRunElevated =>
-            CoreTools.IsAdministrator() || RequiresAdminRights();
+            _ranElevated switch
+            {
+                1 => true,
+                0 => false,
+                _ => CoreTools.IsAdministrator() || RequiresAdminRights(),
+            };
 
         public static bool CanRetrySkippingIntegrityChecks(
             IPackageManager manager,
             InstallOptions options,
-            OperationType role,
             bool willRunElevated
         )
         {
             if (!manager.Capabilities.CanSkipIntegrityChecks || options.SkipHashCheck)
-                return false;
-
-            if (role is OperationType.Uninstall)
                 return false;
 
             return !willRunElevated || IntegrityCheckSkipSurvivesElevation(manager);
@@ -270,6 +273,8 @@ namespace UniGetUI.PackageEngine.Operations
             process.StartInfo.StandardOutputEncoding = Package.Manager.OutputEncoding;
             process.StartInfo.StandardErrorEncoding = Package.Manager.OutputEncoding;
 
+            _ranElevated = IsAdmin ? 1 : 0;
+
             ApplyCapabilities(
                 IsAdmin,
                 Options.InteractiveInstallation,
@@ -339,6 +344,7 @@ namespace UniGetUI.PackageEngine.Operations
             Package.Manager.OperationHelper.ApplyElevationRequirements(Package, Options, Role);
 
             bool requestElevated = RequiresAdminRights();
+            _ranElevated = requestElevated ? 1 : 0;
             using var client = CreateBrokerClient(requestElevated);
 
             // Check broker availability. Brokered operations must not fall back to local
@@ -963,29 +969,21 @@ namespace UniGetUI.PackageEngine.Operations
             if (!winget.ReportedInstallerHashMismatch(returnCode))
                 return;
 
-            var placeholders = new Dictionary<string, object?> { { "package", Package.Name } };
+            Metadata.FailureMessage = CoreTools.Translate(
+                "The installer for {package} does not match the hash in its manifest",
+                new Dictionary<string, object?> { { "package", Package.Name } }
+            );
 
-            if (WillRunElevated && !winget.HonorsIntegrityCheckSkipWhenElevated)
-            {
-                Metadata.FailureMessage = CoreTools.Translate(
-                    "The installer for {package} does not match the hash published in its manifest, and WinGet refuses to skip that check while running as administrator",
-                    placeholders
-                );
-            }
-            else if (Options.SkipHashCheck)
-            {
-                Metadata.FailureMessage = CoreTools.Translate(
-                    "The installer for {package} does not match the hash published in its manifest; WinGet only skips that check once its InstallerHashOverride administrator setting is enabled",
-                    placeholders
-                );
-            }
-            else
-            {
-                Metadata.FailureMessage = CoreTools.Translate(
-                    "The installer for {package} does not match the hash published in its manifest, so it was not run",
-                    placeholders
-                );
-            }
+            Line(
+                WillRunElevated && !winget.HonorsIntegrityCheckSkipWhenElevated
+                    ? CoreTools.Translate(
+                        "The package manifest is likely out of date. WinGet cannot skip this check while running as administrator."
+                    )
+                    : CoreTools.Translate(
+                        "The package manifest is likely out of date. Skipping this check requires WinGet's InstallerHashOverride administrator setting."
+                    ),
+                LineType.Error
+            );
 #endif
         }
 

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -161,20 +161,26 @@ namespace UniGetUI.PackageEngine.Operations
         public static bool CanRetrySkippingIntegrityChecks(
             IPackageManager manager,
             InstallOptions options,
+            OperationType role,
             bool willRunElevated
         )
         {
             if (!manager.Capabilities.CanSkipIntegrityChecks || options.SkipHashCheck)
                 return false;
 
-            return !willRunElevated || IntegrityCheckSkipSurvivesElevation(manager);
+            return IntegrityCheckSkipIsHonored(manager, role, willRunElevated);
         }
 
-        private static bool IntegrityCheckSkipSurvivesElevation(IPackageManager manager)
+        private static bool IntegrityCheckSkipIsHonored(
+            IPackageManager manager,
+            OperationType role,
+            bool willRunElevated
+        )
         {
 #if WINDOWS
             if (manager is WinGet winget)
-                return winget.HonorsIntegrityCheckSkipWhenElevated;
+                return role is not OperationType.Uninstall
+                    && (!willRunElevated || winget.HonorsIntegrityCheckSkipWhenElevated);
 #endif
             return true;
         }

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -148,6 +148,34 @@ namespace UniGetUI.PackageEngine.Operations
             !Settings.Get(Settings.K.ProhibitElevation)
             && (Package.OverridenOptions.RunAsAdministrator is true || Options.RunAsAdministrator);
 
+        public virtual bool WillRunElevated =>
+            CoreTools.IsAdministrator() || RequiresAdminRights();
+
+        public static bool CanRetrySkippingIntegrityChecks(
+            IPackageManager manager,
+            InstallOptions options,
+            OperationType role,
+            bool willRunElevated
+        )
+        {
+            if (!manager.Capabilities.CanSkipIntegrityChecks || options.SkipHashCheck)
+                return false;
+
+            if (role is OperationType.Uninstall)
+                return false;
+
+            return !willRunElevated || IntegrityCheckSkipSurvivesElevation(manager);
+        }
+
+        private static bool IntegrityCheckSkipSurvivesElevation(IPackageManager manager)
+        {
+#if WINDOWS
+            if (manager is WinGet winget)
+                return winget.HonorsIntegrityCheckSkipWhenElevated;
+#endif
+            return true;
+        }
+
         protected override void ApplyRetryAction(string retryMode)
         {
             switch (retryMode)
@@ -900,8 +928,12 @@ namespace UniGetUI.PackageEngine.Operations
                 ReturnCode
             );
 
-            if (veredict is OperationVeredict.Failure && Role is OperationType.Update)
-                ExplainNotApplicableUpdate(Output, ReturnCode);
+            if (veredict is OperationVeredict.Failure)
+            {
+                if (Role is OperationType.Update)
+                    ExplainNotApplicableUpdate(Output, ReturnCode);
+                ExplainInstallerHashMismatch(ReturnCode);
+            }
 
             return Task.FromResult(veredict);
         }
@@ -919,6 +951,41 @@ namespace UniGetUI.PackageEngine.Operations
                 "{package} may already be up to date, or no installer matches this system",
                 new Dictionary<string, object?> { { "package", Package.Name } }
             );
+#endif
+        }
+
+        private void ExplainInstallerHashMismatch(int returnCode)
+        {
+#if WINDOWS
+            if (Package.Manager is not WinGet winget)
+                return;
+
+            if (!winget.ReportedInstallerHashMismatch(returnCode))
+                return;
+
+            var placeholders = new Dictionary<string, object?> { { "package", Package.Name } };
+
+            if (WillRunElevated && !winget.HonorsIntegrityCheckSkipWhenElevated)
+            {
+                Metadata.FailureMessage = CoreTools.Translate(
+                    "The installer for {package} does not match the hash published in its manifest, and WinGet refuses to skip that check while running as administrator",
+                    placeholders
+                );
+            }
+            else if (Options.SkipHashCheck)
+            {
+                Metadata.FailureMessage = CoreTools.Translate(
+                    "The installer for {package} does not match the hash published in its manifest; WinGet only skips that check once its InstallerHashOverride administrator setting is enabled",
+                    placeholders
+                );
+            }
+            else
+            {
+                Metadata.FailureMessage = CoreTools.Translate(
+                    "The installer for {package} does not match the hash published in its manifest, so it was not run",
+                    placeholders
+                );
+            }
 #endif
         }
 

--- a/src/UniGetUI.PackageEngine.Tests/OperationHistoryTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/OperationHistoryTests.cs
@@ -1,4 +1,5 @@
 using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.Operations;
 using UniGetUI.PackageEngine.Operations.History;
 using UniGetUI.PackageEngine.Serializable;
@@ -107,6 +108,7 @@ public sealed class OperationHistoryTests : IDisposable
         var record = Record("persisted");
         record.Output.Add(new OperationHistoryOutputLine { Text = "line one", Type = "Information" });
         record.Output.Add(new OperationHistoryOutputLine { Text = "boom", Type = "Error" });
+        record.RanElevated = true;
         OperationHistoryStore.Add(record);
 
         // Drop the in-memory cache so the next read must deserialize the file.
@@ -118,7 +120,50 @@ public sealed class OperationHistoryTests : IDisposable
         Assert.Equal(2, reloaded.Output.Count);
         Assert.Equal("boom", reloaded.Output[1].Text);
         Assert.Equal("Error", reloaded.Output[1].Type);
+        Assert.True(reloaded.RanElevated);
     }
+
+    [Fact]
+    public void PersistsANonElevatedRunAsFalseRatherThanUnknown()
+    {
+        var record = Record("standard");
+        record.RanElevated = false;
+        OperationHistoryStore.Add(record);
+        OperationHistoryStore.InvalidateCache();
+
+        var reloaded = OperationHistoryStore.Get("standard");
+        Assert.NotNull(reloaded);
+        Assert.False(reloaded!.RanElevated);
+    }
+
+    [Fact]
+    public void RecordsWrittenBeforeElevationWasTrackedReloadAsUnknown()
+    {
+        File.WriteAllText(_tempFile, LegacyRecordJson);
+        OperationHistoryStore.InvalidateCache();
+
+        var reloaded = OperationHistoryStore.Get("legacy");
+        Assert.NotNull(reloaded);
+        Assert.Equal("Contoso.Legacy", reloaded!.PackageId);
+        Assert.Null(reloaded.RanElevated);
+    }
+
+    private const string LegacyRecordJson = """
+        [
+          {
+            "Id": "legacy",
+            "Kind": "install-package",
+            "Role": 0,
+            "PackageId": "Contoso.Legacy",
+            "PackageName": "Contoso Legacy",
+            "ManagerName": "winget",
+            "SourceName": "winget",
+            "Status": "succeeded",
+            "TimestampUtc": "2026-01-01T00:00:00.0000000Z",
+            "Output": []
+          }
+        ]
+        """;
 
     [Fact]
     public void CapsAtMaxEntries()
@@ -221,6 +266,37 @@ public sealed class OperationHistoryTests : IDisposable
         Assert.Equal(manager.Id, record.ManagerName);
         Assert.Equal("1.2.3", record.VersionAfter);
         Assert.Equal(OperationHistoryRecord.StatusSucceeded, record.Status);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FromOperation_CapturesTheElevationTheOperationRanWith(bool elevated)
+    {
+        var manager = new PackageManagerBuilder().WithName("Scoop").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithVersion("1.2.3")
+            .Build();
+
+        using var op = new ElevationStubInstallOperation(package, new InstallOptions(), elevated);
+        var record = OperationHistoryRecord.FromOperation(op, OperationHistoryRecord.StatusSucceeded);
+
+        Assert.Equal(elevated, record.RanElevated);
+    }
+
+    private sealed class ElevationStubInstallOperation : InstallPackageOperation
+    {
+        private readonly bool _elevated;
+
+        public ElevationStubInstallOperation(IPackage package, InstallOptions options, bool elevated)
+            : base(package, options, IgnoreParallelInstalls: true)
+        {
+            _elevated = elevated;
+        }
+
+        public override bool WillRunElevated => _elevated;
     }
 
     // The package a Discover install starts from carries the feed's LATEST version, while the

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -2029,8 +2029,11 @@ public sealed class WinGetManagerTests : IDisposable
         OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
         Assert.NotEqual(defaultMessage, operation.Metadata.FailureMessage);
         Assert.Contains("does not match the hash", operation.Metadata.FailureMessage);
-        Assert.Contains("running as administrator", operation.Metadata.FailureMessage);
         Assert.False(operation.Metadata.FailureMessage.EndsWith('.'));
+        Assert.Contains(
+            operation.GetOutput(),
+            line => line.Item1.Contains("cannot skip this check while running as administrator")
+        );
     }
 
     [Fact]
@@ -2055,7 +2058,10 @@ public sealed class WinGetManagerTests : IDisposable
         var veredict = await operation.ProbeProcessVeredict(unchecked((int)0x8A150011), []);
 
         OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
-        Assert.Contains("InstallerHashOverride", operation.Metadata.FailureMessage);
+        Assert.Contains(
+            operation.GetOutput(),
+            line => line.Item1.Contains("InstallerHashOverride")
+        );
     }
 
     [Fact]
@@ -2080,7 +2086,10 @@ public sealed class WinGetManagerTests : IDisposable
         OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
         Assert.NotEqual(defaultMessage, operation.Metadata.FailureMessage);
         Assert.Contains("does not match the hash", operation.Metadata.FailureMessage);
-        Assert.DoesNotContain("running as administrator", operation.Metadata.FailureMessage);
+        Assert.DoesNotContain(
+            operation.GetOutput(),
+            line => line.Item1.Contains("running as administrator")
+        );
     }
 
     [Fact]
@@ -2115,7 +2124,6 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions(),
-                OperationType.Update,
                 willRunElevated: true
             )
         );
@@ -2123,7 +2131,6 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions(),
-                OperationType.Update,
                 willRunElevated: false
             )
         );
@@ -2139,14 +2146,13 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions(),
-                OperationType.Update,
                 willRunElevated: true
             )
         );
     }
 
     [Fact]
-    public void WinGetNeverOffersTheIntegritySkipRetryTwiceOrOnUninstall()
+    public void WinGetNeverOffersTheIntegritySkipRetryWhenAlreadySkipping()
     {
         var manager = new WinGet();
         SetCliToolKind(manager, WinGetCliToolKind.BundledPinget);
@@ -2155,15 +2161,6 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions { SkipHashCheck = true },
-                OperationType.Update,
-                willRunElevated: false
-            )
-        );
-        Assert.False(
-            PackageOperation.CanRetrySkippingIntegrityChecks(
-                manager,
-                new InstallOptions(),
-                OperationType.Uninstall,
                 willRunElevated: false
             )
         );

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -2124,6 +2124,7 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions(),
+                OperationType.Update,
                 willRunElevated: true
             )
         );
@@ -2131,6 +2132,7 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions(),
+                OperationType.Update,
                 willRunElevated: false
             )
         );
@@ -2146,6 +2148,46 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions(),
+                OperationType.Update,
+                willRunElevated: true
+            )
+        );
+    }
+
+    [Fact]
+    public void WinGetDoesNotOfferTheIntegritySkipRetryOnUninstall()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+
+        Assert.False(
+            PackageOperation.CanRetrySkippingIntegrityChecks(
+                manager,
+                new InstallOptions(),
+                OperationType.Uninstall,
+                willRunElevated: false
+            )
+        );
+        Assert.DoesNotContain(
+            "--ignore-security-hash",
+            manager.OperationHelper.GetParameters(
+                new PackageBuilder().WithManager(manager).WithId("Contoso.Tool").Build(),
+                new InstallOptions { SkipHashCheck = true },
+                OperationType.Uninstall
+            )
+        );
+    }
+
+    [Fact]
+    public void OtherManagersKeepTheIntegritySkipRetryOnUninstall()
+    {
+        var manager = new Infrastructure.Fakes.TestPackageManager();
+
+        Assert.True(
+            PackageOperation.CanRetrySkippingIntegrityChecks(
+                manager,
+                new InstallOptions(),
+                OperationType.Uninstall,
                 willRunElevated: true
             )
         );
@@ -2161,6 +2203,7 @@ public sealed class WinGetManagerTests : IDisposable
             PackageOperation.CanRetrySkippingIntegrityChecks(
                 manager,
                 new InstallOptions { SkipHashCheck = true },
+                OperationType.Update,
                 willRunElevated: false
             )
         );

--- a/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/WinGetManagerTests.cs
@@ -2007,10 +2007,176 @@ public sealed class WinGetManagerTests : IDisposable
         Assert.DoesNotContain("may already be up to date", operation.Metadata.FailureMessage);
     }
 
+    [Fact]
+    public async Task WinGetInstallerHashMismatchExplainsTheAdminBlock()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("XiaoweiCloud.CalendarTask")
+            .WithVersion("3.30.298.9128")
+            .WithNewVersion("3.30.299.9142")
+            .Build();
+        using var operation = new VeredictProbingUpdateOperation(package, new InstallOptions())
+        {
+            ElevationOverride = true,
+        };
+        string defaultMessage = operation.Metadata.FailureMessage;
+
+        var veredict = await operation.ProbeProcessVeredict(unchecked((int)0x8A150011), []);
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.NotEqual(defaultMessage, operation.Metadata.FailureMessage);
+        Assert.Contains("does not match the hash", operation.Metadata.FailureMessage);
+        Assert.Contains("running as administrator", operation.Metadata.FailureMessage);
+        Assert.False(operation.Metadata.FailureMessage.EndsWith('.'));
+    }
+
+    [Fact]
+    public async Task WinGetInstallerHashMismatchPointsAtTheOverrideSettingWhenSkippingWasRequested()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("XiaoweiCloud.CalendarTask")
+            .WithVersion("3.30.298.9128")
+            .WithNewVersion("3.30.299.9142")
+            .Build();
+        using var operation = new VeredictProbingUpdateOperation(
+            package,
+            new InstallOptions { SkipHashCheck = true }
+        )
+        {
+            ElevationOverride = false,
+        };
+
+        var veredict = await operation.ProbeProcessVeredict(unchecked((int)0x8A150011), []);
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.Contains("InstallerHashOverride", operation.Metadata.FailureMessage);
+    }
+
+    [Fact]
+    public async Task WinGetInstallerHashMismatchExplainsTheFailureWithoutElevation()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("XiaoweiCloud.CalendarTask")
+            .WithVersion("3.30.298.9128")
+            .WithNewVersion("3.30.299.9142")
+            .Build();
+        using var operation = new VeredictProbingUpdateOperation(package, new InstallOptions())
+        {
+            ElevationOverride = false,
+        };
+        string defaultMessage = operation.Metadata.FailureMessage;
+
+        var veredict = await operation.ProbeProcessVeredict(unchecked((int)0x8A150011), []);
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.NotEqual(defaultMessage, operation.Metadata.FailureMessage);
+        Assert.Contains("does not match the hash", operation.Metadata.FailureMessage);
+        Assert.DoesNotContain("running as administrator", operation.Metadata.FailureMessage);
+    }
+
+    [Fact]
+    public async Task WinGetFailureUnrelatedToTheInstallerHashKeepsTheDefaultMessage()
+    {
+        var manager = new WinGet();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("XiaoweiCloud.CalendarTask")
+            .WithVersion("3.30.298.9128")
+            .WithNewVersion("3.30.299.9142")
+            .Build();
+        using var operation = new VeredictProbingUpdateOperation(package, new InstallOptions())
+        {
+            ElevationOverride = true,
+        };
+        string defaultMessage = operation.Metadata.FailureMessage;
+
+        var veredict = await operation.ProbeProcessVeredict(unchecked((int)0x8A150012), []);
+
+        OperationAssert.HasVeredict(veredict, OperationVeredict.Failure);
+        Assert.Equal(defaultMessage, operation.Metadata.FailureMessage);
+    }
+
+    [Fact]
+    public void WinGetDoesNotOfferTheIntegritySkipRetryWhenTheOperationRunsElevated()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.SystemWinGet);
+
+        Assert.False(
+            PackageOperation.CanRetrySkippingIntegrityChecks(
+                manager,
+                new InstallOptions(),
+                OperationType.Update,
+                willRunElevated: true
+            )
+        );
+        Assert.True(
+            PackageOperation.CanRetrySkippingIntegrityChecks(
+                manager,
+                new InstallOptions(),
+                OperationType.Update,
+                willRunElevated: false
+            )
+        );
+    }
+
+    [Fact]
+    public void WinGetOffersTheIntegritySkipRetryWhenElevatedOnPinget()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.BundledPinget);
+
+        Assert.True(
+            PackageOperation.CanRetrySkippingIntegrityChecks(
+                manager,
+                new InstallOptions(),
+                OperationType.Update,
+                willRunElevated: true
+            )
+        );
+    }
+
+    [Fact]
+    public void WinGetNeverOffersTheIntegritySkipRetryTwiceOrOnUninstall()
+    {
+        var manager = new WinGet();
+        SetCliToolKind(manager, WinGetCliToolKind.BundledPinget);
+
+        Assert.False(
+            PackageOperation.CanRetrySkippingIntegrityChecks(
+                manager,
+                new InstallOptions { SkipHashCheck = true },
+                OperationType.Update,
+                willRunElevated: false
+            )
+        );
+        Assert.False(
+            PackageOperation.CanRetrySkippingIntegrityChecks(
+                manager,
+                new InstallOptions(),
+                OperationType.Uninstall,
+                willRunElevated: false
+            )
+        );
+    }
+
     private sealed class VeredictProbingUpdateOperation : UpdatePackageOperation
     {
         public VeredictProbingUpdateOperation(IPackage package, InstallOptions options)
             : base(package, options) { }
+
+        public bool? ElevationOverride { get; set; }
+
+        public override bool WillRunElevated => ElevationOverride ?? base.WillRunElevated;
 
         public Task<OperationVeredict> ProbeProcessVeredict(int returnCode, List<string> output)
             => GetProcessVeredict(returnCode, output);


### PR DESCRIPTION
This pull request improves how the application handles and explains installer hash mismatches during WinGet package operations, especially when running as administrator or when retrying with integrity checks skipped. It also refines the logic for when the "Retry skipping integrity checks" option is offered and adds comprehensive tests for these scenarios.

**Installer hash mismatch handling and user feedback:**

* Added new user-facing messages to `lang_en.json` to clearly explain when an installer's hash does not match the manifest, including specific guidance for administrator scenarios and when the `InstallerHashOverride` setting is required.
* Enhanced the logic to detect installer hash mismatches (`0x8A150011`) and provide clear, context-sensitive failure explanations to users, including updating the `Metadata.FailureMessage` and output lines. [[1]](diffhunk://#diff-16fa02a11e7cc5f7d63868a42d7a8d7cf08a470a2889d80ed9ae86a6955f38beL295-R296) [[2]](diffhunk://#diff-16fa02a11e7cc5f7d63868a42d7a8d7cf08a470a2889d80ed9ae86a6955f38beR433-R435) [[3]](diffhunk://#diff-c5edf1f9e67afdabfdd3506a6233f12e5e8cfd0a078623908926a0c95e94644eR256-R261) [[4]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cL903-R942) [[5]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cR963-R989)

**Retry logic improvements:**

* Centralized and refined the logic for determining when the "Retry skipping integrity checks" option is available, now considering whether the operation is running elevated and if the manager/tool supports skipping integrity checks in that context. This affects UI menus, dialogs, and IPC API responses. [[1]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cR151-R181) [[2]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cR276-R277) [[3]](diffhunk://#diff-caf66c255b27d4df66df884c213c069783a122c4d3d93400ea0f998aebb3cc7cR347) [[4]](diffhunk://#diff-3010c1369fe2e1d628fbc3b826b9162e3a4d0dbf9af94716a48808d85f2eaf19L58-R59) [[5]](diffhunk://#diff-f961bb8e68c3d1508c3077d5f896fb8a0e56dd4035d12fc8c68812a78cfe835aL269-R270) [[6]](diffhunk://#diff-622ea9826c05caa094f09b8f769d93917f82e15ae6836796ca022962084d324cL103-R104) [[7]](diffhunk://#diff-b4c83da77e785274325f181a83455a4816e7e2fcbdb51bf6ae79fa663fd7b159L407-R411)

**Testing and validation:**

* Added comprehensive unit tests to verify correct behavior and user messaging for installer hash mismatches, administrator context, and retry option availability across different WinGet tool kinds and operation states.

These changes collectively ensure clearer user guidance when hash mismatches occur, more robust and context-aware retry options, and improved test coverage for these critical flows.