### PR TITLE
Add a %NAME% placeholder for custom install locations

### DIFF
--- a/src/Languages/lang_en.json
+++ b/src/Languages/lang_en.json
@@ -1075,5 +1075,9 @@
   "Could not import settings": "Could not import settings",
   "The installer for {package} does not match the hash in its manifest": "The installer for {package} does not match the hash in its manifest",
   "The package manifest is likely out of date. WinGet cannot skip this check while running as administrator.": "The package manifest is likely out of date. WinGet cannot skip this check while running as administrator.",
-  "The package manifest is likely out of date. Skipping this check requires WinGet's InstallerHashOverride administrator setting.": "The package manifest is likely out of date. Skipping this check requires WinGet's InstallerHashOverride administrator setting."
+  "The package manifest is likely out of date. Skipping this check requires WinGet's InstallerHashOverride administrator setting.": "The package manifest is likely out of date. Skipping this check requires WinGet's InstallerHashOverride administrator setting.",
+  "Subfolder for each package:": "Subfolder for each package:",
+  "%PACKAGE% is replaced with the package ID, and %NAME% with the package name.": "%PACKAGE% is replaced with the package ID, and %NAME% with the package name.",
+  "Package name": "Package name",
+  "No subfolder": "No subfolder"
 }

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/InstallOptionsViewModel.cs
@@ -48,6 +48,7 @@ public partial class InstallOptionsViewModel : ObservableObject
     public string ParamsUpdateLabel { get; } = CoreTools.Translate("Custom update arguments:");
     public string ParamsUninstallLabel { get; } = CoreTools.Translate("Custom uninstall arguments:");
     public string CliArgsHintLabel { get; } = CoreTools.Translate("These fields are independent: an argument set for Install won't apply to Update or Uninstall, and vice versa.");
+    public string LocationPlaceholderHintLabel { get; } = CoreTools.Translate("%PACKAGE% is replaced with the package ID, and %NAME% with the package name.");
     public string EnvVarSyntaxHintLabel { get; } = Settings.Get(Settings.K.ExpandEnvVarsWithPercentSyntax)
         ? CoreTools.Translate("Environment variables use %VARIABLE% syntax.")
         : CoreTools.Translate("Environment variables use <VARIABLE> syntax.");

--- a/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/DialogPages/OperationViewModel.cs
@@ -308,7 +308,7 @@ public sealed partial class OperationViewModel : ViewModelBase
     private static async Task ShowInstallOptionsAsync(PackageOperation packageOp)
     {
         if (GetMainWindow() is not { } mainWindow) return;
-        var opts = await InstallOptionsFactory.LoadApplicableAsync(packageOp.Package);
+        var opts = await InstallOptionsFactory.LoadForPackageAsync(packageOp.Package);
         var win = new InstallOptionsWindow(packageOp.Package, OperationType.None, opts);
         await win.ShowDialog(mainWindow);
         await InstallOptionsFactory.SaveForPackageAsync(opts, packageOp.Package);

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InstallOptionsPanelViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InstallOptionsPanelViewModel.cs
@@ -311,10 +311,12 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
 
     private string _subfolderLabelFor(string location)
     {
-        if (location.EndsWith(InstallOptionsFactory.PackageNamePlaceholder, StringComparison.OrdinalIgnoreCase))
+        string trimmed = location.TrimEnd('/', '\\');
+
+        if (trimmed.EndsWith(InstallOptionsFactory.PackageNamePlaceholder, StringComparison.OrdinalIgnoreCase))
             return _subfolderNameLabel;
 
-        if (location.EndsWith(InstallOptionsFactory.PackageIdPlaceholder, StringComparison.OrdinalIgnoreCase))
+        if (trimmed.EndsWith(InstallOptionsFactory.PackageIdPlaceholder, StringComparison.OrdinalIgnoreCase))
             return _subfolderIdLabel;
 
         return _subfolderNoneLabel;
@@ -328,28 +330,45 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
             InstallOptionsFactory.PackageNamePlaceholder,
         ];
 
-        bool stripped = false;
+        string basePath = location.TrimEnd('/', '\\');
+
         foreach (var placeholder in placeholders)
         {
-            if (location.EndsWith(placeholder, StringComparison.OrdinalIgnoreCase))
+            if (basePath.EndsWith(placeholder, StringComparison.OrdinalIgnoreCase))
             {
-                location = location[..^placeholder.Length];
-                stripped = true;
+                basePath = basePath[..^placeholder.Length];
                 break;
             }
         }
 
-        if (subfolderLabel == _subfolderNameLabel)
-            return location.TrimEnd('/', '\\')
-                + Path.DirectorySeparatorChar
-                + InstallOptionsFactory.PackageNamePlaceholder;
+        basePath = _asDirectoryPath(basePath);
 
-        if (subfolderLabel == _subfolderIdLabel)
-            return location.TrimEnd('/', '\\')
-                + Path.DirectorySeparatorChar
-                + InstallOptionsFactory.PackageIdPlaceholder;
+        string subfolder =
+            subfolderLabel == _subfolderNameLabel ? InstallOptionsFactory.PackageNamePlaceholder
+            : subfolderLabel == _subfolderIdLabel ? InstallOptionsFactory.PackageIdPlaceholder
+            : "";
 
-        return stripped ? location.TrimEnd('/', '\\') : location;
+        if (basePath.Length is 0)
+            return subfolder;
+
+        if (subfolder.Length is 0)
+            return basePath;
+
+        return basePath[^1] is '/' or '\\'
+            ? basePath + subfolder
+            : basePath + Path.DirectorySeparatorChar + subfolder;
+    }
+
+    private static string _asDirectoryPath(string path)
+    {
+        string trimmed = path.TrimEnd('/', '\\');
+
+        if (trimmed.Length is 0)
+            return path.Length is 0 ? path : path[..1];
+
+        return trimmed.Length is 2 && trimmed[1] is ':'
+            ? trimmed + Path.DirectorySeparatorChar
+            : trimmed;
     }
 
     // ── Navigation ────────────────────────────────────────────────────────────

--- a/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InstallOptionsPanelViewModel.cs
+++ b/src/UniGetUI.Avalonia/ViewModels/Pages/SettingsPages/InstallOptionsPanelViewModel.cs
@@ -18,6 +18,9 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
 {
     private readonly IPackageManager _manager;
     private readonly string _defaultLocationLabel;
+    private readonly string _subfolderIdLabel = CoreTools.Translate("Package ID");
+    private readonly string _subfolderNameLabel = CoreTools.Translate("Package name");
+    private readonly string _subfolderNoneLabel = CoreTools.Translate("No subfolder");
 
     public event EventHandler? NavigateToAdministratorRequested;
 
@@ -55,6 +58,8 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
     [ObservableProperty] private bool _locationSelectEnabled;
     [ObservableProperty] private bool _locationResetEnabled;
     [ObservableProperty] private string _locationText = "";
+    [ObservableProperty] private ObservableCollection<string> _subfolderItems = [];
+    [ObservableProperty] private string? _selectedSubfolder;
 
     // ── CLI args ──────────────────────────────────────────────────────────────
     [ObservableProperty] private bool _cliSectionEnabled;
@@ -74,6 +79,8 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
     public string LocationLabel { get; } = CoreTools.Translate("Install location:");
     public string SelectDirLabel { get; } = CoreTools.Translate("Select");
     public string ResetDirLabel { get; } = CoreTools.Translate("Reset");
+    public string SubfolderLabel { get; } = CoreTools.Translate("Subfolder for each package:");
+    public string LocationPlaceholderHintLabel { get; } = CoreTools.Translate("%PACKAGE% is replaced with the package ID, and %NAME% with the package name.");
     public string InstallArgsLabel { get; } = CoreTools.Translate("Custom install arguments:");
     public string UpdateArgsLabel { get; } = CoreTools.Translate("Custom update arguments:");
     public string UninstallArgsLabel { get; } = CoreTools.Translate("Custom uninstall arguments:");
@@ -92,11 +99,18 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
     public double ArchOpacity => ArchitectureEnabled ? 1.0 : 0.5;
     public double ScopeOpacity => ScopeEnabled ? 1.0 : 0.5;
     public double LocationOpacity => LocationSelectEnabled ? 1.0 : 0.5;
+    public bool SubfolderEnabled => LocationSelectEnabled && LocationResetEnabled;
 
     partial void OnCliSectionEnabledChanged(bool value) => OnPropertyChanged(nameof(CliOpacity));
     partial void OnArchitectureEnabledChanged(bool value) => OnPropertyChanged(nameof(ArchOpacity));
     partial void OnScopeEnabledChanged(bool value) => OnPropertyChanged(nameof(ScopeOpacity));
-    partial void OnLocationSelectEnabledChanged(bool value) => OnPropertyChanged(nameof(LocationOpacity));
+    partial void OnLocationResetEnabledChanged(bool value) => OnPropertyChanged(nameof(SubfolderEnabled));
+
+    partial void OnLocationSelectEnabledChanged(bool value)
+    {
+        OnPropertyChanged(nameof(LocationOpacity));
+        OnPropertyChanged(nameof(SubfolderEnabled));
+    }
 
     // Mark HasChanges when user edits options (guards against firing during load)
     partial void OnAdminCheckedChanged(bool value) => HasChanges = !IsLoading;
@@ -106,6 +120,13 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
     partial void OnUninstallPreviousCheckedChanged(bool value) => HasChanges = !IsLoading;
     partial void OnSelectedArchitectureChanged(string? value) => HasChanges = !IsLoading;
     partial void OnSelectedScopeChanged(string? value) => HasChanges = !IsLoading;
+
+    partial void OnSelectedSubfolderChanged(string? value)
+    {
+        if (IsLoading || value is null || !LocationResetEnabled) return;
+        LocationText = _withSubfolder(LocationText, value);
+        HasChanges = true;
+    }
 
     public InstallOptionsPanelViewModel(IPackageManager manager)
     {
@@ -121,6 +142,11 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
         _scopeItems.Add(CoreTools.Translate("Default"));
         _scopeItems.Add(CoreTools.Translate(CommonTranslations.ScopeNames[PackageScope.Local]));
         _scopeItems.Add(CoreTools.Translate(CommonTranslations.ScopeNames[PackageScope.Global]));
+
+        _subfolderItems.Add(_subfolderIdLabel);
+        _subfolderItems.Add(_subfolderNameLabel);
+        _subfolderItems.Add(_subfolderNoneLabel);
+        _selectedSubfolder = _subfolderIdLabel;
 
         _ = DoLoadOptions();
     }
@@ -236,6 +262,7 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
         {
             LocationText = options.CustomInstallLocation;
             LocationResetEnabled = true;
+            SelectedSubfolder = _subfolderLabelFor(LocationText);
         }
         else
         {
@@ -243,6 +270,7 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
                 ? _defaultLocationLabel
                 : CoreTools.Translate("Install location can't be changed for {0} packages", _manager.DisplayName);
             LocationResetEnabled = false;
+            SelectedSubfolder = _subfolderIdLabel;
         }
 
         // CLI
@@ -267,7 +295,7 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
         if (folders is not [{ } folder]) return;
         var path = folder.TryGetLocalPath();
         if (string.IsNullOrEmpty(path)) return;
-        LocationText = path.TrimEnd('/').TrimEnd('\\') + "/%PACKAGE%";
+        LocationText = _withSubfolder(path, SelectedSubfolder);
         LocationResetEnabled = true;
         HasChanges = true;
     }
@@ -275,9 +303,53 @@ public partial class InstallOptionsPanelViewModel : ViewModelBase
     [RelayCommand]
     private void ResetLocation()
     {
-        LocationText = _defaultLocationLabel;
         LocationResetEnabled = false;
+        LocationText = _defaultLocationLabel;
+        SelectedSubfolder = _subfolderIdLabel;
         HasChanges = true;
+    }
+
+    private string _subfolderLabelFor(string location)
+    {
+        if (location.EndsWith(InstallOptionsFactory.PackageNamePlaceholder, StringComparison.OrdinalIgnoreCase))
+            return _subfolderNameLabel;
+
+        if (location.EndsWith(InstallOptionsFactory.PackageIdPlaceholder, StringComparison.OrdinalIgnoreCase))
+            return _subfolderIdLabel;
+
+        return _subfolderNoneLabel;
+    }
+
+    private string _withSubfolder(string location, string? subfolderLabel)
+    {
+        string[] placeholders =
+        [
+            InstallOptionsFactory.PackageIdPlaceholder,
+            InstallOptionsFactory.PackageNamePlaceholder,
+        ];
+
+        bool stripped = false;
+        foreach (var placeholder in placeholders)
+        {
+            if (location.EndsWith(placeholder, StringComparison.OrdinalIgnoreCase))
+            {
+                location = location[..^placeholder.Length];
+                stripped = true;
+                break;
+            }
+        }
+
+        if (subfolderLabel == _subfolderNameLabel)
+            return location.TrimEnd('/', '\\')
+                + Path.DirectorySeparatorChar
+                + InstallOptionsFactory.PackageNamePlaceholder;
+
+        if (subfolderLabel == _subfolderIdLabel)
+            return location.TrimEnd('/', '\\')
+                + Path.DirectorySeparatorChar
+                + InstallOptionsFactory.PackageIdPlaceholder;
+
+        return stripped ? location.TrimEnd('/', '\\') : location;
     }
 
     // ── Navigation ────────────────────────────────────────────────────────────

--- a/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
+++ b/src/UniGetUI.Avalonia/Views/DialogPages/InstallOptionsControl.axaml
@@ -343,6 +343,12 @@
                                  FontSize="14"
                                  HorizontalAlignment="Stretch"/>
 
+                        <TextBlock Text="{Binding LocationPlaceholderHintLabel}"
+                                   IsVisible="{Binding LocationEnabled}"
+                                   TextWrapping="Wrap"
+                                   Opacity="0.7"
+                                   FontSize="12"/>
+
                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"
                               IsVisible="{Binding LocationEnabled}">
                             <TextBlock Text="{Binding EnvVarSyntaxHintLabel}"

--- a/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
+++ b/src/UniGetUI.Avalonia/Views/Pages/SettingsPages/InstallOptionsPanel.axaml
@@ -143,6 +143,27 @@
                              FontSize="14"
                              Opacity="0.6"/>
 
+                    <Grid ColumnDefinitions="*,*">
+                        <TextBlock x:Name="SubfolderLabelBlock"
+                                   Grid.Column="0"
+                                   Text="{Binding SubfolderLabel}"
+                                   VerticalAlignment="Center"
+                                   FontSize="14"
+                                   Opacity="{Binding LocationOpacity}"/>
+                        <ComboBox Grid.Column="1"
+                                  ItemsSource="{Binding SubfolderItems}"
+                                  SelectedItem="{Binding SelectedSubfolder}"
+                                  IsEnabled="{Binding SubfolderEnabled}"
+                                  HorizontalAlignment="Stretch"
+                                  MaxWidth="200"
+                                  automation:AutomationProperties.LabeledBy="{Binding #SubfolderLabelBlock}"/>
+                    </Grid>
+                    <TextBlock Text="{Binding LocationPlaceholderHintLabel}"
+                               IsVisible="{Binding LocationSelectEnabled}"
+                               TextWrapping="Wrap"
+                               Opacity="0.7"
+                               FontSize="12"/>
+
                     <!-- CLI disabled warning -->
                     <TextBlock Text="{Binding CliDisabledLabel}"
                                IsVisible="{Binding CliDisabledWarningVisible}"

--- a/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI.Avalonia/Views/SoftwarePages/PackageBundlesPage.cs
@@ -527,8 +527,11 @@ public class PackageBundlesPage : AbstractPackagesPage
                 IReadOnlyList<string> param;
                 try
                 {
+                    var exported = pkg.installation_options.Copy();
+                    exported.CustomInstallLocation = InstallOptionsFactory.ExpandPackagePlaceholders(
+                        exported.CustomInstallLocation, pkg);
                     param = pkg.Manager.OperationHelper.GetStandaloneParameters(
-                        pkg, pkg.installation_options, OperationType.Install);
+                        pkg, exported, OperationType.Install);
                 }
                 catch (InvalidOperationException ex)
                 {

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallOptionsFactory.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallOptionsFactory.cs
@@ -167,7 +167,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
                 instance = LoadForManager(package.Manager);
             }
 
-            instance.CustomInstallLocation = _expandPackagePlaceholders(
+            instance.CustomInstallLocation = ExpandPackagePlaceholders(
                 instance.CustomInstallLocation,
                 package
             );
@@ -400,13 +400,13 @@ namespace UniGetUI.PackageEngine.PackageClasses
             }
         }
 
-        private static string _expandPackagePlaceholders(string location, IPackage package)
+        public static string ExpandPackagePlaceholders(string location, IPackage package)
         {
             if (!location.Contains('%'))
                 return location;
 
-            string legalizedId = CoreTools.MakeValidFileName(package.Id);
-            string legalizedName = CoreTools.MakeValidFileName(package.Name);
+            string legalizedId = _legalizeFolderName(package.Id);
+            string legalizedName = _legalizeFolderName(package.Name);
 
             if (legalizedName.Length is 0)
                 legalizedName = legalizedId;
@@ -415,6 +415,9 @@ namespace UniGetUI.PackageEngine.PackageClasses
                 .Replace(PackageIdPlaceholder, legalizedId, StringComparison.OrdinalIgnoreCase)
                 .Replace(PackageNamePlaceholder, legalizedName, StringComparison.OrdinalIgnoreCase);
         }
+
+        private static string _legalizeFolderName(string value) =>
+            CoreTools.MakeValidFileName(value.Replace("%", ""));
 
         private static string _expandEnvironmentVariables(string value)
         {

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallOptionsFactory.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallOptionsFactory.cs
@@ -18,6 +18,9 @@ namespace UniGetUI.PackageEngine.PackageClasses
     /// </summary>
     public static class InstallOptionsFactory
     {
+        public const string PackageIdPlaceholder = "%PACKAGE%";
+        public const string PackageNamePlaceholder = "%NAME%";
+
         public static bool IsIdentityScopedOptionsFile(string fileName) =>
             StoragePath.IsIdentityScoped(fileName);
 
@@ -162,14 +165,12 @@ namespace UniGetUI.PackageEngine.PackageClasses
                     $"Package {package.Id} does not override options, will use package manager's default..."
                 );
                 instance = LoadForManager(package.Manager);
-
-                var legalizedId = CoreTools.MakeValidFileName(package.Id);
-                instance.CustomInstallLocation = instance.CustomInstallLocation.Replace(
-                    "%PACKAGE%",
-                    legalizedId
-                );
             }
 
+            instance.CustomInstallLocation = _expandPackagePlaceholders(
+                instance.CustomInstallLocation,
+                package
+            );
             instance.CustomInstallLocationIsExplicit = locationIsExplicit;
 
             if (elevated is not null)
@@ -397,6 +398,22 @@ namespace UniGetUI.PackageEngine.PackageClasses
                     .Replace(">", "")
                     .Replace("\n", "");
             }
+        }
+
+        private static string _expandPackagePlaceholders(string location, IPackage package)
+        {
+            if (!location.Contains('%'))
+                return location;
+
+            string legalizedId = CoreTools.MakeValidFileName(package.Id);
+            string legalizedName = CoreTools.MakeValidFileName(package.Name);
+
+            if (legalizedName.Length is 0)
+                legalizedName = legalizedId;
+
+            return location
+                .Replace(PackageIdPlaceholder, legalizedId, StringComparison.OrdinalIgnoreCase)
+                .Replace(PackageNamePlaceholder, legalizedName, StringComparison.OrdinalIgnoreCase);
         }
 
         private static string _expandEnvironmentVariables(string value)

--- a/src/UniGetUI.PackageEngine.Tests/InstallOptionsFactoryTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/InstallOptionsFactoryTests.cs
@@ -327,6 +327,46 @@ public sealed class InstallOptionsFactoryTests : IDisposable
         Assert.Equal(@"D:\Programs\Contoso Tool", resolved.CustomInstallLocation);
     }
 
+    [Fact]
+    public void LoadApplicable_DoesNotLetPackageMetadataIntroduceEnvironmentVariables()
+    {
+        var varName = $"UNIGETUI_TEST_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(varName, @"C:\Expanded");
+        try
+        {
+            Settings.Set(Settings.K.ExpandEnvVarsWithPercentSyntax, true);
+            var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();
+            var package = new PackageBuilder()
+                .WithManager(manager)
+                .WithId($"Contoso.%{varName}%")
+                .WithName($"Contoso %{varName}% Tool")
+                .Build();
+
+            InstallOptionsFactory.SaveForManager(
+                new InstallOptions { CustomInstallLocation = @"D:\Programs\%NAME%\%PACKAGE%" },
+                manager
+            );
+            InstallOptionsFactory.SaveForPackage(new InstallOptions(), package);
+
+            var resolved = InstallOptionsFactory.LoadApplicable(package);
+
+            Assert.Equal(
+                $@"D:\Programs\Contoso {varName} Tool\Contoso.{varName}",
+                resolved.CustomInstallLocation
+            );
+            Assert.DoesNotContain(
+                @"C:\Expanded",
+                resolved.CustomInstallLocation,
+                StringComparison.Ordinal
+            );
+        }
+        finally
+        {
+            Settings.Set(Settings.K.ExpandEnvVarsWithPercentSyntax, false);
+            Environment.SetEnvironmentVariable(varName, null);
+        }
+    }
+
     [Theory]
     [InlineData("..")]
     [InlineData(@"..\..\Windows\System32")]

--- a/src/UniGetUI.PackageEngine.Tests/InstallOptionsFactoryTests.cs
+++ b/src/UniGetUI.PackageEngine.Tests/InstallOptionsFactoryTests.cs
@@ -260,6 +260,125 @@ public sealed class InstallOptionsFactoryTests : IDisposable
     }
 
     [Fact]
+    public void LoadApplicable_ExpandsNameTokenFromManagerDefaults()
+    {
+        var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Notepad++.Notepad++")
+            .WithName("Notepad++")
+            .Build();
+
+        InstallOptionsFactory.SaveForManager(
+            new InstallOptions { CustomInstallLocation = @"D:\Programs\%NAME%" },
+            manager
+        );
+        InstallOptionsFactory.SaveForPackage(new InstallOptions(), package);
+
+        var resolved = InstallOptionsFactory.LoadApplicable(package);
+
+        Assert.Equal(@"D:\Programs\Notepad++", resolved.CustomInstallLocation);
+        Assert.False(resolved.CustomInstallLocationIsExplicit);
+    }
+
+    [Fact]
+    public void LoadApplicable_ExpandsTokensInExplicitPackageLocation()
+    {
+        var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithName("Contoso Tool")
+            .Build();
+
+        InstallOptionsFactory.SaveForPackage(
+            new InstallOptions
+            {
+                OverridesNextLevelOpts = true,
+                CustomInstallLocation = @"D:\Programs\%name%\%package%",
+            },
+            package
+        );
+
+        var resolved = InstallOptionsFactory.LoadApplicable(package);
+
+        Assert.Equal(@"D:\Programs\Contoso Tool\Contoso.Tool", resolved.CustomInstallLocation);
+        Assert.True(resolved.CustomInstallLocationIsExplicit);
+    }
+
+    [Fact]
+    public void LoadApplicable_SanitizesNameTokenForUseAsAFolderName()
+    {
+        var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId($"Pkg{Guid.NewGuid():N}")
+            .WithName("Contoso: Tool*")
+            .Build();
+
+        InstallOptionsFactory.SaveForManager(
+            new InstallOptions { CustomInstallLocation = @"D:\Programs\%NAME%" },
+            manager
+        );
+        InstallOptionsFactory.SaveForPackage(new InstallOptions(), package);
+
+        var resolved = InstallOptionsFactory.LoadApplicable(package);
+
+        Assert.Equal(@"D:\Programs\Contoso Tool", resolved.CustomInstallLocation);
+    }
+
+    [Theory]
+    [InlineData("..")]
+    [InlineData(@"..\..\Windows\System32")]
+    [InlineData("../../etc")]
+    [InlineData("   ")]
+    [InlineData("CON")]
+    public void LoadApplicable_KeepsTheNameTokenInsideTheConfiguredDirectory(string name)
+    {
+        var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId($"Pkg{Guid.NewGuid():N}")
+            .WithName(name)
+            .Build();
+
+        InstallOptionsFactory.SaveForManager(
+            new InstallOptions { CustomInstallLocation = @"D:\Programs\%NAME%" },
+            manager
+        );
+        InstallOptionsFactory.SaveForPackage(new InstallOptions(), package);
+
+        var resolved = InstallOptionsFactory.LoadApplicable(package);
+
+        Assert.StartsWith(@"D:\Programs\", resolved.CustomInstallLocation, StringComparison.Ordinal);
+        Assert.Equal(
+            @"D:\Programs",
+            Path.GetDirectoryName(Path.GetFullPath(resolved.CustomInstallLocation))
+        );
+    }
+
+    [Fact]
+    public void LoadApplicable_FallsBackToPackageIdWhenNameCannotBeAFolderName()
+    {
+        var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();
+        var package = new PackageBuilder()
+            .WithManager(manager)
+            .WithId("Contoso.Tool")
+            .WithName("?*|")
+            .Build();
+
+        InstallOptionsFactory.SaveForManager(
+            new InstallOptions { CustomInstallLocation = @"D:\Programs\%NAME%" },
+            manager
+        );
+        InstallOptionsFactory.SaveForPackage(new InstallOptions(), package);
+
+        var resolved = InstallOptionsFactory.LoadApplicable(package);
+
+        Assert.Equal(@"D:\Programs\Contoso.Tool", resolved.CustomInstallLocation);
+    }
+
+    [Fact]
     public void LoadApplicable_MarksLocationExplicitOnlyForPerPackageOverrides()
     {
         var manager = new PackageManagerBuilder().WithName($"Manager{Guid.NewGuid():N}").Build();


### PR DESCRIPTION
This pull request introduces support for customizing the install location subfolder for each package, allowing users to use placeholders for package ID (`%PACKAGE%`) and package name (`%NAME%`). The changes include UI enhancements, new logic for placeholder expansion and sanitization, and comprehensive tests to ensure robust behavior.

**Install location subfolder customization:**
- Added UI elements in `InstallOptionsPanelViewModel` and related XAML files to let users select a subfolder style (by package ID, name, or none) for the install location. The UI now explains the available placeholders and their meaning. [[1]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cR21-R23) [[2]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cR61-R62) [[3]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cR82-R83) [[4]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cR102-R113) [[5]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cR146-R150) [[6]](diffhunk://#diff-87670d4b1b9a4f1be36df4ffab0995d935849bb0494cad41edb37d7ce5526506R346-R351) [[7]](diffhunk://#diff-934865ad3f65a4c664685e3543a3f1b09adcbb7afd2a4ea2573371da67d2f7c3R146-R166) [[8]](diffhunk://#diff-f8d36a381022aa27a72a2569e4660c301689d5490e8a2ad5c8d755f701331fafL1078-R1082)

**Placeholder expansion and sanitization:**
- Introduced `%PACKAGE%` and `%NAME%` constants in `InstallOptionsFactory` and implemented logic to expand and sanitize these placeholders in install paths, ensuring they are valid folder names and falling back to the package ID if necessary. [[1]](diffhunk://#diff-e32660f72ec152b43a185d2eb6ac8241d32f666091a7371a74d43c7cc3eab61eR21-R23) [[2]](diffhunk://#diff-e32660f72ec152b43a185d2eb6ac8241d32f666091a7371a74d43c7cc3eab61eR403-R418) [[3]](diffhunk://#diff-e32660f72ec152b43a185d2eb6ac8241d32f666091a7371a74d43c7cc3eab61eL165-R173)

**Improved logic and refactoring:**
- Refactored how install options are loaded and saved, including updating method calls and ensuring the selected subfolder is correctly reflected in the install path. [[1]](diffhunk://#diff-f961bb8e68c3d1508c3077d5f896fb8a0e56dd4035d12fc8c68812a78cfe835aL311-R311) [[2]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cR265-R273) [[3]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cL270-R354) [[4]](diffhunk://#diff-0ea7eb21f93194ec660a6d6e8636415b2e1685bc55cc25230ff913032d5ca96cR124-R130)

**Testing and validation:**
- Added comprehensive tests in `InstallOptionsFactoryTests` to verify placeholder expansion, sanitization, fallback logic, and directory safety, ensuring correct and secure behavior across a variety of package names and IDs.

**Localization:**
- Updated English language resources to include new strings for the install subfolder feature and placeholder explanations.